### PR TITLE
ci: fix cpplint script to run only in PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
         run: pip install cpplint
 
       - name: Run cpplint
+        if: github.event_name == 'pull_request'
         run: git diff --name-only HEAD origin/${{ github.base_ref }} | xargs cpplint --filter=-legal/copyright,-whitespace/line_length,-build/namespaces,-runtime/references
 
       - name: Run clang-format lint


### PR DESCRIPTION
# Description

Modify the script so that it runs only when there is a PR event.
There is a problem with the cpplint script when the approved PR is merged into the main branch.