### PR TITLE
refac: enable omitting ostream operator

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -17,7 +17,7 @@ IncludeBlocks: Regroup
 IncludeCategories:
   # C system headers.  The header_dependency_test.py contains a copy of this
   # list; be sure to update that test anytime this list changes.
-  - Regex:    '^[<"](aio|arpa/inet|assert|complex|cpio|ctype|curses|dirent|dlfcn|errno|fcntl|fenv|float|fmtmsg|fnmatch|ftw|glob|grp|iconv|inttypes|iso646|langinfo|libgen|limits|locale|math|monetary|mqueue|ndbm|netdb|net/if|netinet/in|netinet/tcp|nl_types|poll|pthread|pwd|regex|sched|search|semaphore|setjmp|signal|spawn|stdalign|stdarg|stdatomic|stdbool|stddef|stdint|stdio|stdlib|stdnoreturn|string|strings|stropts|sys/ipc|syslog|sys/mman|sys/msg|sys/resource|sys/select|sys/sem|sys/shm|sys/socket|sys/stat|sys/statvfs|sys/time|sys/times|sys/types|sys/uio|sys/un|sys/utsname|sys/wait|tar|term|termios|tgmath|threads|time|trace|uchar|ulimit|uncntrl|unistd|utime|utmpx|wchar|wctype|wordexp)\.h[">]$'
+  - Regex:    '^[<"](aio|arpa/inet|assert|complex|cpio|ctype|curses|dirent|dlfcn|errno|fcntl|fenv|float|fmtmsg|fnmatch|ftw|glob|grp|iconv|inttypes|iso646|langinfo|libgen|limits|locale|math|monetary|mqueue|ndbm|netdb|net/if|netinet/in|netinet/tcp|nl_types|poll|pthread|pwd|regex|sched|search|semaphore|setjmp|signal|spawn|stdalign|stdarg|stdatomic|stdbool|stddef|stdint|stdio|stdlib|stdnoreturn|string|strings|stropts|sys/ioctl|sys/ipc|syslog|sys/mman|sys/msg|sys/resource|sys/select|sys/sem|sys/shm|sys/socket|sys/stat|sys/statvfs|sys/time|sys/times|sys/types|sys/uio|sys/un|sys/utsname|sys/wait|tar|term|termios|tgmath|threads|time|trace|uchar|ulimit|uncntrl|unistd|utime|utmpx|wchar|wctype|wordexp)\.h[">]$'
     Priority: 20
   # C++ system headers (as of C++23).  The header_dependency_test.py contains a
   # copy of this list; be sure to update that test anytime this list changes.

--- a/bazel/tachyon_deps.bzl
+++ b/bazel/tachyon_deps.bzl
@@ -64,7 +64,10 @@ def tachyon_deps():
             strip_prefix = "glog-0.5.0",
             urls = ["https://github.com/google/glog/archive/v0.5.0.zip"],
             patch_args = ["-p1"],
-            patches = ["@kroma_network_tachyon//third_party/glog:enable_constexpr_check_op.patch"],
+            patches = [
+                "@kroma_network_tachyon//third_party/glog:enable_constexpr_check_op.patch",
+                "@kroma_network_tachyon//third_party/glog:enable_elaborate_ostream_operator.patch",
+            ],
         )
 
     if not native.existing_rule("com_github_soblin_matplotlibcpp17"):

--- a/tachyon/base/apple/bridging.h
+++ b/tachyon/base/apple/bridging.h
@@ -81,7 +81,7 @@
     DCHECK(!cf_val || TypeCF##GetTypeID() == CFGetTypeID(cf_val));          \
     return cf_val;                                                          \
   }                                                                         \
-  }
+  }  // namespace tachyon::base::apple
 
 #define CF_TO_NS_MUTABLE_CAST_IMPL(name)                                 \
   CF_TO_NS_CAST_IMPL(CF##name, NS##name)                                 \
@@ -110,7 +110,7 @@
     DCHECK(!cf_val || CF##name##GetTypeID() == CFGetTypeID(cf_val));     \
     return cf_val;                                                       \
   }                                                                      \
-  }
+  }  // namespace tachyon::base::apple
 
 // List of toll-free bridged types taken from:
 // https://web.archive.org/web/20111124025525/http://www.cocoadev.com/index.pl?TollFreeBridged
@@ -158,4 +158,4 @@ id _Nullable CFToNSOwnershipCast(base::ScopedCFTypeRef<CFT>) {
 
 }  // namespace tachyon::base::apple
 
-#endif  // BASE_APPLE_BRIDGING_H_
+#endif  // TACHYON_BASE_APPLE_BRIDGING_H_

--- a/tachyon/base/binding/callable_util.h
+++ b/tachyon/base/binding/callable_util.h
@@ -2,6 +2,8 @@
 #define TACHYON_BASE_BINDING_CALLABLE_UTIL_H_
 
 #include <type_traits>
+#include <tuple>
+#include <utility>
 
 #include "tachyon/base/template_util.h"
 #include "tachyon/base/type_list.h"

--- a/tachyon/base/binding/cpp_constructor_matcher.h
+++ b/tachyon/base/binding/cpp_constructor_matcher.h
@@ -2,6 +2,7 @@
 #define TACHYON_BASE_BINDING_CPP_CONSTRUCTOR_MATCHER_H_
 
 #include <memory>
+#include <utility>
 #include <vector>
 
 #include "tachyon/base/binding/cpp_constructor.h"

--- a/tachyon/base/binding/cpp_stack_value.h
+++ b/tachyon/base/binding/cpp_stack_value.h
@@ -2,6 +2,7 @@
 #define TACHYON_BASE_BINDING_CPP_STACK_VALUE_H_
 
 #include <type_traits>
+#include <utility>
 
 #include "tachyon/base/binding/cpp_value.h"
 

--- a/tachyon/base/binding/cpp_unique_ptr.h
+++ b/tachyon/base/binding/cpp_unique_ptr.h
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include <type_traits>
+#include <utility>
 
 #include "tachyon/base/binding/cpp_value.h"
 

--- a/tachyon/base/binding/cpp_value_factory.h
+++ b/tachyon/base/binding/cpp_value_factory.h
@@ -2,6 +2,7 @@
 #define TACHYON_BASE_BINDING_CPP_VALUE_FACTORY_H_
 
 #include <memory>
+#include <utility>
 
 #include "tachyon/base/binding/cpp_raw_ptr.h"
 #include "tachyon/base/binding/cpp_shared_ptr.h"

--- a/tachyon/base/binding/holder_util.h
+++ b/tachyon/base/binding/holder_util.h
@@ -2,6 +2,7 @@
 #define TACHYON_BASE_BINDING_HOLDER_UTIL_H_
 
 #include <memory>
