### PR TITLE
feat(math): create point from x coordinate if (x, y) belongs to a curve point

### DIFF
--- a/tachyon/math/elliptic_curves/short_weierstrass/affine_point.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/affine_point.h
@@ -1,6 +1,7 @@
 #ifndef TACHYON_MATH_ELLIPTIC_CURVES_SHORT_WEIERSTRASS_AFFINE_POINT_H_
 #define TACHYON_MATH_ELLIPTIC_CURVES_SHORT_WEIERSTRASS_AFFINE_POINT_H_
 
+#include <optional>
 #include <string>
 #include <type_traits>
 #include <utility>
@@ -59,6 +60,13 @@ class AffinePoint<_Curve, std::enable_if_t<_Curve::kIsSWCurve>> final
     AffinePoint ret = {std::move(x), std::move(y)};
     CHECK(ret.IsOnCurve());
     return ret;
+  }
+
+  constexpr static std::optional<AffinePoint> CreateFromX(const BaseField& x,
+                                                          bool pick_odd) {
+    AffinePoint point;
+    if (!Curve::GetPointFromX(x, pick_odd, &point)) return std::nullopt;
+    return point;
   }
 
   constexpr static AffinePoint Zero() { return AffinePoint(); }

--- a/tachyon/math/elliptic_curves/short_weierstrass/affine_point_unittest.cc
+++ b/tachyon/math/elliptic_curves/short_weierstrass/affine_point_unittest.cc
@@ -163,4 +163,27 @@ TYPED_TEST(AffinePointTest, IsOnCurve) {
   EXPECT_TRUE(valid_point.IsOnCurve());
 }
 
+TYPED_TEST(AffinePointTest, CreateFromX) {
+  using AffinePointTy = TypeParam;
+  using BaseField = typename AffinePointTy::BaseField;
+
+  {
+    std::optional<AffinePointTy> p =
+        AffinePointTy::CreateFromX(BaseField(3), /*pick_odd=*/true);
+    ASSERT_TRUE(p.has_value());
+    EXPECT_EQ(p->y(), BaseField(5));
+  }
+  {
+    std::optional<AffinePointTy> p =
+        AffinePointTy::CreateFromX(BaseField(3), /*pick_odd=*/false);
+    ASSERT_TRUE(p.has_value());
+    EXPECT_EQ(p->y(), BaseField(2));
+  }
+  {
+    std::optional<AffinePointTy> p =
+        AffinePointTy::CreateFromX(BaseField(1), /*pick_odd=*/false);
+    ASSERT_FALSE(p.has_value());
+  }
+}
+
 }  // namespace tachyon::math

--- a/tachyon/math/elliptic_curves/short_weierstrass/jacobian_point.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/jacobian_point.h
@@ -1,6 +1,7 @@
 #ifndef TACHYON_MATH_ELLIPTIC_CURVES_SHORT_WEIERSTRASS_JACOBIAN_POINT_H_
 #define TACHYON_MATH_ELLIPTIC_CURVES_SHORT_WEIERSTRASS_JACOBIAN_POINT_H_
 
+#include <optional>
 #include <string>
 #include <type_traits>
 #include <utility>
@@ -57,6 +58,13 @@ class JacobianPoint<_Curve, std::enable_if_t<_Curve::kIsSWCurve>> final
     JacobianPoint ret = {std::move(x), std::move(y), std::move(z)};
     CHECK(ret.IsOnCurve());
     return ret;
+  }
+
+  constexpr static std::optional<JacobianPoint> CreateFromX(const BaseField& x,
+                                                            bool pick_odd) {
+    JacobianPoint point;
+    if (!Curve::GetPointFromX(x, pick_odd, &point)) return std::nullopt;
+    return point;
   }
 
   constexpr static JacobianPoint Zero() { return JacobianPoint(); }

--- a/tachyon/math/elliptic_curves/short_weierstrass/jacobian_point_unittest.cc
+++ b/tachyon/math/elliptic_curves/short_weierstrass/jacobian_point_unittest.cc
@@ -219,4 +219,16 @@ TYPED_TEST(JacobianPointTest, ToXYZZ) {
       PointXYZZTy(BaseField(1), BaseField(2), BaseField(2), BaseField(6)));
 }
 
