### PR TITLE
fix(c): fix typo

### DIFF
--- a/tachyon/c/math/elliptic_curves/generator/generator.cc
+++ b/tachyon/c/math/elliptic_curves/generator/generator.cc
@@ -486,7 +486,7 @@ int GenerationConfig::GenerateG1Src() const {
       "#include \"tachyon/cc/math/elliptic_curves/point_conversions.h\"",
       "#include \"tachyon/math/elliptic_curves/%{header_dir_name}/g1.h\"",
       "",
-      "void tachyon_%{type}_init() {",
+      "void %{g1}_init() {",
       "  tachyon::math::%{type}::G1AffinePoint::Curve::Init();",
       "}",
       "",

--- a/tachyon/c/math/elliptic_curves/short_weierstrass/affine_point_unittest.cc
+++ b/tachyon/c/math/elliptic_curves/short_weierstrass/affine_point_unittest.cc
@@ -12,9 +12,7 @@ namespace {
 
 class AffinePointTest : public testing::Test {
  public:
-  static void SetUpTestSuite() {
-    tachyon::math::bn254::G1AffinePoint::Curve::Init();
-  }
+  static void SetUpTestSuite() { tachyon_bn254_g1_init(); }
 
   void SetUp() override {
     a_ = tachyon::math::bn254::G1AffinePoint::Random();

--- a/tachyon/c/math/elliptic_curves/short_weierstrass/jacobian_point_unittest.cc
+++ b/tachyon/c/math/elliptic_curves/short_weierstrass/jacobian_point_unittest.cc
@@ -12,9 +12,7 @@ namespace {
 
 class JacobianPointTest : public testing::Test {
  public:
-  static void SetUpTestSuite() {
-    tachyon::math::bn254::G1JacobianPoint::Curve::Init();
-  }
+  static void SetUpTestSuite() { tachyon_bn254_g1_init(); }
 
   void SetUp() override {
     a_ = tachyon::math::bn254::G1JacobianPoint::Random();

--- a/tachyon/c/math/elliptic_curves/short_weierstrass/point_xyzz_unittest.cc
+++ b/tachyon/c/math/elliptic_curves/short_weierstrass/point_xyzz_unittest.cc
@@ -12,9 +12,7 @@ namespace {
 
 class PointXYZZTest : public testing::Test {
  public:
-  static void SetUpTestSuite() {
-    tachyon::math::bn254::G1PointXYZZ::Curve::Init();
-  }
+  static void SetUpTestSuite() { tachyon_bn254_g1_init(); }
 
   void SetUp() override {
     a_ = tachyon::math::bn254::G1PointXYZZ::Random();

--- a/tachyon/c/math/elliptic_curves/short_weierstrass/projective_point_unittest.cc
+++ b/tachyon/c/math/elliptic_curves/short_weierstrass/projective_point_unittest.cc
@@ -12,9 +12,7 @@ namespace {
 
 class ProjectivePointTest : public testing::Test {
  public:
-  static void SetUpTestSuite() {
-    tachyon::math::bn254::G1ProjectivePoint::Curve::Init();
-  }
+  static void SetUpTestSuite() { tachyon_bn254_g1_init(); }
 
   void SetUp() override {
     a_ = tachyon::math::bn254::G1ProjectivePoint::Random();


### PR DESCRIPTION
# Description

This fixes c api error. For example, when seeing a generated pair of files `bls/bl12_381/g1.h` and `bls/bls12_381/g1.cc`, in `.cc` `g1` was missing.

```c++
TACHYON_C_EXPORT void tachyon_bls12_381_g1_init();
```

```c++
void tachyon_bls12_381_init() {
  tachyon::math::bls12_381::G1AffinePoint::Curve::Init();
}
```