+#include <utility>
 
 namespace tachyon::base {
 namespace internal {

--- a/tachyon/base/binding/property_util.h
+++ b/tachyon/base/binding/property_util.h
@@ -2,6 +2,7 @@
 #define TACHYON_BASE_BINDING_PROPERTY_UTIL_H_
 
 #include <functional>
+#include <utility>
 #include <type_traits>
 
 namespace tachyon::base {

--- a/tachyon/base/binding/test/colored_point.h
+++ b/tachyon/base/binding/test/colored_point.h
@@ -1,6 +1,8 @@
 #ifndef TACHYON_BASE_BINDING_TEST_COLORED_POINT_H_
 #define TACHYON_BASE_BINDING_TEST_COLORED_POINT_H_
 
+#include <string>
+
 #include "tachyon/base/binding/test/color.h"
 #include "tachyon/base/binding/test/point.h"
 

--- a/tachyon/base/binding/test/variant.h
+++ b/tachyon/base/binding/test/variant.h
@@ -3,6 +3,9 @@
 
 #include <stdint.h>
 
+#include <vector>
+#include <string>
+
 #include "tachyon/base/binding/test/point.h"
 
 namespace tachyon::base::test {

--- a/tachyon/base/buffer/string_buffer.h
+++ b/tachyon/base/buffer/string_buffer.h
@@ -2,6 +2,7 @@
 #define TACHYON_BASE_BUFFER_STRING_BUFFER_H_
 
 #include <string>
+#include <utility>
 
 #include "tachyon/base/buffer/buffer.h"
 

--- a/tachyon/base/buffer/vector_buffer.h
+++ b/tachyon/base/buffer/vector_buffer.h
@@ -2,6 +2,7 @@
 #define TACHYON_BASE_BUFFER_VECTOR_BUFFER_H_
 
 #include <vector>
+#include <utility>
 
 #include "tachyon/base/buffer/buffer.h"
 

--- a/tachyon/base/color/color.cc
+++ b/tachyon/base/color/color.cc
@@ -4,6 +4,8 @@
 
 #include "tachyon/base/color/color.h"
 
+#include <vector>
+
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_split.h"
 

--- a/tachyon/base/color/color.cc
+++ b/tachyon/base/color/color.cc
@@ -167,10 +167,6 @@ Rgba Rgba::Swap(const RgbaIndexes& rgba_indexes) const {
   return swapped;
 }
 
-std::ostream& operator<<(std::ostream& os, Rgba rgba) {
-  return os << rgba.ToString();
-}
-
 std::string Hsv::ToString() const { return ToHsvaString(); }
 
 std::string Hsv::ToHsvString() const {
@@ -195,10 +191,6 @@ bool Hsv::FromString(const std::string& text) {
   }
 
   return false;
-}
-
-std::ostream& operator<<(std::ostream& os, const Hsv& hsv) {
-  return os << hsv.ToString();
 }
 
 }  // namespace tachyon::base

--- a/tachyon/base/color/color.h
+++ b/tachyon/base/color/color.h
@@ -112,8 +112,6 @@ inline bool operator==(Rgba rgb, Rgba rgb2) { return rgb.rgba == rgb2.rgba; }
 
 inline bool operator!=(Rgba rgb, Rgba rgb2) { return !operator==(rgb, rgb2); }
 
-TACHYON_EXPORT std::ostream& operator<<(std::ostream& os, Rgba rgb);
-
 struct TACHYON_EXPORT Hsv {
   constexpr Hsv() : Hsv(0, 0, 0, 1) {}
   constexpr Hsv(float h, float s, float v, float a = 1)
@@ -163,8 +161,6 @@ inline bool operator==(const Hsv& hsv, const Hsv& hsv2) {
 inline bool operator!=(const Hsv& hsv, const Hsv& hsv2) {
   return !operator==(hsv, hsv2);
 }
-
-TACHYON_EXPORT std::ostream& operator<<(std::ostream& os, const Hsv& hsv);
 
 }  // namespace tachyon::base
 

--- a/tachyon/base/color/color.h
+++ b/tachyon/base/color/color.h
@@ -118,7 +118,8 @@ struct TACHYON_EXPORT Hsv {
   constexpr Hsv() : Hsv(0, 0, 0, 1) {}
   constexpr Hsv(float h, float s, float v, float a = 1)
       : h(h), s(s), v(v), a(a) {}
-  constexpr Hsv(const float* data) : Hsv(data[0], data[1], data[2], data[3]) {}
+  constexpr explicit Hsv(const float* data)
+      : Hsv(data[0], data[1], data[2], data[3]) {}
 
   Hsv(const Hsv& other) = default;
   Hsv& operator=(const Hsv& other) = default;

--- a/tachyon/base/console/console.cc
+++ b/tachyon/base/console/console.cc
@@ -48,7 +48,7 @@ void Console::Info::Init() {
 Console::Info& Console::GetInfo() {
   static Console::Info info;
   return info;
-};
+}
 
 // This was taken and modified from
 // LICENSE: undefined

--- a/tachyon/base/console/sgr_parameter_list.h
+++ b/tachyon/base/console/sgr_parameter_list.h
@@ -1,3 +1,4 @@
+// NOLINT(build/header_guard)
 // Copyright (c) 2020 The Console Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/tachyon/base/console/sgr_parameters.h
+++ b/tachyon/base/console/sgr_parameters.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef TACHYON_CONSOLE_SGR_PARAMETERS_H_
-#define TACHYON_CONSOLE_SGR_PARAMETERS_H_
+#ifndef TACHYON_BASE_CONSOLE_SGR_PARAMETERS_H_
+#define TACHYON_BASE_CONSOLE_SGR_PARAMETERS_H_
 
 #include <stdint.h>
 
@@ -37,4 +37,4 @@ TACHYON_EXPORT uint8_t Ansi8BitColor(uint8_t r, uint8_t g, uint8_t b);
 
 }  // namespace tachyon::base
 
-#endif  // TACHYON_CONSOLE_SGR_PARAMETERS_H_
+#endif  // TACHYON_BASE_CONSOLE_SGR_PARAMETERS_H_

--- a/tachyon/base/console/table_writer.cc
+++ b/tachyon/base/console/table_writer.cc
@@ -1,14 +1,16 @@
 #include "tachyon/base/console/table_writer.h"
 
+#include <sys/ioctl.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <iomanip>
 #include <iostream>
+#include <limits>
 #include <numeric>
 #include <sstream>
 
 #include "absl/strings/strip.h"
-#include <sys/ioctl.h>
 
 namespace tachyon::base {
 

--- a/tachyon/base/console/table_writer.cc
+++ b/tachyon/base/console/table_writer.cc
@@ -210,8 +210,4 @@ TableWriterBuilder& TableWriterBuilder::StripLeadingAsciiWhitespace() {
 
 TableWriter TableWriterBuilder::Build() const { return writer_; }
 
-std::ostream& operator<<(std::ostream& os, const TableWriter& table_writer) {
-  return os << table_writer.ToString();
-}
-
 }  // namespace tachyon::base

--- a/tachyon/base/console/table_writer.h
+++ b/tachyon/base/console/table_writer.h
@@ -95,9 +95,6 @@ class TACHYON_EXPORT TableWriterBuilder {
   TableWriter writer_;
 };
 
-TACHYON_EXPORT std::ostream& operator<<(std::ostream& os,
-                                        const TableWriter& table_writer);
-
 }  // namespace tachyon::base
 
 #endif  // TACHYON_BASE_CONSOLE_TABLE_WRITER_H_

--- a/tachyon/base/endian_utils_unittest.cc
+++ b/tachyon/base/endian_utils_unittest.cc
@@ -1,5 +1,7 @@
 #include "tachyon/base/endian_utils.h"
 
+#include <vector>
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 

--- a/tachyon/base/files/file_path.cc
+++ b/tachyon/base/files/file_path.cc
@@ -269,7 +269,7 @@ FilePath& FilePath::operator/=(const FilePath& component) {
 }
 
 bool FilePath::IsAbsolute() const {
- return path_.length() > 0 && FilePath::IsSeparator(path_[0]);
+  return path_.length() > 0 && FilePath::IsSeparator(path_[0]);
 }
 
 bool FilePath::EndsWithSeparator() const {

--- a/tachyon/base/files/file_path_flag.h
+++ b/tachyon/base/files/file_path_flag.h
@@ -1,6 +1,8 @@
 #ifndef TACHYON_BASE_FILES_FILE_PATH_FLAG_H_
 #define TACHYON_BASE_FILES_FILE_PATH_FLAG_H_
 
+#include <string>
+
 #include "tachyon/base/files/file_path.h"
 #include "tachyon/base/flag/flag.h"
 

--- a/tachyon/base/files/file_unittest.cc
+++ b/tachyon/base/files/file_unittest.cc
@@ -547,9 +547,9 @@ TEST(FileTest, Duplicate) {
   base::ScopedTempDir temp_dir;
   ASSERT_TRUE(temp_dir.CreateUniqueTempDir());
   FilePath file_path = temp_dir.GetPath().Append("file");
-  File file(file_path,(base::File::FLAG_CREATE |
-                       base::File::FLAG_READ |
-                       base::File::FLAG_WRITE));
+  File file(file_path, (base::File::FLAG_CREATE |
+                        base::File::FLAG_READ |
+                        base::File::FLAG_WRITE));
   ASSERT_TRUE(file.IsValid());
 
   File file2(file.Duplicate());
@@ -574,10 +574,10 @@ TEST(FileTest, DuplicateDeleteOnClose) {
   base::ScopedTempDir temp_dir;
   ASSERT_TRUE(temp_dir.CreateUniqueTempDir());
   FilePath file_path = temp_dir.GetPath().Append("file");
-  File file(file_path,(base::File::FLAG_CREATE |
-                       base::File::FLAG_READ |
-                       base::File::FLAG_WRITE |
-                       base::File::FLAG_DELETE_ON_CLOSE));
+  File file(file_path, (base::File::FLAG_CREATE |
+                        base::File::FLAG_READ |
+                        base::File::FLAG_WRITE |
+                        base::File::FLAG_DELETE_ON_CLOSE));
   ASSERT_TRUE(file.IsValid());
   File file2(file.Duplicate());
   ASSERT_TRUE(file2.IsValid());

--- a/tachyon/base/flag/flag.h
+++ b/tachyon/base/flag/flag.h
@@ -5,7 +5,9 @@
 #ifndef TACHYON_BASE_FLAG_FLAG_H_
 #define TACHYON_BASE_FLAG_FLAG_H_
 
+#include <string>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 #include "absl/strings/substitute.h"

--- a/tachyon/base/flag/flag_parser.h
+++ b/tachyon/base/flag/flag_parser.h
@@ -6,6 +6,8 @@
 #define TACHYON_BASE_FLAG_FLAG_PARSER_H_
 
 #include <memory>
+#include <utility>
+#include <string>
 #include <type_traits>
 #include <vector>
 
@@ -146,8 +148,8 @@ class TACHYON_EXPORT SubParser : public FlagBase,
  public:
   SubParser();
   ~SubParser();
-  SubParser(const FlagBase& other) = delete;
-  SubParser& operator=(const FlagBase& other) = delete;
+  SubParser(const SubParser& other) = delete;
+  SubParser& operator=(const SubParser& other) = delete;
 
   // FlagBase methods
   bool IsSubParser() const override;

--- a/tachyon/base/flag/flag_value_traits.h
+++ b/tachyon/base/flag/flag_value_traits.h
@@ -7,9 +7,11 @@
 
 #include <stdint.h>
 
+#include <limits>
 #include <numeric>
 #include <string>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 #include "absl/strings/substitute.h"

--- a/tachyon/base/flag/numeric_flags.h
+++ b/tachyon/base/flag/numeric_flags.h
@@ -1,6 +1,8 @@
 #ifndef TACHYON_BASE_FLAG_NUMERIC_FLAGS_H_
 #define TACHYON_BASE_FLAG_NUMERIC_FLAGS_H_
 
+#include <string>
+
 #include "tachyon/base/flag/flag.h"
 
 namespace tachyon::base {

--- a/tachyon/base/functional/callback.h
+++ b/tachyon/base/functional/callback.h
@@ -6,6 +6,7 @@
 #define TACHYON_BASE_FUNCTIONAL_CALLBACK_H_
 
 #include <functional>
+#include <utility>
 #include <type_traits>
 
 #include "absl/functional/function_ref.h"

--- a/tachyon/base/functional/functor_traits.h
+++ b/tachyon/base/functional/functor_traits.h
@@ -8,6 +8,7 @@
 #define TACHYON_BASE_FUNCTIONAL_FUNCTOR_TRAITS_H_
 
 #include <functional>
+#include <utility>
 
 #include "absl/meta/type_traits.h"
 

--- a/tachyon/base/strings/string_number_conversions.h
+++ b/tachyon/base/strings/string_number_conversions.h
@@ -1,9 +1,10 @@
-#ifndef TACHYON_STRINGS_STRING_NUMBER_CONVERSIONS_H_
-#define TACHYON_STRINGS_STRING_NUMBER_CONVERSIONS_H_
+#ifndef TACHYON_BASE_STRINGS_STRING_NUMBER_CONVERSIONS_H_
+#define TACHYON_BASE_STRINGS_STRING_NUMBER_CONVERSIONS_H_
 
 #include <string>
 #include <string_view>
 #include <type_traits>
+#include <vector>
 
 #include "absl/strings/numbers.h"
 #include "absl/strings/str_cat.h"
@@ -63,4 +64,4 @@ TACHYON_EXPORT bool HexStringToSpan(std::string_view input,
 
 }  // namespace tachyon::base
 
-#endif  // TACHYON_STRINGS_STRING_NUMBER_CONVERSIONS_H_
+#endif  // TACHYON_BASE_STRINGS_STRING_NUMBER_CONVERSIONS_H_

--- a/tachyon/base/strings/string_number_conversions_internal.h
+++ b/tachyon/base/strings/string_number_conversions_internal.h
@@ -7,6 +7,7 @@
 
 #include <stdint.h>
 
+#include <algorithm>
 #include <limits>
 #include <optional>
 #include <string_view>

--- a/tachyon/base/strings/string_util.cc
+++ b/tachyon/base/strings/string_util.cc
@@ -1,5 +1,7 @@
 #include "tachyon/base/strings/string_util.h"
 
+#include <utility>
+
 #include "absl/strings/ascii.h"
 #include "absl/strings/str_cat.h"
 

--- a/tachyon/base/time/time_delta_flag.h
+++ b/tachyon/base/time/time_delta_flag.h
@@ -2,6 +2,7 @@
 #define TACHYON_BASE_TIME_TIME_DELTA_FLAG_H_
 
 #include <functional>
+#include <string>
 
 #include "tachyon/base/flag/flag.h"
 #include "tachyon/base/numerics/safe_conversions.h"

--- a/tachyon/crypto/commitments/pedersen/pedersen.h
+++ b/tachyon/crypto/commitments/pedersen/pedersen.h
@@ -89,11 +89,6 @@ class PedersenParams {
   std::vector<PointTy> generators_;
 };
 
-template <typename PointTy>
-std::ostream& operator<<(std::ostream& os, const PedersenParams<PointTy>& p) {
-  return os << p.ToString();
-}
-
 };  // namespace tachyon::crypto
 
 #endif  // TACHYON_CRYPTO_COMMITMENTS_PEDERSEN_PEDERSEN_H_

--- a/tachyon/device/allocator.cc
+++ b/tachyon/device/allocator.cc
@@ -35,13 +35,21 @@ std::string AllocatorStats::DebugString() const {
       "Reserved:         %20lld\n"
       "PeakReserved:     %20lld\n"
       "LargestFreeBlock: %20lld\n",
+      // NOLINTNEXTLINE(runtime/int)
       static_cast<long long>(this->bytes_limit ? *this->bytes_limit : 0),
+      // NOLINTNEXTLINE(runtime/int)
       static_cast<long long>(this->bytes_in_use),
+      // NOLINTNEXTLINE(runtime/int)
       static_cast<long long>(this->peak_bytes_in_use),
+      // NOLINTNEXTLINE(runtime/int)
       static_cast<long long>(this->num_allocs),
+      // NOLINTNEXTLINE(runtime/int)
       static_cast<long long>(this->largest_alloc_size),
+      // NOLINTNEXTLINE(runtime/int)
       static_cast<long long>(this->bytes_reserved),
+      // NOLINTNEXTLINE(runtime/int)
       static_cast<long long>(this->peak_bytes_reserved),
+      // NOLINTNEXTLINE(runtime/int)
       static_cast<long long>(this->largest_free_block_bytes));
 }
 

--- a/tachyon/device/allocator.h
+++ b/tachyon/device/allocator.h
@@ -23,7 +23,9 @@ limitations under the License.
 #include <functional>
 #include <limits>
 #include <optional>
+#include <string>
 #include <string_view>
+#include <vector>
 
 #include "tachyon/base/logging.h"
 #include "tachyon/device/numa.h"

--- a/tachyon/device/allocator_registry.cc
+++ b/tachyon/device/allocator_registry.cc
@@ -16,6 +16,7 @@ limitations under the License.
 #include "tachyon/device/allocator_registry.h"
 
 #include <string>
+#include <utility>
 
 #include "tachyon/base/logging.h"
 #include "tachyon/base/no_destructor.h"

--- a/tachyon/device/gpu/cuda/cuda_driver.h
+++ b/tachyon/device/gpu/cuda/cuda_driver.h
@@ -18,6 +18,11 @@ limitations under the License.
 #ifndef TACHYON_DEVICE_GPU_CUDA_CUDA_DRIVER_H_
 #define TACHYON_DEVICE_GPU_CUDA_CUDA_DRIVER_H_
 
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
 #include "absl/container/node_hash_map.h"
 #include "absl/strings/str_cat.h"
 #include "absl/synchronization/mutex.h"

--- a/tachyon/device/gpu/device_perf_info.h
+++ b/tachyon/device/gpu/device_perf_info.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef TACHYON_GPU_DEVICE_PERF_INFO_H_
-#define TACHYON_GPU_DEVICE_PERF_INFO_H_
+#ifndef TACHYON_DEVICE_GPU_DEVICE_PERF_INFO_H_
+#define TACHYON_DEVICE_GPU_DEVICE_PERF_INFO_H_
 
 #include <cstdint>
 #include <optional>
@@ -45,4 +45,4 @@ TACHYON_EXPORT void SetDevicePerfInfo(const DevicePerfInfo& device_perf_info);
 
 }  // namespace tachyon::device::gpu
 
-#endif  // TACHYON_GPU_DEVICE_PERF_INFO_H_
+#endif  // TACHYON_DEVICE_GPU_DEVICE_PERF_INFO_H_

--- a/tachyon/device/gpu/gpu_cudamallocasync_allocator.cc
+++ b/tachyon/device/gpu/gpu_cudamallocasync_allocator.cc
@@ -15,9 +15,10 @@ limitations under the License.
 
 #include "tachyon/device/gpu/gpu_cudamallocasync_allocator.h"
 
+#include <algorithm>
 #include <map>
 #include <memory>
-#include <mutex>
+#include <mutex>  // NOLINT(build/c++11)
 #include <optional>
 #include <string>
 #include <vector>
@@ -352,7 +353,7 @@ void GpuCudaMallocAsyncAllocator::DeallocateRaw(void* ptr) {
     if (result == CUDA_ERROR_DEINITIALIZED) {
       // It happens with multi-GPU that Tachyon free the GPU allocation after
       // the driver is unloaded. It is safe to ignore this error here.
-      // TODO: Find how to fix the shutdown steps in Tachyon.
+      // TODO(chokobole): Find how to fix the shutdown steps in Tachyon.
       VLOG(1) << "Ignoring CUDA error: " << GetCudaErrorMessage(result);
     } else {
       size_t free, total;

--- a/tachyon/device/gpu/gpu_cudamallocasync_allocator.h
+++ b/tachyon/device/gpu/gpu_cudamallocasync_allocator.h
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#ifndef TACHYON_DEVICE_GPU_CUDAMALLOCASYNC_ALLOCATOR_H_
-#define TACHYON_DEVICE_GPU_CUDAMALLOCASYNC_ALLOCATOR_H_
+#ifndef TACHYON_DEVICE_GPU_GPU_CUDAMALLOCASYNC_ALLOCATOR_H_
+#define TACHYON_DEVICE_GPU_GPU_CUDAMALLOCASYNC_ALLOCATOR_H_
 
 #include <memory>
 #include <optional>
@@ -139,4 +139,4 @@ class GpuCudaMallocAsyncAllocator : public Allocator {
 
 }  // namespace tachyon::device::gpu
 
-#endif  // TACHYON_DEVICE_GPU_CUDAMALLOCASYNC_ALLOCATOR_H_
+#endif  // TACHYON_DEVICE_GPU_GPU_CUDAMALLOCASYNC_ALLOCATOR_H_

--- a/tachyon/device/gpu/gpu_device_functions.h
+++ b/tachyon/device/gpu/gpu_device_functions.h
@@ -1,6 +1,8 @@
 #ifndef TACHYON_DEVICE_GPU_GPU_DEVICE_FUNCTIONS_H_
 #define TACHYON_DEVICE_GPU_GPU_DEVICE_FUNCTIONS_H_
 
+#include <string>
+
 #if TACHYON_CUDA
 #include "third_party/gpus/cuda/include/cuda.h"
 #include "third_party/gpus/cuda/include/cuda_runtime_api.h"

--- a/tachyon/device/gpu/gpu_memory.h
+++ b/tachyon/device/gpu/gpu_memory.h
@@ -1,8 +1,9 @@
-#ifndef TACHYON_DEVICE_GPU_MEMORY_H_
-#define TACHYON_DEVICE_GPU_MEMORY_H_
+#ifndef TACHYON_DEVICE_GPU_GPU_MEMORY_H_
+#define TACHYON_DEVICE_GPU_GPU_MEMORY_H_
 
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "absl/types/span.h"
 
@@ -333,4 +334,4 @@ class GpuMemory {
 
 }  // namespace tachyon::device::gpu
 
-#endif  // TACHYON_DEVICE_GPU_MEMORY_H_
+#endif  // TACHYON_DEVICE_GPU_GPU_MEMORY_H_

--- a/tachyon/device/gpu/gpu_memory_unittest.cc
+++ b/tachyon/device/gpu/gpu_memory_unittest.cc
@@ -1,5 +1,8 @@
 #include "tachyon/device/gpu/gpu_memory.h"
 
+#include <limits>
+#include <vector>
+
 #include "gtest/gtest.h"
 
 #include "tachyon/base/containers/container_util.h"

--- a/tachyon/device/gpu/gpu_util.cc
+++ b/tachyon/device/gpu/gpu_util.cc
@@ -4,6 +4,8 @@
 
 #include "tachyon/device/gpu/gpu_util.h"
 
+#include <vector>
+
 #include "tachyon/base/strings/string_number_conversions.h"
 #include "tachyon/device/gpu/device_perf_info.h"
 #include "tachyon/device/gpu/gpu_info.h"

--- a/tachyon/device/gpu/gpu_util.h
+++ b/tachyon/device/gpu/gpu_util.h
@@ -30,4 +30,4 @@ GetIntelGpuGeneration(const GPUInfo& gpu_info);
 
 }  // namespace tachyon::device::gpu
 
-#endif  // GPU_CONFIG_GPU_UTIL_H_
+#endif  // TACHYON_DEVICE_GPU_GPU_UTIL_H_

--- a/tachyon/device/numa.cc
+++ b/tachyon/device/numa.cc
@@ -1,10 +1,13 @@
 #include "tachyon/device/numa.h"
 
+#include <algorithm>
+
 #include "tachyon/base/logging.h"
 #include "tachyon/base/memory/aligned_memory.h"
 #include "tachyon/build/build_config.h"
 
 #if defined(TACHYON_USE_NUMA)
+// NOLINTNEXTLINE(build/include_subdir)
 #include "hwloc.h"  // from @hwloc
 #endif
 

--- a/tachyon/device/tracking_allocator.cc
+++ b/tachyon/device/tracking_allocator.cc
@@ -15,6 +15,9 @@ limitations under the License.
 
 #include "tachyon/device/tracking_allocator.h"
 
+#include <algorithm>
+#include <utility>
+
 #include "tachyon/base/logging.h"
 
 namespace tachyon::device {

--- a/tachyon/device/tracking_allocator.h
+++ b/tachyon/device/tracking_allocator.h
@@ -17,6 +17,8 @@ limitations under the License.
 #define TACHYON_DEVICE_TRACKING_ALLOCATOR_H_
 
 #include <optional>
+#include <string>
+#include <tuple>
 #include <unordered_map>
 
 #include "absl/base/thread_annotations.h"

--- a/tachyon/math/base/arithmetics_results.h
+++ b/tachyon/math/base/arithmetics_results.h
@@ -1,7 +1,6 @@
 #ifndef TACHYON_MATH_BASE_ARITHMETICS_RESULTS_H_
 #define TACHYON_MATH_BASE_ARITHMETICS_RESULTS_H_
 
-#include <ostream>
 #include <string>
 
 #include "absl/strings/substitute.h"
@@ -26,11 +25,6 @@ struct AddResult {
 };
 
 template <typename T>
-std::ostream& operator<<(std::ostream& os, const AddResult<T>& result) {
-  return os << result.ToString();
-}
-
-template <typename T>
 struct SubResult {
   T result = 0;
   T borrow = 0;
@@ -46,11 +40,6 @@ struct SubResult {
     return absl::Substitute("($0, $1)", result.ToString(), borrow.ToString());
   }
 };
-
-template <typename T>
-std::ostream& operator<<(std::ostream& os, const SubResult<T>& result) {
-  return os << result.ToString();
-}
 
 template <typename T>
 struct MulResult {
@@ -70,11 +59,6 @@ struct MulResult {
 };
 
 template <typename T>
-std::ostream& operator<<(std::ostream& os, const MulResult<T>& result) {
-  return os << result.ToString();
-}
-
-template <typename T>
 struct DivResult {
   T quotient = 0;
   T remainder = 0;
@@ -91,11 +75,6 @@ struct DivResult {
                             remainder.ToString());
   }
 };
-
-template <typename T>
-std::ostream& operator<<(std::ostream& os, const DivResult<T>& result) {
-  return os << result.ToString();
-}
 
 }  // namespace tachyon::math
 

--- a/tachyon/math/base/big_int.h
+++ b/tachyon/math/base/big_int.h
@@ -907,11 +907,6 @@ struct ALIGNAS(internal::LimbsAlignment(N)) BigInt {
 };
 
 template <size_t N>
-std::ostream& operator<<(std::ostream& os, const BigInt<N>& bigint) {
-  return os << bigint.ToString();
-}
-
-template <size_t N>
 class BitTraits<BigInt<N>> {
  public:
   constexpr static bool kIsDynamic = false;

--- a/tachyon/math/elliptic_curves/BUILD.bazel
+++ b/tachyon/math/elliptic_curves/BUILD.bazel
@@ -14,5 +14,4 @@ tachyon_cc_library(
         "projective_point.h",
         "semigroups.h",
     ],
-    deps = ["//tachyon/base:no_destructor"],
 )

--- a/tachyon/math/elliptic_curves/affine_point.h
+++ b/tachyon/math/elliptic_curves/affine_point.h
@@ -9,11 +9,6 @@ namespace tachyon::math {
 template <typename Curve, typename SFINAE = void>
 class AffinePoint;
 
-template <typename Curve>
-std::ostream& operator<<(std::ostream& os, const AffinePoint<Curve>& point) {
-  return os << point.ToString();
-}
-
 template <typename ScalarField, typename Curve,
           std::enable_if_t<std::is_same_v<
               ScalarField, typename Curve::ScalarField>>* = nullptr>

--- a/tachyon/math/elliptic_curves/jacobian_point.h
+++ b/tachyon/math/elliptic_curves/jacobian_point.h
@@ -1,19 +1,12 @@
 #ifndef TACHYON_MATH_ELLIPTIC_CURVES_JACOBIAN_POINT_H_
 #define TACHYON_MATH_ELLIPTIC_CURVES_JACOBIAN_POINT_H_
 
-#include <ostream>
-
 #include "tachyon/math/elliptic_curves/point_conversions_forward.h"
 
 namespace tachyon::math {
 
 template <typename Curve, typename SFINAE = void>
 class JacobianPoint;
-
-template <typename Curve>
-std::ostream& operator<<(std::ostream& os, const JacobianPoint<Curve>& point) {
-  return os << point.ToString();
-}
 
 template <typename ScalarField, typename Curve,
           std::enable_if_t<std::is_same_v<

--- a/tachyon/math/elliptic_curves/jacobian_point.h
+++ b/tachyon/math/elliptic_curves/jacobian_point.h
@@ -3,7 +3,6 @@
 
 #include <ostream>
 
-#include "tachyon/base/no_destructor.h"
 #include "tachyon/math/elliptic_curves/point_conversions_forward.h"
 
 namespace tachyon::math {

--- a/tachyon/math/elliptic_curves/point_xyzz.h
+++ b/tachyon/math/elliptic_curves/point_xyzz.h
@@ -1,19 +1,12 @@
 #ifndef TACHYON_MATH_ELLIPTIC_CURVES_POINT_XYZZ_H_
 #define TACHYON_MATH_ELLIPTIC_CURVES_POINT_XYZZ_H_
 
-#include <ostream>
-
 #include "tachyon/math/elliptic_curves/point_conversions_forward.h"
 
 namespace tachyon::math {
 
 template <typename Curve, typename SFINAE = void>
 class PointXYZZ;
-
-template <typename Curve>
-std::ostream& operator<<(std::ostream& os, const PointXYZZ<Curve>& point) {
-  return os << point.ToString();
-}
 
 template <typename ScalarField, typename Curve,
           std::enable_if_t<std::is_same_v<

--- a/tachyon/math/elliptic_curves/point_xyzz.h
+++ b/tachyon/math/elliptic_curves/point_xyzz.h
@@ -3,7 +3,6 @@
 
 #include <ostream>
 
-#include "tachyon/base/no_destructor.h"
 #include "tachyon/math/elliptic_curves/point_conversions_forward.h"
 
 namespace tachyon::math {

--- a/tachyon/math/elliptic_curves/projective_point.h
+++ b/tachyon/math/elliptic_curves/projective_point.h
@@ -3,7 +3,6 @@
 
 #include <ostream>
 
-#include "tachyon/base/no_destructor.h"
 #include "tachyon/math/elliptic_curves/point_conversions_forward.h"
 
 namespace tachyon::math {

--- a/tachyon/math/elliptic_curves/projective_point.h
+++ b/tachyon/math/elliptic_curves/projective_point.h
@@ -1,20 +1,12 @@
 #ifndef TACHYON_MATH_ELLIPTIC_CURVES_PROJECTIVE_POINT_H_
 #define TACHYON_MATH_ELLIPTIC_CURVES_PROJECTIVE_POINT_H_
 
-#include <ostream>
-
 #include "tachyon/math/elliptic_curves/point_conversions_forward.h"
 
 namespace tachyon::math {
 
 template <typename Curve, typename SFINAE = void>
 class ProjectivePoint;
-
-template <typename Curve>
-std::ostream& operator<<(std::ostream& os,
-                         const ProjectivePoint<Curve>& point) {
-  return os << point.ToString();
-}
 
 template <typename ScalarField, typename Curve,
           std::enable_if_t<std::is_same_v<

--- a/tachyon/math/finite_fields/cubic_extension_field.h
+++ b/tachyon/math/finite_fields/cubic_extension_field.h
@@ -308,12 +308,6 @@ class CubicExtensionField : public Field<CubicExtensionField<Derived>> {
   BaseField c2_;
 };
 
-template <typename Derived>
-std::ostream& operator<<(std::ostream& os,
-                         const CubicExtensionField<Derived>& f) {
-  return os << f.ToString();
-}
-
 template <
     typename BaseField, typename Derived,
     std::enable_if_t<std::is_same_v<BaseField, typename Derived::BaseField>>* =

--- a/tachyon/math/finite_fields/prime_field.h
+++ b/tachyon/math/finite_fields/prime_field.h
@@ -4,7 +4,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include <ostream>
 #include <string>
 
 #include "gtest/gtest_prod.h"
@@ -292,11 +291,6 @@ class PrimeField<_Config, std::enable_if_t<!_Config::kIsSpecialPrime>> final
 
   BigInt<N> value_;
 };
-
-template <typename Config>
-std::ostream& operator<<(std::ostream& os, const PrimeField<Config>& f) {
-  return os << f.ToString();
-}
 
 }  // namespace tachyon::math
 

--- a/tachyon/math/finite_fields/prime_field_gmp.h
+++ b/tachyon/math/finite_fields/prime_field_gmp.h
@@ -5,7 +5,6 @@
 
 #include <stddef.h>
 
-#include <ostream>
 #include <string>
 #include <utility>
 
@@ -238,11 +237,6 @@ class PrimeFieldGmp final : public PrimeFieldBase<PrimeFieldGmp<_Config>> {
 
   mpz_class value_;
 };
-
-template <typename Config>
-std::ostream& operator<<(std::ostream& os, const PrimeFieldGmp<Config>& f) {
-  return os << f.ToString();
-}
 
 }  // namespace tachyon::math
 

--- a/tachyon/math/finite_fields/prime_field_gpu.h
+++ b/tachyon/math/finite_fields/prime_field_gpu.h
@@ -4,7 +4,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include <ostream>
 #include <string>
 
 #if TACHYON_CUDA
@@ -410,11 +409,6 @@ class PrimeFieldGpu final : public PrimeFieldBase<PrimeFieldGpu<_Config>> {
 
   BigInt<N> value_;
 };
-
-template <typename Config>
-std::ostream& operator<<(std::ostream& os, const PrimeFieldGpu<Config>& f) {
-  return os << f.ToString();
-}
 
 }  // namespace tachyon::math
 

--- a/tachyon/math/finite_fields/prime_field_gpu_debug.h
+++ b/tachyon/math/finite_fields/prime_field_gpu_debug.h
@@ -4,7 +4,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include <ostream>
 #include <string>
 
 #include "tachyon/base/random.h"
@@ -371,12 +370,6 @@ class PrimeFieldGpuDebug final
 
   BigInt<N> value_;
 };
-
-template <typename Config>
-std::ostream& operator<<(std::ostream& os,
-                         const PrimeFieldGpuDebug<Config>& f) {
-  return os << f.ToString();
-}
 
 }  // namespace tachyon::math
 

--- a/tachyon/math/finite_fields/quadratic_extension_field.h
+++ b/tachyon/math/finite_fields/quadratic_extension_field.h
@@ -6,7 +6,6 @@
 #ifndef TACHYON_MATH_FINITE_FIELDS_QUADRATIC_EXTENSION_FIELD_H_
 #define TACHYON_MATH_FINITE_FIELDS_QUADRATIC_EXTENSION_FIELD_H_
 
-#include <ostream>
 #include <string>
 #include <utility>
 
@@ -257,12 +256,6 @@ class QuadraticExtensionField : public Field<Derived> {
   BaseField c0_;
   BaseField c1_;
 };
-
-template <typename Derived>
-std::ostream& operator<<(std::ostream& os,
-                         const QuadraticExtensionField<Derived>& f) {
-  return os << f.ToString();
-}
 
 template <
     typename BaseField, typename Derived,

--- a/tachyon/math/geometry/point2.h
+++ b/tachyon/math/geometry/point2.h
@@ -38,11 +38,6 @@ struct Point2 {
   }
 };
 
-template <typename T>
-std::ostream& operator<<(std::ostream& os, const Point2<T>& point) {
-  return os << point.ToString();
-}
-
 }  // namespace tachyon::math
 
 #endif  // TACHYON_MATH_GEOMETRY_POINT2_H_

--- a/tachyon/math/geometry/point3.h
+++ b/tachyon/math/geometry/point3.h
@@ -42,11 +42,6 @@ struct Point3 {
   }
 };
 
-template <typename T>
-std::ostream& operator<<(std::ostream& os, const Point3<T>& point) {
-  return os << point.ToString();
-}
-
 }  // namespace tachyon::math
 
 #endif  // TACHYON_MATH_GEOMETRY_POINT3_H_

--- a/tachyon/math/geometry/point4.h
+++ b/tachyon/math/geometry/point4.h
@@ -44,11 +44,6 @@ struct Point4 {
   }
 };
 
-template <typename T>
-std::ostream& operator<<(std::ostream& os, const Point4<T>& point) {
-  return os << point.ToString();
-}
-
 }  // namespace tachyon::math
 
 #endif  // TACHYON_MATH_GEOMETRY_POINT4_H_

--- a/tachyon/math/matrix/sparse/sparse_matrix.h
+++ b/tachyon/math/matrix/sparse/sparse_matrix.h
@@ -178,11 +178,6 @@ class ELLSparseMatrix {
   std::vector<Elements> elements_list_;
 };
 
-template <typename T>
-std::ostream& operator<<(std::ostream& os, const ELLSparseMatrix<T>& matrix) {
-  return os << matrix.ToString();
-}
-
 // CSR(Compressed Sparse Row) format is a sparse matrix format that stores only
 // non-zero values in a vector. The |row_ptrs| vector stores the index of the
 // first element of each row in the |elements| vector.
@@ -343,11 +338,6 @@ class CSRSparseMatrix {
   Elements elements_;
   std::vector<size_t> row_ptrs_;
 };
-
-template <typename T>
-std::ostream& operator<<(std::ostream& os, const CSRSparseMatrix<T>& matrix) {
-  return os << matrix.ToString();
-}
 
 }  // namespace tachyon::math
 

