### PR TITLE
refac: rename batch to multi

### DIFF
--- a/tachyon/math/base/BUILD.bazel
+++ b/tachyon/math/base/BUILD.bazel
@@ -140,6 +140,7 @@ tachyon_cc_unittest(
         ":sign",
         "//tachyon/base/buffer:vector_buffer",
         "//tachyon/base/containers:container_util",
+        "//tachyon/math/elliptic_curves/msm/test:msm_test_set",
         "//tachyon/math/elliptic_curves/short_weierstrass/test:curve_config",
         "//tachyon/math/finite_fields/test:gf7",
     ],

--- a/tachyon/math/base/BUILD.bazel
+++ b/tachyon/math/base/BUILD.bazel
@@ -106,6 +106,7 @@ tachyon_cc_library(
         "//tachyon/base:openmp_util",
         "//tachyon/base/containers:adapters",
         "//tachyon/base/containers:container_util",
+        "//tachyon/base/types:always_false",
         "@com_google_absl//absl/types:span",
     ],
 )

--- a/tachyon/math/base/semigroups.h
+++ b/tachyon/math/base/semigroups.h
@@ -334,7 +334,7 @@ class AdditiveSemigroup {
   template <typename F,
             typename ReturnTy =
                 typename internal::AdditiveSemigroupTraits<G>::ReturnTy>
-  static std::vector<ReturnTy> BatchScalarMul(const F& scalar,
+  static std::vector<ReturnTy> MultiScalarMul(const F& scalar,
                                               const std::vector<G>& bases) {
     size_t size = bases.size();
     std::vector<ReturnTy> ret(size);
@@ -353,7 +353,7 @@ class AdditiveSemigroup {
   template <typename F,
             typename ReturnTy =
                 typename internal::AdditiveSemigroupTraits<G>::ReturnTy>
-  static std::vector<ReturnTy> BatchScalarMul(const std::vector<F>& scalars,
+  static std::vector<ReturnTy> MultiScalarMul(const std::vector<F>& scalars,
                                               const G& base) {
     size_t size = scalars.size();
     std::vector<ReturnTy> ret(size);
@@ -372,7 +372,7 @@ class AdditiveSemigroup {
   template <typename F,
             typename ReturnTy =
                 typename internal::AdditiveSemigroupTraits<G>::ReturnTy>
-  static std::vector<ReturnTy> BatchScalarMul(const std::vector<F>& scalars,
+  static std::vector<ReturnTy> MultiScalarMul(const std::vector<F>& scalars,
                                               std::vector<G>& bases) {
     CHECK_EQ(scalars.size(), bases.size());
     size_t size = scalars.size();

--- a/tachyon/math/base/semigroups_unittest.cc
+++ b/tachyon/math/base/semigroups_unittest.cc
@@ -113,7 +113,7 @@ TEST(SemigroupsTest, AddOverAddInPlace) {
 
 namespace {
 
-class BatchScalarTest : public testing::Test {
+class MultiScalarMulTest : public testing::Test {
  public:
   using BaseTy = test::AffinePoint;
   using BaseField = typename BaseTy::BaseField;
@@ -127,7 +127,7 @@ class BatchScalarTest : public testing::Test {
 // scalar: s
 // bases: [G₀, G₁, ..., Gₙ₋₁]
 // return: [sG₀, sG₁, ..., sGₙ₋₁]
-TEST_F(BatchScalarTest, BatchScalarMulSSMB) {
+TEST_F(MultiScalarMulTest, SingleScalarMultiBases) {
   BaseField s = BaseField(3);
   std::vector<BaseTy> bases = {BaseTy::Random(), BaseTy::Random(),
                                BaseTy::Random()};
@@ -135,29 +135,29 @@ TEST_F(BatchScalarTest, BatchScalarMulSSMB) {
   for (const BaseTy& base : bases) {
     expected.push_back(base.ScalarMul(s.ToBigInt()));
   }
-  std::vector<ReturnTy> batched_bases = BaseTy::BatchScalarMul(s, bases);
+  std::vector<ReturnTy> actual = BaseTy::MultiScalarMul(s, bases);
 
-  EXPECT_EQ(batched_bases, expected);
+  EXPECT_EQ(actual, expected);
 }
 
 // scalars: [s₀, s₁, ..., sₙ₋₁]
 // base: G
 // return: [s₀G, s₁G, ..., sₙ₋₁G]
-TEST_F(BatchScalarTest, BatchScalarMulMSSB) {
+TEST_F(MultiScalarMulTest, MultiScalarsSingleBase) {
   std::vector<BaseField> scalars = {BaseField(3), BaseField(4), BaseField(5)};
   BaseTy base = BaseTy::Random();
   std::vector<ReturnTy> expected;
   for (const BaseField& scalar : scalars) {
     expected.push_back(base.ScalarMul(scalar.ToBigInt()));
   }
-  std::vector<ReturnTy> batched_bases = BaseTy::BatchScalarMul(scalars, base);
-  EXPECT_EQ(batched_bases, expected);
+  std::vector<ReturnTy> actual = BaseTy::MultiScalarMul(scalars, base);
+  EXPECT_EQ(actual, expected);
 }
 
 // scalars: [s₀, s₁, ..., sₙ₋₁]
 // bases: [G₀, G₁, ..., Gₙ₋₁]
 // return: [s₀G₀, s₁G₁, ..., sₙ₋₁Gₙ₋₁]
-TEST_F(BatchScalarTest, BatchScalarMulMSMB) {
+TEST_F(MultiScalarMulTest, MultiScalarsMultiBases) {
   std::vector<BaseField> scalars = {BaseField(3), BaseField(4), BaseField(5)};
   std::vector<BaseTy> bases = {BaseTy::Random(), BaseTy::Random(),
                                BaseTy::Random()};
@@ -165,8 +165,8 @@ TEST_F(BatchScalarTest, BatchScalarMulMSMB) {
   for (size_t i = 0; i < scalars.size(); ++i) {
     expected.push_back(bases[i].ScalarMul(scalars[i].ToBigInt()));
   }
-  std::vector<ReturnTy> batched_bases = BaseTy::BatchScalarMul(scalars, bases);
-  EXPECT_EQ(batched_bases, expected);
+  std::vector<ReturnTy> actual = BaseTy::MultiScalarMul(scalars, bases);
+  EXPECT_EQ(actual, expected);
 }
 
 }  // namespace tachyon::math

--- a/tachyon/math/base/semigroups_unittest.cc
+++ b/tachyon/math/base/semigroups_unittest.cc
@@ -142,9 +142,9 @@ MSMTestSet<test::AffinePoint> MultiScalarMulTest::test_set_;
 // return: [sG₀, sG₁, ..., sGₙ₋₁]
 TEST_F(MultiScalarMulTest, SingleScalarMultiBases) {
   std::vector<test::JacobianPoint> expected;
-  const BigInt<1> scalar = test_set_.scalars[0].ToBigInt();
+  const GF7& scalar = test_set_.scalars[0];
   for (const test::AffinePoint& base : test_set_.bases) {
-    expected.push_back(base.ScalarMul(scalar));
+    expected.push_back(base * scalar);
   }
   std::vector<test::JacobianPoint> actual =
       test::AffinePoint::MultiScalarMul(test_set_.scalars[0], test_set_.bases);
@@ -157,7 +157,7 @@ TEST_F(MultiScalarMulTest, SingleScalarMultiBases) {
 TEST_F(MultiScalarMulTest, MultiScalarsSingleBase) {
   std::vector<test::JacobianPoint> expected;
   for (const GF7& scalar : test_set_.scalars) {
-    expected.push_back(test_set_.bases[0].ScalarMul(scalar.ToBigInt()));
+    expected.push_back(test_set_.bases[0] * scalar);
   }
   std::vector<test::JacobianPoint> actual =
       test::AffinePoint::MultiScalarMul(test_set_.scalars, test_set_.bases[0]);
@@ -171,7 +171,7 @@ TEST_F(MultiScalarMulTest, MultiScalarsMultiBases) {
   std::vector<test::JacobianPoint> expected;
   for (auto& [scalar, base] :
        base::Zipped(test_set_.scalars, test_set_.bases)) {
-    expected.push_back(base.ScalarMul(scalar.ToBigInt()));
+    expected.push_back(base * scalar);
   }
   std::vector<test::JacobianPoint> actual =
       test::AffinePoint::MultiScalarMul(test_set_.scalars, test_set_.bases);

--- a/tachyon/math/base/semigroups_unittest.cc
+++ b/tachyon/math/base/semigroups_unittest.cc
@@ -146,9 +146,20 @@ TEST_F(MultiScalarMulTest, SingleScalarMultiBases) {
   for (const test::AffinePoint& base : test_set_.bases) {
     expected.push_back(base * scalar);
   }
-  std::vector<test::JacobianPoint> actual =
-      test::AffinePoint::MultiScalarMul(test_set_.scalars[0], test_set_.bases);
-  EXPECT_EQ(actual, expected);
+  {
+    std::vector<test::JacobianPoint> actual;
+    actual.resize(test_set_.bases.size());
+    ASSERT_TRUE(test::AffinePoint::MultiScalarMul(test_set_.scalars[0],
+                                                  test_set_.bases, &actual));
+    EXPECT_EQ(actual, expected);
+  }
+  {
+    std::vector<test::JacobianPoint> actual;
+    actual.resize(test_set_.bases.size());
+    ASSERT_TRUE(test::AffinePoint::MultiScalarMul(
+        test_set_.scalars[0], absl::MakeConstSpan(test_set_.bases), &actual));
+    EXPECT_EQ(actual, expected);
+  }
 }
 
 // scalars: [s₀, s₁, ..., sₙ₋₁]
@@ -159,9 +170,20 @@ TEST_F(MultiScalarMulTest, MultiScalarsSingleBase) {
   for (const GF7& scalar : test_set_.scalars) {
     expected.push_back(test_set_.bases[0] * scalar);
   }
-  std::vector<test::JacobianPoint> actual =
-      test::AffinePoint::MultiScalarMul(test_set_.scalars, test_set_.bases[0]);
-  EXPECT_EQ(actual, expected);
+  {
+    std::vector<test::JacobianPoint> actual;
+    actual.resize(test_set_.scalars.size());
+    ASSERT_TRUE(test::AffinePoint::MultiScalarMul(test_set_.scalars,
+                                                  test_set_.bases[0], &actual));
+    EXPECT_EQ(actual, expected);
+  }
+  {
+    std::vector<test::JacobianPoint> actual;
+    actual.resize(test_set_.bases.size());
+    ASSERT_TRUE(test::AffinePoint::MultiScalarMul(
+        absl::MakeConstSpan(test_set_.scalars), test_set_.bases[0], &actual));
+    EXPECT_EQ(actual, expected);
+  }
 }
 
 // scalars: [s₀, s₁, ..., sₙ₋₁]
@@ -173,9 +195,21 @@ TEST_F(MultiScalarMulTest, MultiScalarsMultiBases) {
        base::Zipped(test_set_.scalars, test_set_.bases)) {
     expected.push_back(base * scalar);
   }
-  std::vector<test::JacobianPoint> actual =
-      test::AffinePoint::MultiScalarMul(test_set_.scalars, test_set_.bases);
-  EXPECT_EQ(actual, expected);
+  {
+    std::vector<test::JacobianPoint> actual;
+    actual.resize(test_set_.scalars.size());
+    ASSERT_TRUE(test::AffinePoint::MultiScalarMul(test_set_.scalars,
+                                                  test_set_.bases, &actual));
+    EXPECT_EQ(actual, expected);
+  }
+  {
+    std::vector<test::JacobianPoint> actual;
+    actual.resize(test_set_.bases.size());
+    ASSERT_TRUE(test::AffinePoint::MultiScalarMul(
+        absl::MakeConstSpan(test_set_.scalars),
+        absl::MakeConstSpan(test_set_.bases), &actual));
+    EXPECT_EQ(actual, expected);
+  }
 }
 
 }  // namespace tachyon::math

--- a/tachyon/math/elliptic_curves/affine_point_unittest.cc
+++ b/tachyon/math/elliptic_curves/affine_point_unittest.cc
@@ -11,7 +11,7 @@ namespace {
 
 class AffinePointTest : public testing::Test {
  public:
-  static void SetUpTestSuite() { test::AffinePoint::Curve::Init(); }
+  static void SetUpTestSuite() { test::G1Curve::Init(); }
 };
 
 }  // namespace

--- a/tachyon/math/elliptic_curves/jacobian_point_unittest.cc
+++ b/tachyon/math/elliptic_curves/jacobian_point_unittest.cc
@@ -11,7 +11,7 @@ namespace {
 
 class JacobianPointTest : public testing::Test {
  public:
-  static void SetUpTestSuite() { test::JacobianPoint::Curve::Init(); }
+  static void SetUpTestSuite() { test::G1Curve::Init(); }
 };
 
 }  // namespace

--- a/tachyon/math/elliptic_curves/msm/kernels/cuzk/cuzk_kernels.cu.h
+++ b/tachyon/math/elliptic_curves/msm/kernels/cuzk/cuzk_kernels.cu.h
@@ -203,7 +203,7 @@ __global__ void ReduceBucketsStep1(
 
   if (start != 0) {
     result -= running_sum;
-    result += running_sum.ScalarMul(BigInt<1>(start));
+    result += running_sum.ScalarMul(start);
   }
 
   intermediate_results[gid * gnum + gtid] = result;

--- a/tachyon/math/elliptic_curves/msm/test/msm_test_set.h
+++ b/tachyon/math/elliptic_curves/msm/test/msm_test_set.h
@@ -95,7 +95,7 @@ struct MSMTestSet {
             typename internal::AdditiveSemigroupTraits<PointTy>::ReturnTy;
         AddResultTy sum = AddResultTy::Zero();
         for (size_t i = 0; i < bases.size(); ++i) {
-          sum += bases[i].ScalarMul(scalars[i].ToBigInt());
+          sum += bases[i] * scalars[i];
         }
         answer = ConvertPoint<Bucket>(sum);
         break;

--- a/tachyon/math/elliptic_curves/point_xyzz_unittest.cc
+++ b/tachyon/math/elliptic_curves/point_xyzz_unittest.cc
@@ -11,7 +11,7 @@ namespace {
 
 class PointXYZZTest : public testing::Test {
  public:
-  static void SetUpTestSuite() { test::PointXYZZ::Curve::Init(); }
+  static void SetUpTestSuite() { test::G1Curve::Init(); }
 };
 
 }  // namespace

--- a/tachyon/math/elliptic_curves/projective_point_unittest.cc
+++ b/tachyon/math/elliptic_curves/projective_point_unittest.cc
@@ -11,7 +11,7 @@ namespace {
 
 class ProjectivePointTest : public testing::Test {
  public:
-  static void SetUpTestSuite() { test::ProjectivePoint::Curve::Init(); }
+  static void SetUpTestSuite() { test::G1Curve::Init(); }
 };
 
 }  // namespace

--- a/tachyon/math/elliptic_curves/short_weierstrass/affine_point.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/affine_point.h
@@ -178,7 +178,7 @@ class AffinePoint<_Curve, std::enable_if_t<_Curve::kIsSWCurve>> final
   constexpr PointXYZZ<Curve> DoubleXYZZ() const;
 
   constexpr JacobianPoint<Curve> operator*(const ScalarField& v) const {
-    return this->ScalarMul(v.ToBigInt());
+    return this->ScalarMul(v);
   }
 
  private:

--- a/tachyon/math/elliptic_curves/short_weierstrass/jacobian_point.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/jacobian_point.h
@@ -191,7 +191,7 @@ class JacobianPoint<_Curve, std::enable_if_t<_Curve::kIsSWCurve>> final
   }
 
   constexpr JacobianPoint operator*(const ScalarField& v) const {
-    return this->ScalarMul(v.ToBigInt());
+    return this->ScalarMul(v);
   }
   constexpr JacobianPoint& operator*=(const ScalarField& v) {
     return *this = operator*(v);

--- a/tachyon/math/elliptic_curves/short_weierstrass/point_xyzz.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/point_xyzz.h
@@ -208,7 +208,7 @@ class PointXYZZ<_Curve, std::enable_if_t<_Curve::kIsSWCurve>> final
   }
 
   constexpr PointXYZZ operator*(const ScalarField& v) const {
-    return this->ScalarMul(v.ToBigInt());
+    return this->ScalarMul(v);
   }
   constexpr PointXYZZ& operator*=(const ScalarField& v) {
     return *this = operator*(v);

--- a/tachyon/math/elliptic_curves/short_weierstrass/projective_point.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/projective_point.h
@@ -187,7 +187,7 @@ class ProjectivePoint<_Curve, std::enable_if_t<_Curve::kIsSWCurve>> final
   }
 
   constexpr ProjectivePoint operator*(const ScalarField& v) const {
-    return this->ScalarMul(v.ToBigInt());
+    return this->ScalarMul(v);
   }
   constexpr ProjectivePoint& operator*=(const ScalarField& v) {
     return *this = operator*(v);

--- a/tachyon/math/elliptic_curves/short_weierstrass/test/curve_config.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/test/curve_config.h
@@ -48,17 +48,17 @@ BaseField CurveConfig<BaseField, ScalarField>::kB;
 template <typename BaseField, typename ScalarField>
 Point2<BaseField> CurveConfig<BaseField, ScalarField>::kGenerator;
 
-using AffinePoint = math::AffinePoint<SWCurve<CurveConfig<GF7, GF7>>>;
-using ProjectivePoint = math::ProjectivePoint<SWCurve<CurveConfig<GF7, GF7>>>;
-using JacobianPoint = math::JacobianPoint<SWCurve<CurveConfig<GF7, GF7>>>;
-using PointXYZZ = math::PointXYZZ<SWCurve<CurveConfig<GF7, GF7>>>;
+using G1Curve = SWCurve<CurveConfig<GF7, GF7>>;
+using AffinePoint = math::AffinePoint<G1Curve>;
+using ProjectivePoint = math::ProjectivePoint<G1Curve>;
+using JacobianPoint = math::JacobianPoint<G1Curve>;
+using PointXYZZ = math::PointXYZZ<G1Curve>;
 #if defined(TACHYON_GMP_BACKEND)
-using AffinePointGmp = math::AffinePoint<SWCurve<CurveConfig<GF7Gmp, GF7Gmp>>>;
-using ProjectivePointGmp =
-    math::ProjectivePoint<SWCurve<CurveConfig<GF7Gmp, GF7Gmp>>>;
-using JacobianPointGmp =
-    math::JacobianPoint<SWCurve<CurveConfig<GF7Gmp, GF7Gmp>>>;
-using PointXYZZGmp = math::PointXYZZ<SWCurve<CurveConfig<GF7Gmp, GF7Gmp>>>;
+using G1CurveGmp = SWCurve<CurveConfig<GF7Gmp, GF7Gmp>>;
+using AffinePointGmp = math::AffinePoint<G1CurveGmp>;
+using ProjectivePointGmp = math::ProjectivePoint<G1CurveGmp>;
+using JacobianPointGmp = math::JacobianPoint<G1CurveGmp>;
+using PointXYZZGmp = math::PointXYZZ<G1CurveGmp>;
 #endif  // defined(TACHYON_GMP_BACKEND)
 
 }  // namespace test


### PR DESCRIPTION
# Description

- Unlike `BatchInverse`, `BatchScalarMul` doesn't have a benifit itself when doing in batch. It just parallelize if openmp feature is turned on. So to deliver its meaning clearer, this commit renames the functions.

- This PR also generalizes `ScalarMul` and `MultiScalarMul` by accepting more type as function argumetns.