+TYPED_TEST(JacobianPointTest, IsOnCurve) {
+  using JacobianPointTy = TypeParam;
+  using BaseField = typename JacobianPointTy::BaseField;
+
+  JacobianPointTy invalid_point(BaseField(1), BaseField(2), BaseField(1));
+  EXPECT_FALSE(invalid_point.IsOnCurve());
+  JacobianPointTy valid_point(BaseField(3), BaseField(2), BaseField(1));
+  EXPECT_TRUE(valid_point.IsOnCurve());
+  valid_point = JacobianPointTy(BaseField(3), BaseField(5), BaseField(1));
+  EXPECT_TRUE(valid_point.IsOnCurve());
+}
+
 }  // namespace tachyon::math

--- a/tachyon/math/elliptic_curves/short_weierstrass/jacobian_point_unittest.cc
+++ b/tachyon/math/elliptic_curves/short_weierstrass/jacobian_point_unittest.cc
@@ -231,4 +231,27 @@ TYPED_TEST(JacobianPointTest, IsOnCurve) {
   EXPECT_TRUE(valid_point.IsOnCurve());
 }
 
+TYPED_TEST(JacobianPointTest, CreateFromX) {
+  using JacobianPointTy = TypeParam;
+  using BaseField = typename JacobianPointTy::BaseField;
+
+  {
+    std::optional<JacobianPointTy> p =
+        JacobianPointTy::CreateFromX(BaseField(3), /*pick_odd=*/true);
+    ASSERT_TRUE(p.has_value());
+    EXPECT_EQ(p->y(), BaseField(5));
+  }
+  {
+    std::optional<JacobianPointTy> p =
+        JacobianPointTy::CreateFromX(BaseField(3), /*pick_odd=*/false);
+    ASSERT_TRUE(p.has_value());
+    EXPECT_EQ(p->y(), BaseField(2));
+  }
+  {
+    std::optional<JacobianPointTy> p =
+        JacobianPointTy::CreateFromX(BaseField(1), /*pick_odd=*/false);
+    ASSERT_FALSE(p.has_value());
+  }
+}
+
 }  // namespace tachyon::math

--- a/tachyon/math/elliptic_curves/short_weierstrass/point_xyzz.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/point_xyzz.h
@@ -1,6 +1,7 @@
 #ifndef TACHYON_MATH_ELLIPTIC_CURVES_SHORT_WEIERSTRASS_POINT_XYZZ_H_
 #define TACHYON_MATH_ELLIPTIC_CURVES_SHORT_WEIERSTRASS_POINT_XYZZ_H_
 
+#include <optional>
 #include <string>
 #include <type_traits>
 #include <utility>
@@ -62,6 +63,13 @@ class PointXYZZ<_Curve, std::enable_if_t<_Curve::kIsSWCurve>> final
     PointXYZZ ret = {std::move(x), std::move(y), std::move(zz), std::move(zzz)};
     CHECK(ret.IsOnCurve());
     return ret;
+  }
+
+  constexpr static std::optional<PointXYZZ> CreateFromX(const BaseField& x,
+                                                        bool pick_odd) {
+    PointXYZZ point;
+    if (!Curve::GetPointFromX(x, pick_odd, &point)) return std::nullopt;
+    return point;
   }
 
   constexpr static PointXYZZ Zero() { return PointXYZZ(); }

--- a/tachyon/math/elliptic_curves/short_weierstrass/point_xyzz_unittest.cc
+++ b/tachyon/math/elliptic_curves/short_weierstrass/point_xyzz_unittest.cc
@@ -245,4 +245,27 @@ TYPED_TEST(PointXYZZTest, IsOnCurve) {
   EXPECT_TRUE(valid_point.IsOnCurve());
 }
 
