### PR TITLE
feat(zk): implement halo2 permutation keygen

### DIFF
--- a/tachyon/zk/plonk/BUILD.bazel
+++ b/tachyon/zk/plonk/BUILD.bazel
@@ -3,6 +3,12 @@ load("//bazel:tachyon_cc.bzl", "tachyon_cc_library")
 package(default_visibility = ["//visibility:public"])
 
 tachyon_cc_library(
+    name = "commitment",
+    hdrs = ["commitment.h"],
+    deps = ["//tachyon/math/elliptic_curves:points"],
+)
+
+tachyon_cc_library(
     name = "constraint_system",
     hdrs = ["constraint_system.h"],
     deps = [

--- a/tachyon/zk/plonk/commitment.h
+++ b/tachyon/zk/plonk/commitment.h
@@ -1,0 +1,23 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
+#ifndef TACHYON_ZK_PLONK_COMMITMENT_H_
+#define TACHYON_ZK_PLONK_COMMITMENT_H_
+
+#include <vector>
+
+#include "tachyon/math/elliptic_curves/affine_point.h"
+
+namespace tachyon::zk {
+
+template <typename Curve>
+using Commitment = math::AffinePoint<Curve>;
+template <typename Curve>
+using Commitments = std::vector<Commitment<Curve>>;
+
+}  // namespace tachyon::zk
+
+#endif  // TACHYON_ZK_PLONK_COMMITMENT_H_

--- a/tachyon/zk/plonk/permutation/BUILD.bazel
+++ b/tachyon/zk/plonk/permutation/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//bazel:tachyon_cc.bzl", "tachyon_cc_library")
+load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_unittest")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -6,4 +6,27 @@ tachyon_cc_library(
     name = "label",
     hdrs = ["label.h"],
     deps = ["//tachyon:export"],
+)
+
+tachyon_cc_library(
+    name = "lookup_table",
+    hdrs = ["lookup_table.h"],
+    deps = [
+        ":label",
+        "//tachyon/base/containers:container_util",
+        "//tachyon/math/polynomials/univariate:univariate_evaluation_domain",
+        "@com_google_googletest//:gtest_prod",
+    ],
+)
+
+tachyon_cc_unittest(
+    name = "permutation_unittests",
+    srcs = [
+        "lookup_table_unittest.cc",
+    ],
+    deps = [
+        ":lookup_table",
+        "//tachyon/math/elliptic_curves/bn/bn254:g1",
+        "//tachyon/math/polynomials/univariate:univariate_evaluation_domain_factory",
+    ],
 )

--- a/tachyon/zk/plonk/permutation/BUILD.bazel
+++ b/tachyon/zk/plonk/permutation/BUILD.bazel
@@ -20,6 +20,15 @@ tachyon_cc_library(
 )
 
 tachyon_cc_library(
+    name = "permutation_argument",
+    hdrs = ["permutation_argument.h"],
+    deps = [
+        "//tachyon/base/containers:contains",
+        "//tachyon/zk/plonk/circuit:column",
+    ],
+)
+
+tachyon_cc_library(
     name = "permutation_proving_key",
     hdrs = ["permutation_proving_key.h"],
     deps = [
@@ -42,11 +51,13 @@ tachyon_cc_unittest(
     name = "permutation_unittests",
     srcs = [
         "lookup_table_unittest.cc",
+        "permutation_argument_unittest.cc",
         "permutation_proving_key_unittest.cc",
         "permutation_verifying_key_unittest.cc",
     ],
     deps = [
         ":lookup_table",
+        ":permutation_argument",
         ":permutation_proving_key",
         ":permutation_verifying_key",
         "//tachyon/base/buffer:vector_buffer",

--- a/tachyon/zk/plonk/permutation/BUILD.bazel
+++ b/tachyon/zk/plonk/permutation/BUILD.bazel
@@ -19,14 +19,39 @@ tachyon_cc_library(
     ],
 )
 
+tachyon_cc_library(
+    name = "permutation_proving_key",
+    hdrs = ["permutation_proving_key.h"],
+    deps = [
+        "//tachyon/base/buffer:copyable",
+        "//tachyon/zk/plonk:commitment",
+    ],
+)
+
+tachyon_cc_library(
+    name = "permutation_verifying_key",
+    hdrs = ["permutation_verifying_key.h"],
+    deps = [
+        "//tachyon/base/buffer:copyable",
+        "//tachyon/math/polynomials/univariate:univariate_evaluations",
+        "//tachyon/math/polynomials/univariate:univariate_polynomial",
+    ],
+)
+
 tachyon_cc_unittest(
     name = "permutation_unittests",
     srcs = [
         "lookup_table_unittest.cc",
+        "permutation_proving_key_unittest.cc",
+        "permutation_verifying_key_unittest.cc",
     ],
     deps = [
         ":lookup_table",
+        ":permutation_proving_key",
+        ":permutation_verifying_key",
+        "//tachyon/base/buffer:vector_buffer",
         "//tachyon/math/elliptic_curves/bn/bn254:g1",
+        "//tachyon/math/finite_fields/test:gf7",
         "//tachyon/math/polynomials/univariate:univariate_evaluation_domain_factory",
     ],
 )

--- a/tachyon/zk/plonk/permutation/BUILD.bazel
+++ b/tachyon/zk/plonk/permutation/BUILD.bazel
@@ -57,21 +57,34 @@ tachyon_cc_library(
     ],
 )
 
+tachyon_cc_library(
+    name = "permutation_assembly",
+    hdrs = ["permutation_assembly.h"],
+    deps = [
+        ":cycle_store",
+        ":label",
+        ":lookup_table",
+        ":permutation_argument",
+        ":permutation_proving_key",
+        ":permutation_verifying_key",
+        "//tachyon/base:openmp_util",
+        "//tachyon/base/containers:container_util",
+        "//tachyon/math/polynomials/univariate:univariate_evaluation_domain",
+    ],
+)
+
 tachyon_cc_unittest(
     name = "permutation_unittests",
     srcs = [
         "cycle_store_unittest.cc",
         "lookup_table_unittest.cc",
         "permutation_argument_unittest.cc",
+        "permutation_assembly_unittest.cc",
         "permutation_proving_key_unittest.cc",
         "permutation_verifying_key_unittest.cc",
     ],
     deps = [
-        ":cycle_store",
-        ":lookup_table",
-        ":permutation_argument",
-        ":permutation_proving_key",
-        ":permutation_verifying_key",
+        ":permutation_assembly",
         "//tachyon/base/buffer:vector_buffer",
         "//tachyon/math/elliptic_curves/bn/bn254:g1",
         "//tachyon/math/finite_fields/test:gf7",

--- a/tachyon/zk/plonk/permutation/BUILD.bazel
+++ b/tachyon/zk/plonk/permutation/BUILD.bazel
@@ -1,0 +1,9 @@
+load("//bazel:tachyon_cc.bzl", "tachyon_cc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+tachyon_cc_library(
+    name = "label",
+    hdrs = ["label.h"],
+    deps = ["//tachyon:export"],
+)

--- a/tachyon/zk/plonk/permutation/BUILD.bazel
+++ b/tachyon/zk/plonk/permutation/BUILD.bazel
@@ -3,6 +3,16 @@ load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_unittest")
 package(default_visibility = ["//visibility:public"])
 
 tachyon_cc_library(
+    name = "cycle_store",
+    srcs = ["cycle_store.cc"],
+    hdrs = ["cycle_store.h"],
+    deps = [
+        ":label",
+        "//tachyon/base/containers:container_util",
+    ],
+)
+
+tachyon_cc_library(
     name = "label",
     hdrs = ["label.h"],
     deps = ["//tachyon:export"],
@@ -50,12 +60,14 @@ tachyon_cc_library(
 tachyon_cc_unittest(
     name = "permutation_unittests",
     srcs = [
+        "cycle_store_unittest.cc",
         "lookup_table_unittest.cc",
         "permutation_argument_unittest.cc",
         "permutation_proving_key_unittest.cc",
         "permutation_verifying_key_unittest.cc",
     ],
     deps = [
+        ":cycle_store",
         ":lookup_table",
         ":permutation_argument",
         ":permutation_proving_key",

--- a/tachyon/zk/plonk/permutation/cycle_store.cc
+++ b/tachyon/zk/plonk/permutation/cycle_store.cc
@@ -1,0 +1,53 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
+#include "tachyon/zk/plonk/permutation/cycle_store.h"
+
+#include <utility>
+
+namespace tachyon::zk {
+
+bool CycleStore::MergeCycle(const Label& label, const Label& label2) {
+  Label left_cycle_base = GetCycleBase(label);
+  Label right_cycle_base = GetCycleBase(label2);
+  if (left_cycle_base == right_cycle_base) return false;
+
+  // Ensure that the cell with a larger cycle size becomes the left.
+  if (sizes_[left_cycle_base] < sizes_[right_cycle_base]) {
+    std::swap(left_cycle_base, right_cycle_base);
+  }
+
+  // Merge the right cycle into the left one.
+  sizes_[left_cycle_base] += sizes_[right_cycle_base];
+  Label l = right_cycle_base;
+  while (true) {
+    aux_[l] = left_cycle_base;
+    l = mapping_[l];
+    if (l == right_cycle_base) {
+      break;
+    }
+  }
+
+  std::swap(mapping_[label], mapping_[label2]);
+  return true;
+}
+
+std::vector<Label> CycleStore::GetAllLabels(const Label& label) const {
+  std::vector<Label> ret;
+  Label base = GetCycleBase(label);
+  Label l = base;
+  ret.push_back(l);
+  while (true) {
+    l = mapping_[l];
+    ret.push_back(l);
+    if (l == base) {
+      break;
+    }
+  }
+  return ret;
+}
+
+}  // namespace tachyon::zk

--- a/tachyon/zk/plonk/permutation/cycle_store.h
+++ b/tachyon/zk/plonk/permutation/cycle_store.h
@@ -1,0 +1,130 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
+#ifndef TACHYON_ZK_PLONK_PERMUTATION_CYCLE_STORE_H_
+#define TACHYON_ZK_PLONK_PERMUTATION_CYCLE_STORE_H_
+
+#include <utility>
+#include <vector>
+
+#include "tachyon/base/containers/container_util.h"
+#include "tachyon/export.h"
+#include "tachyon/zk/plonk/permutation/label.h"
+
+namespace tachyon::zk {
+
+// CycleStore stores cycle that is used to constrain equality between values.
+//
+//   For example, given two disjoint cycles (A B C D) and (E F G H):
+//
+//   A +---> B
+//   ^       +
+//   |       |
+//   +       v
+//   D <---+ C       E +---> F
+//                   ^       +
+//                   |       |
+//                   +       v
+//                   H <---+ G
+//
+//   CycleStore store;
+//   Label a; // A
+//   Label b; // B
+//   Label e; // E
+//
+//   CHECK_EQ(store.GetCycleBase(a), store.GetCycleBase(b));
+//   CHECK(store.CheckSameCycle(a, b));
+//   CHECK_NE(store.GetCycleBase(a), store.GetCycleBase(e));
+//   CHECK(!store.CheckSameCycle(a, e));
+//
+//   CHECK_EQ(store.GetCycleSize(a), size_t{4});
+//
+//   After adding constraint B ≡ E the above algorithm produces the cycle:
+//
+//   A +---> B +-------------+
+//   ^                       |
+//   |                       |
+//   +                       v
+//   D <---+ C <---+ E       F
+//                   ^       +
+//                   |       |
+//                   +       v
+//                   H <---+ G
+//
+//   CHECK_EQ(store.GetCycleBase(a), store.GetCycleBase(b));
+//   CHECK(store.CheckSameCycle(a, b));
+//   CHECK_EQ(store.GetCycleBase(a), store.GetCycleBase(e));
+//   CHECK(store.CheckSameCycle(a, e));
+//
+//   CHECK_EQ(store.GetCycleSize(a), size_t{8});
+//
+// See
+// https://zcash.github.io/halo2/design/proving-system/permutation.html#algorithm.
+class TACHYON_EXPORT CycleStore {
+ public:
+  template <typename T>
+  class Table {
+   public:
+    Table() = default;
+    explicit Table(std::vector<std::vector<T>> values)
+        : values_(std::move(values)) {}
+
+    T& operator[](const Label& l) { return values_[l.col][l.row]; }
+    const T& operator[](const Label& l) const { return values_[l.col][l.row]; }
+
+   private:
+    std::vector<std::vector<T>> values_;
+  };
+
+  CycleStore() = default;
+  CycleStore(size_t cols, size_t rows) {
+    mapping_ = Table(base::CreateVector(cols, [rows](size_t col) {
+      return base::CreateVector(rows,
+                                [col](size_t row) { return Label(col, row); });
+    }));
+    aux_ = mapping_;
+    sizes_ =
+        Table(base::CreateVector(cols, base::CreateVector(rows, size_t{1})));
+  }
+
+  // Return the next label of given |label| within a cycle.
+  const Label& GetNextLabel(const Label& label) const {
+    return mapping_[label];
+  }
+
+  // Return the representative of cycle of given |label|.
+  const Label& GetCycleBase(const Label& label) const { return aux_[label]; }
+
+  // Return the size of the representative of cycle of given |label|.
+  size_t GetCycleSize(const Label& label) const {
+    return sizes_[GetCycleBase(label)];
+  }
+
+  // Return whether the representative of cycles of given |label| and |label2|
+  // belong to the same cycle.
+  bool CheckSameCycle(const Label& label, const Label& label2) const {
+    return GetCycleBase(label) == GetCycleBase(label2);
+  }
+
+  // Return false if the cycles of |label| and |label2| are same.
+  // Return true if two cycles are merged.
+  bool MergeCycle(const Label& label, const Label& label2);
+
+  // Return all the labels that are belong to the cycle of given |label|.
+  std::vector<Label> GetAllLabels(const Label& label) const;
+
+ private:
+  // |mapping_| keeps track of the next label for each cycle.
+  Table<Label> mapping_;
+  // |aux_| keeps track of the cycle for each label.
+  Table<Label> aux_;
+  // |sizes_| keeps track of the size of each cycle.
+  Table<size_t> sizes_;
+};
+
+}  // namespace tachyon::zk
+
+#endif  // TACHYON_ZK_PLONK_PERMUTATION_CYCLE_STORE_H_

--- a/tachyon/zk/plonk/permutation/cycle_store_unittest.cc
+++ b/tachyon/zk/plonk/permutation/cycle_store_unittest.cc
@@ -1,0 +1,53 @@
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
+#include "tachyon/zk/plonk/permutation/cycle_store.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include "tachyon/base/random.h"
+
+namespace tachyon::zk {
+
+TEST(CycleStoreTest, MergeCycle) {
+  constexpr size_t kCols = 10;
+  constexpr size_t kRows = 10;
+
+  CycleStore store(kCols, kRows);
+  std::vector<Label> labels;
+  labels.reserve(kCols * kRows);
+  for (size_t col = 0; col < kCols; ++col) {
+    for (size_t row = 0; row < kRows; ++row) {
+      Label l(col, row);
+      EXPECT_EQ(store.GetCycleBase(l), l);
+      EXPECT_EQ(store.GetCycleSize(l), size_t{1});
+      labels.push_back(l);
+    }
+  }
+
+  for (int i = 0; i < 10; ++i) {
+    Label label = base::UniformElement(labels);
+    Label label2 = base::UniformElement(labels);
+
+    bool belong_to_same_cycle = store.CheckSameCycle(label, label2);
+    size_t cycle_size = store.GetCycleSize(label);
+    size_t cycle_size2 = store.GetCycleSize(label2);
+    EXPECT_NE(belong_to_same_cycle, store.MergeCycle(label, label2));
+    if (belong_to_same_cycle) {
+      EXPECT_EQ(cycle_size, cycle_size2);
+      EXPECT_EQ(cycle_size, store.GetCycleSize(label));
+      EXPECT_EQ(cycle_size2, store.GetCycleSize(label2));
+    } else {
+      EXPECT_EQ(cycle_size + cycle_size2, store.GetCycleSize(label));
+      EXPECT_EQ(cycle_size + cycle_size2, store.GetCycleSize(label2));
+      EXPECT_TRUE(store.CheckSameCycle(label, label2));
+    }
+    EXPECT_THAT(store.GetAllLabels(label),
+                testing::UnorderedElementsAreArray(store.GetAllLabels(label2)));
+  }
+}
+
+}  // namespace tachyon::zk

--- a/tachyon/zk/plonk/permutation/label.h
+++ b/tachyon/zk/plonk/permutation/label.h
@@ -1,0 +1,30 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
+#ifndef TACHYON_ZK_PLONK_PERMUTATION_LABEL_H_
+#define TACHYON_ZK_PLONK_PERMUTATION_LABEL_H_
+
+#include <stddef.h>
+
+#include "tachyon/export.h"
+
+namespace tachyon::zk {
+
+struct TACHYON_EXPORT Label {
+  size_t col = 0;
+  size_t row = 0;
+
+  Label(size_t col, size_t row) : col(col), row(row) {}
+
+  bool operator==(const Label& other) const {
+    return col == other.col && row == other.row;
+  }
+  bool operator!=(const Label& other) const { return !operator==(other); }
+};
+
+}  // namespace tachyon::zk
+
+#endif  // TACHYON_ZK_PLONK_PERMUTATION_LABEL_H_

--- a/tachyon/zk/plonk/permutation/lookup_table.h
+++ b/tachyon/zk/plonk/permutation/lookup_table.h
@@ -1,0 +1,88 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
+#ifndef TACHYON_ZK_PLONK_PERMUTATION_LOOKUP_TABLE_H_
+#define TACHYON_ZK_PLONK_PERMUTATION_LOOKUP_TABLE_H_
+
+#include <utility>
+#include <vector>
+
+#include "gtest/gtest_prod.h"
+
+#include "tachyon/base/containers/container_util.h"
+#include "tachyon/math/polynomials/univariate/univariate_evaluation_domain.h"
+#include "tachyon/zk/plonk/permutation/label.h"
+
+namespace tachyon::zk {
+
+// The |LookupTable| contains elements that are the product-of-powers
+// of 𝛿 and w (called "label"). And each permutation polynomial (in evaluation
+// form) is constructed by assigning elements in the |LookupTable|.
+//
+// Let modulus = 2ˢ * T + 1, then
+// |LookupTable|
+// = [[𝛿ⁱw⁰, 𝛿ⁱw¹, 𝛿ⁱw², ..., 𝛿ⁱwⁿ⁻¹] for i in range(0..T-1)]
+template <typename F, size_t MaxDegree>
+class LookupTable {
+ public:
+  using Rows = std::vector<F>;
+  using Table = std::vector<Rows>;
+
+  LookupTable() = default;
+
+  const F& operator[](const Label& label) const {
+    return table_[label.col][label.row];
+  }
+  F& operator[](const Label& label) { return table_[label.col][label.row]; }
+
+  static LookupTable Construct(
+      size_t size,
+      const math::UnivariateEvaluationDomain<F, MaxDegree>* domain) {
+    // The w is gᵀ with order 2ˢ where modulus = 2ˢ * T + 1.
+    std::vector<F> omega_powers =
+        domain->GetRootsOfUnity(MaxDegree + 1, domain->group_gen());
+
+    // The 𝛿 is g^2ˢ with order T where modulus = 2ˢ * T + 1.
+    F delta = GetDelta();
+
+    Table lookup_table;
+    lookup_table.reserve(size);
+    // Assign [𝛿⁰w⁰, 𝛿⁰w¹, 𝛿⁰w², ..., 𝛿⁰wⁿ⁻¹] to the first row.
+    lookup_table.push_back(std::move(omega_powers));
+
+    // Assign [𝛿ⁱw⁰, 𝛿ⁱw¹, 𝛿ⁱw², ..., 𝛿ⁱwⁿ⁻¹] to each row.
+    for (size_t i = 1; i < size; ++i) {
+      Rows rows = base::CreateVector(MaxDegree + 1, F::Zero());
+      // TODO(dongchangYoo): Optimize this with
+      // https://github.com/kroma-network/tachyon/pull/115.
+      for (size_t j = 0; j <= MaxDegree; ++j) {
+        rows[j] = lookup_table[i - 1][j] * delta;
+      }
+      lookup_table.push_back(std::move(rows));
+    }
+    return LookupTable(std::move(lookup_table));
+  }
+
+ private:
+  FRIEND_TEST(LookupTableTest, Construct);
+
+  explicit LookupTable(Table table) : table_(std::move(table)) {}
+
+  // Calculate 𝛿 = g^2ˢ with order T (i.e., T-th root of unity),
+  // where T = F::Config::kTrace.
+  constexpr static F GetDelta() {
+    F g = F::FromMontgomery(F::Config::kSubgroupGenerator);
+    typename F::BigIntTy s(F::Config::kTwoAdicity);
+    F adicity = F(2).Pow(s);
+    return g.Pow(adicity.ToBigInt());
+  }
+
+  Table table_;
+};
+
+}  // namespace tachyon::zk
+
+#endif  // TACHYON_ZK_PLONK_PERMUTATION_LOOKUP_TABLE_H_

--- a/tachyon/zk/plonk/permutation/lookup_table_unittest.cc
+++ b/tachyon/zk/plonk/permutation/lookup_table_unittest.cc
@@ -1,0 +1,51 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
+#include "tachyon/zk/plonk/permutation/lookup_table.h"
+
+#include <memory>
+
+#include "gtest/gtest.h"
+
+#include "tachyon/math/elliptic_curves/bn/bn254/g1.h"
+#include "tachyon/math/polynomials/univariate/univariate_evaluation_domain_factory.h"
+
+namespace tachyon::zk {
+
+namespace {
+
+class LookupTableTest : public testing::Test {
+ public:
+  static void SetUpTestSuite() { math::bn254::G1Curve::Init(); }
+};
+
+}  // namespace
+
+TEST_F(LookupTableTest, Construct) {
+  constexpr size_t kMaxDegree = 7;
+  constexpr size_t kCols = 4;
+
+  using F = math::bn254::G1Curve::ScalarField;
+
+  std::unique_ptr<math::UnivariateEvaluationDomain<F, kMaxDegree>> domain =
+      math::UnivariateEvaluationDomainFactory<F, kMaxDegree>::Create(
+          kMaxDegree + 1);
+  LookupTable<F, kMaxDegree> lookup_table =
+      LookupTable<F, kMaxDegree>::Construct(kCols, domain.get());
+  F omega = domain->group_gen();
+  std::vector<F> omega_powers = domain->GetRootsOfUnity(kMaxDegree + 1, omega);
+
+  F delta = lookup_table.GetDelta();
+  EXPECT_NE(delta, F::One());
+  EXPECT_EQ(delta.Pow(F::Config::kTrace), F::One());
+  for (size_t i = 1; i < kCols; ++i) {
+    for (size_t j = 0; j < kMaxDegree + 1; ++j) {
+      omega_powers[j] *= delta;
+      EXPECT_EQ(omega_powers[j], lookup_table[Label(i, j)]);
+    }
+  }
+}
+}  // namespace tachyon::zk

--- a/tachyon/zk/plonk/permutation/permutation_argument.h
+++ b/tachyon/zk/plonk/permutation/permutation_argument.h
@@ -1,0 +1,40 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
+#ifndef TACHYON_ZK_PLONK_PERMUTATION_PERMUTATION_ARGUMENT_H_
+#define TACHYON_ZK_PLONK_PERMUTATION_PERMUTATION_ARGUMENT_H_
+
+#include <utility>
+#include <vector>
+
+#include "tachyon/base/containers/contains.h"
+#include "tachyon/zk/plonk/circuit/column.h"
+
+namespace tachyon::zk {
+
+// TODO(dongchangYoo): impl logics related to prove and verify.
+class PermutationArgument {
+ public:
+  PermutationArgument() = default;
+  explicit PermutationArgument(const std::vector<AnyColumn>& columns)
+      : columns_(columns) {}
+  explicit PermutationArgument(std::vector<AnyColumn>&& columns)
+      : columns_(std::move(columns)) {}
+
+  void AddColumn(const AnyColumn& column) {
+    if (base::Contains(columns_, column)) return;
+    columns_.push_back(column);
+  }
+
+  const std::vector<AnyColumn>& columns() const { return columns_; }
+
+ private:
+  std::vector<AnyColumn> columns_;
+};
+
+}  // namespace tachyon::zk
+
+#endif  // TACHYON_ZK_PLONK_PERMUTATION_PERMUTATION_ARGUMENT_H_

--- a/tachyon/zk/plonk/permutation/permutation_argument_unittest.cc
+++ b/tachyon/zk/plonk/permutation/permutation_argument_unittest.cc
@@ -1,0 +1,39 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
+#include "tachyon/zk/plonk/permutation/permutation_argument.h"
+
+#include "gtest/gtest.h"
+
+#include "tachyon/base/random.h"
+
+namespace tachyon::zk {
+
+TEST(PermutationArgumentTest, AddColumn) {
+  std::vector<AnyColumn> columns = {
+      FixedColumn(0), AdviceColumn(1, kSecondPhase), InstanceColumn(2)};
+  PermutationArgument argument(columns);
+  EXPECT_EQ(argument.columns(), columns);
+
+  // Already included column should not be added.
+  AnyColumn col = base::UniformElement(columns);
+  argument.AddColumn(col);
+  EXPECT_EQ(argument.columns(), columns);
+
+  // Advice column whose phase is different should be added.
+  AdviceColumn col2(1, Phase(3));
+  argument.AddColumn(col2);
+  columns.push_back(col2);
+  EXPECT_EQ(argument.columns(), columns);
+
+  // New Instance column should be added.
+  InstanceColumn col3(3);
+  argument.AddColumn(col3);
+  columns.push_back(col3);
+  EXPECT_EQ(argument.columns(), columns);
+}
+
+}  // namespace tachyon::zk

--- a/tachyon/zk/plonk/permutation/permutation_assembly.h
+++ b/tachyon/zk/plonk/permutation/permutation_assembly.h
@@ -1,0 +1,155 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
+#ifndef TACHYON_ZK_PLONK_PERMUTATION_PERMUTATION_ASSEMBLY_H_
+#define TACHYON_ZK_PLONK_PERMUTATION_PERMUTATION_ASSEMBLY_H_
+
+#include <utility>
+#include <vector>
+
+#include "tachyon/base/containers/container_util.h"
+#include "tachyon/base/openmp_util.h"
+#include "tachyon/math/polynomials/univariate/univariate_evaluation_domain.h"
+#include "tachyon/zk/plonk/permutation/cycle_store.h"
+#include "tachyon/zk/plonk/permutation/label.h"
+#include "tachyon/zk/plonk/permutation/lookup_table.h"
+#include "tachyon/zk/plonk/permutation/permutation_argument.h"
+#include "tachyon/zk/plonk/permutation/permutation_proving_key.h"
+#include "tachyon/zk/plonk/permutation/permutation_verifying_key.h"
+
+namespace tachyon::zk {
+
+// Struct that accumulates all the necessary data in order to construct the
+// permutation argument.
+template <typename Curve, size_t MaxDegree>
+class PermutationAssembly {
+ public:
+  constexpr static size_t kRows = MaxDegree + 1;
+
+  using ScalarField = typename Curve::ScalarField;
+  using Evals = math::UnivariateEvaluations<ScalarField, MaxDegree>;
+  using DensePoly = math::UnivariateDensePolynomial<ScalarField, MaxDegree>;
+
+  // It has parameters for commitment and provide commit function.
+  // TODO(dongchangYoo): substitute it to KZGParams, but not implemented yet.
+  using ParamsTy = std::vector<math::AffinePoint<Curve>>;
+
+  PermutationAssembly() = default;
+
+  // Constructor with |PermutationArgument|.
+  explicit PermutationAssembly(const PermutationArgument& p)
+      : PermutationAssembly(p.columns()) {}
+
+  // Constructor with permutation columns.
+  explicit PermutationAssembly(const std::vector<AnyColumn>& columns)
+      : columns_(columns), cycle_store_(CycleStore(columns_.size(), kRows)) {}
+
+  explicit PermutationAssembly(std::vector<AnyColumn>&& columns)
+      : columns_(std::move(columns)),
+        cycle_store_(CycleStore(columns_.size(), kRows)) {}
+
+  const std::vector<AnyColumn>& columns() const { return columns_; }
+  const CycleStore& cycle_store() const { return cycle_store_; }
+
+  bool Copy(const AnyColumn& left_column, size_t left_row,
+            const AnyColumn& right_column, size_t right_row) {
+    CHECK_LE(left_row, kRows);
+    CHECK_LE(right_row, kRows);
+
+    // Get indices of each column.
+    size_t left_col_idx = GetColumnIndex(left_column);
+    size_t right_col_idx = GetColumnIndex(right_column);
+
+    cycle_store_.MergeCycle(Label(left_col_idx, left_row),
+                            Label(right_col_idx, right_row));
+    return true;
+  }
+
+  // Returns |PermutationVerifyingKey| which has commitments for permutations.
+  constexpr PermutationVerifyingKey<Curve> BuildVerifyingKey(
+      math::UnivariateEvaluationDomain<ScalarField, MaxDegree>* domain) const {
+    std::vector<Evals> permutations = GeneratePermutations(domain);
+
+    // TODO(dongchangYoo): calculate commitments after complete Params. See
+    // https://github.com/kroma-network/halo2/blob/7d0a36990452c8e7ebd600de258420781a9b7917/halo2_proofs/src/plonk/permutation/keygen.rs#L153-L162.
+    Commitments<Curve> commitments;
+
+    return PermutationVerifyingKey<Curve>(commitments);
+  }
+
+  // Returns the |PermutationProvingKey| that has the coefficient form and
+  // evaluation form of the permutation.
+  constexpr PermutationProvingKey<ScalarField, MaxDegree> BuildProvingKey(
+      math::UnivariateEvaluationDomain<ScalarField, MaxDegree>* domain) const {
+    // The polynomials of permutations in evaluation form.
+    std::vector<Evals> permutations = GeneratePermutations(domain);
+
+    // The polynomials of permutations with coefficients.
+    std::vector<DensePoly> polys;
+    polys.reserve(columns_.size());
+    for (size_t i = 0; i < columns_.size(); ++i) {
+      DensePoly poly = domain->IFFT(permutations[i]);
+      polys.push_back(std::move(poly));
+    }
+
+    return PermutationProvingKey<ScalarField, MaxDegree>(
+        std::move(permutations), std::move(polys));
+  }
+
+  // Generate the permutation polynomials based on the accumulated copy
+  // permutations. Note that the permutation polynomials are in evaluation
+  // form.
+  std::vector<Evals> GeneratePermutations(
+      math::UnivariateEvaluationDomain<ScalarField, MaxDegree>* domain) const {
+    LookupTable<ScalarField, MaxDegree> lookup_table =
+        LookupTable<ScalarField, MaxDegree>::Construct(columns_.size(), domain);
+
+    // Init evaluation formed polynomials with all-zero coefficients
+    std::vector<Evals> permutations =
+        base::CreateVector(columns_.size(), Evals::Zero(MaxDegree));
+
+    // Assign lookup_table to permutations
+#if defined(TACHYON_HAS_OPENMP)
+    size_t thread_num = omp_get_max_threads();
+#else
+    size_t thread_num = 1;
+#endif  // defined(TACHYON_HAS_OPENMP)
+    size_t chunk_size = (columns_.size() + thread_num - 1) / thread_num;
+
+    auto chunks = base::Chunked(permutations, chunk_size);
+    std::vector<absl::Span<Evals>> chunks_vector =
+        base::Map(chunks.begin(), chunks.end(),
+                  [](const absl::Span<Evals>& chunk) { return chunk; });
+
+    OPENMP_PARALLEL_FOR(size_t c = 0; c < chunks_vector.size(); ++c) {
+      const absl::Span<Evals>& chunk = chunks_vector[c];
+
+      size_t i = c * chunk_size;
+      for (Evals& evals : chunk) {
+        for (size_t j = 0; j <= MaxDegree; ++j) {
+          *evals[j] = lookup_table[cycle_store_.GetNextLabel(Label(i, j))];
+        }
+        ++i;
+      }
+    }
+    return permutations;
+  }
+
+ private:
+  size_t GetColumnIndex(const AnyColumn& column) const {
+    auto it = std::find(columns_.begin(), columns_.end(), column);
+    CHECK_NE(it, columns_.end());
+    return std::distance(columns_.begin(), it);
+  }
+
+  // Columns that participate on the copy permutation argument.
+  std::vector<AnyColumn> columns_;
+  CycleStore cycle_store_;
+};
+
+}  // namespace tachyon::zk
+
+#endif  // TACHYON_ZK_PLONK_PERMUTATION_PERMUTATION_ASSEMBLY_H_

--- a/tachyon/zk/plonk/permutation/permutation_assembly_unittest.cc
+++ b/tachyon/zk/plonk/permutation/permutation_assembly_unittest.cc
@@ -1,0 +1,64 @@
+#include "tachyon/zk/plonk/permutation/permutation_assembly.h"
+
+#include <memory>
+
+#include "gtest/gtest.h"
+
+#include "tachyon/base/buffer/vector_buffer.h"
+#include "tachyon/math/elliptic_curves/bn/bn254/g1.h"
+#include "tachyon/math/polynomials/univariate/univariate_evaluation_domain_factory.h"
+
+namespace tachyon::zk {
+namespace {
+
+constexpr static size_t MaxDegree = 7;
+
+using Curve = math::bn254::G1Curve;
+using F = Curve::ScalarField;
+using Evals = PermutationAssembly<Curve, MaxDegree>::Evals;
+
+class PermutationAssemblyTest : public testing::Test {
+ public:
+  static void SetUpTestSuite() { Curve::Init(); }
+
+  void SetUp() override {
+    columns_ = {AnyColumn(0), AdviceColumn(1), FixedColumn(2),
+                InstanceColumn(3)};
+    argment_ = PermutationArgument(columns_);
+    assembly_ = PermutationAssembly<Curve, MaxDegree>(argment_);
+
+    domain_ = math::UnivariateEvaluationDomainFactory<F, MaxDegree>::Create(
+        MaxDegree + 1);
+  }
+
+ protected:
+  std::vector<AnyColumn> columns_;
+  PermutationArgument argment_;
+  PermutationAssembly<Curve, MaxDegree> assembly_;
+  std::unique_ptr<math::UnivariateEvaluationDomain<F, MaxDegree>> domain_;
+};
+
+}  // namespace
+
+TEST_F(PermutationAssemblyTest, GeneratePermutation) {
+  // Check initial permutation polynomials w/o any copy.
+  std::vector<Evals> permutations =
+      assembly_.GeneratePermutations(domain_.get());
+
+  LookupTable<F, MaxDegree> lookup_table =
+      LookupTable<F, MaxDegree>::Construct(columns_.size(), domain_.get());
+
+  for (size_t i = 0; i < columns_.size(); ++i) {
+    for (size_t j = 0; j <= MaxDegree; ++j) {
+      EXPECT_EQ(*permutations[i][j], lookup_table[Label(i, j)]);
+    }
+  }
+}
+
+// TODO(dongchangYoo): check if it produces the same value as zcash-halo2
+TEST_F(PermutationAssemblyTest, BuildVerifyingKey) {}
+
+// TODO(dongchangYoo): check if it produces the same value as zcash-halo2
+TEST_F(PermutationAssemblyTest, BuildProvingKey) {}
+
+}  // namespace tachyon::zk

--- a/tachyon/zk/plonk/permutation/permutation_proving_key.h
+++ b/tachyon/zk/plonk/permutation/permutation_proving_key.h
@@ -1,0 +1,84 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
+#ifndef TACHYON_ZK_PLONK_PERMUTATION_PERMUTATION_PROVING_KEY_H_
+#define TACHYON_ZK_PLONK_PERMUTATION_PERMUTATION_PROVING_KEY_H_
+
+#include <utility>
+#include <vector>
+
+#include "tachyon/base/buffer/copyable.h"
+#include "tachyon/math/polynomials/univariate/univariate_evaluations.h"
+#include "tachyon/math/polynomials/univariate/univariate_polynomial.h"
+
+namespace tachyon {
+namespace zk {
+
+template <typename F, size_t MaxDegree>
+class PermutationProvingKey {
+ public:
+  using DensePoly = math::UnivariateDensePolynomial<F, MaxDegree>;
+  using Evals = math::UnivariateEvaluations<F, MaxDegree>;
+
+  PermutationProvingKey() = default;
+  PermutationProvingKey(const std::vector<Evals>& permutations,
+                        const std::vector<DensePoly>& polys)
+      : permutations_(permutations), polys_(polys) {}
+  PermutationProvingKey(std::vector<Evals>&& permutations,
+                        std::vector<DensePoly>&& polys)
+      : permutations_(std::move(permutations)), polys_(std::move(polys)) {}
+
+  const std::vector<Evals>& permutations() const { return permutations_; }
+  const std::vector<DensePoly>& polys() const { return polys_; }
+
+  size_t BytesLength() const { return base::EstimateSize(this); }
+
+  bool operator==(const PermutationProvingKey& other) const {
+    return permutations_ == other.permutations_ && polys_ == other.polys_;
+  }
+  bool operator!=(const PermutationProvingKey& other) const {
+    return !operator==(other);
+  }
+
+ private:
+  std::vector<Evals> permutations_;
+  std::vector<DensePoly> polys_;
+};
+
+}  // namespace zk
+
+namespace base {
+
+template <typename F, size_t MaxDegree>
+class Copyable<zk::PermutationProvingKey<F, MaxDegree>> {
+ public:
+  static bool WriteTo(const zk::PermutationProvingKey<F, MaxDegree>& pk,
+                      Buffer* buffer) {
+    return buffer->WriteMany(pk.permutations(), pk.polys());
+  }
+
+  static bool ReadFrom(const Buffer& buffer,
+                       zk::PermutationProvingKey<F, MaxDegree>* pk) {
+    std::vector<math::UnivariateEvaluations<F, MaxDegree>> perms;
+    std::vector<math::UnivariateDensePolynomial<F, MaxDegree>> poly;
+    if (!buffer.ReadMany(&perms, &poly)) return false;
+
+    *pk = zk::PermutationProvingKey<F, MaxDegree>(std::move(perms),
+                                                  std::move(poly));
+    return true;
+  }
+
+  static size_t EstimateSize(
+      const zk::PermutationProvingKey<F, MaxDegree>& pk) {
+    return base::EstimateSize(pk.permutations()) +
+           base::EstimateSize(pk.polys());
+  }
+};
+
+}  // namespace base
+}  // namespace tachyon
+
+#endif  // TACHYON_ZK_PLONK_PERMUTATION_PERMUTATION_PROVING_KEY_H_

--- a/tachyon/zk/plonk/permutation/permutation_proving_key_unittest.cc
+++ b/tachyon/zk/plonk/permutation/permutation_proving_key_unittest.cc
@@ -1,0 +1,45 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
+#include "tachyon/zk/plonk/permutation/permutation_proving_key.h"
+
+#include "gtest/gtest.h"
+
+#include "tachyon/base/buffer/vector_buffer.h"
+#include "tachyon/math/finite_fields/test/gf7.h"
+
+namespace tachyon::zk {
+
+namespace {
+
+class PermutationProvingKeyTest : public testing::Test {
+ public:
+  static void SetUpTestSuite() { math::GF7::Init(); }
+};
+
+}  // namespace
+
+TEST_F(PermutationProvingKeyTest, Copyable) {
+  constexpr size_t kMaxDegree = 7;
+
+  using ProvingKey = PermutationProvingKey<math::GF7, kMaxDegree>;
+  using DensePoly = ProvingKey::DensePoly;
+  using Evals = ProvingKey::Evals;
+
+  ProvingKey expected({Evals::Random(kMaxDegree)},
+                      {DensePoly::Random(kMaxDegree)});
+  ProvingKey value;
+
+  base::VectorBuffer write_buf;
+  write_buf.Write(expected);
+
+  write_buf.set_buffer_offset(0);
+
+  write_buf.Read(&value);
+  EXPECT_EQ(value, expected);
+}
+
+}  // namespace tachyon::zk

--- a/tachyon/zk/plonk/permutation/permutation_verifying_key.h
+++ b/tachyon/zk/plonk/permutation/permutation_verifying_key.h
@@ -1,0 +1,72 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
+#ifndef TACHYON_ZK_PLONK_PERMUTATION_PERMUTATION_VERIFYING_KEY_H_
+#define TACHYON_ZK_PLONK_PERMUTATION_PERMUTATION_VERIFYING_KEY_H_
+
+#include <utility>
+#include <vector>
+
+#include "tachyon/base/buffer/copyable.h"
+#include "tachyon/zk/plonk/commitment.h"
+
+namespace tachyon {
+namespace zk {
+
+template <typename Curve>
+class PermutationVerifyingKey {
+ public:
+  PermutationVerifyingKey() = default;
+
+  explicit PermutationVerifyingKey(const Commitments<Curve>& commitments)
+      : commitments_(commitments) {}
+  explicit PermutationVerifyingKey(Commitments<Curve>&& commitments)
+      : commitments_(std::move(commitments)) {}
+
+  const Commitments<Curve>& commitments() const { return commitments_; }
+
+  size_t BytesLength() const { return base::EstimateSize(this); }
+
+  bool operator==(const PermutationVerifyingKey& other) const {
+    return commitments_ == other.commitments_;
+  }
+  bool operator!=(const PermutationVerifyingKey& other) const {
+    return commitments_ != other.commitments_;
+  }
+
+ private:
+  Commitments<Curve> commitments_;
+};
+
+}  // namespace zk
+
+namespace base {
+
+template <typename Curve>
+class Copyable<zk::PermutationVerifyingKey<Curve>> {
+ public:
+  static bool WriteTo(const zk::PermutationVerifyingKey<Curve>& vk,
+                      Buffer* buffer) {
+    return buffer->Write(vk.commitments());
+  }
+
+  static bool ReadFrom(const Buffer& buffer,
+                       zk::PermutationVerifyingKey<Curve>* vk) {
+    zk::Commitments<Curve> commitments;
+    if (!buffer.Read(&commitments)) return false;
+    *vk = zk::PermutationVerifyingKey<Curve>(std::move(commitments));
+    return true;
+  }
+
+  static size_t EstimateSize(const zk::PermutationVerifyingKey<Curve>& vk) {
+    return base::EstimateSize(vk.commitments());
+  }
+};
+
+}  // namespace base
+}  // namespace tachyon
+
+#endif  // TACHYON_ZK_PLONK_PERMUTATION_PERMUTATION_VERIFYING_KEY_H_

--- a/tachyon/zk/plonk/permutation/permutation_verifying_key_unittest.cc
+++ b/tachyon/zk/plonk/permutation/permutation_verifying_key_unittest.cc
@@ -1,0 +1,40 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
+#include "tachyon/zk/plonk/permutation/permutation_verifying_key.h"
+
+#include "gtest/gtest.h"
+
+#include "tachyon/base/buffer/vector_buffer.h"
+#include "tachyon/math/elliptic_curves/bn/bn254/g1.h"
+
+namespace tachyon::zk {
+
+namespace {
+
+class PermutationVerifyingKeyTest : public testing::Test {
+ public:
+  static void SetUpTestSuite() { math::bn254::G1Curve::Init(); }
+};
+
+}  // namespace
+
+TEST_F(PermutationVerifyingKeyTest, Copyable) {
+  using VerifyingKey = PermutationVerifyingKey<math::bn254::G1Curve>;
+
+  VerifyingKey expected({Commitment<math::bn254::G1Curve>::Random()});
+  VerifyingKey value;
+
+  base::VectorBuffer write_buf;
+  write_buf.Write(expected);
+
+  write_buf.set_buffer_offset(0);
+
+  write_buf.Read(&value);
+  EXPECT_EQ(value, expected);
+}
+
+}  // namespace tachyon::zk


### PR DESCRIPTION
This PR implements `keygen` logics for copy permutation. (see, [Permutation Assembly in Halo2](https://github.com/kroma-network/halo2/blob/dev/halo2_proofs/src/plonk/permutation/keygen.rs))

Once the `KZGParams` class is completed, an update will be made to add the `commit()` logic to `PermutationAssembly`.