--- a/tachyon/math/matrix/sparse/sparse_matrix.h
+++ b/tachyon/math/matrix/sparse/sparse_matrix.h
@@ -183,7 +183,7 @@ std::ostream& operator<<(std::ostream& os, const ELLSparseMatrix<T>& matrix) {
   return os << matrix.ToString();
 }
 
-// CSR(Compresed Sparse Row) format is a sparse matrix format that stores only
+// CSR(Compressed Sparse Row) format is a sparse matrix format that stores only
 // non-zero values in a vector. The |row_ptrs| vector stores the index of the
 // first element of each row in the |elements| vector.
 // For example, the following matrix:

--- a/tachyon/math/polynomials/multivariate/multivariate_polynomial.h
+++ b/tachyon/math/polynomials/multivariate/multivariate_polynomial.h
@@ -118,12 +118,6 @@ class MultivariatePolynomial final
   Coefficients coefficients_;
 };
 
-template <typename Coefficients>
-std::ostream& operator<<(std::ostream& os,
-                         const MultivariatePolynomial<Coefficients>& p) {
-  return os << p.ToString();
-}
-
 template <typename F, size_t MaxDegree>
 using MultivariateSparsePolynomial =
     MultivariatePolynomial<MultivariateSparseCoefficients<F, MaxDegree>>;

