### PR TITLE
refac(math): refactor univariate polynomial parts

### DIFF
--- a/tachyon/math/polynomials/univariate/univariate_dense_coefficients.h
+++ b/tachyon/math/polynomials/univariate/univariate_dense_coefficients.h
@@ -80,11 +80,11 @@ class UnivariateDenseCoefficients {
     return !operator==(other);
   }
 
-  constexpr F* Get(size_t i) {
-    return const_cast<F*>(std::as_const(*this).Get(i));
+  constexpr F* operator[](size_t i) {
+    return const_cast<F*>(std::as_const(*this).operator[](i));
   }
 
-  constexpr const F* Get(size_t i) const {
+  constexpr const F* operator[](size_t i) const {
     if (i < coefficients_.size()) {
       return &coefficients_[i];
     }

--- a/tachyon/math/polynomials/univariate/univariate_evaluation_domain.h
+++ b/tachyon/math/polynomials/univariate/univariate_evaluation_domain.h
@@ -29,6 +29,7 @@ class UnivariateEvaluationDomain : public EvaluationDomain<F, MaxDegree> {
 
   using Evals = UnivariateEvaluations<F, MaxDegree>;
   using DensePoly = UnivariateDensePolynomial<F, MaxDegree>;
+  using DenseCoeffs = UnivariateDenseCoefficients<F, MaxDegree>;
   using SparseCoeffs = UnivariateSparseCoefficients<F, MaxDegree>;
   using SparsePoly = UnivariateSparsePolynomial<F, MaxDegree>;
 
@@ -106,7 +107,7 @@ class UnivariateEvaluationDomain : public EvaluationDomain<F, MaxDegree> {
   // is computed in time O(m). Then given the evaluations of a degree d
   // polynomial P over H, where d < m, P(𝜏) can be computed as P(𝜏) =
   // Σ{i in m} L_{i, H}(𝜏) * |P(gⁱ)|.
-  constexpr std::vector<F> EvaluateAllLagrangeCoefficients(const F& tau) const {
+  constexpr DenseCoeffs EvaluateAllLagrangeCoefficients(const F& tau) const {
     // Evaluate all Lagrange polynomials at 𝜏 to get the lagrange
     // coefficients.
     //
@@ -131,7 +132,7 @@ class UnivariateEvaluationDomain : public EvaluationDomain<F, MaxDegree> {
         }
         omega_i *= group_gen_;
       }
-      return u;
+      return DenseCoeffs(std::move(u));
     } else {
       // In this case we have to compute Z_H(𝜏) * vᵢ / (𝜏 - h * gⁱ)
       // for i in 0..|size_|. We actually compute this by computing
@@ -167,7 +168,7 @@ class UnivariateEvaluationDomain : public EvaluationDomain<F, MaxDegree> {
       // and return these
       // Z_H(𝜏) * vᵢ / (𝜏 - h * gⁱ)
       F::BatchInverseInPlace(lagrange_coefficients_inverse);
-      return lagrange_coefficients_inverse;
+      return DenseCoeffs(std::move(lagrange_coefficients_inverse));
     }
   }
 

--- a/tachyon/math/polynomials/univariate/univariate_evaluation_domain_unittest.cc
+++ b/tachyon/math/polynomials/univariate/univariate_evaluation_domain_unittest.cc
@@ -182,6 +182,7 @@ TYPED_TEST(UnivariateEvaluationDomainTest, NonSystematicLagrangeCoefficients) {
   using F = typename UnivariateEvaluationDomainType::Field;
   using BaseUnivariateEvaluationDomainType =
       UnivariateEvaluationDomain<F, UnivariateEvaluationDomainType::kMaxDegree>;
+  using DenseCoeffs = typename UnivariateEvaluationDomainType::DenseCoeffs;
   using DensePoly = typename UnivariateEvaluationDomainType::DensePoly;
   using Evals = typename UnivariateEvaluationDomainType::Evals;
 
@@ -193,7 +194,7 @@ TYPED_TEST(UnivariateEvaluationDomainTest, NonSystematicLagrangeCoefficients) {
     this->TestDomains(
         domain_size, [domain_size, &rand_pt, &rand_poly, &actual_eval](
                          const BaseUnivariateEvaluationDomainType& d) {
-          std::vector<F> lagrange_coeffs =
+          DenseCoeffs lagrange_coeffs =
               d.EvaluateAllLagrangeCoefficients(rand_pt);
 
           Evals poly_evals = d.FFT(rand_poly);
@@ -202,7 +203,7 @@ TYPED_TEST(UnivariateEvaluationDomainTest, NonSystematicLagrangeCoefficients) {
           // evaluation
           F interpolated_eval = F::Zero();
           for (size_t i = 0; i < domain_size; ++i) {
-            interpolated_eval += lagrange_coeffs[i] * (*poly_evals[i]);
+            interpolated_eval += (*lagrange_coeffs[i]) * (*poly_evals[i]);
           }
           EXPECT_EQ(actual_eval, interpolated_eval);
         });
@@ -215,6 +216,7 @@ TYPED_TEST(UnivariateEvaluationDomainTest, SystematicLagrangeCoefficients) {
   // low. We generate lagrange coefficients for each element in the domain.
   using UnivariateEvaluationDomainType = TypeParam;
   using F = typename UnivariateEvaluationDomainType::Field;
+  using DenseCoeffs = typename UnivariateEvaluationDomainType::DenseCoeffs;
   using BaseUnivariateEvaluationDomainType =
       UnivariateEvaluationDomain<F, UnivariateEvaluationDomainType::kMaxDegree>;
 
@@ -225,15 +227,15 @@ TYPED_TEST(UnivariateEvaluationDomainTest, SystematicLagrangeCoefficients) {
         [domain_size](const BaseUnivariateEvaluationDomainType& d) {
           for (size_t i = 0; i < domain_size; ++i) {
             F x = d.GetElement(i);
-            std::vector<F> lagrange_coeffs =
-                d.EvaluateAllLagrangeCoefficients(x);
+            DenseCoeffs lagrange_coeffs = d.EvaluateAllLagrangeCoefficients(x);
             for (size_t j = 0; j < domain_size; ++j) {
               // Lagrange coefficient for the evaluation point,
               // which should be 1 if i == j
               if (i == j) {
-                EXPECT_TRUE(lagrange_coeffs[j].IsOne());
+                EXPECT_TRUE(lagrange_coeffs[j]->IsOne());
               } else {
-                EXPECT_TRUE(lagrange_coeffs[j].IsZero());
+                EXPECT_TRUE(lagrange_coeffs[j] == nullptr ||
+                            lagrange_coeffs[j]->IsZero());
               }
             }
           }

--- a/tachyon/math/polynomials/univariate/univariate_polynomial.h
+++ b/tachyon/math/polynomials/univariate/univariate_polynomial.h
@@ -69,11 +69,9 @@ class UnivariatePolynomial final
     return !operator==(other);
   }
 
-  constexpr Field* operator[](size_t i) { return coefficients_.Get(i); }
+  constexpr Field* operator[](size_t i) { return coefficients_[i]; }
 
-  constexpr const Field* operator[](size_t i) const {
-    return coefficients_.Get(i);
-  }
+  constexpr const Field* operator[](size_t i) const { return coefficients_[i]; }
 
   constexpr const Field* GetLeadingCoefficient() const {
     return coefficients_.GetLeadingCoefficient();

--- a/tachyon/math/polynomials/univariate/univariate_sparse_coefficients.h
+++ b/tachyon/math/polynomials/univariate/univariate_sparse_coefficients.h
@@ -95,11 +95,11 @@ class UnivariateSparseCoefficients {
     return !operator==(other);
   }
 
-  constexpr F* Get(size_t i) {
-    return const_cast<F*>(std::as_const(*this).Get(i));
+  constexpr F* operator[](size_t i) {
+    return const_cast<F*>(std::as_const(*this).operator[](i));
   }
 
-  constexpr const F* Get(size_t i) const {
+  constexpr const F* operator[](size_t i) const {
     auto it = std::lower_bound(
         terms_.begin(), terms_.end(), i,
         [](const Term& term, size_t degree) { return term.degree < degree; });


### PR DESCRIPTION
# Description

- change return type for `EvaluateAllLagrangeCoefficients()` from `std::vector<F>` to `DenseCoefficients<F, MaxDegree>`
- implement `operator[]` instead of `Get()` for `UnivariateXXXCoefficients`.