+TYPED_TEST(PointXYZZTest, CreateFromX) {
+  using PointXYZZTy = TypeParam;
+  using BaseField = typename PointXYZZTy::BaseField;
+
+  {
+    std::optional<PointXYZZTy> p =
+        PointXYZZTy::CreateFromX(BaseField(3), /*pick_odd=*/true);
+    ASSERT_TRUE(p.has_value());
+    EXPECT_EQ(p->y(), BaseField(5));
+  }
+  {
+    std::optional<PointXYZZTy> p =
+        PointXYZZTy::CreateFromX(BaseField(3), /*pick_odd=*/false);
+    ASSERT_TRUE(p.has_value());
+    EXPECT_EQ(p->y(), BaseField(2));
+  }
+  {
+    std::optional<PointXYZZTy> p =
+        PointXYZZTy::CreateFromX(BaseField(1), /*pick_odd=*/false);
+    ASSERT_FALSE(p.has_value());
+  }
+}
+
 }  // namespace tachyon::math

--- a/tachyon/math/elliptic_curves/short_weierstrass/point_xyzz_unittest.cc
+++ b/tachyon/math/elliptic_curves/short_weierstrass/point_xyzz_unittest.cc
@@ -230,4 +230,19 @@ TYPED_TEST(PointXYZZTest, ToJacobian) {
             JacobianPointTy(BaseField(2), BaseField(2), BaseField(5)));
 }
 
+TYPED_TEST(PointXYZZTest, IsOnCurve) {
+  using PointXYZZTy = TypeParam;
+  using BaseField = typename PointXYZZTy::BaseField;
+
+  PointXYZZTy invalid_point(BaseField(1), BaseField(2), BaseField(1),
+                            BaseField(1));
+  EXPECT_FALSE(invalid_point.IsOnCurve());
+  PointXYZZTy valid_point(BaseField(3), BaseField(2), BaseField(1),
+                          BaseField(1));
+  EXPECT_TRUE(valid_point.IsOnCurve());
+  valid_point =
+      PointXYZZTy(BaseField(3), BaseField(5), BaseField(1), BaseField(1));
+  EXPECT_TRUE(valid_point.IsOnCurve());
+}
+
 }  // namespace tachyon::math

--- a/tachyon/math/elliptic_curves/short_weierstrass/projective_point.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/projective_point.h
@@ -60,6 +60,13 @@ class ProjectivePoint<_Curve, std::enable_if_t<_Curve::kIsSWCurve>> final
     return ret;
   }
 
+  constexpr static std::optional<ProjectivePoint> CreateFromX(
+      const BaseField& x, bool pick_odd) {
+    ProjectivePoint point;
+    if (!Curve::GetPointFromX(x, pick_odd, &point)) return std::nullopt;
+    return point;
+  }
+
   constexpr static ProjectivePoint Zero() { return ProjectivePoint(); }
 
   constexpr static ProjectivePoint Generator() {

--- a/tachyon/math/elliptic_curves/short_weierstrass/projective_point_unittest.cc
+++ b/tachyon/math/elliptic_curves/short_weierstrass/projective_point_unittest.cc
@@ -235,4 +235,27 @@ TYPED_TEST(ProjectivePointTest, IsOnCurve) {
   EXPECT_TRUE(valid_point.IsOnCurve());
 }
 
+TYPED_TEST(ProjectivePointTest, CreateFromX) {
+  using ProjectivePointTy = TypeParam;
+  using BaseField = typename ProjectivePointTy::BaseField;
+
+  {
+    std::optional<ProjectivePointTy> p =
+        ProjectivePointTy::CreateFromX(BaseField(3), /*pick_odd=*/true);
+    ASSERT_TRUE(p.has_value());
+    EXPECT_EQ(p->y(), BaseField(5));
+  }
+  {
+    std::optional<ProjectivePointTy> p =
+        ProjectivePointTy::CreateFromX(BaseField(3), /*pick_odd=*/false);
+    ASSERT_TRUE(p.has_value());
+    EXPECT_EQ(p->y(), BaseField(2));
+  }
+  {
+    std::optional<ProjectivePointTy> p =
+        ProjectivePointTy::CreateFromX(BaseField(1), /*pick_odd=*/false);
+    ASSERT_FALSE(p.has_value());
+  }
+}
+
 }  // namespace tachyon::math

--- a/tachyon/math/elliptic_curves/short_weierstrass/projective_point_unittest.cc
+++ b/tachyon/math/elliptic_curves/short_weierstrass/projective_point_unittest.cc
@@ -223,4 +223,16 @@ TYPED_TEST(ProjectivePointTest, ToXYZZ) {
       PointXYZZTy(BaseField(3), BaseField(4), BaseField(2), BaseField(6)));
 }
 