--- a/tachyon/math/polynomials/multivariate/multivariate_sparse_coefficients.h
+++ b/tachyon/math/polynomials/multivariate/multivariate_sparse_coefficients.h
@@ -345,12 +345,6 @@ class MultivariateSparseCoefficients {
   std::vector<Term> terms_;
 };
 
-template <typename F, size_t MaxDegree>
-std::ostream& operator<<(
-    std::ostream& os, const MultivariateSparseCoefficients<F, MaxDegree>& p) {
-  return os << p.ToString();
-}
-
 }  // namespace tachyon::math
 
 #endif  // TACHYON_MATH_POLYNOMIALS_MULTIVARIATE_MULTIVARIATE_SPARSE_COEFFICIENTS_H_

--- a/tachyon/math/polynomials/univariate/univariate_dense_coefficients.h
+++ b/tachyon/math/polynomials/univariate/univariate_dense_coefficients.h
@@ -195,12 +195,6 @@ class UnivariateDenseCoefficients {
   std::vector<F> coefficients_;
 };
 
-template <typename F, size_t MaxDegree>
-std::ostream& operator<<(std::ostream& os,
-                         const UnivariateDenseCoefficients<F, MaxDegree>& p) {
-  return os << p.ToString();
-}
-
 }  // namespace tachyon::math
 
 #endif  // TACHYON_MATH_POLYNOMIALS_UNIVARIATE_UNIVARIATE_DENSE_COEFFICIENTS_H_

