### PR TITLE
feat(math): move radix2 funcs to parent class

### DIFF
--- a/tachyon/math/polynomials/univariate/BUILD.bazel
+++ b/tachyon/math/polynomials/univariate/BUILD.bazel
@@ -48,7 +48,10 @@ tachyon_cc_library(
 tachyon_cc_library(
     name = "univariate_evaluation_domain_factory",
     hdrs = ["univariate_evaluation_domain_factory.h"],
-    deps = [":radix2_evaluation_domain"],
+    deps = [
+        ":mixed_radix_evaluation_domain",
+        ":radix2_evaluation_domain",
+    ],
 )
 
 tachyon_cc_library(

--- a/tachyon/math/polynomials/univariate/radix2_evaluation_domain.h
+++ b/tachyon/math/polynomials/univariate/radix2_evaluation_domain.h
@@ -84,34 +84,6 @@ class Radix2EvaluationDomain : public UnivariateEvaluationDomain<F, MaxDegree> {
     return min_num_chunks_for_compaction_;
   }
 
-  // Computes the first |size| roots of unity for the entire domain.
-  // e.g. for the domain [1, g, g², ..., gⁿ⁻¹}] and |size| = n / 2, it computes
-  // [1, g, g², ..., g^{(n / 2) - 1}]
-  constexpr std::vector<F> GetRootsOfUnity(size_t size, const F& root) const {
-#if defined(TACHYON_HAS_OPENMP)
-    uint32_t log_size = base::bits::SafeLog2Ceiling(this->size_);
-    if (log_size <= kMinLogRootsOfUnitySizeForParallelization)
-#endif
-      return ComputePowersSerial(size, root);
-#if defined(TACHYON_HAS_OPENMP)
-    size_t required_log_size = size_t{base::bits::SafeLog2Ceiling(size)};
-    F power = root;
-    // [g, g², g⁴, g⁸, ..., g^(2^(|required_log_size|))]
-    std::vector<F> log_powers =
-        base::CreateVector(required_log_size, [&power]() {
-          F old_value = power;
-          power.SquareInPlace();
-          return old_value;
-        });
-
-    // allocate the return array and start the recursion
-    std::vector<F> powers =
-        base::CreateVector(size_t{1} << required_log_size, F::Zero());
-    GetRootsOfUnityRecursive(powers, absl::MakeConstSpan(log_powers));
-    return powers;
-#endif
-  }
-
  private:
   template <typename T>
   FRIEND_TEST(UnivariateEvaluationDomainTest, RootsOfUnity);
@@ -174,8 +146,7 @@ class Radix2EvaluationDomain : public UnivariateEvaluationDomain<F, MaxDegree> {
     CHECK_GE(log_n, log_d);
     size_t duplicity_of_initials = size_t{1} << (log_n - log_d);
     evals.evaluations_.resize(n, F::Zero());
-    UnivariateEvaluationDomain<F, MaxDegree>::SwapElements(evals, num_coeffs,
-                                                           log_n);
+    this->SwapElements(evals, num_coeffs, log_n);
     if (duplicity_of_initials > 1) {
       auto chunks = base::Chunked(evals.evaluations_, duplicity_of_initials);
       std::vector<absl::Span<F>> chunks_vector =
@@ -217,8 +188,7 @@ class Radix2EvaluationDomain : public UnivariateEvaluationDomain<F, MaxDegree> {
   constexpr void FFTHelperInPlace(Evals& evals) const {
     uint32_t log_len = static_cast<uint32_t>(base::bits::Log2Ceiling(
         static_cast<uint32_t>(evals.evaluations_.size())));
-    UnivariateEvaluationDomain<F, MaxDegree>::SwapElements(
-        evals, evals.evaluations_.size() - 1, log_len);
+    this->SwapElements(evals, evals.evaluations_.size() - 1, log_len);
     OutInHelper(evals, this->group_gen_, 1);
   }
 
@@ -229,8 +199,8 @@ class Radix2EvaluationDomain : public UnivariateEvaluationDomain<F, MaxDegree> {
     InOutHelper(poly, this->group_gen_inv_);
     uint32_t log_len = static_cast<uint32_t>(base::bits::Log2Ceiling(
         static_cast<uint32_t>(poly.coefficients_.coefficients_.size())));
-    UnivariateEvaluationDomain<F, MaxDegree>::SwapElements(
-        poly, poly.coefficients_.coefficients_.size() - 1, log_len);
+    this->SwapElements(poly, poly.coefficients_.coefficients_.size() - 1,
+                       log_len);
   }
 
   template <FFTOrder Order, typename PolyOrEvals>
@@ -265,67 +235,8 @@ class Radix2EvaluationDomain : public UnivariateEvaluationDomain<F, MaxDegree> {
     }
   }
 
-#if defined(TACHYON_HAS_OPENMP)
-  constexpr void GetRootsOfUnityRecursive(
-      std::vector<F>& out, const absl::Span<const F>& log_powers) const {
-    CHECK_EQ(out.size(), size_t{1} << log_powers.size());
-    // base case: just compute the powers sequentially,
-    // g = log_powers[0], |out| = [1, g, g², ..., g^(|log_powers.size() - 1|)]
-    if (log_powers.size() <=
-        size_t{kMinLogRootsOfUnitySizeForParallelization}) {
-      out[0] = F::One();
-      for (size_t i = 1; i < out.size(); ++i) {
-        out[i] = out[i - 1] * log_powers[0];
-      }
-      return;
-    }
-
-    // recursive case:
-    // 1. split |log_powers| in half
-    // |log_powers| =[g, g², g⁴, g⁸]
-    size_t half_size = (1 + log_powers.size()) / 2;
-    // |log_powers_lo| = [g, g²]
-    absl::Span<const F> log_powers_lo = log_powers.subspan(0, half_size);
-    // |log_powers_lo| = [g⁴, g⁸]
-    absl::Span<const F> log_powers_hi = log_powers.subspan(half_size);
-    std::vector<F> src_lo =
-        base::CreateVector(1 << log_powers_lo.size(), F::Zero());
-    std::vector<F> src_hi =
-        base::CreateVector(1 << log_powers_hi.size(), F::Zero());
-
-    // clang-format off
-    // 2. compute each half individually
-    // |src_lo| = [1, g, g², g³]
-    // |src_hi| = [1, g⁴, g⁸, g¹²]
-    // clang-format on
-#pragma omp parallel for
-    for (size_t i = 0; i < 2; ++i) {
-      GetRootsOfUnityRecursive(i == 0 ? src_lo : src_hi,
-                               i == 0 ? log_powers_lo : log_powers_hi);
-    }
-
-    // clang-format off
-    // 3. recombine halves
-    // At this point, out is a blank slice.
-    // |out| = [1, g, g², g³, g⁴, g⁵, g⁶, g⁷, g⁸, ... g¹², g¹³, g¹⁴, g¹⁵]
-    // clang-format on
-    auto out_chunks = base::Chunked(out, src_lo.size());
-    std::vector<absl::Span<F>> out_chunks_vector =
-        base::Map(out_chunks.begin(), out_chunks.end(),
-                  [](const absl::Span<F>& chunk) { return chunk; });
-#pragma omp parallel for
-    for (size_t i = 0; i < out_chunks_vector.size(); ++i) {
-      const F& hi = src_hi[i];
-      absl::Span<F> out_chunks = out_chunks_vector[i];
-      for (size_t j = 0; j < out_chunks.size(); ++j) {
-        out_chunks[j] = hi * src_lo[j];
-      }
-    }
-  }
-#endif
-
   constexpr void InOutHelper(DensePoly& poly, const F& root) const {
-    std::vector<F> roots = GetRootsOfUnity(this->size_ / 2, root);
+    std::vector<F> roots = this->GetRootsOfUnity(this->size_ / 2, root);
     size_t step = 1;
     bool first = true;
 
@@ -367,7 +278,7 @@ class Radix2EvaluationDomain : public UnivariateEvaluationDomain<F, MaxDegree> {
 
   constexpr void OutInHelper(Evals& evals, const F& root,
                              size_t start_gap) const {
-    std::vector<F> roots_cache = GetRootsOfUnity(this->size_ / 2, root);
+    std::vector<F> roots_cache = this->GetRootsOfUnity(this->size_ / 2, root);
     // The |std::min| is only necessary for the case where
     // |min_num_chunks_for_compaction_ = 1|. Else, notice that we compact the
     // |roots_cache| by a |step| of at least |min_num_chunks_for_compaction_|.
@@ -406,18 +317,6 @@ class Radix2EvaluationDomain : public UnivariateEvaluationDomain<F, MaxDegree> {
           gap);
       gap *= 2;
     }
-  }
-
-  constexpr static std::vector<F> ComputePowersSerial(size_t size,
-                                                      const F& root) {
-    return ComputePowersAndMulByConstSerial(size, root, F::One());
-  }
-
-  constexpr static std::vector<F> ComputePowersAndMulByConstSerial(
-      size_t size, const F& root, const F& c) {
-    F value = c;
-    return base::CreateVector(
-        size, [&value, root]() { return std::exchange(value, value * root); });
   }
 
   size_t min_num_chunks_for_compaction_ = kDefaultMinNumChunksForCompaction;

--- a/tachyon/math/polynomials/univariate/univariate_evaluation_domain_factory.h
+++ b/tachyon/math/polynomials/univariate/univariate_evaluation_domain_factory.h
@@ -16,7 +16,7 @@ namespace tachyon::math {
 template <typename F>
 constexpr size_t MaxDegreeForEvaluationDomainFactory() {
   size_t i = 1;
-  if constexpr (Config::kHasLargeSubgroupRootOfUnity) {
+  if constexpr (F::Config::kHasLargeSubgroupRootOfUnity) {
     for (size_t i = 0; i <= F::Config::kSmallSubgroupAdicity; ++i) {
       i *= F::Config::kSmallSubgroupBase;
     }

--- a/tachyon/math/polynomials/univariate/univariate_evaluation_domain_unittest.cc
+++ b/tachyon/math/polynomials/univariate/univariate_evaluation_domain_unittest.cc
@@ -310,23 +310,18 @@ TYPED_TEST(UnivariateEvaluationDomainTest, RootsOfUnity) {
   using UnivariateEvaluationDomainType = TypeParam;
   using F = typename UnivariateEvaluationDomainType::Field;
 
-  if constexpr (std::is_same_v<F, bls12_381::Fr>) {
-    for (size_t coeffs = 0; coeffs < kNumCoeffs; ++coeffs) {
-      std::unique_ptr<UnivariateEvaluationDomainType> domain =
-          UnivariateEvaluationDomainType::Create(coeffs);
-      std::vector<bls12_381::Fr> actual_roots =
-          domain->GetRootsOfUnity(domain->size() / 2, domain->group_gen());
-      for (const bls12_381::Fr& value : actual_roots) {
-        EXPECT_TRUE(domain->EvaluateVanishingPolynomial(value).IsZero());
-      }
-      EXPECT_EQ(actual_roots.size(), domain->size() / 2);
-      std::vector<bls12_381::Fr> expected_roots = domain->GetElements();
-      EXPECT_EQ(absl::MakeConstSpan(actual_roots),
-                absl::Span(expected_roots.data(), actual_roots.size()));
+  for (size_t coeffs = 0; coeffs < kNumCoeffs; ++coeffs) {
+    std::unique_ptr<UnivariateEvaluationDomainType> domain =
+        UnivariateEvaluationDomainType::Create(coeffs);
+    std::vector<F> actual_roots =
+        domain->GetRootsOfUnity(domain->size(), domain->group_gen());
+    for (const F& value : actual_roots) {
+      EXPECT_TRUE(domain->EvaluateVanishingPolynomial(value).IsZero());
     }
-  } else {
-    GTEST_SKIP() << "Skip testing RootsOfUnity on "
-                    "MixedRadixEvaluationDomain";
+    EXPECT_EQ(actual_roots.size(), domain->size());
+    std::vector<F> expected_roots = domain->GetElements();
+    EXPECT_EQ(absl::MakeConstSpan(actual_roots),
+              absl::Span(expected_roots.data(), actual_roots.size()));
   }
 }
 


### PR DESCRIPTION
The `GetRootsOfDomain()` func, which was only implemented in `Radix2EvaluationDomain`, has been moved to the Base class so it can be used there as well.
And fix some bug.