### PR TITLE
build!: organize simd copts

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,10 +6,6 @@
 # Other build options:
 #     dbg:       Build with debug info
 #
-# Prime field implementation options:
-#     gmp_backend:        Support a prime field with gmp backend.
-#     polygon_zkevm_backend: Support a prime field with polygon zkevm prover backend.
-#
 # Hardware support options:
 #     cuda: Build with NVIDIA GPU support (cuda).
 #     rocm: Build with AMD GPU support (rocm).
@@ -67,6 +63,17 @@ build:macos --host_cxxopt=-std=c++17
 build:macos --objccopt=-std=c++17
 build:windows --cxxopt=/std:c++17
 build:windows --host_cxxopt=/std:c++17
+
+# Instruction set optimizations
+# TODO(chokobole): Create a feature in toolchains for avx/avx2 to
+# avoid having to define linux/win separately.
+build:avx_linux --copt=-mavx
+build:avx2_linux --copt=-mavx2
+build:avx512_linux --copt=-mavx512f
+build:native_arch_linux --copt=-march=native
+build:avx_windows --copt=/arch=AVX
+build:avx2_windows --copt=/arch=AVX2
+build:avx512_windows --copt=/arch=AVX512
 
 # Enable googletest build with absl.
 # See https://github.com/google/googletest/blob/v1.13.0/BUILD.bazel#L67C1-L70