--- a/tachyon/math/polynomials/univariate/univariate_polynomial.h
+++ b/tachyon/math/polynomials/univariate/univariate_polynomial.h
@@ -189,12 +189,6 @@ class UnivariatePolynomial final
   Coefficients coefficients_;
 };
 
-template <typename Coefficients>
-std::ostream& operator<<(std::ostream& os,
-                         const UnivariatePolynomial<Coefficients>& p) {
-  return os << p.ToString();
-}
-
 template <typename F, size_t MaxDegree>
 using UnivariateDensePolynomial =
     UnivariatePolynomial<UnivariateDenseCoefficients<F, MaxDegree>>;

--- a/tachyon/math/polynomials/univariate/univariate_sparse_coefficients.h
+++ b/tachyon/math/polynomials/univariate/univariate_sparse_coefficients.h
@@ -183,12 +183,6 @@ class UnivariateSparseCoefficients {
   std::vector<Term> terms_;
 };
 
-template <typename F, size_t MaxDegree>
-std::ostream& operator<<(std::ostream& os,
-                         const UnivariateSparseCoefficients<F, MaxDegree>& p) {
-  return os << p.ToString();
-}
-
 }  // namespace tachyon::math
 
 #endif  // TACHYON_MATH_POLYNOMIALS_UNIVARIATE_UNIVARIATE_SPARSE_COEFFICIENTS_H_

