### PR TITLE
fix(c): create point at infinity when needed

### DIFF
--- a/tachyon/c/math/elliptic_curves/msm/msm.cc
+++ b/tachyon/c/math/elliptic_curves/msm/msm.cc
@@ -20,6 +20,9 @@ bn254::G1JacobianPoint DoMSM(const tachyon_bn254_point2* bases_in,
       reinterpret_cast<const Point2<bn254::Fq>*>(bases_in), bases_len);
   std::vector<bn254::G1AffinePoint> bases =
       base::Map(points, [](const Point2<bn254::Fq>& point) {
+        if (point.x.IsZero() && point.y.IsZero()) {
+          return bn254::G1AffinePoint::Zero();
+        }
         return bn254::G1AffinePoint(point);
       });
   absl::Span<const bn254::Fr> scalars(

--- a/tachyon/c/math/elliptic_curves/msm/msm_gpu.cc
+++ b/tachyon/c/math/elliptic_curves/msm/msm_gpu.cc
@@ -104,6 +104,9 @@ bn254::G1JacobianPoint DoMSMGpu(const tachyon_bn254_point2* bases_in,
       reinterpret_cast<const Point2<bn254::Fq>*>(bases_in), bases_len);
   std::vector<bn254::G1AffinePoint> bases =
       base::Map(points, [](const Point2<bn254::Fq>& point) {
+        if (point.x.IsZero() && point.y.IsZero()) {
+          return bn254::G1AffinePoint::Zero();
+        }
         return bn254::G1AffinePoint(point);
       });
   absl::Span<const bn254::Fr> scalars(


### PR DESCRIPTION
# Description

`G1AffinePoint(BaseField(0), BaseField(0))` isn't a point at infinity. To make it, you need to call `G1AffinePoint::Zero()`