--- a/README.md
+++ b/README.md
@@ -68,18 +68,20 @@ Please follow the instructions [here](https://bazel.build/install).
 
 ### GMP backend prime field
 
-- `--config gmp_backend`: Enable [gmp](https://gmplib.org/) prime field backend.
+- `--//:gmp_backend`: Enable [gmp](https://gmplib.org/) prime field backend.
 
   ```shell
-  > bazel build --config ${os} --config gmp_backend //...
+  > bazel build --//:${os} --//:gmp_backend //...
   ```
 
 ### Polygon zkEVM backend prime field
 
-- `--config polygon_zkevm_backend`: Enable [goldilocks](https://github.com/0xPolygonHermez/goldilocks) and [zkevm-prover](https://github.com/0xPolygonHermez/zkevm-prover) prime field backend.
+_NOTE:_: Only x86_64 is supported.
+
+- `--//:polygon_zkevm_backend`: Enable [goldilocks](https://github.com/0xPolygonHermez/goldilocks) and [zkevm-prover](https://github.com/0xPolygonHermez/zkevm-prover) prime field backend.
 
   ```shell
-  > bazel build --config ${os} --config polygon_zkevm_backend //...
+  > bazel build --config ${os} --config avx512_${os} --//:polygon_zkevm_backend //...
   ```
 
 ### Hardware acceleration

--- a/bazel/tachyon.bzl
+++ b/bazel/tachyon.bzl
@@ -38,6 +38,12 @@ def if_linux(a, b = []):
         "//conditions:default": b,
     })
 
+def if_linux_x86_64(a, b = []):
+    return select({
+        "@kroma_network_tachyon//linux_x86_64": a,
+        "//conditions:default": b,
+    })
+
 def if_macos(a, b = []):
     return select({
         "@platforms//os:macos": a,

--- a/bazel/tachyon_cc.bzl
+++ b/bazel/tachyon_cc.bzl
@@ -5,6 +5,7 @@ load(
     "if_has_exception",
     "if_has_matplotlib",
     "if_has_rtti",
+    "if_linux_x86_64",
     "if_static",
 )
 
@@ -25,6 +26,9 @@ def tachyon_exceptions(force_exceptions):
 
 def tachyon_rtti(force_rtti):
     return if_has_rtti(["-frtti"], (["-frtti"] if force_rtti else ["-fno-rtti"]))
+
+def tachyon_simd_copts():
+    return if_linux_x86_64(["-msse3"])
 
 def tachyon_copts(safe_code = True):
     return tachyon_warnings(safe_code) + tachyon_hide_symbols()

--- a/tachyon/math/finite_fields/BUILD.bazel
+++ b/tachyon/math/finite_fields/BUILD.bazel
@@ -1,4 +1,3 @@
-load("@polygon_zkevm_goldilocks//:build_defs.bzl", "goldilocks_copts")
 load("@local_config_cuda//cuda:build_defs.bzl", "if_cuda")
 load(
     "//bazel:tachyon.bzl",
@@ -137,7 +136,6 @@ tachyon_cc_benchmark(
     name = "prime_field_benchmark",
     size = "small",
     srcs = ["prime_field_benchmark.cc"],
-    copts = goldilocks_copts(),
     deps = [
         "//tachyon/math/elliptic_curves/bn/bn254:fq",
         "//tachyon/math/elliptic_curves/bn/bn254:fr",

--- a/tachyon/math/finite_fields/goldilocks_prime/BUILD.bazel
+++ b/tachyon/math/finite_fields/goldilocks_prime/BUILD.bazel
@@ -1,4 +1,3 @@
-load("@polygon_zkevm_goldilocks//:build_defs.bzl", "goldilocks_copts")
 load("//bazel:tachyon.bzl", "if_polygon_zkevm_backend")
 load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_test")
 load("//tachyon/math/finite_fields/generator:build_defs.bzl", "generate_prime_fields")
@@ -12,7 +11,6 @@ GOLDILOCKS_MODULUS = "18446744069414584321"
 generate_prime_fields(
     name = "goldilocks",
     class_name = "Goldilocks",
-    copts = goldilocks_copts(),
     hdr_include_override = """#include "tachyon/export.h"
 #if defined(TACHYON_GMP_BACKEND)
 #include "tachyon/math/finite_fields/prime_field_gmp.h"
@@ -58,6 +56,5 @@ tachyon_cc_library(
 tachyon_cc_test(
     name = "goldilocks_prime_unittests",
     srcs = if_polygon_zkevm_backend(["prime_field_goldilocks_unittest.cc"]),
-    copts = goldilocks_copts(),
     deps = [":goldilocks"],
 )

--- a/third_party/polygon_zkevm/goldilocks/build_defs.bzl
+++ b/third_party/polygon_zkevm/goldilocks/build_defs.bzl
@@ -1,8 +1,0 @@
-def goldilocks_copts():
-    return select({
-        "@kroma_network_tachyon//:x86_64_and_polygon_zkevm": [
-            "-mavx",
-            "-mavx512f",
-        ],
-        "//conditions:default": [],
-    })

--- a/third_party/polygon_zkevm/goldilocks/goldilocks.BUILD
+++ b/third_party/polygon_zkevm/goldilocks/goldilocks.BUILD
@@ -1,5 +1,4 @@
 load("@rules_cc//cc:defs.bzl", "cc_library")
-load(":build_defs.bzl", "goldilocks_copts")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -16,7 +15,6 @@ cc_library(
         "src/goldilocks_base_field_scalar.hpp",
         "src/goldilocks_base_field_tools.hpp",
     ],
-    copts = goldilocks_copts(),
     include_prefix = "third_party/polygon_zkevm_goldilocks/include",
     includes = ["src"],
     strip_include_prefix = "src",

--- a/third_party/polygon_zkevm/goldilocks/workspace.bzl
+++ b/third_party/polygon_zkevm/goldilocks/workspace.bzl
@@ -9,7 +9,4 @@ def repo():
         sha256 = "675f31ee46f826047a4d9d7a0fa5d4b5f14caec9d43cb175be744e4e8da84fd4",
         strip_prefix = "goldilocks-e33eb7cb60ba483807040ee5e9ad6d1ea8dbf315",
         build_file = "//third_party/polygon_zkevm/goldilocks:goldilocks.BUILD",
-        link_files = {
-            "//third_party/polygon_zkevm/goldilocks:build_defs.bzl": "build_defs.bzl",
-        },
     )


### PR DESCRIPTION
# Description

This organizes simd copts. If you want to make use of simd instructions, now you need to give flags at once not independently give a `copts` to each `cc_library` or something. This is because `linkopts` are able to be delegated but `copts` are not.