### PR TITLE
refac(math): rename monoids to semigroups

### DIFF
--- a/tachyon/math/base/BUILD.bazel
+++ b/tachyon/math/base/BUILD.bazel
@@ -50,15 +50,15 @@ tachyon_cc_library(
 )
 
 tachyon_cc_library(
-    name = "groups",
-    hdrs = ["groups.h"],
-    deps = [":monoids"],
-)
-
-tachyon_cc_library(
     name = "field",
     hdrs = ["field.h"],
     deps = [":rings"],
+)
+
+tachyon_cc_library(
+    name = "groups",
+    hdrs = ["groups.h"],
+    deps = [":semigroups"],
 )
 
 tachyon_cc_library(
@@ -67,20 +67,20 @@ tachyon_cc_library(
 )
 
 tachyon_cc_library(
-    name = "monoids",
-    hdrs = ["monoids.h"],
-    deps = [
-        ":bit_iterator",
-        "@com_google_absl//absl/types:span",
-    ],
-)
-
-tachyon_cc_library(
     name = "rings",
     hdrs = ["rings.h"],
     deps = [
         ":groups",
         "//tachyon/base:template_util",
+    ],
+)
+
+tachyon_cc_library(
+    name = "semigroups",
+    hdrs = ["semigroups.h"],
+    deps = [
+        ":bit_iterator",
+        "@com_google_absl//absl/types:span",
     ],
 )
 

--- a/tachyon/math/base/groups.h
+++ b/tachyon/math/base/groups.h
@@ -1,7 +1,7 @@
 #ifndef TACHYON_MATH_BASE_GROUPS_H_
 #define TACHYON_MATH_BASE_GROUPS_H_
 
-#include "tachyon/math/base/monoids.h"
+#include "tachyon/math/base/semigroups.h"
 
 namespace tachyon {
 namespace math {
@@ -14,7 +14,7 @@ SUPPORTS_BINARY_OPERATOR(Mod);
 }  // namespace internal
 
 template <typename G>
-class MultiplicativeGroup : public MultiplicativeMonoid<G> {
+class MultiplicativeGroup : public MultiplicativeSemigroup<G> {
  public:
   template <typename G2>
   constexpr auto operator/(const G2& other) const {
@@ -53,7 +53,7 @@ class MultiplicativeGroup : public MultiplicativeMonoid<G> {
 };
 
 template <typename G>
-class AdditiveGroup : public AdditiveMonoid<G> {
+class AdditiveGroup : public AdditiveSemigroup<G> {
  public:
   template <typename G2>
   constexpr auto operator-(const G2& other) const {

--- a/tachyon/math/base/rings.h
+++ b/tachyon/math/base/rings.h
@@ -10,7 +10,7 @@ namespace tachyon {
 namespace math {
 
 template <typename F>
-class Ring : public AdditiveGroup<F>, public MultiplicativeMonoid<F> {
+class Ring : public AdditiveGroup<F>, public MultiplicativeSemigroup<F> {
  public:
   template <
       typename InputIterator,

--- a/tachyon/math/base/semigroups.h
+++ b/tachyon/math/base/semigroups.h
@@ -1,5 +1,5 @@
-#ifndef TACHYON_MATH_BASE_MONOIDS_H_
-#define TACHYON_MATH_BASE_MONOIDS_H_
+#ifndef TACHYON_MATH_BASE_SEMIGROUPS_H_
+#define TACHYON_MATH_BASE_SEMIGROUPS_H_
 
 #include "absl/types/span.h"
 
@@ -45,7 +45,7 @@ SUPPORTS_UNARY_IN_PLACE_OPERATOR(Double);
 }  // namespace internal
 
 template <typename G>
-class MultiplicativeMonoid {
+class MultiplicativeSemigroup {
  public:
   template <typename G2>
   constexpr auto operator*(const G2& other) const {
@@ -115,7 +115,7 @@ class MultiplicativeMonoid {
 };
 
 template <typename G>
-class AdditiveMonoid {
+class AdditiveSemigroup {
  public:
   template <typename G2>
   constexpr auto operator+(const G2& other) const {
@@ -177,4 +177,4 @@ class AdditiveMonoid {
 }  // namespace math
 }  // namespace tachyon
 
-#endif  // TACHYON_MATH_BASE_MONOIDS_H_
+#endif  // TACHYON_MATH_BASE_SEMIGROUPS_H_

--- a/tachyon/math/elliptic_curves/short_weierstrass/affine_point.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/affine_point.h
@@ -118,7 +118,7 @@ class AffinePoint<Config,
     return absl::Substitute("($0, $1)", x_.ToString(), y_.ToString());
   }
 
-  // AdditiveMonoid methods
+  // AdditiveSemigroup methods
   template <typename U>
   constexpr JacobianPoint<Config> Add(const U& other) const {
     JacobianPoint<Config> point = ToJacobian();

--- a/tachyon/math/elliptic_curves/short_weierstrass/jacobian_point.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/jacobian_point.h
@@ -131,7 +131,7 @@ class JacobianPoint<Config,
                             z_.ToString());
   }
 
-  // AdditiveMonoid methods
+  // AdditiveSemigroup methods
   constexpr JacobianPoint& AddInPlace(const JacobianPoint& other);
   constexpr JacobianPoint& AddInPlace(const AffinePoint<Config>& other);
   constexpr JacobianPoint& DoubleInPlace();

--- a/tachyon/math/finite_fields/prime_field_gmp.h
+++ b/tachyon/math/finite_fields/prime_field_gmp.h
@@ -140,7 +140,7 @@ class PrimeFieldGmp : public PrimeFieldBase<PrimeFieldGmp<_Config>> {
     return gmp::DivBy2Exp(value_, exp);
   }
 
-  // AdditiveMonoid methods
+  // AdditiveSemigroup methods
   PrimeFieldGmp Add(const PrimeFieldGmp& other) const {
     return PrimeFieldGmp(DoMod(value_ + other.value_));
   }
@@ -171,7 +171,7 @@ class PrimeFieldGmp : public PrimeFieldBase<PrimeFieldGmp<_Config>> {
     return *this;
   }
 
-  // MultiplicativeMonoid methods
+  // MultiplicativeSemigroup methods
   PrimeFieldGmp Mul(const PrimeFieldGmp& other) const {
     return PrimeFieldGmp(DoMod(value_ * other.value_));
   }

--- a/tachyon/math/finite_fields/prime_field_mont.h
+++ b/tachyon/math/finite_fields/prime_field_mont.h
@@ -150,7 +150,7 @@ class PrimeFieldMont : public PrimeFieldBase<PrimeFieldMont<_Config>> {
     return gmp::DivBy2Exp(ToMpzClass(), exp);
   }
 
-  // AdditiveMonoid methods
+  // AdditiveSemigroup methods
   PrimeFieldMont& AddInPlace(const PrimeFieldMont& other) {
     uint64_t carry = 0;
     value_.AddInPlace(other.value_, carry);
@@ -182,7 +182,7 @@ class PrimeFieldMont : public PrimeFieldBase<PrimeFieldMont<_Config>> {
   }
 
   // TODO(chokobole): Support bigendian.
-  // MultiplicativeMonoid methods
+  // MultiplicativeSemigroup methods
   PrimeFieldMont& MulInPlace(const PrimeFieldMont& other) {
     if constexpr (Config::kCanUseNoCarryMulOptimization) {
       BigInt<N> r;

--- a/tachyon/math/matrix/matrix.h
+++ b/tachyon/math/matrix/matrix.h
@@ -139,7 +139,7 @@ class Matrix : public Ring<Matrix<T, Rows_, Cols_>>,
     return !operator==(other);
   }
 
-  // AdditiveMonoid methods
+  // AdditiveSemigroup methods
   constexpr Matrix Add(const Matrix& other) const {
     Matrix ret;
     for (size_t i = 0; i < Size; ++i) {
@@ -185,7 +185,7 @@ class Matrix : public Ring<Matrix<T, Rows_, Cols_>>,
     return *this;
   }
 
-  // MultiplicativeMonoid methods
+  // MultiplicativeSemigroup methods
   template <size_t Cols2>
   constexpr Matrix<T, Rows, Cols2> Mul(
       const Matrix<T, Cols, Cols2>& other) const {

--- a/tachyon/math/polynomials/univariate_polynomial.h
+++ b/tachyon/math/polynomials/univariate_polynomial.h
@@ -95,7 +95,7 @@ class UnivariatePolynomial
         *this, other);                                                         \
   }
 
-  // AdditiveMonoid methods
+  // AdditiveSemigroup methods
   OPERATION_METHOD(Add)
 
   // AdditiveGroup methods
@@ -105,7 +105,7 @@ class UnivariatePolynomial
     return internal::UnivariatePolynomialOp<Coefficients>::NegInPlace(*this);
   }
 
-  // MultiplicativeMonoid methods
+  // MultiplicativeSemigroup methods
   OPERATION_METHOD(Mul)
 
   OPERATION_METHOD(Div)


### PR DESCRIPTION
Considering the definition of a monoid in abstract algebra, the currently implemented 'monoids' should be renamed as 'semigroups'.

See https://en.wikipedia.org/wiki/Monoid

Resolves: #3
