### PR TITLE
perf: remove parallel loop

### DIFF
--- a/tachyon/math/elliptic_curves/msm/algorithms/pippenger.h
+++ b/tachyon/math/elliptic_curves/msm/algorithms/pippenger.h
@@ -173,18 +173,15 @@ class Pippenger {
     for (std::vector<int64_t>& scalar_digit : scalar_digits) {
       scalar_digit.resize(window_count_);
     }
+    for (size_t i = 0; i < scalars.size(); ++i) {
+      FillDigits(scalars[i], window_bits_, &scalar_digits[i]);
+    }
     if (parallel_windows_) {
-      OPENMP_PARALLEL_FOR(size_t i = 0; i < scalars.size(); ++i) {
-        FillDigits(scalars[i], window_bits_, &scalar_digits[i]);
-      }
       OPENMP_PARALLEL_FOR(size_t i = 0; i < window_count_; ++i) {
         AccumulateSingleWindowNAFSum(bases_first, scalar_digits, i,
                                      &(*window_sums)[i]);
       }
     } else {
-      for (size_t i = 0; i < scalars.size(); ++i) {
-        FillDigits(scalars[i], window_bits_, &scalar_digits[i]);
-      }
       for (size_t i = 0; i < window_count_; ++i) {
         AccumulateSingleWindowNAFSum(bases_first, scalar_digits, i,
                                      &(*window_sums)[i]);

--- a/tachyon/math/elliptic_curves/msm/algorithms/pippenger_benchmark.cc
+++ b/tachyon/math/elliptic_curves/msm/algorithms/pippenger_benchmark.cc
@@ -47,28 +47,28 @@ BENCHMARK_TEMPLATE(BM_PippengerNonUniform, bn254::G1AffinePoint)
 // clang-format off
 // Executing tests from //tachyon/math/elliptic_curves/msm/algorithms:pippenger_benchmark
 // -----------------------------------------------------------------------------
-// 2023-08-30T05:54:01+00:00
-// Running /home/ryan/.cache/bazel/_bazel_ryan/2e01f4ccafa60589f9bbdbefc5d15e2a/execroot/kroma_network_tachyon/bazel-out/k8-opt/bin/tachyon/math/elliptic_curves/msm/algorithms/pippenger_benchmark.runfiles/kroma_network_tachyon/tachyon/math/elliptic_curves/msm/algorithms/pippenger_benchmark
-// Run on (32 X 5500 MHz CPU s)
+// 2023-08-31T23:50:45+00:00
+// Running /home/ryan/.cache/bazel/_bazel_ryan/d6800124b8b6155cc6ab653ae18dfdd6/execroot/kroma_network_tachyon/bazel-out/k8-opt/bin/tachyon/math/elliptic_curves/msm/algorithms/pippenger_benchmark.runfiles/kroma_network_tachyon/tachyon/math/elliptic_curves/msm/algorithms/pippenger_benchmark
+// Run on (32 X 5489.54 MHz CPU s)
 // CPU Caches:
 //   L1 Data 48 KiB (x16)
 //   L1 Instruction 32 KiB (x16)
 //   L2 Unified 2048 KiB (x16)
 //   L3 Unified 36864 KiB (x1)
-// Load Average: 2.71, 2.64, 1.87
+// Load Average: 4.14, 3.58, 2.97
 // -----------------------------------------------------------------------------------------------
 // Benchmark                                                     Time             CPU   Iterations
 // -----------------------------------------------------------------------------------------------
-// BM_PippengerRandom<bn254::G1AffinePoint>/32768         34908874 ns     33396236 ns           21
-// BM_PippengerRandom<bn254::G1AffinePoint>/65536         61684394 ns     55921674 ns           10
-// BM_PippengerRandom<bn254::G1AffinePoint>/131072       109082434 ns     86647108 ns            9
-// BM_PippengerRandom<bn254::G1AffinePoint>/262144       215575314 ns    148382267 ns            5
-// BM_PippengerRandom<bn254::G1AffinePoint>/524288       410419226 ns    279332868 ns            3
-// BM_PippengerRandom<bn254::G1AffinePoint>/1048576      755907536 ns    512204693 ns            1
-// BM_PippengerNonUniform<bn254::G1AffinePoint>/32768     39093761 ns     36180793 ns           25
-// BM_PippengerNonUniform<bn254::G1AffinePoint>/65536     57416010 ns     51653336 ns           10
-// BM_PippengerNonUniform<bn254::G1AffinePoint>/131072   108107143 ns     90550465 ns            9
-// BM_PippengerNonUniform<bn254::G1AffinePoint>/262144   205311680 ns    162177059 ns            5
-// BM_PippengerNonUniform<bn254::G1AffinePoint>/524288   396333456 ns    260226808 ns            3
-// BM_PippengerNonUniform<bn254::G1AffinePoint>/1048576  745496988 ns    504996463 ns            1
+// BM_PippengerRandom<bn254::G1AffinePoint>/32768         34569606 ns     32515164 ns           23
+// BM_PippengerRandom<bn254::G1AffinePoint>/65536         59088051 ns     49972215 ns           12
+// BM_PippengerRandom<bn254::G1AffinePoint>/131072       104039362 ns     84752183 ns            7
+// BM_PippengerRandom<bn254::G1AffinePoint>/262144       220377350 ns    158326024 ns            5
+// BM_PippengerRandom<bn254::G1AffinePoint>/524288       405006965 ns    266241591 ns            3
+// BM_PippengerRandom<bn254::G1AffinePoint>/1048576      793197632 ns    544881375 ns            1
+// BM_PippengerNonUniform<bn254::G1AffinePoint>/32768     31510353 ns     29713886 ns           26
+// BM_PippengerNonUniform<bn254::G1AffinePoint>/65536     55103302 ns     52560911 ns           10
+// BM_PippengerNonUniform<bn254::G1AffinePoint>/131072   102975157 ns     89503428 ns            9
+// BM_PippengerNonUniform<bn254::G1AffinePoint>/262144   208537149 ns    150291432 ns            5
+// BM_PippengerNonUniform<bn254::G1AffinePoint>/524288   407595555 ns    267039153 ns            3
+// BM_PippengerNonUniform<bn254::G1AffinePoint>/1048576  775470257 ns    513212445 ns            1
 // clang-format on


### PR DESCRIPTION
# Description

If we use parallel loop, there should be performance gain by thread numbers. If not, I think using parallel loop only takes engineering cost(Whether there's no race condition or not)