### PR TITLE
fix(math): fix `IsOne` for sparse univariate polynomials

### DIFF
--- a/tachyon/math/polynomials/univariate/sparse_coefficients.h
+++ b/tachyon/math/polynomials/univariate/sparse_coefficients.h
@@ -109,7 +109,8 @@ class SparseCoefficients {
   constexpr bool IsZero() const { return terms_.empty(); }
 
   constexpr bool IsOne() const {
-    return terms_.size() == 1 && terms_[0].coefficient.IsOne();
+    return terms_.size() == 1 && terms_[0].degree == 0 &&
+           terms_[0].coefficient.IsOne();
   }
 
   constexpr size_t Degree() const {

--- a/tachyon/math/polynomials/univariate/sparse_polynomial_unittest.cc
+++ b/tachyon/math/polynomials/univariate/sparse_polynomial_unittest.cc
@@ -51,6 +51,7 @@ TEST_F(SparseUnivariatePolynomialTest, IsZero) {
 TEST_F(SparseUnivariatePolynomialTest, IsOne) {
   EXPECT_TRUE(Poly::One().IsOne());
   EXPECT_TRUE(Poly(Coeffs({{0, GF7(1)}})).IsOne());
+  EXPECT_FALSE(Poly(Coeffs({{1, GF7(1)}})).IsOne());
   for (size_t i = 0; i < polys_.size() - 1; ++i) {
     EXPECT_FALSE(polys_[i].IsOne());
   }


### PR DESCRIPTION
# Description

Before this PR, `IsOne` did not check whether the degree is 0 or not. This PR fixes it.