--- a/third_party/glog/enable_elaborate_ostream_operator.patch
+++ b/third_party/glog/enable_elaborate_ostream_operator.patch
@@ -1,0 +1,91 @@
+diff --git a/src/glog/logging.h.in b/src/glog/logging.h.in
+index 04cdf3b..d378aac 100644
+--- a/src/glog/logging.h.in
++++ b/src/glog/logging.h.in
+@@ -44,6 +44,7 @@
+ #include <ostream>
+ #include <sstream>
+ #include <string>
++#include <type_traits>
+ #if @ac_cv_have_unistd_h@
+ # include <unistd.h>
+ #endif
+@@ -716,13 +717,75 @@ inline std::ostream& operator<<(
+ 
+ @ac_google_start_namespace@
+ 
+-// This formats a value for a failing CHECK_XX statement.  Ordinarily,
+-// it uses the definition for operator<<, with a few special cases below.
++// Uses expression SFINAE to detect whether using operator<< would work.
++template <typename T, typename = void>
++struct SupportsOstreamOperator : std::false_type {};
+ template <typename T>
+-inline void MakeCheckOpValueString(std::ostream* os, const T& v) {
++struct SupportsOstreamOperator<T, decltype(void(std::declval<std::ostream&>()
++                                                << std::declval<T>()))>
++    : std::true_type {};
++
++template <typename T, typename = void>
++struct SupportsToString : std::false_type {};
++template <typename T>
++struct SupportsToString<T, decltype(void(std::declval<T>().ToString()))>
++    : std::true_type {};
++
++// I/O manipulators are function pointers, but should be sent directly to the
++// `ostream` instead of being cast to `const void*` like other function
++// pointers.
++template <typename T, typename = void>
++constexpr bool IsIomanip = false;
++template <typename T>
++constexpr bool
++    IsIomanip<T&(T&), std::enable_if_t<std::is_base_of_v<std::ios_base, T>>> =
++        true;
++
++// Function pointers implicitly convert to `bool`, so use this to avoid printing
++// function pointers as 1 or 0.
++template <typename T, typename = void>
++constexpr bool WillBeIncorrectlyStreamedAsBool = false;
++template <typename T>
++constexpr bool WillBeIncorrectlyStreamedAsBool<
++    T, std::enable_if_t<std::is_function_v<std::remove_pointer_t<T>> &&
++                        !IsIomanip<std::remove_pointer_t<T>>>> = true;
++
++template <typename T>
++inline std::enable_if_t<
++    SupportsOstreamOperator<const T&>::value &&
++    !WillBeIncorrectlyStreamedAsBool<T>>
++MakeCheckOpValueString(std::ostream* os, const T& v) {
+   (*os) << v;
+ }
+ 
++// Functions and function pointers.
++template <typename T>
++inline std::enable_if_t<
++    SupportsOstreamOperator<const T&>::value &&
++   WillBeIncorrectlyStreamedAsBool<T>>
++MakeCheckOpValueString(std::ostream* os, const T& v) {
++  const void* vp = reinterpret_cast<const void*>(v);
++  (*os) << std::addressof(vp);
++}
++
++// Non-streamables that have a `ToString` member.
++template <typename T>
++inline std::enable_if_t<!SupportsOstreamOperator<const T&>::value &&
++                        SupportsToString<const T&>::value>
++MakeCheckOpValueString(std::ostream* os, const T& v) {
++  MakeCheckOpValueString(os, v.ToString());
++}
++
++// Non-streamable enums (i.e. scoped enums where no `operator<<` overload was
++// declared).
++template <typename T>
++inline std::enable_if_t<!SupportsOstreamOperator<const T&>::value &&
++                        std::is_enum_v<T>>
++MakeCheckOpValueString(std::ostream* os, T v) {
++  MakeCheckOpValueString(
++      os, static_cast<std::underlying_type_t<T>>(v));
++}
++
+ // Overrides for char types provide readable values for unprintable
+ // characters.
+ template <> GOOGLE_GLOG_DLL_DECL


### PR DESCRIPTION
# Description

Now the google logging knows how to stream the value if the type of value supports `ToString()`! (Also this PR includes cpplint fix commit on the codes that we manage directly)

```c++
class F {
  std::string ToString() const { return "F()"; }
};

F f;
LOG(INFO) << f;
```

- If `operator<<()` is implemented for type T and is incorrectly streamed as boolean(such as function and function pointer), then glog stringify it with `std::addressof()`.
- If `ToString()` is implemented for type T, then glog uses `ToString()`.
- Else, `operator<<()` should be implemented for type T.