+TYPED_TEST(ProjectivePointTest, IsOnCurve) {
+  using ProjectivePointTy = TypeParam;
+  using BaseField = typename ProjectivePointTy::BaseField;
+
+  ProjectivePointTy invalid_point(BaseField(1), BaseField(2), BaseField(1));
+  EXPECT_FALSE(invalid_point.IsOnCurve());
+  ProjectivePointTy valid_point(BaseField(3), BaseField(2), BaseField(1));
+  EXPECT_TRUE(valid_point.IsOnCurve());
+  valid_point = ProjectivePointTy(BaseField(3), BaseField(5), BaseField(1));
+  EXPECT_TRUE(valid_point.IsOnCurve());
+}
+
 }  // namespace tachyon::math

--- a/tachyon/math/elliptic_curves/short_weierstrass/sw_curve.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/sw_curve.h
@@ -1,8 +1,11 @@
 #ifndef TACHYON_MATH_ELLIPTIC_CURVES_SHORT_WEIERSTRASS_SW_CURVE_H_
 #define TACHYON_MATH_ELLIPTIC_CURVES_SHORT_WEIERSTRASS_SW_CURVE_H_
 
+#include <utility>
+
 #include "tachyon/math/elliptic_curves/affine_point.h"
 #include "tachyon/math/elliptic_curves/jacobian_point.h"
+#include "tachyon/math/elliptic_curves/point_conversions.h"
 #include "tachyon/math/elliptic_curves/point_xyzz.h"
 #include "tachyon/math/elliptic_curves/projective_point.h"
 #include "tachyon/math/elliptic_curves/short_weierstrass/sw_curve_traits.h"
@@ -11,7 +14,7 @@ namespace tachyon::math {
 
 // Config for Short Weierstrass model.
 // See https://www.hyperelliptic.org/EFD/g1p/auto-shortw.html for more details.
-// This config represents `y² = x³ + a * x + b`, where `a` and `b` are
+// This config represents y² = x³ + a * x + b, where a and b are
 // constants.
 template <typename SWCurveConfig>
 class SWCurve {
@@ -35,6 +38,46 @@ class SWCurve {
     ScalarField::Init();
 
     Config::Init();
+  }
+
+  // Attempts to construct an affine point given an |x| coordinate. The
+  // point is not guaranteed to be in the prime order subgroup.
+  // If |pick_odd| is set to true, it chooses an odd(positive) y coordinate.
+  template <typename PointTy>
+  constexpr static bool GetPointFromX(const BaseField& x, bool pick_odd,
+                                      PointTy* point) {
+    BaseField even_y;
+    BaseField odd_y;
+    if (!GetYsFromX(x, &even_y, &odd_y)) return false;
+    if constexpr (std::is_same_v<PointTy, AffinePointTy>) {
+      *point = AffinePointTy(x, pick_odd ? odd_y : even_y);
+    } else {
+      AffinePointTy affine_point(x, pick_odd ? odd_y : even_y);
+      *point = ConvertPoint<PointTy>(affine_point);
+    }
+    return true;
+  }
+
+  // Returns true and populates |even_y| and |odd_y| with the two possible
+  // y-coordinates corresponding to the given x-coordinate if the |x| coordinate
+  // corresponds to a curve point. Otherwise, returns false.
+  constexpr static bool GetYsFromX(const BaseField& x, BaseField* even_y,
+                                   BaseField* odd_y) {
+    BaseField right = x.Square() * x + Config::kB;
+    if constexpr (!Config::kAIsZero) {
+      right += Config::kA * x;
+    }
+    BaseField y;
+    if (!right.SquareRoot(&y)) return false;
+
+    if (y.ToBigInt().IsEven()) {
+      *odd_y = -y;
+      *even_y = std::move(y);
+    } else {
+      *even_y = -y;
+      *odd_y = std::move(y);
+    }
+    return true;
   }
 
   constexpr static bool IsOnCurve(const AffinePointTy& point) {


### PR DESCRIPTION
# Description

This PR implements point creation from x coordinate using #90.
This also adds missing `IsOnCurve` tests to `JacobianPoint`, `ProjectivePoint` and `PointXYZZ`.