### PR TITLE
build: add bazel `tachyon_cc_unittest` and `tachyon_cuda_unittest` rule

### DIFF
--- a/bazel/tachyon_cc.bzl
+++ b/bazel/tachyon_cc.bzl
@@ -138,6 +138,16 @@ def tachyon_cc_test(
         **kwargs
     )
 
+def tachyon_cc_unittest(
+        name,
+        size = "small",
+        **kwargs):
+    tachyon_cc_test(
+        name = name,
+        size = size,
+        **kwargs
+    )
+
 def tachyon_cc_benchmark(
         name,
         copts = [],
@@ -316,6 +326,16 @@ def tachyon_cuda_test(
         tags = tags + ["cuda"],
         size = size,
         deps = [":" + lib_name],
+    )
+
+def tachyon_cuda_unittest(
+        name,
+        size = "small",
+        **kwargs):
+    tachyon_cuda_test(
+        name = name,
+        size = size,
+        **kwargs
     )
 
 def _get_hdrs(hdrs, deps):

--- a/tachyon/BUILD.bazel
+++ b/tachyon/BUILD.bazel
@@ -8,7 +8,7 @@ load(
 load(
     "//bazel:tachyon_cc.bzl",
     "tachyon_cc_library",
-    "tachyon_cc_test",
+    "tachyon_cc_unittest",
 )
 load("//tachyon/build:version.bzl", "write_version_header")
 
@@ -40,9 +40,8 @@ tachyon_cc_library(
     deps = [":export"],
 )
 
-tachyon_cc_test(
+tachyon_cc_unittest(
     name = "tachyon_unittests",
-    size = "small",
     srcs = [
         "version_unittest.cc",
     ],

--- a/tachyon/base/BUILD.bazel
+++ b/tachyon/base/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//bazel:tachyon.bzl", "if_posix")
-load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_test")
+load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_unittest")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -110,9 +110,8 @@ tachyon_cc_library(
     hdrs = ["type_list.h"],
 )
 
-tachyon_cc_test(
+tachyon_cc_unittest(
     name = "base_unittests",
-    size = "small",
     srcs = [
         "bit_cast_unittest.cc",
         "bits_unittest.cc",

--- a/tachyon/base/buffer/BUILD.bazel
+++ b/tachyon/base/buffer/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_test")
+load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_unittest")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -41,9 +41,8 @@ tachyon_cc_library(
     deps = [":buffer"],
 )
 
-tachyon_cc_test(
+tachyon_cc_unittest(
     name = "buffer_unittests",
-    size = "small",
     srcs = ["buffer_unittest.cc"],
     deps = [
         ":copyable",

--- a/tachyon/base/color/BUILD.bazel
+++ b/tachyon/base/color/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_test")
+load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_unittest")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -24,9 +24,8 @@ tachyon_cc_library(
     deps = [":color"],
 )
 
-tachyon_cc_test(
+tachyon_cc_unittest(
     name = "color_unittests",
-    size = "small",
     srcs = [
         "color_conversions_unittest.cc",
         "color_unittest.cc",

--- a/tachyon/base/containers/BUILD.bazel
+++ b/tachyon/base/containers/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_test")
+load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_unittest")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -73,9 +73,8 @@ tachyon_cc_library(
     ],
 )
 
-tachyon_cc_test(
+tachyon_cc_unittest(
     name = "containers_unittests",
-    size = "small",
     srcs = [
         "adapters_unittest.cc",
         "circular_deque_unittest.cc",

--- a/tachyon/base/files/BUILD.bazel
+++ b/tachyon/base/files/BUILD.bazel
@@ -7,7 +7,7 @@ load(
 load(
     "//bazel:tachyon_cc.bzl",
     "tachyon_cc_library",
-    "tachyon_cc_test",
+    "tachyon_cc_unittest",
     "tachyon_objc_library",
 )
 
@@ -127,9 +127,8 @@ tachyon_cc_library(
     deps = [":file_util"],
 )
 
-tachyon_cc_test(
+tachyon_cc_unittest(
     name = "files_unittests",
-    size = "small",
     srcs = [
         "file_enumerator_unittest.cc",
         "file_path_unittest.cc",

--- a/tachyon/base/flag/BUILD.bazel
+++ b/tachyon/base/flag/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_test")
+load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_unittest")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -32,9 +32,8 @@ tachyon_cc_library(
     ],
 )
 
-tachyon_cc_test(
+tachyon_cc_unittest(
     name = "flag_unittests",
-    size = "small",
     srcs = [
         "flag_parser_unittest.cc",
         "flag_unittest.cc",

--- a/tachyon/base/functional/BUILD.bazel
+++ b/tachyon/base/functional/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_test")
+load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_unittest")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -45,9 +45,8 @@ tachyon_cc_library(
     hdrs = ["invoke.h"],
 )
 
-tachyon_cc_test(
+tachyon_cc_unittest(
     name = "functional_unittests",
-    size = "small",
     srcs = [
         "function_ref_unittest.cc",
         "identity_unittest.cc",

--- a/tachyon/base/memory/BUILD.bazel
+++ b/tachyon/base/memory/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_test")
+load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_unittest")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -14,9 +14,8 @@ tachyon_cc_library(
     hdrs = ["scoped_policy.h"],
 )
 
-tachyon_cc_test(
+tachyon_cc_unittest(
     name = "memory_unittests",
-    size = "small",
     srcs = ["aligned_memory_unittest.cc"],
     deps = [":aligned_memory"],
 )

--- a/tachyon/base/ranges/BUILD.bazel
+++ b/tachyon/base/ranges/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_test")
+load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_unittest")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -27,9 +27,8 @@ tachyon_cc_library(
     deps = ["//tachyon/base:template_util"],
 )
 
-tachyon_cc_test(
+tachyon_cc_unittest(
     name = "ranges_unittests",
-    size = "small",
     srcs = [
         "algorithm_unittest.cc",
         "functional_unittest.cc",

--- a/tachyon/base/strings/BUILD.bazel
+++ b/tachyon/base/strings/BUILD.bazel
@@ -2,7 +2,7 @@ load("//bazel:tachyon.bzl", "if_macos")
 load(
     "//bazel:tachyon_cc.bzl",
     "tachyon_cc_library",
-    "tachyon_cc_test",
+    "tachyon_cc_unittest",
     "tachyon_objc_library",
 )
 
@@ -89,9 +89,8 @@ tachyon_objc_library(
     alwayslink = True,
 )
 
-tachyon_cc_test(
+tachyon_cc_unittest(
     name = "strings_unittests",
-    size = "small",
     srcs = [
         "string_number_conversions_unittest.cc",
         "string_util_unittest.cc",

--- a/tachyon/base/time/BUILD.bazel
+++ b/tachyon/base/time/BUILD.bazel
@@ -2,7 +2,7 @@ load("//bazel:tachyon.bzl", "if_macos", "if_posix")
 load(
     "//bazel:tachyon_cc.bzl",
     "tachyon_cc_library",
-    "tachyon_cc_test",
+    "tachyon_cc_unittest",
     "tachyon_objc_library",
 )
 load(":time_buildflags.bzl", "time_buildflag_header")
@@ -89,9 +89,8 @@ tachyon_objc_library(
     alwayslink = True,
 )
 
-tachyon_cc_test(
+tachyon_cc_unittest(
     name = "time_unittests",
-    size = "small",
     srcs = [
         "time_delta_flag_unittest.cc",
         "time_interval_unittest.cc",

--- a/tachyon/c/BUILD.bazel
+++ b/tachyon/c/BUILD.bazel
@@ -12,7 +12,7 @@ load(
     "collect_hdrs",
     "tachyon_cc_library",
     "tachyon_cc_shared_library",
-    "tachyon_cc_test",
+    "tachyon_cc_unittest",
 )
 load("//tachyon/build:version.bzl", "write_version_header")
 
@@ -83,9 +83,8 @@ collect_hdrs(
     ],
 )
 
-tachyon_cc_test(
+tachyon_cc_unittest(
     name = "c_unittests",
-    size = "small",
     srcs = [
         "version_unittest.cc",
     ],

--- a/tachyon/c/math/elliptic_curves/msm/BUILD.bazel
+++ b/tachyon/c/math/elliptic_curves/msm/BUILD.bazel
@@ -2,9 +2,9 @@ load("//bazel:tachyon.bzl", "if_gpu_is_configured")
 load(
     "//bazel:tachyon_cc.bzl",
     "tachyon_cc_library",
-    "tachyon_cc_test",
+    "tachyon_cc_unittest",
     "tachyon_cuda_binary",
-    "tachyon_cuda_test",
+    "tachyon_cuda_unittest",
 )
 
 package(default_visibility = ["//visibility:public"])
@@ -56,9 +56,8 @@ tachyon_cc_library(
     ],
 )
 
-tachyon_cc_test(
+tachyon_cc_unittest(
     name = "msm_unittests",
-    size = "small",
     srcs = ["msm_unittest.cc"],
     deps = [
         "//tachyon/base:bits",
@@ -67,9 +66,8 @@ tachyon_cc_test(
     ],
 )
 
-tachyon_cuda_test(
+tachyon_cuda_unittest(
     name = "msm_gpu_unittests",
-    size = "small",
     srcs = if_gpu_is_configured(["msm_gpu_unittest.cc"]),
     deps = [
         "//tachyon/base:bits",

--- a/tachyon/c/math/elliptic_curves/short_weierstrass/BUILD.bazel
+++ b/tachyon/c/math/elliptic_curves/short_weierstrass/BUILD.bazel
@@ -1,8 +1,7 @@
-load("//bazel:tachyon_cc.bzl", "tachyon_cc_test")
+load("//bazel:tachyon_cc.bzl", "tachyon_cc_unittest")
 
-tachyon_cc_test(
+tachyon_cc_unittest(
     name = "short_weierstrass_unittests",
-    size = "small",
     srcs = [
         "affine_point_unittest.cc",
         "jacobian_point_unittest.cc",

--- a/tachyon/c/math/finite_fields/BUILD.bazel
+++ b/tachyon/c/math/finite_fields/BUILD.bazel
@@ -1,8 +1,7 @@
-load("//bazel:tachyon_cc.bzl", "tachyon_cc_test")
+load("//bazel:tachyon_cc.bzl", "tachyon_cc_unittest")
 
-tachyon_cc_test(
+tachyon_cc_unittest(
     name = "finite_fields_unittests",
-    size = "small",
     srcs = ["prime_field_unittest.cc"],
     deps = [
         "//tachyon/c/math/elliptic_curves/bn/bn254:fr",

--- a/tachyon/cc/BUILD.bazel
+++ b/tachyon/cc/BUILD.bazel
@@ -11,7 +11,7 @@ load(
     "collect_hdrs",
     "tachyon_cc_library",
     "tachyon_cc_shared_library",
-    "tachyon_cc_test",
+    "tachyon_cc_unittest",
 )
 load("//tachyon/build:version.bzl", "write_version_header")
 
@@ -43,9 +43,8 @@ tachyon_cc_library(
     deps = [":export"],
 )
 
-tachyon_cc_test(
+tachyon_cc_unittest(
     name = "cc_unittests",
-    size = "small",
     srcs = [
         "version_unittest.cc",
     ],

--- a/tachyon/cc/math/elliptic_curves/short_weierstrass/BUILD.bazel
+++ b/tachyon/cc/math/elliptic_curves/short_weierstrass/BUILD.bazel
@@ -1,8 +1,7 @@
-load("//bazel:tachyon_cc.bzl", "tachyon_cc_test")
+load("//bazel:tachyon_cc.bzl", "tachyon_cc_unittest")
 
-tachyon_cc_test(
+tachyon_cc_unittest(
     name = "short_weierstrass_unittests",
-    size = "small",
     srcs = [
         "affine_point_unittest.cc",
         "jacobian_point_unittest.cc",

--- a/tachyon/cc/math/finite_fields/BUILD.bazel
+++ b/tachyon/cc/math/finite_fields/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_test")
+load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_unittest")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -16,9 +16,8 @@ tachyon_cc_library(
     hdrs = ["prime_field_traits.h"],
 )
 
-tachyon_cc_test(
+tachyon_cc_unittest(
     name = "finite_fields_unittests",
-    size = "small",
     srcs = ["prime_field_unittest.cc"],
     deps = [
         "//tachyon/cc/math/elliptic_curves/bn/bn254:fr",

--- a/tachyon/crypto/commitments/pedersen/BUILD.bazel
+++ b/tachyon/crypto/commitments/pedersen/BUILD.bazel
@@ -1,7 +1,7 @@
 load(
     "//bazel:tachyon_cc.bzl",
     "tachyon_cc_library",
-    "tachyon_cc_test",
+    "tachyon_cc_unittest",
 )
 
 tachyon_cc_library(
@@ -13,9 +13,8 @@ tachyon_cc_library(
     ],
 )
 
-tachyon_cc_test(
+tachyon_cc_unittest(
     name = "pedersen_unittests",
-    size = "small",
     srcs = ["pedersen_unittest.cc"],
     deps = [
         ":pedersen",

--- a/tachyon/crypto/hashes/BUILD.bazel
+++ b/tachyon/crypto/hashes/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_test")
+load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_unittest")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -12,9 +12,8 @@ tachyon_cc_library(
     ],
 )
 
-tachyon_cc_test(
+tachyon_cc_unittest(
     name = "serializable_unittests",
-    size = "small",
     srcs = [
         "prime_field_serializable_unittest.cc",
     ],

--- a/tachyon/crypto/hashes/sponge/poseidon/BUILD.bazel
+++ b/tachyon/crypto/hashes/sponge/poseidon/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_test")
+load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_unittest")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -32,9 +32,8 @@ tachyon_cc_library(
     ],
 )
 
-tachyon_cc_test(
+tachyon_cc_unittest(
     name = "poseidon_unittests",
-    size = "small",
     srcs = [
         "grain_lfsr_unittest.cc",
         "poseidon_config_unittest.cc",

--- a/tachyon/device/BUILD.bazel
+++ b/tachyon/device/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//bazel:tachyon.bzl", "if_has_numa")
-load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_test")
+load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_unittest")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -37,9 +37,8 @@ tachyon_cc_library(
     ] + if_has_numa(["@hwloc"]),
 )
 
-tachyon_cc_test(
+tachyon_cc_unittest(
     name = "device_unittests",
-    size = "small",
     srcs = ["numa_unittest.cc"],
     deps = [":numa"],
 )

--- a/tachyon/device/gpu/BUILD.bazel
+++ b/tachyon/device/gpu/BUILD.bazel
@@ -4,7 +4,7 @@ load(
     "//bazel:tachyon_cc.bzl",
     "tachyon_cc_library",
     "tachyon_cuda_defines",
-    "tachyon_cuda_test",
+    "tachyon_cuda_unittest",
 )
 
 package(default_visibility = ["//visibility:public"])
@@ -154,9 +154,8 @@ tachyon_cc_library(
     ],
 )
 
-tachyon_cuda_test(
+tachyon_cuda_unittest(
     name = "gpu_unittests",
-    size = "small",
     srcs = if_gpu_is_configured(["gpu_memory_unittest.cc"]),
     deps = [
         ":gpu_memory",

--- a/tachyon/device/gpu/cuda/BUILD.bazel
+++ b/tachyon/device/gpu/cuda/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@local_config_cuda//cuda:build_defs.bzl", "if_cuda")
-load("//bazel:tachyon_cc.bzl", "tachyon_cuda_library", "tachyon_cuda_test")
+load("//bazel:tachyon_cc.bzl", "tachyon_cuda_library", "tachyon_cuda_unittest")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -31,9 +31,8 @@ tachyon_cuda_library(
     ]),
 )
 
-tachyon_cuda_test(
+tachyon_cuda_unittest(
     name = "cuda_unittests",
-    size = "small",
     srcs = [
         "cuda_driver_unittest.cc",
     ],

--- a/tachyon/math/base/BUILD.bazel
+++ b/tachyon/math/base/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_test")
+load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_unittest")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -93,9 +93,8 @@ tachyon_cc_library(
     ],
 )
 
-tachyon_cc_test(
+tachyon_cc_unittest(
     name = "base_unittests",
-    size = "small",
     srcs = [
         "arithmetics_unittest.cc",
         "big_int_unittest.cc",

--- a/tachyon/math/base/gmp/BUILD.bazel
+++ b/tachyon/math/base/gmp/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_test")
+load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_unittest")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -42,9 +42,8 @@ tachyon_cc_library(
     ],
 )
 
-tachyon_cc_test(
+tachyon_cc_unittest(
     name = "gmp_unittests",
-    size = "small",
     srcs = [
         "gmp_util_unittest.cc",
     ],

--- a/tachyon/math/elliptic_curves/msm/BUILD.bazel
+++ b/tachyon/math/elliptic_curves/msm/BUILD.bazel
@@ -2,8 +2,8 @@ load("//bazel:tachyon.bzl", "if_gmp_backend", "if_gpu_is_configured")
 load(
     "//bazel:tachyon_cc.bzl",
     "tachyon_cc_library",
-    "tachyon_cc_test",
-    "tachyon_cuda_test",
+    "tachyon_cc_unittest",
+    "tachyon_cuda_unittest",
 )
 
 package(default_visibility = ["//visibility:public"])
@@ -42,9 +42,8 @@ tachyon_cc_library(
     ],
 )
 
-tachyon_cc_test(
+tachyon_cc_unittest(
     name = "msm_unittests",
-    size = "small",
     srcs = [
         "variable_base_msm_unittest.cc",
     ] + if_gmp_backend([
@@ -58,9 +57,8 @@ tachyon_cc_test(
     ],
 )
 
-tachyon_cuda_test(
+tachyon_cuda_unittest(
     name = "msm_gpu_unittests",
-    size = "small",
     srcs = if_gpu_is_configured(["variable_base_msm_gpu_unittest.cc"]),
     deps = [
         ":variable_base_msm_gpu",

--- a/tachyon/math/elliptic_curves/msm/algorithms/cuzk/BUILD.bazel
+++ b/tachyon/math/elliptic_curves/msm/algorithms/cuzk/BUILD.bazel
@@ -3,7 +3,7 @@ load(
     "//bazel:tachyon_cc.bzl",
     "tachyon_cc_library",
     "tachyon_cuda_library",
-    "tachyon_cuda_test",
+    "tachyon_cuda_unittest",
 )
 
 package(default_visibility = ["//visibility:public"])
@@ -53,9 +53,8 @@ tachyon_cc_library(
     ],
 )
 
-tachyon_cuda_test(
+tachyon_cuda_unittest(
     name = "algorithms_gpu_unittests",
-    size = "small",
     srcs = if_gpu_is_configured(["cuzk_unittest.cc"]),
     deps = [
         ":cuzk",

--- a/tachyon/math/elliptic_curves/msm/algorithms/pippenger/BUILD.bazel
+++ b/tachyon/math/elliptic_curves/msm/algorithms/pippenger/BUILD.bazel
@@ -2,7 +2,7 @@ load(
     "//bazel:tachyon_cc.bzl",
     "tachyon_cc_benchmark",
     "tachyon_cc_library",
-    "tachyon_cc_test",
+    "tachyon_cc_unittest",
 )
 
 package(default_visibility = ["//visibility:public"])
@@ -42,9 +42,8 @@ tachyon_cc_library(
     deps = ["//tachyon:export"],
 )
 
-tachyon_cc_test(
+tachyon_cc_unittest(
     name = "algorithms_unittests",
-    size = "small",
     srcs = [
         "pippenger_adapter_unittest.cc",
         "pippenger_unittest.cc",

--- a/tachyon/math/elliptic_curves/short_weierstrass/BUILD.bazel
+++ b/tachyon/math/elliptic_curves/short_weierstrass/BUILD.bazel
@@ -2,7 +2,7 @@ load("//bazel:tachyon.bzl", "if_cuda_and_gmp_backend")
 load(
     "//bazel:tachyon_cc.bzl",
     "tachyon_cc_library",
-    "tachyon_cc_test",
+    "tachyon_cc_unittest",
     "tachyon_cuda_test",
 )
 
@@ -43,9 +43,8 @@ tachyon_cc_library(
     srcs = ["sw_curve_traits.h"],
 )
 
-tachyon_cc_test(
+tachyon_cc_unittest(
     name = "short_weierstrass_unittests",
-    size = "small",
     srcs = [
         "affine_point_unittest.cc",
         "jacobian_point_unittest.cc",

--- a/tachyon/math/finite_fields/BUILD.bazel
+++ b/tachyon/math/finite_fields/BUILD.bazel
@@ -10,7 +10,9 @@ load(
     "tachyon_cc_benchmark",
     "tachyon_cc_library",
     "tachyon_cc_test",
+    "tachyon_cc_unittest",
     "tachyon_cuda_test",
+    "tachyon_cuda_unittest",
 )
 
 package(default_visibility = ["//visibility:public"])
@@ -194,9 +196,8 @@ tachyon_cc_library(
     ],
 )
 
-tachyon_cc_test(
+tachyon_cc_unittest(
     name = "finite_fields_unittests",
-    size = "small",
     srcs = [
         "cubic_extension_field_unittest.cc",
         "modulus_unittest.cc",
@@ -214,9 +215,8 @@ tachyon_cc_test(
     ],
 )
 
-tachyon_cuda_test(
+tachyon_cuda_unittest(
     name = "finite_fields_gpu_unittests",
-    size = "small",
     srcs = if_gpu_is_configured(["prime_field_gpu_unittest.cc"]),
     deps = [
         ":prime_field_conversions",

--- a/tachyon/math/finite_fields/goldilocks_prime/BUILD.bazel
+++ b/tachyon/math/finite_fields/goldilocks_prime/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//bazel:tachyon.bzl", "if_polygon_zkevm_backend")
-load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_test")
+load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_unittest")
 load("//tachyon/math/finite_fields/generator/prime_field_generator:build_defs.bzl", "generate_prime_fields")
 
 package(default_visibility = ["//visibility:public"])
@@ -53,9 +53,8 @@ tachyon_cc_library(
     ]),
 )
 
-tachyon_cc_test(
+tachyon_cc_unittest(
     name = "goldilocks_prime_unittests",
-    size = "small",
     srcs = if_polygon_zkevm_backend(["prime_field_goldilocks_unittest.cc"]),
     deps = [":goldilocks"],
 )

--- a/tachyon/math/geometry/BUILD.bazel
+++ b/tachyon/math/geometry/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_test")
+load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_unittest")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -20,9 +20,8 @@ tachyon_cc_library(
     deps = ["@com_google_absl//absl/strings"],
 )
 
-tachyon_cc_test(
+tachyon_cc_unittest(
     name = "geometry_unittests",
-    size = "small",
     srcs = [
         "point2_unittest.cc",
         "point3_unittest.cc",

--- a/tachyon/math/matrix/sparse/BUILD.bazel
+++ b/tachyon/math/matrix/sparse/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_test")
+load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_unittest")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -14,9 +14,8 @@ tachyon_cc_library(
     ],
 )
 
-tachyon_cc_test(
+tachyon_cc_unittest(
     name = "sparse_unittests",
-    size = "small",
     srcs = ["sparse_matrix_unittest.cc"],
     deps = [
         ":sparse_matrix",

--- a/tachyon/math/polynomials/multivariate/BUILD.bazel
+++ b/tachyon/math/polynomials/multivariate/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_test")
+load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_unittest")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -22,9 +22,8 @@ tachyon_cc_library(
     ],
 )
 
-tachyon_cc_test(
+tachyon_cc_unittest(
     name = "multivariate_polynomials_unittests",
-    size = "small",
     srcs = [
         "multivariate_polynomial_unittest.cc",
     ],

--- a/tachyon/math/polynomials/univariate/BUILD.bazel
+++ b/tachyon/math/polynomials/univariate/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_test")
+load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_unittest")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -23,9 +23,8 @@ tachyon_cc_library(
     ],
 )
 
-tachyon_cc_test(
+tachyon_cc_unittest(
     name = "univariate_polynomials_unittests",
-    size = "small",
     srcs = [
         "dense_polynomial_unittest.cc",
         "sparse_polynomial_unittest.cc",

--- a/tachyon/node/test/bazel/tachyon_jest.bzl
+++ b/tachyon/node/test/bazel/tachyon_jest.bzl
@@ -11,3 +11,13 @@ def tachyon_jest_test(
         node_modules = node_modules,
         **kwargs
     )
+
+def tachyon_jest_unittest(
+        name,
+        size = "small",
+        **kwargs):
+    tachyon_jest_test(
+        name = name,
+        size = size,
+        **kwargs
+    )

--- a/tachyon/node/test/src/math/elliptic_curves/short_weierstrass/BUILD.bazel
+++ b/tachyon/node/test/src/math/elliptic_curves/short_weierstrass/BUILD.bazel
@@ -1,8 +1,8 @@
 load("//bazel:tachyon_ts.bzl", "tachyon_ts_project")
-load("//bazel:tachyon_jest.bzl", "tachyon_jest_test")
+load("//bazel:tachyon_jest.bzl", "tachyon_jest_unittest")
 
 tachyon_ts_project(
-    name = "short_weierstrass_ts",
+    name = "short_weierstrass",
     testonly = True,
     srcs = [
         "affine_point.spec.ts",
@@ -13,7 +13,7 @@ tachyon_ts_project(
     data = ["@kroma_network_tachyon//tachyon/node:tachyon"],
 )
 
-tachyon_jest_test(
-    name = "short_weierstrass",
-    data = [":short_weierstrass_ts"],
+tachyon_jest_unittest(
+    name = "short_weierstrass_unittests",
+    data = [":short_weierstrass"],
 )

--- a/tachyon/node/test/src/math/finite_fields/BUILD.bazel
+++ b/tachyon/node/test/src/math/finite_fields/BUILD.bazel
@@ -1,14 +1,14 @@
 load("//bazel:tachyon_ts.bzl", "tachyon_ts_project")
-load("//bazel:tachyon_jest.bzl", "tachyon_jest_test")
+load("//bazel:tachyon_jest.bzl", "tachyon_jest_unittest")
 
 tachyon_ts_project(
-    name = "finite_fields_ts",
+    name = "finite_fields",
     testonly = True,
     srcs = ["prime_field.spec.ts"],
     data = ["@kroma_network_tachyon//tachyon/node:tachyon"],
 )
 
-tachyon_jest_test(
-    name = "finite_fields",
-    data = [":finite_fields_ts"],
+tachyon_jest_unittest(
+    name = "finite_fields_unittests",
+    data = [":finite_fields"],
 )

--- a/tachyon/py/test/bazel/tachyon_py.bzl
+++ b/tachyon/py/test/bazel/tachyon_py.bzl
@@ -35,3 +35,11 @@ def tachyon_py_test(
         srcs_version = srcs_version,
         **kwargs
     )
+
+def tachyon_py_unittest(
+        name,
+        **kwargs):
+    py_test(
+        name = name + "_unittests",
+        **kwargs
+    )

--- a/tachyon/py/test/tachyon/math/elliptic_curves/short_weierstrass/BUILD.bazel
+++ b/tachyon/py/test/tachyon/math/elliptic_curves/short_weierstrass/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@pip_deps//:requirements.bzl", "requirement")
-load("//bazel:tachyon_py.bzl", "tachyon_py_test")
+load("//bazel:tachyon_py.bzl", "tachyon_py_unittest")
 
-tachyon_py_test(
+tachyon_py_unittest(
     name = "short_weierstrass_unittests",
     srcs = [
         "affine_point_unittest.py",

--- a/tachyon/py/test/tachyon/math/finite_fields/BUILD.bazel
+++ b/tachyon/py/test/tachyon/math/finite_fields/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@pip_deps//:requirements.bzl", "requirement")
-load("//bazel:tachyon_py.bzl", "tachyon_py_test")
+load("//bazel:tachyon_py.bzl", "tachyon_py_unittest")
 
-tachyon_py_test(
+tachyon_py_unittest(
     name = "finite_fields_unittests",
     srcs = [
         "finite_fields_unittests.py",


### PR DESCRIPTION
# Description

This helps you omit repetitive `size = "small"` for a simple unittest.
