### PR TITLE
chore(crypto): fix namespace from math to crypto

### DIFF
--- a/tachyon/crypto/commitments/pedersen/pedersen.h
+++ b/tachyon/crypto/commitments/pedersen/pedersen.h
@@ -8,12 +8,12 @@
 #include "tachyon/math/elliptic_curves/msm/variable_base_msm.h"
 #include "tachyon/math/elliptic_curves/point_conversions.h"
 
-namespace tachyon::math {
+namespace tachyon::crypto {
 
 template <typename PointTy>
 class PedersenParams {
  public:
-  using Bucket = typename Pippenger<PointTy>::Bucket;
+  using Bucket = typename math::Pippenger<PointTy>::Bucket;
   using ScalarField = typename PointTy::ScalarField;
 
   PedersenParams() = default;
@@ -52,11 +52,11 @@ class PedersenParams {
   template <typename R>
   bool Commit(const std::vector<ScalarField>& v, const ScalarField& r,
               R* out) const {
-    VariableBaseMSM<PointTy> msm;
+    math::VariableBaseMSM<PointTy> msm;
     Bucket generator_msm_v;
     if (!msm.Run(generators_, v, &generator_msm_v)) return false;
 
-    *out = r * h_ + ConvertPoint<R>(generator_msm_v);
+    *out = r * h_ + math::ConvertPoint<R>(generator_msm_v);
     return true;
   }
 
@@ -83,6 +83,6 @@ std::ostream& operator<<(std::ostream& os, const PedersenParams<PointTy>& p) {
   return os << p.ToString();
 }
 
-};  // namespace tachyon::math
+};  // namespace tachyon::crypto
 
 #endif  // TACHYON_CRYPTO_COMMITMENTS_PEDERSEN_PEDERSEN_H_

--- a/tachyon/crypto/commitments/pedersen/pedersen_unittest.cc
+++ b/tachyon/crypto/commitments/pedersen/pedersen_unittest.cc
@@ -4,13 +4,13 @@
 
 #include "tachyon/math/elliptic_curves/bn/bn254/g1.h"
 
-namespace tachyon::math {
+namespace tachyon::crypto {
 
 namespace {
 
 class PedersenTest : public testing::Test {
  public:
-  static void SetUpTestSuite() { bn254::G1Curve::Init(); }
+  static void SetUpTestSuite() { math::bn254::G1Curve::Init(); }
 };
 
 }  // namespace
@@ -18,21 +18,21 @@ class PedersenTest : public testing::Test {
 TEST_F(PedersenTest, CommitPedersen) {
   const size_t max_size = 3;
 
-  PedersenParams<bn254::G1JacobianPoint> params =
-      PedersenParams<bn254::G1JacobianPoint>::Random(max_size);
+  PedersenParams<math::bn254::G1JacobianPoint> params =
+      PedersenParams<math::bn254::G1JacobianPoint>::Random(max_size);
 
-  std::vector<bn254::Fr> v =
-      base::CreateVector(max_size, []() { return bn254::Fr::Random(); });
+  std::vector<math::bn254::Fr> v =
+      base::CreateVector(max_size, []() { return math::bn254::Fr::Random(); });
 
-  bn254::Fr r = bn254::Fr::Random();
-  bn254::G1JacobianPoint commitment;
+  math::bn254::Fr r = math::bn254::Fr::Random();
+  math::bn254::G1JacobianPoint commitment;
   ASSERT_TRUE(params.Commit(v, r, &commitment));
 
-  VariableBaseMSM<bn254::G1JacobianPoint> msm;
-  bn254::G1JacobianPoint msm_result;
+  math::VariableBaseMSM<math::bn254::G1JacobianPoint> msm;
+  math::bn254::G1JacobianPoint msm_result;
   ASSERT_TRUE(msm.Run(params.generators(), v, &msm_result));
 
   EXPECT_EQ(commitment, msm_result + r * params.h());
 }
 
-}  // namespace tachyon::math
+}  // namespace tachyon::crypto


### PR DESCRIPTION
# Description

This PR fix the namespace from `math` to `crypto` in `pedersen.h`.