### PR TITLE
feat: enable customized group inverse

### DIFF
--- a/tachyon/math/base/BUILD.bazel
+++ b/tachyon/math/base/BUILD.bazel
@@ -75,7 +75,10 @@ tachyon_cc_library(
 tachyon_cc_library(
     name = "groups",
     hdrs = ["groups.h"],
-    deps = [":semigroups"],
+    deps = [
+        ":semigroups",
+        "//tachyon/base/types:always_false",
+    ],
 )
 
 tachyon_cc_library(

--- a/tachyon/math/base/groups.h
+++ b/tachyon/math/base/groups.h
@@ -48,7 +48,7 @@ class MultiplicativeGroup : public MultiplicativeSemigroup<G> {
   template <
       typename G2,
       std::enable_if_t<internal::SupportsDivInPlace<G, G2>::value>* = nullptr>
-  constexpr auto& operator/=(const G2& other) {
+  constexpr G& operator/=(const G2& other) {
     G* g = static_cast<G*>(this);
     return g->DivInPlace(other);
   }
@@ -58,7 +58,7 @@ class MultiplicativeGroup : public MultiplicativeSemigroup<G> {
       typename G2,
       std::enable_if_t<!internal::SupportsDivInPlace<G, G2>::value &&
                        internal::SupportsMulInPlace<G, G2>::value>* = nullptr>
-  constexpr auto& operator/=(const G2& other) {
+  constexpr G& operator/=(const G2& other) {
     G* g = static_cast<G*>(this);
     return g->MulInPlace(other.Inverse());
   }
@@ -100,7 +100,7 @@ class AdditiveGroup : public AdditiveSemigroup<G> {
   template <
       typename G2,
       std::enable_if_t<internal::SupportsSubInPlace<G, G2>::value>* = nullptr>
-  constexpr auto& operator-=(const G2& other) {
+  constexpr G& operator-=(const G2& other) {
     G* g = static_cast<G*>(this);
     return g->SubInPlace(other);
   }
@@ -110,7 +110,7 @@ class AdditiveGroup : public AdditiveSemigroup<G> {
       typename G2,
       std::enable_if_t<!internal::SupportsSubInPlace<G, G2>::value &&
                        internal::SupportsAddInPlace<G, G2>::value>* = nullptr>
-  constexpr auto& operator-=(const G2& other) {
+  constexpr G& operator-=(const G2& other) {
     G* g = static_cast<G*>(this);
     return g->AddInPlace(other.Negative());
   }

--- a/tachyon/math/base/groups_unittest.cc
+++ b/tachyon/math/base/groups_unittest.cc
@@ -57,6 +57,39 @@ TEST(GroupsTest, DivOverMul) {
   static_cast<void>(c);
 }
 
+TEST(GroupsTest, InverseOverride) {
+  class IntInverse {
+   public:
+    IntInverse() = default;
+    explicit IntInverse(int denominator) : denominator_(denominator) {}
+    IntInverse(const IntInverse& other) : denominator_(other.denominator_) {}
+
+    bool operator==(const IntInverse& other) const {
+      return denominator_ == other.denominator_;
+    }
+
+   private:
+    int denominator_ = 0;
+  };
+
+  class Int : public MultiplicativeGroup<Int> {
+   public:
+    Int() = default;
+    explicit Int(int value) : value_(value) {}
+    Int(const Int& other) : value_(other.value_) {}
+
+    IntInverse Inverse() const { return IntInverse(value_); }
+
+    bool operator==(const Int& other) const { return value_ == other.value_; }
+
+   private:
+    int value_ = 0;
+  };
+
+  Int a(3);
+  EXPECT_EQ(a.Inverse(), IntInverse(3));
+}
+
 TEST(GroupsTest, Sub) {
   class Int : public AdditiveGroup<Int> {
    public:
@@ -107,6 +140,39 @@ TEST(GroupsTest, SubOverAdd) {
 
   Int c = a - b;
   static_cast<void>(c);
+}
+
+TEST(GroupsTest, NegativeOverride) {
+  class IntNegative {
+   public:
+    IntNegative() = default;
+    explicit IntNegative(int value) : value_(value) {}
+    IntNegative(const IntNegative& other) : value_(other.value_) {}
+
+    bool operator==(const IntNegative& other) const {
+      return value_ == other.value_;
+    }
+
+   private:
+    int value_ = 0;
+  };
+
+  class Int : public AdditiveGroup<Int> {
+   public:
+    Int() = default;
+    explicit Int(int value) : value_(value) {}
+    Int(const Int& other) : value_(other.value_) {}
+
+    IntNegative Negative() const { return IntNegative(-value_); }
+
+    bool operator==(const Int& other) const { return value_ == other.value_; }
+
+   private:
+    int value_ = 0;
+  };
+
+  Int a(3);
+  EXPECT_EQ(-a, IntNegative(-3));
 }
 
 }  // namespace tachyon::math

--- a/tachyon/math/base/groups_unittest.cc
+++ b/tachyon/math/base/groups_unittest.cc
@@ -8,7 +8,7 @@ namespace tachyon::math {
 TEST(GroupsTest, Div) {
   class Int : public MultiplicativeGroup<Int> {
    public:
-    Int() : value_(0) {}
+    Int() = default;
     explicit Int(int value) : value_(value) {}
     Int(const Int& other) : value_(other.value_) {}
 
@@ -18,7 +18,7 @@ TEST(GroupsTest, Div) {
     bool operator==(const Int& other) const { return value_ == other.value_; }
 
    private:
-    int value_;
+    int value_ = 0;
   };
 
   Int a(3);
@@ -33,7 +33,7 @@ TEST(GroupsTest, Div) {
 TEST(GroupsTest, DivOverMul) {
   class Int : public MultiplicativeGroup<Int> {
    public:
-    Int() : value_(0) {}
+    Int() = default;
     explicit Int(int value) : value_(value) {}
     Int(const Int& other) : value_(other.value_) {}
 
@@ -44,7 +44,7 @@ TEST(GroupsTest, DivOverMul) {
     bool operator==(const Int& other) const { return value_ == other.value_; }
 
    private:
-    int value_;
+    int value_ = 0;
   };
 
   Int a(3);
@@ -93,7 +93,7 @@ TEST(GroupsTest, InverseOverride) {
 TEST(GroupsTest, Sub) {
   class Int : public AdditiveGroup<Int> {
    public:
-    Int() : value_(0) {}
+    Int() = default;
     explicit Int(int value) : value_(value) {}
     Int(const Int& other) : value_(other.value_) {}
 
@@ -103,7 +103,7 @@ TEST(GroupsTest, Sub) {
     bool operator==(const Int& other) const { return value_ == other.value_; }
 
    private:
-    int value_;
+    int value_ = 0;
   };
 
   Int a(3);
@@ -118,7 +118,7 @@ TEST(GroupsTest, Sub) {
 TEST(GroupsTest, SubOverAdd) {
   class Int : public AdditiveGroup<Int> {
    public:
-    Int() : value_(0) {}
+    Int() = default;
     explicit Int(int value) : value_(value) {}
     Int(const Int& other) : value_(other.value_) {}
 
@@ -129,7 +129,7 @@ TEST(GroupsTest, SubOverAdd) {
     bool operator==(const Int& other) const { return value_ == other.value_; }
 
    private:
-    int value_;
+    int value_ = 0;
   };
 
   Int a(3);

--- a/tachyon/math/base/semigroups.h
+++ b/tachyon/math/base/semigroups.h
@@ -83,7 +83,7 @@ class MultiplicativeSemigroup {
   template <
       typename G2,
       std::enable_if_t<internal::SupportsMulInPlace<G, G2>::value>* = nullptr>
-  constexpr auto& operator*=(const G2& other) {
+  constexpr G& operator*=(const G2& other) {
     G* g = static_cast<G*>(this);
     return g->MulInPlace(other);
   }
@@ -172,7 +172,7 @@ class AdditiveSemigroup {
   template <
       typename G2,
       std::enable_if_t<internal::SupportsAddInPlace<G, G2>::value>* = nullptr>
-  constexpr auto& operator+=(const G2& other) {
+  constexpr G& operator+=(const G2& other) {
     G* g = static_cast<G*>(this);
     return g->AddInPlace(other);
   }

--- a/tachyon/math/base/semigroups_unittest.cc
+++ b/tachyon/math/base/semigroups_unittest.cc
@@ -8,7 +8,7 @@ namespace tachyon::math {
 TEST(SemigroupsTest, Mul) {
   class Int : public MultiplicativeSemigroup<Int> {
    public:
-    Int() : value_(0) {}
+    Int() = default;
     explicit Int(int value) : value_(value) {}
     Int(const Int& other) : value_(other.value_) {}
 
@@ -17,7 +17,7 @@ TEST(SemigroupsTest, Mul) {
     bool operator==(const Int& other) const { return value_ == other.value_; }
 
    private:
-    int value_;
+    int value_ = 0;
   };
 
   Int a(3);
@@ -31,7 +31,7 @@ TEST(SemigroupsTest, Mul) {
 TEST(SemigroupsTest, MulOverMulInPlace) {
   class Int : public MultiplicativeSemigroup<Int> {
    public:
-    Int() : value_(0) {}
+    Int() = default;
     explicit Int(int value) : value_(value) {}
     Int(const Int& other) : value_(other.value_) {}
 
@@ -41,7 +41,7 @@ TEST(SemigroupsTest, MulOverMulInPlace) {
     bool operator==(const Int& other) const { return value_ == other.value_; }
 
    private:
-    int value_;
+    int value_ = 0;
   };
 
   Int a(3);
@@ -60,7 +60,7 @@ TEST(SemigroupsTest, MulOverMulInPlace) {
 TEST(SemigroupsTest, Add) {
   class Int : public AdditiveSemigroup<Int> {
    public:
-    Int() : value_(0) {}
+    Int() = default;
     explicit Int(int value) : value_(value) {}
     Int(const Int& other) : value_(other.value_) {}
 
@@ -69,7 +69,7 @@ TEST(SemigroupsTest, Add) {
     bool operator==(const Int& other) const { return value_ == other.value_; }
 
    private:
-    int value_;
+    int value_ = 0;
   };
 
   Int a(3);
@@ -83,7 +83,7 @@ TEST(SemigroupsTest, Add) {
 TEST(SemigroupsTest, AddOverAddInPlace) {
   class Int : public AdditiveSemigroup<Int> {
    public:
-    Int() : value_(0) {}
+    Int() = default;
     explicit Int(int value) : value_(value) {}
     Int(const Int& other) : value_(other.value_) {}
 
@@ -93,7 +93,7 @@ TEST(SemigroupsTest, AddOverAddInPlace) {
     bool operator==(const Int& other) const { return value_ == other.value_; }
 
    private:
-    int value_;
+    int value_ = 0;
   };
 
   Int a(3);


### PR DESCRIPTION
# Description

Previously, `Negative()` and `Inverse()` depends on `NegInPlace()` and `InverseInPlace()` internally. But there's a case that those functions require the return type to be different. In this case, the derived class needs to define its own `Negative()` and `Inverse()`.