### PR TITLE
test: add proper tags to tests

### DIFF
--- a/bazel/tachyon_cc.bzl
+++ b/bazel/tachyon_cc.bzl
@@ -285,6 +285,7 @@ def tachyon_cuda_test(
         name,
         deps = [],
         tags = [],
+        size = "medium",
         **kwargs):
     lib_name = "{}_lib".format(name)
     tachyon_cuda_library(
@@ -301,6 +302,7 @@ def tachyon_cuda_test(
     tachyon_cc_test(
         name = name,
         tags = tags + ["cuda"],
+        size = size,
         deps = [":" + lib_name],
     )
 

--- a/tachyon/BUILD.bazel
+++ b/tachyon/BUILD.bazel
@@ -42,6 +42,7 @@ tachyon_cc_library(
 
 tachyon_cc_test(
     name = "tachyon_unittests",
+    size = "small",
     srcs = [
         "version_unittest.cc",
     ],

--- a/tachyon/base/BUILD.bazel
+++ b/tachyon/base/BUILD.bazel
@@ -105,6 +105,7 @@ tachyon_cc_library(
 
 tachyon_cc_test(
     name = "base_unittests",
+    size = "small",
     srcs = [
         "bit_cast_unittest.cc",
         "bits_unittest.cc",

--- a/tachyon/base/color/BUILD.bazel
+++ b/tachyon/base/color/BUILD.bazel
@@ -26,6 +26,7 @@ tachyon_cc_library(
 
 tachyon_cc_test(
     name = "color_unittests",
+    size = "small",
     srcs = [
         "color_conversions_unittest.cc",
         "color_unittest.cc",

--- a/tachyon/base/containers/BUILD.bazel
+++ b/tachyon/base/containers/BUILD.bazel
@@ -75,6 +75,7 @@ tachyon_cc_library(
 
 tachyon_cc_test(
     name = "containers_unittests",
+    size = "small",
     srcs = [
         "adapters_unittest.cc",
         "circular_deque_unittest.cc",

--- a/tachyon/base/files/BUILD.bazel
+++ b/tachyon/base/files/BUILD.bazel
@@ -129,6 +129,7 @@ tachyon_cc_library(
 
 tachyon_cc_test(
     name = "files_unittests",
+    size = "small",
     srcs = [
         "file_unittest.cc",
         "file_enumerator_unittest.cc",

--- a/tachyon/base/flag/BUILD.bazel
+++ b/tachyon/base/flag/BUILD.bazel
@@ -34,6 +34,7 @@ tachyon_cc_library(
 
 tachyon_cc_test(
     name = "flag_unittests",
+    size = "small",
     srcs = [
         "flag_parser_unittest.cc",
         "flag_unittest.cc",

--- a/tachyon/base/functional/BUILD.bazel
+++ b/tachyon/base/functional/BUILD.bazel
@@ -47,6 +47,7 @@ tachyon_cc_library(
 
 tachyon_cc_test(
     name = "functional_unittests",
+    size = "small",
     srcs = [
         "function_ref_unittest.cc",
         "identity_unittest.cc",

--- a/tachyon/base/memory/BUILD.bazel
+++ b/tachyon/base/memory/BUILD.bazel
@@ -16,6 +16,7 @@ tachyon_cc_library(
 
 tachyon_cc_test(
     name = "memory_unittests",
+    size = "small",
     srcs = ["aligned_memory_unittest.cc"],
     deps = [":aligned_memory"],
 )

--- a/tachyon/base/ranges/BUILD.bazel
+++ b/tachyon/base/ranges/BUILD.bazel
@@ -29,6 +29,7 @@ tachyon_cc_library(
 
 tachyon_cc_test(
     name = "ranges_unittests",
+    size = "small",
     srcs = [
         "algorithm_unittest.cc",
         "functional_unittest.cc",

--- a/tachyon/base/strings/BUILD.bazel
+++ b/tachyon/base/strings/BUILD.bazel
@@ -91,6 +91,7 @@ tachyon_objc_library(
 
 tachyon_cc_test(
     name = "strings_unittests",
+    size = "small",
     srcs = [
         "string_number_conversions_unittest.cc",
         "string_util_unittest.cc",

--- a/tachyon/base/time/BUILD.bazel
+++ b/tachyon/base/time/BUILD.bazel
@@ -91,6 +91,7 @@ tachyon_objc_library(
 
 tachyon_cc_test(
     name = "time_unittests",
+    size = "small",
     srcs = [
         "time_delta_flag_unittest.cc",
         "time_interval_unittest.cc",

--- a/tachyon/c/math/elliptic_curves/msm/BUILD.bazel
+++ b/tachyon/c/math/elliptic_curves/msm/BUILD.bazel
@@ -76,6 +76,7 @@ tachyon_cuda_library(
 
 tachyon_cc_test(
     name = "msm_unittests",
+    size = "small",
     srcs = ["msm_unittest.cc"],
     deps = [
         ":msm",
@@ -87,6 +88,7 @@ tachyon_cc_test(
 
 tachyon_cuda_test(
     name = "msm_gpu_unittest",
+    size = "small",
     srcs = if_gpu_is_configured(["msm_gpu_unittest.cc"]),
     deps = [
         ":msm_gpu",

--- a/tachyon/device/BUILD.bazel
+++ b/tachyon/device/BUILD.bazel
@@ -39,6 +39,7 @@ tachyon_cc_library(
 
 tachyon_cc_test(
     name = "device_unittests",
+    size = "small",
     srcs = ["numa_unittest.cc"],
     deps = [":numa"],
 )

--- a/tachyon/device/gpu/BUILD.bazel
+++ b/tachyon/device/gpu/BUILD.bazel
@@ -156,6 +156,7 @@ tachyon_cc_library(
 
 tachyon_cuda_test(
     name = "gpu_unittests",
+    size = "small",
     srcs = if_gpu_is_configured(["gpu_memory_unittest.cc"]),
     deps = [
         ":gpu_memory",

--- a/tachyon/device/gpu/cuda/BUILD.bazel
+++ b/tachyon/device/gpu/cuda/BUILD.bazel
@@ -31,6 +31,7 @@ tachyon_cuda_library(
 
 tachyon_cuda_test(
     name = "cuda_unittests",
+    size = "small",
     srcs = [
         "cuda_driver_unittest.cc",
     ],

--- a/tachyon/math/base/BUILD.bazel
+++ b/tachyon/math/base/BUILD.bazel
@@ -100,6 +100,7 @@ tachyon_cc_library(
 
 tachyon_cc_test(
     name = "base_unittests",
+    size = "small",
     srcs = [
         "arithmetics_unittest.cc",
         "big_int_unittest.cc",

--- a/tachyon/math/base/gmp/BUILD.bazel
+++ b/tachyon/math/base/gmp/BUILD.bazel
@@ -54,6 +54,7 @@ tachyon_cc_library(
 
 tachyon_cc_test(
     name = "gmp_unittests",
+    size = "small",
     srcs = [
         "gmp_identities_unittest.cc",
         "gmp_util_unittest.cc",

--- a/tachyon/math/elliptic_curves/msm/BUILD.bazel
+++ b/tachyon/math/elliptic_curves/msm/BUILD.bazel
@@ -51,6 +51,7 @@ tachyon_cc_library(
 
 tachyon_cc_test(
     name = "msm_unittests",
+    size = "small",
     srcs = [
         "variable_base_msm_unittest.cc",
     ] + if_gmp_backend([
@@ -67,6 +68,7 @@ tachyon_cc_test(
 
 tachyon_cuda_test(
     name = "msm_gpu_unittests",
+    size = "small",
     srcs = if_gpu_is_configured(["variable_base_msm_gpu_unittest.cc"]),
     deps = [
         ":variable_base_msm",

--- a/tachyon/math/elliptic_curves/msm/algorithms/BUILD.bazel
+++ b/tachyon/math/elliptic_curves/msm/algorithms/BUILD.bazel
@@ -48,6 +48,7 @@ tachyon_cc_library(
 
 tachyon_cc_test(
     name = "algorithms_unittests",
+    size = "small",
     srcs = [
         "pippenger_adapter_unittest.cc",
         "pippenger_unittest.cc",

--- a/tachyon/math/elliptic_curves/short_weierstrass/BUILD.bazel
+++ b/tachyon/math/elliptic_curves/short_weierstrass/BUILD.bazel
@@ -46,6 +46,7 @@ tachyon_cc_library(
 
 tachyon_cc_test(
     name = "short_weierstrass_unittests",
+    size = "small",
     srcs = [
         "affine_point_unittest.cc",
         "jacobian_point_unittest.cc",
@@ -60,6 +61,7 @@ tachyon_cc_test(
 
 tachyon_cuda_test(
     name = "short_weierstrass_correctness_gpu_tests",
+    size = "small",
     srcs = if_cuda_and_gmp_backend([
         "affine_point_correctness_gpu_test.cc",
         "non_affine_point_correctness_gpu_test.cc",

--- a/tachyon/math/finite_fields/BUILD.bazel
+++ b/tachyon/math/finite_fields/BUILD.bazel
@@ -84,6 +84,7 @@ tachyon_cc_library(
 
 tachyon_cc_test(
     name = "finite_fields_unittests",
+    size = "small",
     srcs = [
         "modulus_unittest.cc",
         "prime_field_unittest.cc",
@@ -96,6 +97,7 @@ tachyon_cc_test(
 
 tachyon_cuda_test(
     name = "finite_fields_gpu_unittests",
+    size = "small",
     srcs = if_gpu_is_configured(["prime_field_gpu_unittest.cc"]),
     deps = [
         "//tachyon/device/gpu:gpu_memory",
@@ -107,6 +109,7 @@ tachyon_cuda_test(
 
 tachyon_cc_test(
     name = "finite_field_correctness_tests",
+    size = "small",
     srcs = if_gmp_backend(["prime_field_correctness_test.cc"]),
     deps = [
         ":prime_field_gpu",
@@ -121,6 +124,7 @@ tachyon_cc_test(
 
 tachyon_cuda_test(
     name = "finite_field_correctness_gpu_tests",
+    size = "small",
     srcs = if_cuda_and_gmp_backend(["prime_field_correctness_gpu_test.cc"]),
     deps = [
         ":prime_field_gpu",

--- a/tachyon/math/finite_fields/goldilocks_prime/BUILD.bazel
+++ b/tachyon/math/finite_fields/goldilocks_prime/BUILD.bazel
@@ -55,6 +55,7 @@ tachyon_cc_library(
 
 tachyon_cc_test(
     name = "goldilocks_prime_unittests",
+    size = "small",
     srcs = if_polygon_zkevm_backend(["prime_field_goldilocks_unittest.cc"]),
     deps = [":goldilocks"],
 )

--- a/tachyon/math/geometry/BUILD.bazel
+++ b/tachyon/math/geometry/BUILD.bazel
@@ -22,6 +22,7 @@ tachyon_cc_library(
 
 tachyon_cc_test(
     name = "geometry_unittests",
+    size = "small",
     srcs = [
         "point2_unittest.cc",
         "point3_unittest.cc",

--- a/tachyon/math/matrix/sparse/BUILD.bazel
+++ b/tachyon/math/matrix/sparse/BUILD.bazel
@@ -16,6 +16,7 @@ tachyon_cc_library(
 
 tachyon_cc_test(
     name = "sparse_unittests",
+    size = "small",
     srcs = ["sparse_matrix_unittest.cc"],
     deps = [
         ":sparse_matrix",

--- a/tachyon/math/polynomials/multivariate/BUILD.bazel
+++ b/tachyon/math/polynomials/multivariate/BUILD.bazel
@@ -25,6 +25,7 @@ tachyon_cc_library(
 
 tachyon_cc_test(
     name = "multivariate_polynomials_unittests",
+    size = "small",
     srcs = [
         "multivariate_polynomial_unittest.cc",
     ],

--- a/tachyon/math/polynomials/univariate/BUILD.bazel
+++ b/tachyon/math/polynomials/univariate/BUILD.bazel
@@ -26,6 +26,7 @@ tachyon_cc_library(
 
 tachyon_cc_test(
     name = "univariate_polynomials_unittests",
+    size = "small",
     srcs = [
         "dense_polynomial_unittest.cc",
         "sparse_polynomial_unittest.cc",

--- a/vendors/halo2/BUILD.bazel
+++ b/vendors/halo2/BUILD.bazel
@@ -59,6 +59,7 @@ tachyon_cc_library(
 
 tachyon_rust_test(
     name = "halo2_test",
+    size = "small",
     aliases = aliases(),
     crate = ":halo2",
     crate_features = FEATUERS,


### PR DESCRIPTION
# Description

This commits add tags to tests whose size is small. I found such tests using this command.

```
> bazel test --test_verbose_timeout_warnings --config cuda //...
```

See https://bazel.build/reference/be/common-definitions#common-attributes-tests
