### PR TITLE
feat(math): impl function that gen entire root of unity

### DIFF
--- a/tachyon/math/polynomials/univariate/univariate_evaluation_domain_unittest.cc
+++ b/tachyon/math/polynomials/univariate/univariate_evaluation_domain_unittest.cc
@@ -315,7 +315,7 @@ TYPED_TEST(UnivariateEvaluationDomainTest, RootsOfUnity) {
       std::unique_ptr<UnivariateEvaluationDomainType> domain =
           UnivariateEvaluationDomainType::Create(coeffs);
       std::vector<bls12_381::Fr> actual_roots =
-          domain->GetRootsOfUnity(domain->group_gen());
+          domain->GetRootsOfUnity(domain->size() / 2, domain->group_gen());
       for (const bls12_381::Fr& value : actual_roots) {
         EXPECT_TRUE(domain->EvaluateVanishingPolynomial(value).IsZero());
       }


### PR DESCRIPTION
# Description

Currently, the `GetRootsOfUnity()` function returns the first half of R.O.U.
In this commit, it changes to generate R.O.U based on a given size.
