### PR TITLE
fix(c): fix bug occured from #15

### DIFF
--- a/tachyon/c/math/elliptic_curves/msm/msm_gpu.cc
+++ b/tachyon/c/math/elliptic_curves/msm/msm_gpu.cc
@@ -101,8 +101,10 @@ void DoReleaseMSMGpu() {
 bn254::G1JacobianPoint DoMSMGpuInternal(
     absl::Span<const bn254::G1AffinePoint> bases,
     absl::Span<const bn254::Fr> scalars) {
-  CHECK(g_d_bases.CopyFrom(bases.data(), gpu::GpuMemoryType::kHost));
-  CHECK(g_d_scalars.CopyFrom(scalars.data(), gpu::GpuMemoryType::kHost));
+  CHECK(g_d_bases.CopyFrom(bases.data(), gpu::GpuMemoryType::kHost, 0,
+                           bases.size()));
+  CHECK(g_d_scalars.CopyFrom(scalars.data(), gpu::GpuMemoryType::kHost, 0,
+                             scalars.size()));
 
   msm::ExecutionConfig<bn254::G1AffinePointGpu::Curve> config;
   config.mem_pool = g_mem_pool.get();


### PR DESCRIPTION
# Description

This PR fixes the segmentation fault when running benchmarking msm_gpu. When benchmarking msm_gpu, it allocates memories that is able to run with the maximum degree, and if you try to copy data with the `length` of the gpu memory, then sometimes it tries to copy more than its allocation size.