### PR TITLE
feat: implement range

### DIFF
--- a/tachyon/base/BUILD.bazel
+++ b/tachyon/base/BUILD.bazel
@@ -84,6 +84,7 @@ tachyon_cc_library(
     srcs = ["random.cc"],
     hdrs = ["random.h"],
     deps = [
+        ":range",
         "//tachyon:export",
         "@com_google_absl//absl/random",
     ],

--- a/tachyon/base/BUILD.bazel
+++ b/tachyon/base/BUILD.bazel
@@ -90,6 +90,11 @@ tachyon_cc_library(
 )
 
 tachyon_cc_library(
+    name = "range",
+    hdrs = ["range.h"],
+)
+
+tachyon_cc_library(
     name = "scoped_generic",
     hdrs = ["scoped_generic.h"],
     deps = [":logging"],
@@ -120,6 +125,7 @@ tachyon_cc_unittest(
         "endian_utils_unittest.cc",
         "environment_unittest.cc",
         "random_unittest.cc",
+        "range_unittest.cc",
         "scoped_generic_unittest.cc",
     ],
     deps = [
@@ -129,6 +135,7 @@ tachyon_cc_unittest(
         ":endian_utils",
         ":environment",
         ":random",
+        ":range",
         ":scoped_generic",
         "//tachyon/base/containers:contains",
         "//tachyon/base/containers:cxx20_erase",

--- a/tachyon/base/bits_unittest.cc
+++ b/tachyon/base/bits_unittest.cc
@@ -281,7 +281,7 @@ TEST(BitsTest, LeftMostBit) {
 TEST(BitsTest, BitRev) {
   std::bitset<64> value;
   for (size_t i = 0; i < 20; ++i) {
-    value.flip(Uniform(0, 64));
+    value.flip(UniformElement(value));
   }
   std::bitset<64> expected;
   for (size_t i = 0; i < 64; ++i) {

--- a/tachyon/base/random.h
+++ b/tachyon/base/random.h
@@ -5,25 +5,34 @@
 
 #include "absl/random/random.h"
 
+#include "tachyon/base/range.h"
 #include "tachyon/export.h"
 
 namespace tachyon::base {
 
 TACHYON_EXPORT absl::BitGen& GetAbslBitGen();
 
-template <typename L, typename R>
-auto Uniform(L min, R max) {
-  return absl::Uniform(GetAbslBitGen(), min, max);
+template <typename T, bool IsStartInclusive, bool IsEndInclusive>
+T Uniform(const Range<T, IsStartInclusive, IsEndInclusive>& range) {
+  if constexpr (IsStartInclusive && IsEndInclusive) {
+    return absl::Uniform(absl::IntervalClosedClosed, GetAbslBitGen(),
+                         range.start, range.end);
+  } else if constexpr (IsStartInclusive && !IsEndInclusive) {
+    return absl::Uniform(absl::IntervalClosedOpen, GetAbslBitGen(), range.start,
+                         range.end);
+  } else if constexpr (!IsStartInclusive && IsEndInclusive) {
+    return absl::Uniform(absl::IntervalOpenClosed, GetAbslBitGen(), range.start,
+                         range.end);
+  } else {
+    return absl::Uniform(absl::IntervalOpenOpen, GetAbslBitGen(), range.start,
+                         range.end);
+  }
 }
 
-template <typename TagType, typename L, typename R>
-auto Uniform(TagType tag, L min, R max) {
-  return absl::Uniform(tag, GetAbslBitGen(), min, max);
-}
-
-template <typename T>
-const T& Uniform(const std::vector<T>& vec) {
-  return vec[Uniform(static_cast<size_t>(0), vec.size())];
+template <typename Container,
+          typename R = decltype(std::declval<Container>()[0])>
+R UniformElement(Container&& container) {
+  return container[Uniform(Range<size_t>::Until(std::size(container)))];
 }
 
 TACHYON_EXPORT bool Bernoulli(double probability);

--- a/tachyon/base/random_unittest.cc
+++ b/tachyon/base/random_unittest.cc
@@ -9,15 +9,55 @@ constexpr int kMin = 0;
 constexpr int kMax = 1000;
 constexpr size_t kCount = 1000;
 
-TEST(Random, BasicTest) {
-  int r = Uniform(kMin, kMax);
+template <typename RangeType>
+class RandomWithRangeTest : public testing::Test {};
+
+using RangeTypes =
+    testing::Types<Range<int, false, false>, Range<int, false, true>,
+                   Range<int, true, false>, Range<int, true, true>>;
+TYPED_TEST_SUITE(RandomWithRangeTest, RangeTypes);
+
+TYPED_TEST(RandomWithRangeTest, SampleDifferentValue) {
+  using RangeType = TypeParam;
+
+  int r = Uniform(RangeType(kMin, kMax));
   for (size_t i = 0; i < kCount; ++i) {
-    if (r != Uniform(kMin, kMax)) {
+    if (r != Uniform(RangeType(kMin, kMax))) {
       SUCCEED();
       return;
     }
   }
   FAIL() << "random seems not working";
+}
+
+TYPED_TEST(RandomWithRangeTest, SampleWithinRange) {
+  using RangeType = TypeParam;
+
+  RangeType range(kMin, kMax);
+  int value = Uniform(range);
+  EXPECT_TRUE(range.Contains(value));
+}
+
+TEST(RandomTest, UniformElementWithArray) {
+  int arr[] = {1, 2, 3};
+  int r = UniformElement(arr);
+  EXPECT_GE(r, 1);
+  EXPECT_LE(r, 3);
+}
+
+TEST(RandomTest, UniformElementWithVector) {
+  std::vector<int> vec = {1, 2, 3};
+  int& r = UniformElement(vec);
+  EXPECT_GE(r, 1);
+  EXPECT_LE(r, 3);
+  r = 2;
+}
+
+TEST(RandomTest, UniformElementWithConstVector) {
+  const std::vector<int> vec = {1, 2, 3};
+  const int& r = UniformElement(vec);
+  EXPECT_GE(r, 1);
+  EXPECT_LE(r, 3);
 }
 
 }  // namespace tachyon::base

--- a/tachyon/base/range.h
+++ b/tachyon/base/range.h
@@ -1,0 +1,86 @@
+#ifndef TACHYON_BASE_RANGE_H_
+#define TACHYON_BASE_RANGE_H_
+
+#include <limits>
+#include <string>
+#include <type_traits>
+
+#include "absl/strings/substitute.h"
+
+namespace tachyon::base {
+
+template <typename T, bool IsStartInclusive = true, bool IsEndInclusive = false,
+          typename SFINAE = void>
+struct Range;
+
+template <typename T, bool IsStartInclusive, bool IsEndInclusive>
+struct Range<T, IsStartInclusive, IsEndInclusive,
+             std::enable_if_t<std::is_arithmetic_v<T>>> {
+  constexpr static bool kIsStartInclusive = IsStartInclusive;
+  constexpr static bool kIsEndInclusive = IsEndInclusive;
+
+  // Returns the lowest finite value representable by the numeric type T, that
+  // is, a finite value x such that there is no other finite value y where
+  // y < x. This is different from std::numeric_limits<T>::min() for
+  // floating-point types. Only meaningful for bounded types.
+  // See https://en.cppreference.com/w/cpp/types/numeric_limits/lowest
+  // NOTE(chokobole): I used |lowest()| over |min()| for the reason above.
+  T start = std::numeric_limits<T>::lowest();
+  T end = std::numeric_limits<T>::max();
+
+  constexpr Range() = default;
+  constexpr Range(T start, T end) : start(start), end(end) {}
+
+  constexpr static Range All() { return Range(); }
+
+  constexpr static Range From(T start) {
+    Range range;
+    range.start = start;
+    return range;
+  }
+
+  constexpr static Range Until(T end) {
+    Range range;
+    range.end = end;
+    return range;
+  }
+
+  // Returns true if the range doesn't contain any value. |Contains()| always
+  // gives you false in this case.
+  constexpr bool IsEmpty() const {
+    if constexpr (IsStartInclusive && IsEndInclusive) {
+      return start > end;
+    } else {
+      return start >= end;
+    }
+  }
+
+  // Returns true if the range contains |value|.
+  constexpr bool Contains(T value) const {
+    if constexpr (IsStartInclusive && IsEndInclusive) {
+      return start <= value && value <= end;
+    } else if constexpr (IsStartInclusive && !IsEndInclusive) {
+      return start <= value && value < end;
+    } else if constexpr (!IsStartInclusive && IsEndInclusive) {
+      return start < value && value <= end;
+    } else {
+      return start < value && value < end;
+    }
+  }
+
+  std::string ToString() const {
+    if constexpr (IsStartInclusive && IsEndInclusive) {
+      return absl::Substitute("$0 ≤ x ≤ $1", start, end);
+    } else if constexpr (IsStartInclusive && !IsEndInclusive) {
+      return absl::Substitute("$0 ≤ x < $1", start, end);
+    } else if constexpr (!IsStartInclusive && IsEndInclusive) {
+      return absl::Substitute("$0 < x ≤ $1", start, end);
+    } else {
+      return absl::Substitute("$0 < x < $1", start, end);
+    }
+  }
+};
+
+}  // namespace tachyon::base
+
+#endif  // TACHYON_BASE_RANGE_H_

--- a/tachyon/base/range_unittest.cc
+++ b/tachyon/base/range_unittest.cc
@@ -1,0 +1,47 @@
+#include "tachyon/base/range.h"
+
+#include "gtest/gtest.h"
+
+namespace tachyon::base {
+
+template <typename RangeType>
+class RangeTest : public testing::Test {};
+
+using RangeTypes =
+    testing::Types<Range<int, false, false>, Range<int, false, true>,
+                   Range<int, true, false>, Range<int, true, true>>;
+TYPED_TEST_SUITE(RangeTest, RangeTypes);
+
+TYPED_TEST(RangeTest, IsEmpty) {
+  using RangeType = TypeParam;
+
+  RangeType range(3, 3);
+  if constexpr (RangeType::kIsStartInclusive && RangeType::kIsEndInclusive) {
+    EXPECT_FALSE(range.IsEmpty());
+  } else {
+    EXPECT_TRUE(range.IsEmpty());
+  }
+
+  range = RangeType(3, 4);
+  EXPECT_FALSE(range.IsEmpty());
+}
+
+TYPED_TEST(RangeTest, Contains) {
+  using RangeType = TypeParam;
+
+  RangeType range(3, 4);
+  EXPECT_FALSE(range.Contains(2));
+  if constexpr (RangeType::kIsStartInclusive) {
+    EXPECT_TRUE(range.Contains(3));
+  } else {
+    EXPECT_FALSE(range.Contains(3));
+  }
+  if constexpr (RangeType::kIsEndInclusive) {
+    EXPECT_TRUE(range.Contains(4));
+  } else {
+    EXPECT_FALSE(range.Contains(4));
+  }
+  EXPECT_FALSE(range.Contains(5));
+}
+
+}  // namespace tachyon::base

--- a/tachyon/device/gpu/gpu_memory_unittest.cc
+++ b/tachyon/device/gpu/gpu_memory_unittest.cc
@@ -1,6 +1,5 @@
 #include "tachyon/device/gpu/gpu_memory.h"
 
-#include <limits>
 #include <vector>
 
 #include "gtest/gtest.h"
@@ -66,10 +65,8 @@ TEST(GpuMemoryTest, CopyFrom) {
 #endif  // TACHYON_CUDA
 
   {
-    std::vector<int> host_memory = base::CreateVector(512, []() {
-      return base::Uniform(static_cast<int>(0),
-                           std::numeric_limits<int>::max());
-    });
+    std::vector<int> host_memory = base::CreateVector(
+        512, []() { return base::Uniform(base::Range<int>::From(0)); });
     std::vector<std::vector<int>> results;
     results.resize(memories.size());
     for (size_t i = 0; i < memories.size(); ++i) {
@@ -89,7 +86,7 @@ TEST(GpuMemoryTest, CopyFrom) {
     auto unified_memory = GpuMemory<int>::MallocManaged(512);
     absl::Span<int> unified_memory_view(unified_memory.get(), 512);
     for (int& v : unified_memory_view) {
-      v = base::Uniform(static_cast<int>(0), std::numeric_limits<int>::max());
+      v = base::Uniform(base::Range<int>::From(0));
     }
     std::vector<std::vector<int>> results;
     results.resize(memories.size());

--- a/tachyon/math/base/arithmetics_unittest.cc
+++ b/tachyon/math/base/arithmetics_unittest.cc
@@ -11,33 +11,33 @@ namespace tachyon::math::internal {
 namespace {
 
 uint32_t GetRandomLo32() {
-  return base::Uniform(uint32_t{0}, std::numeric_limits<uint32_t>::max() / 2);
+  return base::Uniform(
+      base::Range<uint32_t>::Until(std::numeric_limits<uint32_t>::max() / 2));
 }
 
 uint32_t GetRandomHi32() {
-  return base::Uniform(std::numeric_limits<uint32_t>::max() / 2,
-                       std::numeric_limits<uint32_t>::max());
+  return base::Uniform(
+      base::Range<uint32_t>::From(std::numeric_limits<uint32_t>::max() / 2));
 }
 
 uint32_t GetRandomSqrt32() {
-  return base::Uniform(
-      uint32_t{0},
-      static_cast<uint32_t>(std::sqrt(std::numeric_limits<uint32_t>::max())));
+  return base::Uniform(base::Range<uint32_t>::Until(
+      static_cast<uint32_t>(std::sqrt(std::numeric_limits<uint32_t>::max()))));
 }
 
 uint64_t GetRandomLo64() {
-  return base::Uniform(uint64_t{0}, std::numeric_limits<uint64_t>::max() / 2);
+  return base::Uniform(
+      base::Range<uint64_t>::Until(std::numeric_limits<uint64_t>::max() / 2));
 }
 
 uint64_t GetRandomHi64() {
-  return base::Uniform(std::numeric_limits<uint64_t>::max() / 2,
-                       std::numeric_limits<uint64_t>::max());
+  return base::Uniform(
+      base::Range<uint64_t>::From(std::numeric_limits<uint64_t>::max() / 2));
 }
 
 uint64_t GetRandomSqrt64() {
-  return base::Uniform(
-      uint64_t{0},
-      static_cast<uint64_t>(std::sqrt(std::numeric_limits<uint64_t>::max())));
+  return base::Uniform(base::Range<uint64_t>::Until(
+      static_cast<uint64_t>(std::sqrt(std::numeric_limits<uint64_t>::max()))));
 }
 
 }  // namespace

--- a/tachyon/math/base/big_int.h
+++ b/tachyon/math/base/big_int.h
@@ -105,8 +105,7 @@ struct ALIGNAS(internal::LimbsAlignment(N)) BigInt {
   constexpr static BigInt Random(const BigInt& max = Max()) {
     BigInt ret;
     for (size_t i = 0; i < N; ++i) {
-      ret[i] = base::Uniform<uint64_t, uint64_t>(
-          0, std::numeric_limits<uint64_t>::max());
+      ret[i] = base::Uniform(base::Range<uint64_t>::All());
     }
     while (ret >= max) {
       ret.DivBy2InPlace();

--- a/tachyon/math/elliptic_curves/msm/test/msm_test_set.h
+++ b/tachyon/math/elliptic_curves/msm/test/msm_test_set.h
@@ -68,13 +68,13 @@ struct MSMTestSet {
     {
       std::stringstream ss;
       for (size_t i = 0; i < bases.size(); ++i) {
-        ss << bases[i] << std::endl;
+        ss << bases[i].ToString() << std::endl;
       }
       if (!base::WriteFile(dir.Append("bases.txt"), ss.str())) return false;
     }
     std::stringstream ss;
     for (size_t i = 0; i < scalars.size(); ++i) {
-      ss << scalars[i] << std::endl;
+      ss << scalars[i].ToString() << std::endl;
     }
     return base::WriteFile(dir.Append("scalars.txt"), ss.str());
   }

--- a/tachyon/math/elliptic_curves/msm/test/msm_test_set.h
+++ b/tachyon/math/elliptic_curves/msm/test/msm_test_set.h
@@ -45,7 +45,7 @@ struct MSMTestSet {
     std::vector<ScalarField> scalar_sets =
         base::CreateVector(scalar_size, []() { return ScalarField::Random(); });
     test_set.scalars = base::CreateVector(
-        size, [&scalar_sets]() { return base::Uniform(scalar_sets); });
+        size, [&scalar_sets]() { return base::UniformElement(scalar_sets); });
     test_set.ComputeAnswer(method);
     return test_set;
   }

--- a/tachyon/math/finite_fields/goldilocks_prime/prime_field_goldilocks.h
+++ b/tachyon/math/finite_fields/goldilocks_prime/prime_field_goldilocks.h
@@ -50,7 +50,7 @@ class PrimeField<_Config, std::enable_if_t<_Config::kIsGoldilocks>> final
   static PrimeField Random() { return PrimeField(RandomForTesting()); }
 
   static uint64_t RandomForTesting() {
-    return base::Uniform<uint64_t, uint64_t>(0, Config::kModulus[0]);
+    return base::Uniform(base::Range<uint64_t>::Until(Config::kModulus[0]));
   }
 
   constexpr static PrimeField FromDecString(std::string_view str) {

--- a/tachyon/math/polynomials/multivariate/multivariate_sparse_coefficients.h
+++ b/tachyon/math/polynomials/multivariate/multivariate_sparse_coefficients.h
@@ -192,14 +192,15 @@ class MultivariateSparseCoefficients {
                                                size_t min_term = 1,
                                                size_t max_term = 999) {
     Terms terms;
-    size_t num_terms = base::Uniform(min_term, max_term);
+    size_t num_terms = base::Uniform(base::Range<size_t>(min_term, max_term));
     terms.push_back(Term::Constant(F::Random()));
     for (size_t i = 1; i < num_terms; ++i) {
       for (size_t j = 0; j < arity; ++j) {
         if (base::Bernoulli(0.5) > 0.5) {
           terms.insert(
               terms.begin(),
-              {{{{j, base::Uniform(size_t{0}, exponent)}}}, F::Random()});
+              {{{{j, base::Uniform(base::Range<size_t>(size_t{0}, exponent))}}},
+               F::Random()});
         }
       }
     }


### PR DESCRIPTION
# Description

This PR implements `Range` class that covers all these intervals.

- inclusive and inclusive (a ≤ x ≤ b)
- inclusive and exlusive (a ≤ x < b)
- exclusive and inclusive (a < x ≤ b)
- exclusive and exlusive (a < x < b)

In addition, `UniformXXX()` function now makes use of this `Range`.