### PR TITLE
feat!: remove MaxDegree and use MaxSize only

### DIFF
--- a/tachyon/crypto/commitments/kzg/kzg_commitment_scheme.h
+++ b/tachyon/crypto/commitments/kzg/kzg_commitment_scheme.h
@@ -30,7 +30,7 @@ class KZGCommitmentScheme
       KZGCommitmentScheme<G1PointTy, G2PointTy, ResultTy>>;
   using Field = typename G1PointTy::ScalarField;
 
-  static constexpr size_t kMaxDegree = Base::kMaxSize - 1;
+  static constexpr size_t kMaxSize = Base::kMaxSize;
 
   KZGCommitmentScheme() = default;
 
@@ -41,7 +41,7 @@ class KZGCommitmentScheme
         g1_powers_of_tau_lagrange_(std::move(g1_powers_of_tau_lagrange)),
         tau_g2_(std::move(tau_g2)) {
     CHECK_EQ(g1_powers_of_tau_.size(), g1_powers_of_tau_lagrange_.size());
-    CHECK_LE(g1_powers_of_tau_.size(), Base::kMaxSize);
+    CHECK_LE(g1_powers_of_tau_.size(), kMaxSize);
   }
 
   const std::vector<G1PointTy>& g1_powers_of_tau() const {
@@ -59,7 +59,7 @@ class KZGCommitmentScheme
 
   [[nodiscard]] bool UnsafeSetupWithTau(size_t size, Field tau) {
     using G1JacobianPointTy = typename G1PointTy::JacobianPointTy;
-    using DomainTy = math::UnivariateEvaluationDomain<Field, kMaxDegree>;
+    using DomainTy = math::UnivariateEvaluationDomain<Field, kMaxSize>;
 
     // |g1_powers_of_tau_| = [𝜏⁰g₁, 𝜏¹g₁, ... , 𝜏ⁿ⁻¹g₁]
     G1PointTy g1 = G1PointTy::Generator();
@@ -78,8 +78,7 @@ class KZGCommitmentScheme
 
     // Get |g1_powers_of_tau_lagrange_| from 𝜏 and g₁.
     std::unique_ptr<DomainTy> domain =
-        math::UnivariateEvaluationDomainFactory<Field, kMaxDegree>::Create(
-            size);
+        math::UnivariateEvaluationDomainFactory<Field, kMaxSize>::Create(size);
     typename DomainTy::DenseCoeffs lagrange_coeffs =
         domain->EvaluateAllLagrangeCoefficients(tau);
     std::vector<G1JacobianPointTy> g1_powers_of_tau_lagrange_jacobian;

--- a/tachyon/crypto/commitments/univariate_polynomial_commitment_scheme.h
+++ b/tachyon/crypto/commitments/univariate_polynomial_commitment_scheme.h
@@ -12,24 +12,24 @@ namespace tachyon::crypto {
 template <typename C>
 class UnivariatePolynomialCommitmentScheme : public VectorCommitmentScheme<C> {
  public:
-  constexpr static size_t kMaxDegree = VectorCommitmentScheme<C>::kMaxSize - 1;
+  constexpr static size_t kMaxSize = VectorCommitmentScheme<C>::kMaxSize;
 
   using Field = typename VectorCommitmentScheme<C>::Field;
   using ResultTy = typename VectorCommitmentScheme<C>::ResultTy;
 
   // Commit to |poly| and populates |result| with the commitment.
-  // Return false if the degree of |poly| exceeds |kMaxDegree|.
+  // Return false if the size of |poly| exceeds |kMaxSize|.
   [[nodiscard]] bool Commit(
-      const math::UnivariateDensePolynomial<Field, kMaxDegree>& poly,
+      const math::UnivariateDensePolynomial<Field, kMaxSize>& poly,
       ResultTy* result) const {
     const C* c = static_cast<const C*>(this);
     return c->DoCommit(poly.coefficients().coefficients(), result);
   }
 
   // Commit to |poly| and populates |result| with the commitment.
-  // Return false if the degree of |poly| exceeds |kMaxDegree|.
+  // Return false if the size of |poly| exceeds |kMaxSize|.
   [[nodiscard]] bool CommitLagrange(
-      const math::UnivariateEvaluations<Field, kMaxDegree>& evals,
+      const math::UnivariateEvaluations<Field, kMaxSize>& evals,
       ResultTy* result) const {
     const C* c = static_cast<const C*>(this);
     return c->DoCommitLagrange(evals.evaluations(), result);

--- a/tachyon/math/polynomials/evaluation_domain.h
+++ b/tachyon/math/polynomials/evaluation_domain.h
@@ -5,7 +5,7 @@
 
 namespace tachyon::math {
 
-template <typename F, size_t MaxDegree>
+template <typename F, size_t N>
 class EvaluationDomain {};
 
 }  // namespace tachyon::math

--- a/tachyon/math/polynomials/multivariate/multilinear_dense_evaluations.h
+++ b/tachyon/math/polynomials/multivariate/multilinear_dense_evaluations.h
@@ -20,10 +20,10 @@
 
 namespace tachyon::math {
 
-template <typename F, size_t MaxDegree>
+template <typename F, size_t N>
 class MultilinearDenseEvaluations {
  public:
-  constexpr static const size_t kMaxDegree = MaxDegree;
+  constexpr static const size_t kMaxSize = N;
 
   using Field = F;
 
@@ -32,26 +32,24 @@ class MultilinearDenseEvaluations {
   constexpr explicit MultilinearDenseEvaluations(
       const std::vector<F>& evaluations)
       : evaluations_(evaluations) {
-    CHECK_LE(Degree(), MaxDegree);
+    CHECK_LE(evaluations_.size(), N);
   }
   constexpr explicit MultilinearDenseEvaluations(std::vector<F>&& evaluations)
       : evaluations_(std::move(evaluations)) {
-    CHECK_LE(Degree(), MaxDegree);
+    CHECK_LE(evaluations_.size(), N);
   }
 
-  constexpr static MultilinearDenseEvaluations Zero(size_t degree) {
-    return MultilinearDenseEvaluations(
-        base::CreateVector(size_t{1} << degree, F::Zero()));
+  constexpr static MultilinearDenseEvaluations Zero(size_t size) {
+    return MultilinearDenseEvaluations(base::CreateVector(size, F::Zero()));
   }
 
-  constexpr static MultilinearDenseEvaluations One(size_t degree) {
-    return MultilinearDenseEvaluations(
-        base::CreateVector(size_t{1} << degree, F::One()));
+  constexpr static MultilinearDenseEvaluations One(size_t size) {
+    return MultilinearDenseEvaluations(base::CreateVector(size, F::One()));
   }
 
-  constexpr static MultilinearDenseEvaluations Random(size_t degree) {
+  constexpr static MultilinearDenseEvaluations Random(size_t size) {
     return MultilinearDenseEvaluations(
-        base::CreateVector(size_t{1} << degree, []() { return F::Random(); }));
+        base::CreateVector(size, []() { return F::Random(); }));
   }
 
   constexpr bool operator==(const MultilinearDenseEvaluations& other) const {
@@ -120,8 +118,8 @@ class MultilinearDenseEvaluations {
         poly[b] = left + r * (right - left);
       }
     }
-    return MultilinearDenseEvaluations(std::vector<F>(
-        poly.begin(), poly.begin() + (size_t{1} << (n - k))));
+    return MultilinearDenseEvaluations(
+        std::vector<F>(poly.begin(), poly.begin() + (size_t{1} << (n - k))));
   }
 
   // Evaluate polynomial at |point|. It uses |FixVariables()| internally. The
@@ -149,7 +147,7 @@ class MultilinearDenseEvaluations {
 
  private:
   friend class internal::MultilinearExtensionOp<
-      MultilinearDenseEvaluations<F, MaxDegree>>;
+      MultilinearDenseEvaluations<F, N>>;
 
   std::vector<F> evaluations_;
 };

--- a/tachyon/math/polynomials/multivariate/multilinear_dense_evaluations_unittest.cc
+++ b/tachyon/math/polynomials/multivariate/multilinear_dense_evaluations_unittest.cc
@@ -8,10 +8,11 @@
 namespace tachyon::math {
 
 namespace {
-const size_t kMaxDegree = 4;
 
-using Poly = MultilinearExtension<MultilinearDenseEvaluations<GF7, kMaxDegree>>;
-using Evals = MultilinearDenseEvaluations<GF7, kMaxDegree>;
+constexpr size_t kMaxSize = 5;
+
+using Poly = MultilinearExtension<MultilinearDenseEvaluations<GF7, kMaxSize>>;
+using Evals = MultilinearDenseEvaluations<GF7, kMaxSize>;
 
 class MultilinearDenseEvaluationsTest : public testing::Test {
  public:
@@ -32,7 +33,7 @@ class MultilinearDenseEvaluationsTest : public testing::Test {
 
 TEST_F(MultilinearDenseEvaluationsTest, IsZero) {
   EXPECT_TRUE(Poly().IsZero());
-  EXPECT_TRUE(Poly::Zero(kMaxDegree).IsZero());
+  EXPECT_TRUE(Poly::Zero(kMaxSize).IsZero());
   EXPECT_TRUE(Poly(Evals({GF7(0)})).IsZero());
   for (size_t i = 0; i < polys_.size(); ++i) {
     EXPECT_FALSE(Poly(polys_[i]).IsZero());
@@ -40,7 +41,7 @@ TEST_F(MultilinearDenseEvaluationsTest, IsZero) {
 }
 
 TEST_F(MultilinearDenseEvaluationsTest, IsOne) {
-  EXPECT_TRUE(Poly::One(kMaxDegree).IsOne());
+  EXPECT_TRUE(Poly::One(kMaxSize).IsOne());
   EXPECT_TRUE(Poly(Evals({GF7(1)})).IsOne());
   for (size_t i = 0; i < polys_.size(); ++i) {
     EXPECT_FALSE(polys_[i].IsOne());
@@ -49,9 +50,9 @@ TEST_F(MultilinearDenseEvaluationsTest, IsOne) {
 
 TEST_F(MultilinearDenseEvaluationsTest, Random) {
   bool success = false;
-  Poly r = Poly::Random(kMaxDegree);
+  Poly r = Poly::Random(kMaxSize);
   for (size_t i = 0; i < 100; ++i) {
-    if (r != Poly::Random(kMaxDegree)) {
+    if (r != Poly::Random(kMaxSize)) {
       success = true;
       break;
     }
@@ -71,7 +72,7 @@ TEST_F(MultilinearDenseEvaluationsTest, IndexingOperator) {
   };
 
   for (const auto& test : tests) {
-    for (size_t i = 0; i < kMaxDegree; ++i) {
+    for (size_t i = 0; i < kMaxSize; ++i) {
       if (i < test.evaluations.size()) {
         EXPECT_EQ(*test.poly[i], GF7(test.evaluations[i]));
       } else {
@@ -90,7 +91,7 @@ TEST_F(MultilinearDenseEvaluationsTest, Degree) {
   for (const auto& test : tests) {
     EXPECT_EQ(test.poly.Degree(), test.degree);
   }
-  EXPECT_LE(Poly::Random(kMaxDegree).Degree(), kMaxDegree);
+  EXPECT_LE(Poly::Random(kMaxSize).Degree(), kMaxSize - 1);
 }
 
 TEST_F(MultilinearDenseEvaluationsTest, Evaluate) {

--- a/tachyon/math/polynomials/multivariate/multilinear_extension.h
+++ b/tachyon/math/polynomials/multivariate/multilinear_extension.h
@@ -34,16 +34,16 @@ class MultilinearExtension final
 
   constexpr static bool IsEvaluationForm() { return true; }
 
-  constexpr static MultilinearExtension Zero(size_t degree) {
-    return MultilinearExtension(Evaluations::Zero(degree));
+  constexpr static MultilinearExtension Zero(size_t size) {
+    return MultilinearExtension(Evaluations::Zero(size));
   }
 
-  constexpr static MultilinearExtension One(size_t degree) {
-    return MultilinearExtension(Evaluations::One(degree));
+  constexpr static MultilinearExtension One(size_t size) {
+    return MultilinearExtension(Evaluations::One(size));
   }
 
-  constexpr static MultilinearExtension Random(size_t degree) {
-    return MultilinearExtension(Evaluations::Random(degree));
+  constexpr static MultilinearExtension Random(size_t size) {
+    return MultilinearExtension(Evaluations::Random(size));
   }
 
   constexpr bool IsZero() const { return evaluations_.IsZero(); }
@@ -137,14 +137,14 @@ class MultilinearExtension final
 
  private:
   friend class internal::MultilinearExtensionOp<
-      MultilinearDenseEvaluations<Field, Evaluations::kMaxDegree>>;
+      MultilinearDenseEvaluations<Field, Evaluations::kMaxSize>>;
 
   Evaluations evaluations_;
 };
 
-template <typename F, size_t MaxDegree>
+template <typename F, size_t N>
 using MultilinearDenseExtension =
-    MultilinearExtension<MultilinearDenseEvaluations<F, MaxDegree>>;
+    MultilinearExtension<MultilinearDenseEvaluations<F, N>>;
 
 template <typename Evaluations>
 class PolynomialTraits<MultilinearExtension<Evaluations>> {

--- a/tachyon/math/polynomials/multivariate/multilinear_extension_ops.h
+++ b/tachyon/math/polynomials/multivariate/multilinear_extension_ops.h
@@ -10,10 +10,10 @@
 namespace tachyon::math {
 namespace internal {
 
-template <typename F, size_t MaxDegree>
-class MultilinearExtensionOp<MultilinearDenseEvaluations<F, MaxDegree>> {
+template <typename F, size_t N>
+class MultilinearExtensionOp<MultilinearDenseEvaluations<F, N>> {
  public:
-  using D = MultilinearDenseEvaluations<F, MaxDegree>;
+  using D = MultilinearDenseEvaluations<F, N>;
 
   static MultilinearExtension<D>& AddInPlace(
       MultilinearExtension<D>& self, const MultilinearExtension<D>& other) {

--- a/tachyon/math/polynomials/multivariate/multivariate_polynomial.h
+++ b/tachyon/math/polynomials/multivariate/multivariate_polynomial.h
@@ -19,7 +19,7 @@ template <typename Coefficients>
 class MultivariatePolynomial final
     : public Polynomial<MultivariatePolynomial<Coefficients>> {
  public:
-  constexpr static size_t kMaxDegree = Coefficients::kMaxDegree;
+  constexpr static size_t kMaxSize = Coefficients::kMaxSize;
 
   using Field = typename Coefficients::Field;
   using Literal = typename Coefficients::Literal;
@@ -38,8 +38,9 @@ class MultivariatePolynomial final
     return MultivariatePolynomial(Coefficients::One());
   }
 
-  constexpr static MultivariatePolynomial Random(size_t arity, size_t degree) {
-    return MultivariatePolynomial(Coefficients::Random(arity, degree));
+  constexpr static MultivariatePolynomial Random(size_t arity,
+                                                 size_t exponent) {
+    return MultivariatePolynomial(Coefficients::Random(arity, exponent));
   }
 
   constexpr static bool IsCoefficientForm() { return true; }
@@ -118,9 +119,9 @@ class MultivariatePolynomial final
   Coefficients coefficients_;
 };
 
-template <typename F, size_t MaxDegree>
+template <typename F, size_t N>
 using MultivariateSparsePolynomial =
-    MultivariatePolynomial<MultivariateSparseCoefficients<F, MaxDegree>>;
+    MultivariatePolynomial<MultivariateSparseCoefficients<F, N>>;
 
 template <typename Coefficients>
 class PolynomialTraits<MultivariatePolynomial<Coefficients>> {

--- a/tachyon/math/polynomials/multivariate/multivariate_polynomial_ops.h
+++ b/tachyon/math/polynomials/multivariate/multivariate_polynomial_ops.h
@@ -16,10 +16,10 @@
 namespace tachyon::math {
 namespace internal {
 
-template <typename F, size_t MaxDegree>
-class MultivariatePolynomialOp<MultivariateSparseCoefficients<F, MaxDegree>> {
+template <typename F, size_t N>
+class MultivariatePolynomialOp<MultivariateSparseCoefficients<F, N>> {
  public:
-  using S = MultivariateSparseCoefficients<F, MaxDegree>;
+  using S = MultivariateSparseCoefficients<F, N>;
   using Term = typename S::Term;
   using Terms = std::vector<Term>;
 

--- a/tachyon/math/polynomials/multivariate/multivariate_polynomial_unittest.cc
+++ b/tachyon/math/polynomials/multivariate/multivariate_polynomial_unittest.cc
@@ -9,10 +9,10 @@ namespace tachyon::math {
 namespace {
 
 const size_t kNumVars = 2;
-const size_t kMaxDegree = 5;
+const size_t kMaxSize = 10;
 
-using Poly = MultivariateSparsePolynomial<GF7, kMaxDegree>;
-using Coeffs = MultivariateSparseCoefficients<GF7, kMaxDegree>;
+using Poly = MultivariateSparsePolynomial<GF7, kMaxSize>;
+using Coeffs = MultivariateSparseCoefficients<GF7, kMaxSize>;
 
 class MultivariatePolynomialTest : public testing::Test {
  public:
@@ -213,9 +213,9 @@ TEST_F(MultivariatePolynomialTest, IsOne) {
 
 TEST_F(MultivariatePolynomialTest, Random) {
   bool success = false;
-  Poly r = Poly::Random(kNumVars, kMaxDegree);
+  Poly r = Poly::Random(kNumVars, kMaxSize);
   for (size_t i = 0; i < 100; ++i) {
-    if (r != Poly::Random(kNumVars, kMaxDegree)) {
+    if (r != Poly::Random(kNumVars, kMaxSize)) {
       success = true;
       break;
     }
@@ -261,7 +261,8 @@ TEST_F(MultivariatePolynomialTest, Degree) {
   for (const auto& test : tests) {
     EXPECT_EQ(test.poly.Degree(), test.degree);
   }
-  EXPECT_LE(Poly::Random(kNumVars, kMaxDegree).Degree(), kMaxDegree);
+  // TODO(chokobole): How do we check against max degree?
+  // EXPECT_LE(Poly::Random(kNumVars, kMaxSize).Degree(), ???);
 }
 
 TEST_F(MultivariatePolynomialTest, Evaluate) {

--- a/tachyon/math/polynomials/multivariate/multivariate_sparse_coefficients.h
+++ b/tachyon/math/polynomials/multivariate/multivariate_sparse_coefficients.h
@@ -24,10 +24,10 @@
 #include "tachyon/math/polynomials/multivariate/support_poly_operators.h"
 
 namespace tachyon::math {
-template <typename F, size_t MaxDegree>
+template <typename F, size_t N>
 class MultivariateSparseCoefficients {
  public:
-  constexpr static size_t kMaxDegree = MaxDegree;
+  constexpr static size_t kMaxSize = N;
 
   using Field = F;
 
@@ -171,12 +171,12 @@ class MultivariateSparseCoefficients {
   constexpr MultivariateSparseCoefficients() = default;
   constexpr MultivariateSparseCoefficients(size_t num_vars, const Terms& terms)
       : num_vars_(num_vars), terms_(terms) {
-    CHECK_LE(Degree(), kMaxDegree);
+    CHECK_LE(terms_.size(), N);
     DCHECK(base::ranges::is_sorted(terms_.begin(), terms_.end()));
   }
   constexpr MultivariateSparseCoefficients(size_t num_vars, Terms&& terms)
       : num_vars_(num_vars), terms_(std::move(terms)) {
-    CHECK_LE(Degree(), kMaxDegree);
+    CHECK_LE(terms_.size(), N);
     DCHECK(base::ranges::is_sorted(terms_.begin(), terms_.end()));
   }
 
@@ -190,7 +190,7 @@ class MultivariateSparseCoefficients {
 
   static MultivariateSparseCoefficients Random(size_t arity, size_t exponent,
                                                size_t min_term = 1,
-                                               size_t max_term = 999) {
+                                               size_t max_term = N) {
     Terms terms;
     size_t num_terms = base::Uniform(base::Range<size_t>(min_term, max_term));
     terms.push_back(Term::Constant(F::Random()));
@@ -335,7 +335,7 @@ class MultivariateSparseCoefficients {
 
  private:
   friend class internal::MultivariatePolynomialOp<
-      MultivariateSparseCoefficients<F, MaxDegree>>;
+      MultivariateSparseCoefficients<F, N>>;
 
   static F EvaluateSerial(absl::Span<const Term> terms,
                           const std::vector<F>& points) {
@@ -346,6 +346,7 @@ class MultivariateSparseCoefficients {
                            });
   }
 
+  // TODO(chokobole): Do we need to maintain |num_vars_|?
   size_t num_vars_;
   std::vector<Term> terms_;
 };

--- a/tachyon/math/polynomials/univariate/radix2_evaluation_domain.h
+++ b/tachyon/math/polynomials/univariate/radix2_evaluation_domain.h
@@ -35,15 +35,15 @@ namespace tachyon::math {
 // Defines a domain over which finite field (I)FFTs can be performed. Works
 // only for fields that have a large multiplicative subgroup of size that is a
 // power-of-2.
-template <typename F, size_t MaxDegree = size_t{1} << F::Config::kTwoAdicity>
-class Radix2EvaluationDomain : public UnivariateEvaluationDomain<F, MaxDegree> {
+template <typename F, size_t N = size_t{1} << F::Config::kTwoAdicity>
+class Radix2EvaluationDomain : public UnivariateEvaluationDomain<F, N> {
  public:
   using Field = F;
-  using Evals = UnivariateEvaluations<F, MaxDegree>;
-  using DensePoly = UnivariateDensePolynomial<F, MaxDegree>;
-  using SparsePoly = UnivariateSparsePolynomial<F, MaxDegree>;
+  using Evals = UnivariateEvaluations<F, N>;
+  using DensePoly = UnivariateDensePolynomial<F, N>;
+  using SparsePoly = UnivariateSparsePolynomial<F, N>;
 
-  constexpr static size_t kMaxDegree = MaxDegree;
+  constexpr static size_t kMaxSize = N;
   // Factor that determines if a the degree aware FFT should be called.
   constexpr static size_t kDegreeAwareFFTThresholdFactor = 1 << 2;
   // The minimum size of a chunk at which parallelization of |Butterfly()| is
@@ -86,10 +86,10 @@ class Radix2EvaluationDomain : public UnivariateEvaluationDomain<F, MaxDegree> {
   template <typename T>
   FRIEND_TEST(UnivariateEvaluationDomainTest, RootsOfUnity);
 
-  using UnivariateEvaluationDomain<F, MaxDegree>::UnivariateEvaluationDomain;
+  using UnivariateEvaluationDomain<F, N>::UnivariateEvaluationDomain;
 
   // UnivariateEvaluationDomain methods
-  constexpr std::unique_ptr<UnivariateEvaluationDomain<F, MaxDegree>> Clone()
+  constexpr std::unique_ptr<UnivariateEvaluationDomain<F, N>> Clone()
       const override {
     return absl::WrapUnique(new Radix2EvaluationDomain(*this));
   }
@@ -205,10 +205,10 @@ class Radix2EvaluationDomain : public UnivariateEvaluationDomain<F, MaxDegree> {
     void (*fn)(F&, F&, const F&);
 
     if constexpr (Order == FFTOrder::kInOut) {
-      fn = UnivariateEvaluationDomain<F, MaxDegree>::ButterflyFnInOut;
+      fn = UnivariateEvaluationDomain<F, N>::ButterflyFnInOut;
     } else {
       static_assert(Order == FFTOrder::kOutIn);
-      fn = UnivariateEvaluationDomain<F, MaxDegree>::ButterflyFnOutIn;
+      fn = UnivariateEvaluationDomain<F, N>::ButterflyFnOutIn;
     }
     OPENMP_PARALLEL_FOR(size_t i = 0; i <= poly_or_evals.Degree();
                         i += chunk_size) {

--- a/tachyon/math/polynomials/univariate/univariate_dense_polynomial_unittest.cc
+++ b/tachyon/math/polynomials/univariate/univariate_dense_polynomial_unittest.cc
@@ -8,10 +8,10 @@ namespace tachyon::math {
 
 namespace {
 
-const size_t kMaxDegree = 5;
+const size_t kMaxSize = 6;
 
-using Poly = UnivariateDensePolynomial<GF7, kMaxDegree>;
-using Coeffs = UnivariateDenseCoefficients<GF7, kMaxDegree>;
+using Poly = UnivariateDensePolynomial<GF7, kMaxSize>;
+using Coeffs = UnivariateDenseCoefficients<GF7, kMaxSize>;
 
 class UnivariateDensePolynomialTest : public testing::Test {
  public:
@@ -51,9 +51,9 @@ TEST_F(UnivariateDensePolynomialTest, IsOne) {
 
 TEST_F(UnivariateDensePolynomialTest, Random) {
   bool success = false;
-  Poly r = Poly::Random(kMaxDegree);
+  Poly r = Poly::Random(kMaxSize);
   for (size_t i = 0; i < 100; ++i) {
-    if (r != Poly::Random(kMaxDegree)) {
+    if (r != Poly::Random(kMaxSize)) {
       success = true;
       break;
     }
@@ -71,7 +71,7 @@ TEST_F(UnivariateDensePolynomialTest, IndexingOperator) {
   };
 
   for (const auto& test : tests) {
-    for (size_t i = 0; i < kMaxDegree; ++i) {
+    for (size_t i = 0; i < kMaxSize; ++i) {
       if (i < test.coefficients.size()) {
         EXPECT_EQ(*test.poly[i], GF7(test.coefficients[i]));
       } else {
@@ -93,7 +93,7 @@ TEST_F(UnivariateDensePolynomialTest, Degree) {
   for (const auto& test : tests) {
     EXPECT_EQ(test.poly.Degree(), test.degree);
   }
-  EXPECT_LE(Poly::Random(kMaxDegree).Degree(), kMaxDegree);
+  EXPECT_LE(Poly::Random(kMaxSize).Degree(), kMaxSize - 1);
 }
 
 TEST_F(UnivariateDensePolynomialTest, Evaluate) {

--- a/tachyon/math/polynomials/univariate/univariate_evaluation_domain.h
+++ b/tachyon/math/polynomials/univariate/univariate_evaluation_domain.h
@@ -21,17 +21,17 @@
 
 namespace tachyon::math {
 
-template <typename F, size_t MaxDegree>
-class UnivariateEvaluationDomain : public EvaluationDomain<F, MaxDegree> {
+template <typename F, size_t N>
+class UnivariateEvaluationDomain : public EvaluationDomain<F, N> {
  public:
   static_assert(F::HasRootOfUnity(),
                 "UnivariateEvaluationDomain should have root of unity");
 
-  using Evals = UnivariateEvaluations<F, MaxDegree>;
-  using DensePoly = UnivariateDensePolynomial<F, MaxDegree>;
-  using DenseCoeffs = UnivariateDenseCoefficients<F, MaxDegree>;
-  using SparseCoeffs = UnivariateSparseCoefficients<F, MaxDegree>;
-  using SparsePoly = UnivariateSparsePolynomial<F, MaxDegree>;
+  using Evals = UnivariateEvaluations<F, N>;
+  using DensePoly = UnivariateDensePolynomial<F, N>;
+  using DenseCoeffs = UnivariateDenseCoefficients<F, N>;
+  using SparseCoeffs = UnivariateSparseCoefficients<F, N>;
+  using SparsePoly = UnivariateSparsePolynomial<F, N>;
 
   constexpr UnivariateEvaluationDomain() = default;
 

--- a/tachyon/math/polynomials/univariate/univariate_evaluation_domain_factory.h
+++ b/tachyon/math/polynomials/univariate/univariate_evaluation_domain_factory.h
@@ -14,7 +14,7 @@
 namespace tachyon::math {
 
 template <typename F>
-constexpr size_t MaxDegreeForEvaluationDomainFactory() {
+constexpr size_t MaxSizeForEvaluationDomainFactory() {
   size_t i = 1;
   if constexpr (F::Config::kHasLargeSubgroupRootOfUnity) {
     for (size_t i = 0; i <= F::Config::kSmallSubgroupAdicity; ++i) {
@@ -24,19 +24,17 @@ constexpr size_t MaxDegreeForEvaluationDomainFactory() {
   return i * (size_t{1} << F::Config::kTwoAdicity);
 }
 
-template <typename F,
-          size_t MaxDegree = MaxDegreeForEvaluationDomainFactory<F>()>
+template <typename F, size_t N = MaxSizeForEvaluationDomainFactory<F>()>
 class UnivariateEvaluationDomainFactory {
  public:
   // Construct a domain that is large enough for evaluations of a polynomial
   // having |num_coeffs| coefficients.
-  static std::unique_ptr<UnivariateEvaluationDomain<F, MaxDegree>> Create(
+  static std::unique_ptr<UnivariateEvaluationDomain<F, N>> Create(
       size_t num_coeffs) {
-    if (Radix2EvaluationDomain<F, MaxDegree>::IsValidNumCoeffs(num_coeffs)) {
-      return Radix2EvaluationDomain<F, MaxDegree>::Create(num_coeffs);
-    } else if (MixedRadixEvaluationDomain<F, MaxDegree>::IsValidNumCoeffs(
-                   num_coeffs)) {
-      return MixedRadixEvaluationDomain<F, MaxDegree>::Create(num_coeffs);
+    if (Radix2EvaluationDomain<F, N>::IsValidNumCoeffs(num_coeffs)) {
+      return Radix2EvaluationDomain<F, N>::Create(num_coeffs);
+    } else if (MixedRadixEvaluationDomain<F, N>::IsValidNumCoeffs(num_coeffs)) {
+      return MixedRadixEvaluationDomain<F, N>::Create(num_coeffs);
     }
     NOTREACHED();
     return nullptr;

--- a/tachyon/math/polynomials/univariate/univariate_evaluation_domain_forwards.h
+++ b/tachyon/math/polynomials/univariate/univariate_evaluation_domain_forwards.h
@@ -10,13 +10,13 @@
 
 namespace tachyon::math {
 
-template <typename F, size_t MaxDegree>
+template <typename F, size_t N>
 class UnivariateEvaluationDomain;
 
-template <typename F, size_t MaxDegree>
+template <typename F, size_t N>
 class Radix2EvaluationDomain;
 
-template <typename F, size_t MaxDegree>
+template <typename F, size_t N>
 class MixedRadixEvaluationDomain;
 
 }  // namespace tachyon::math

--- a/tachyon/math/polynomials/univariate/univariate_evaluation_domain_unittest.cc
+++ b/tachyon/math/polynomials/univariate/univariate_evaluation_domain_unittest.cc
@@ -24,7 +24,7 @@ class UnivariateEvaluationDomainTest : public testing::Test {
  public:
   using F = typename UnivariateEvaluationDomainType::Field;
   using BaseUnivariateEvaluationDomainType =
-      UnivariateEvaluationDomain<F, UnivariateEvaluationDomainType::kMaxDegree>;
+      UnivariateEvaluationDomain<F, UnivariateEvaluationDomainType::kMaxSize>;
 
   static void SetUpTestSuite() { F::Init(); }
 
@@ -57,7 +57,7 @@ TYPED_TEST(UnivariateEvaluationDomainTest, VanishingPolynomialEvaluation) {
   using UnivariateEvaluationDomainType = TypeParam;
   using F = typename UnivariateEvaluationDomainType::Field;
   using BaseUnivariateEvaluationDomainType =
-      UnivariateEvaluationDomain<F, UnivariateEvaluationDomainType::kMaxDegree>;
+      UnivariateEvaluationDomain<F, UnivariateEvaluationDomainType::kMaxSize>;
   using SparsePoly = typename UnivariateEvaluationDomainType::SparsePoly;
 
   for (size_t coeffs = 0; coeffs < kNumCoeffs; ++coeffs) {
@@ -76,7 +76,7 @@ TYPED_TEST(UnivariateEvaluationDomainTest,
   using UnivariateEvaluationDomainType = TypeParam;
   using F = typename UnivariateEvaluationDomainType::Field;
   using BaseUnivariateEvaluationDomainType =
-      UnivariateEvaluationDomain<F, UnivariateEvaluationDomainType::kMaxDegree>;
+      UnivariateEvaluationDomain<F, UnivariateEvaluationDomainType::kMaxSize>;
   using SparsePoly = typename UnivariateEvaluationDomainType::SparsePoly;
 
   for (size_t coeffs = 0; coeffs < kNumCoeffs; ++coeffs) {
@@ -93,7 +93,7 @@ TYPED_TEST(UnivariateEvaluationDomainTest, FilterPolynomial) {
   using UnivariateEvaluationDomainType = TypeParam;
   using F = typename UnivariateEvaluationDomainType::Field;
   using BaseUnivariateEvaluationDomainType =
-      UnivariateEvaluationDomain<F, UnivariateEvaluationDomainType::kMaxDegree>;
+      UnivariateEvaluationDomain<F, UnivariateEvaluationDomainType::kMaxSize>;
   using DensePoly = typename UnivariateEvaluationDomainType::DensePoly;
 
   if constexpr (std::is_same_v<F, bls12_381::Fr>) {
@@ -160,7 +160,7 @@ TYPED_TEST(UnivariateEvaluationDomainTest, ContentsOfElements) {
   using UnivariateEvaluationDomainType = TypeParam;
   using F = typename UnivariateEvaluationDomainType::Field;
   using BaseUnivariateEvaluationDomainType =
-      UnivariateEvaluationDomain<F, UnivariateEvaluationDomainType::kMaxDegree>;
+      UnivariateEvaluationDomain<F, UnivariateEvaluationDomainType::kMaxSize>;
 
   for (size_t coeffs = 0; coeffs < kNumCoeffs; ++coeffs) {
     size_t size = size_t{1} << coeffs;
@@ -181,7 +181,7 @@ TYPED_TEST(UnivariateEvaluationDomainTest, NonSystematicLagrangeCoefficients) {
   using UnivariateEvaluationDomainType = TypeParam;
   using F = typename UnivariateEvaluationDomainType::Field;
   using BaseUnivariateEvaluationDomainType =
-      UnivariateEvaluationDomain<F, UnivariateEvaluationDomainType::kMaxDegree>;
+      UnivariateEvaluationDomain<F, UnivariateEvaluationDomainType::kMaxSize>;
   using DenseCoeffs = typename UnivariateEvaluationDomainType::DenseCoeffs;
   using DensePoly = typename UnivariateEvaluationDomainType::DensePoly;
   using Evals = typename UnivariateEvaluationDomainType::Evals;
@@ -218,7 +218,7 @@ TYPED_TEST(UnivariateEvaluationDomainTest, SystematicLagrangeCoefficients) {
   using F = typename UnivariateEvaluationDomainType::Field;
   using DenseCoeffs = typename UnivariateEvaluationDomainType::DenseCoeffs;
   using BaseUnivariateEvaluationDomainType =
-      UnivariateEvaluationDomain<F, UnivariateEvaluationDomainType::kMaxDegree>;
+      UnivariateEvaluationDomain<F, UnivariateEvaluationDomainType::kMaxSize>;
 
   for (size_t domain_dim = 1; domain_dim < 5; ++domain_dim) {
     size_t domain_size = size_t{1} << domain_dim;
@@ -252,7 +252,7 @@ TYPED_TEST(UnivariateEvaluationDomainTest, FFTCorrectness) {
   using UnivariateEvaluationDomainType = TypeParam;
   using F = typename UnivariateEvaluationDomainType::Field;
   using BaseUnivariateEvaluationDomainType =
-      UnivariateEvaluationDomain<F, UnivariateEvaluationDomainType::kMaxDegree>;
+      UnivariateEvaluationDomain<F, UnivariateEvaluationDomainType::kMaxSize>;
   using DensePoly = typename UnivariateEvaluationDomainType::DensePoly;
   using Evals = typename UnivariateEvaluationDomainType::Evals;
 
@@ -280,7 +280,7 @@ TYPED_TEST(UnivariateEvaluationDomainTest, DegreeAwareFFTCorrectness) {
   using UnivariateEvaluationDomainType = TypeParam;
   using F = typename UnivariateEvaluationDomainType::Field;
   using BaseUnivariateEvaluationDomainType =
-      UnivariateEvaluationDomain<F, UnivariateEvaluationDomainType::kMaxDegree>;
+      UnivariateEvaluationDomain<F, UnivariateEvaluationDomainType::kMaxSize>;
   using DensePoly = typename UnivariateEvaluationDomainType::DensePoly;
   using Evals = typename UnivariateEvaluationDomainType::Evals;
 

--- a/tachyon/math/polynomials/univariate/univariate_evaluations.h
+++ b/tachyon/math/polynomials/univariate/univariate_evaluations.h
@@ -23,7 +23,7 @@ namespace tachyon {
 namespace math {
 namespace internal {
 
-template <typename F, size_t MaxDegree>
+template <typename F, size_t N>
 class UnivariateEvaluationsOp;
 
 }  // namespace internal
@@ -36,49 +36,49 @@ class UnivariateEvaluationsOp;
 // evaluation domain, the univariate polynomial can vary.
 // For more information, refer to
 // https://en.wikipedia.org/wiki/Lagrange_polynomial
-template <typename F, size_t MaxDegree>
+template <typename F, size_t N>
 class UnivariateEvaluations final
-    : public Polynomial<UnivariateEvaluations<F, MaxDegree>> {
+    : public Polynomial<UnivariateEvaluations<F, N>> {
  public:
-  constexpr static size_t kMaxDegree = MaxDegree;
+  constexpr static size_t kMaxSize = N;
 
   using Field = F;
 
   constexpr UnivariateEvaluations() : UnivariateEvaluations({F::Zero()}) {}
   constexpr explicit UnivariateEvaluations(const std::vector<F>& evaluations)
       : evaluations_(evaluations) {
-    CHECK_LE(Degree(), MaxDegree);
+    CHECK_LE(evaluations_.size(), kMaxSize);
   }
   constexpr explicit UnivariateEvaluations(std::vector<F>&& evaluations)
       : evaluations_(std::move(evaluations)) {
-    CHECK_LE(Degree(), MaxDegree);
+    CHECK_LE(evaluations_.size(), kMaxSize);
   }
 
   constexpr static bool IsCoefficientForm() { return false; }
 
   constexpr static bool IsEvaluationForm() { return true; }
 
-  constexpr static UnivariateEvaluations Zero(size_t degree) {
+  constexpr static UnivariateEvaluations Zero(size_t size) {
     UnivariateEvaluations ret;
-    ret.evaluations_ = base::CreateVector(degree + 1, F::Zero());
+    ret.evaluations_ = base::CreateVector(size, F::Zero());
     return ret;
   }
 
   // NOTE(chokobole): This is only used at |EvaluationDomain|.
   // See also univariate_polynomial.h.
-  constexpr static UnivariateEvaluations UnsafeZero(size_t degree) {
-    return Zero(degree);
+  constexpr static UnivariateEvaluations UnsafeZero(size_t size) {
+    return Zero(size);
   }
 
-  constexpr static UnivariateEvaluations One(size_t degree) {
+  constexpr static UnivariateEvaluations One(size_t size) {
     UnivariateEvaluations ret;
-    ret.evaluations_ = base::CreateVector(degree + 1, F::One());
+    ret.evaluations_ = base::CreateVector(size, F::One());
     return ret;
   }
 
-  constexpr static UnivariateEvaluations Random(size_t degree) {
+  constexpr static UnivariateEvaluations Random(size_t size) {
     return UnivariateEvaluations(
-        base::CreateVector(degree + 1, []() { return F::Random(); }));
+        base::CreateVector(size, []() { return F::Random(); }));
   }
 
   const std::vector<F>& evaluations() const { return evaluations_; }
@@ -89,6 +89,7 @@ class UnivariateEvaluations final
   }
 
   constexpr bool IsOne() const {
+    if (evaluations_.empty()) return false;
     return std::all_of(evaluations_.begin(), evaluations_.end(),
                        [](const F& value) { return value.IsOne(); });
   }
@@ -118,29 +119,25 @@ class UnivariateEvaluations final
 
   // AdditiveSemigroup methods
   UnivariateEvaluations& AddInPlace(const UnivariateEvaluations& other) {
-    return internal::UnivariateEvaluationsOp<F, MaxDegree>::AddInPlace(*this,
-                                                                       other);
+    return internal::UnivariateEvaluationsOp<F, N>::AddInPlace(*this, other);
   }
 
   // AdditiveGroup methods
   UnivariateEvaluations& SubInPlace(const UnivariateEvaluations& other) {
-    return internal::UnivariateEvaluationsOp<F, MaxDegree>::SubInPlace(*this,
-                                                                       other);
+    return internal::UnivariateEvaluationsOp<F, N>::SubInPlace(*this, other);
   }
 
   UnivariateEvaluations& NegInPlace() {
-    return internal::UnivariateEvaluationsOp<F, MaxDegree>::NegInPlace(*this);
+    return internal::UnivariateEvaluationsOp<F, N>::NegInPlace(*this);
   }
 
   // MultiplicativeSemigroup methods
   UnivariateEvaluations& MulInPlace(const UnivariateEvaluations& other) {
-    return internal::UnivariateEvaluationsOp<F, MaxDegree>::MulInPlace(*this,
-                                                                       other);
+    return internal::UnivariateEvaluationsOp<F, N>::MulInPlace(*this, other);
   }
 
   UnivariateEvaluations& DivInPlace(const UnivariateEvaluations& other) {
-    return internal::UnivariateEvaluationsOp<F, MaxDegree>::DivInPlace(*this,
-                                                                       other);
+    return internal::UnivariateEvaluationsOp<F, N>::DivInPlace(*this, other);
   }
 
   constexpr UnivariateEvaluations operator/(
@@ -155,15 +152,15 @@ class UnivariateEvaluations final
   }
 
  private:
-  friend class internal::UnivariateEvaluationsOp<F, MaxDegree>;
-  friend class Radix2EvaluationDomain<F, MaxDegree>;
-  friend class MixedRadixEvaluationDomain<F, kMaxDegree>;
+  friend class internal::UnivariateEvaluationsOp<F, N>;
+  friend class Radix2EvaluationDomain<F, N>;
+  friend class MixedRadixEvaluationDomain<F, N>;
 
   std::vector<F> evaluations_;
 };
 
-template <typename F, size_t MaxDegree>
-class PolynomialTraits<UnivariateEvaluations<F, MaxDegree>> {
+template <typename F, size_t N>
+class PolynomialTraits<UnivariateEvaluations<F, N>> {
  public:
   constexpr static bool kIsEvaluationForm = true;
 };
@@ -172,24 +169,23 @@ class PolynomialTraits<UnivariateEvaluations<F, MaxDegree>> {
 
 namespace base {
 
-template <typename F, size_t MaxDegree>
-class Copyable<math::UnivariateEvaluations<F, MaxDegree>> {
+template <typename F, size_t N>
+class Copyable<math::UnivariateEvaluations<F, N>> {
  public:
-  static bool WriteTo(const math::UnivariateEvaluations<F, MaxDegree>& evals,
+  static bool WriteTo(const math::UnivariateEvaluations<F, N>& evals,
                       Buffer* buffer) {
     return buffer->Write(evals.evaluations());
   }
 
   static bool ReadFrom(const Buffer& buffer,
-                       math::UnivariateEvaluations<F, MaxDegree>* evals) {
+                       math::UnivariateEvaluations<F, N>* evals) {
     std::vector<F> evals_vec;
     if (!buffer.Read(&evals_vec)) return false;
-    *evals = math::UnivariateEvaluations<F, MaxDegree>(evals_vec);
+    *evals = math::UnivariateEvaluations<F, N>(evals_vec);
     return true;
   }
 
-  static size_t EstimateSize(
-      const math::UnivariateEvaluations<F, MaxDegree>& evals) {
+  static size_t EstimateSize(const math::UnivariateEvaluations<F, N>& evals) {
     return base::EstimateSize(evals.evaluations());
   }
 };

--- a/tachyon/math/polynomials/univariate/univariate_evaluations_ops.h
+++ b/tachyon/math/polynomials/univariate/univariate_evaluations_ops.h
@@ -17,10 +17,10 @@
 namespace tachyon::math {
 namespace internal {
 
-template <typename F, size_t MaxDegree>
+template <typename F, size_t N>
 class UnivariateEvaluationsOp {
  public:
-  using Poly = UnivariateEvaluations<F, MaxDegree>;
+  using Poly = UnivariateEvaluations<F, N>;
 
   static Poly& AddInPlace(Poly& self, const Poly& other) {
     std::vector<F>& l_evaluations = self.evaluations_;

--- a/tachyon/math/polynomials/univariate/univariate_evaluations_unittest.cc
+++ b/tachyon/math/polynomials/univariate/univariate_evaluations_unittest.cc
@@ -9,9 +9,9 @@ namespace tachyon::math {
 
 namespace {
 
-const size_t kMaxDegree = 5;
+const size_t kMaxSize = 6;
 
-using Poly = UnivariateEvaluations<GF7, kMaxDegree>;
+using Poly = UnivariateEvaluations<GF7, kMaxSize>;
 
 class UnivariateEvaluationsTest : public testing::Test {
  public:
@@ -22,7 +22,7 @@ class UnivariateEvaluationsTest : public testing::Test {
     polys_.push_back(Poly({GF7(3)}));
     polys_.push_back(Poly({GF7(2), GF7(5), GF7(5), GF7(2)}));
     polys_.push_back(Poly({GF7(1), GF7(5), GF7(3), GF7(6), GF7(6)}));
-    polys_.push_back(Poly::Zero(0));
+    polys_.push_back(Poly::Zero(1));
   }
 
  protected:
@@ -33,7 +33,7 @@ class UnivariateEvaluationsTest : public testing::Test {
 
 TEST_F(UnivariateEvaluationsTest, IsZero) {
   EXPECT_TRUE(Poly().IsZero());
-  EXPECT_TRUE(Poly::Zero(kMaxDegree).IsZero());
+  EXPECT_TRUE(Poly::Zero(kMaxSize).IsZero());
   EXPECT_TRUE(Poly({GF7(0)}).IsZero());
   EXPECT_FALSE(Poly({GF7(0), GF7(1)}).IsZero());
   for (size_t i = 0; i < polys_.size() - 1; ++i) {
@@ -43,7 +43,7 @@ TEST_F(UnivariateEvaluationsTest, IsZero) {
 }
 
 TEST_F(UnivariateEvaluationsTest, IsOne) {
-  EXPECT_TRUE(Poly::One(kMaxDegree).IsOne());
+  EXPECT_TRUE(Poly::One(kMaxSize).IsOne());
   EXPECT_TRUE(Poly({GF7(1)}).IsOne());
   EXPECT_FALSE(Poly({GF7(0), GF7(1)}).IsZero());
   for (size_t i = 0; i < polys_.size(); ++i) {
@@ -53,9 +53,9 @@ TEST_F(UnivariateEvaluationsTest, IsOne) {
 
 TEST_F(UnivariateEvaluationsTest, Random) {
   bool success = false;
-  Poly r = Poly::Random(kMaxDegree);
+  Poly r = Poly::Random(kMaxSize);
   for (size_t i = 0; i < 100; ++i) {
-    if (r != Poly::Random(kMaxDegree)) {
+    if (r != Poly::Random(kMaxSize)) {
       success = true;
       break;
     }
@@ -73,7 +73,7 @@ TEST_F(UnivariateEvaluationsTest, IndexingOperator) {
   };
 
   for (const auto& test : tests) {
-    for (size_t i = 0; i < kMaxDegree; ++i) {
+    for (size_t i = 0; i < kMaxSize; ++i) {
       if (i < test.evaluations.size()) {
         EXPECT_EQ(*test.poly[i], GF7(test.evaluations[i]));
       } else {

--- a/tachyon/math/polynomials/univariate/univariate_polynomial.h
+++ b/tachyon/math/polynomials/univariate/univariate_polynomial.h
@@ -31,7 +31,7 @@ template <typename Coefficients>
 class UnivariatePolynomial final
     : public Polynomial<UnivariatePolynomial<Coefficients>> {
  public:
-  constexpr static size_t kMaxDegree = Coefficients::kMaxDegree;
+  constexpr static size_t kMaxSize = Coefficients::kMaxSize;
 
   using Field = typename Coefficients::Field;
 
@@ -53,8 +53,8 @@ class UnivariatePolynomial final
     return UnivariatePolynomial(Coefficients::One());
   }
 
-  constexpr static UnivariatePolynomial Random(size_t degree) {
-    return UnivariatePolynomial(Coefficients::Random(degree));
+  constexpr static UnivariatePolynomial Random(size_t size) {
+    return UnivariatePolynomial(Coefficients::Random(size));
   }
 
   constexpr bool IsZero() const { return coefficients_.IsZero(); }
@@ -177,8 +177,8 @@ class UnivariatePolynomial final
 
  private:
   friend class internal::UnivariatePolynomialOp<Coefficients>;
-  friend class Radix2EvaluationDomain<Field, kMaxDegree>;
-  friend class MixedRadixEvaluationDomain<Field, kMaxDegree>;
+  friend class Radix2EvaluationDomain<Field, kMaxSize>;
+  friend class MixedRadixEvaluationDomain<Field, kMaxSize>;
 
   // NOTE(chokobole): This doesn't call |RemoveHighDegreeZeros()| internally.
   // So when the returned evaluations is called with |IsZero()|, it returns
@@ -192,13 +192,13 @@ class UnivariatePolynomial final
   Coefficients coefficients_;
 };
 
-template <typename F, size_t MaxDegree>
+template <typename F, size_t N>
 using UnivariateDensePolynomial =
-    UnivariatePolynomial<UnivariateDenseCoefficients<F, MaxDegree>>;
+    UnivariatePolynomial<UnivariateDenseCoefficients<F, N>>;
 
-template <typename F, size_t MaxDegree>
+template <typename F, size_t N>
 using UnivariateSparsePolynomial =
-    UnivariatePolynomial<UnivariateSparseCoefficients<F, MaxDegree>>;
+    UnivariatePolynomial<UnivariateSparseCoefficients<F, N>>;
 
 template <typename Coefficients>
 class PolynomialTraits<UnivariatePolynomial<Coefficients>> {

--- a/tachyon/math/polynomials/univariate/univariate_polynomial_ops.h
+++ b/tachyon/math/polynomials/univariate/univariate_polynomial_ops.h
@@ -19,11 +19,11 @@
 namespace tachyon::math {
 namespace internal {
 
-template <typename F, size_t MaxDegree>
-class UnivariatePolynomialOp<UnivariateDenseCoefficients<F, MaxDegree>> {
+template <typename F, size_t N>
+class UnivariatePolynomialOp<UnivariateDenseCoefficients<F, N>> {
  public:
-  using D = UnivariateDenseCoefficients<F, MaxDegree>;
-  using S = UnivariateSparseCoefficients<F, MaxDegree>;
+  using D = UnivariateDenseCoefficients<F, N>;
+  using S = UnivariateSparseCoefficients<F, N>;
   using Term = typename S::Term;
 
   static UnivariatePolynomial<D>& AddInPlace(
@@ -318,11 +318,11 @@ class UnivariatePolynomialOp<UnivariateDenseCoefficients<F, MaxDegree>> {
   }
 };
 
-template <typename F, size_t MaxDegree>
-class UnivariatePolynomialOp<UnivariateSparseCoefficients<F, MaxDegree>> {
+template <typename F, size_t N>
+class UnivariatePolynomialOp<UnivariateSparseCoefficients<F, N>> {
  public:
-  using D = UnivariateDenseCoefficients<F, MaxDegree>;
-  using S = UnivariateSparseCoefficients<F, MaxDegree>;
+  using D = UnivariateDenseCoefficients<F, N>;
+  using S = UnivariateSparseCoefficients<F, N>;
   using Term = typename S::Term;
 
   static UnivariatePolynomial<D> Add(const UnivariatePolynomial<S>& self,

--- a/tachyon/math/polynomials/univariate/univariate_sparse_polynomial_unittest.cc
+++ b/tachyon/math/polynomials/univariate/univariate_sparse_polynomial_unittest.cc
@@ -10,10 +10,10 @@ namespace tachyon::math {
 
 namespace {
 
-const size_t kMaxDegree = 5;
+constexpr size_t kMaxSize = 6;
 
-using Poly = UnivariateSparsePolynomial<GF7, kMaxDegree>;
-using Coeffs = UnivariateSparseCoefficients<GF7, kMaxDegree>;
+using Poly = UnivariateSparsePolynomial<GF7, kMaxSize>;
+using Coeffs = UnivariateSparseCoefficients<GF7, kMaxSize>;
 
 class UnivariateSparsePolynomialTest : public testing::Test {
  public:
@@ -56,9 +56,9 @@ TEST_F(UnivariateSparsePolynomialTest, IsOne) {
 
 TEST_F(UnivariateSparsePolynomialTest, Random) {
   bool success = false;
-  Poly r = Poly::Random(kMaxDegree);
+  Poly r = Poly::Random(kMaxSize);
   for (size_t i = 0; i < 100; ++i) {
-    if (r != Poly::Random(kMaxDegree)) {
+    if (r != Poly::Random(kMaxSize)) {
       success = true;
       break;
     }
@@ -81,7 +81,7 @@ TEST_F(UnivariateSparsePolynomialTest, IndexingOperator) {
   };
 
   for (const auto& test : tests) {
-    for (size_t i = 0; i < kMaxDegree; ++i) {
+    for (size_t i = 0; i < kMaxSize; ++i) {
       if (i < test.coefficients.size()) {
         if (test.coefficients[i].has_value()) {
           EXPECT_EQ(*test.poly[i], GF7(test.coefficients[i].value()));
@@ -107,7 +107,7 @@ TEST_F(UnivariateSparsePolynomialTest, Degree) {
   for (const auto& test : tests) {
     EXPECT_EQ(test.poly.Degree(), test.degree);
   }
-  EXPECT_LE(Poly::Random(kMaxDegree).Degree(), kMaxDegree);
+  EXPECT_LE(Poly::Random(kMaxSize).Degree(), kMaxSize - 1);
 }
 
 TEST_F(UnivariateSparsePolynomialTest, Evaluate) {
@@ -223,8 +223,8 @@ TEST_F(UnivariateSparsePolynomialTest, MultiplicativeOperators) {
   Poly one = Poly::One();
   Poly zero = Poly::Zero();
 
-  using DensePoly = UnivariateDensePolynomial<GF7, kMaxDegree>;
-  using DenseCoeffs = UnivariateDenseCoefficients<GF7, kMaxDegree>;
+  using DensePoly = UnivariateDensePolynomial<GF7, kMaxSize>;
+  using DenseCoeffs = UnivariateDenseCoefficients<GF7, kMaxSize>;
 
   struct {
     const Poly& a;

--- a/tachyon/zk/plonk/circuit/expressions/evaluator/test/evaluator_test.h
+++ b/tachyon/zk/plonk/circuit/expressions/evaluator/test/evaluator_test.h
@@ -16,11 +16,11 @@
 
 namespace tachyon::zk {
 
-constexpr size_t kMaxDegree = 5;
+constexpr size_t kMaxSize = 6;
 
 using GF7 = math::GF7;
-using Poly = math::UnivariateDensePolynomial<GF7, kMaxDegree>;
-using Coeffs = math::UnivariateDenseCoefficients<GF7, kMaxDegree>;
+using Poly = math::UnivariateDensePolynomial<GF7, kMaxSize>;
+using Coeffs = math::UnivariateDenseCoefficients<GF7, kMaxSize>;
 
 class EvaluatorTest : public testing::Test {
  public:

--- a/tachyon/zk/plonk/circuit/rotation.h
+++ b/tachyon/zk/plonk/circuit/rotation.h
@@ -50,8 +50,8 @@ class TACHYON_EXPORT Rotation {
     return size_t{base::bit_cast<uint32_t>(value % size)};
   }
 
-  template <typename F, size_t MaxDegree>
-  F RotateOmega(const math::UnivariateEvaluationDomain<F, MaxDegree>* domain,
+  template <typename F, size_t N>
+  F RotateOmega(const math::UnivariateEvaluationDomain<F, N>* domain,
                 const F& point) const {
     if (value_ >= 0) {
       return point * domain->group_gen().Pow(math::BigInt<1>(value_));

--- a/tachyon/zk/plonk/keys/proving_key.h
+++ b/tachyon/zk/plonk/keys/proving_key.h
@@ -14,11 +14,11 @@ namespace tachyon::zk {
 template <typename PCSTy>
 class ProvingKey {
  public:
-  static constexpr size_t kMaxDegree = PCSTy::kMaxDegree;
+  static constexpr size_t kMaxSize = PCSTy::kMaxSize;
 
   using F = typename PCSTy::Field;
-  using DensePoly = math::UnivariateDensePolynomial<F, kMaxDegree>;
-  using Evals = math::UnivariateEvaluations<F, kMaxDegree>;
+  using DensePoly = math::UnivariateDensePolynomial<F, kMaxSize>;
+  using Evals = math::UnivariateEvaluations<F, kMaxSize>;
 
   ProvingKey(VerifyingKey<PCSTy> verifying_key, DensePoly l0, DensePoly l_last,
              DensePoly l_active_row, Evals fixed_values, Evals fixed_polys,

--- a/tachyon/zk/plonk/keys/verifying_key.h
+++ b/tachyon/zk/plonk/keys/verifying_key.h
@@ -18,14 +18,14 @@ namespace tachyon::zk {
 template <typename PCSTy>
 class VerifyingKey {
  public:
-  constexpr static kMaxDegree = PCSTy::kMaxDegree;
+  constexpr static kMaxSize = PCSTy::kMaxSize;
 
   using F = typename PCSTy::Field;
   using Commitment = typename PCSTy::ResultTy;
   using Commitments = std::vector<Commitment>;
 
   VerifyingKey(
-      std::unique_ptr<math::UnivariateEvaluationDomain<F, kMaxDegree>> domain,
+      std::unique_ptr<math::UnivariateEvaluationDomain<F, kMaxSize>> domain,
       Commitments fixed_commitments,
       PermutationVerifyingKey<PCSTy> permutation_verifying_key,
       ConstraintSystem<F> constraint_system)
@@ -34,7 +34,7 @@ class VerifyingKey {
         permutation_verifying_Key_(std::move(permutation_verifying_key)),
         constraint_system_(std::move(constraint_system)) {}
 
-  const math::UnivariateEvaluationDomain<F, kMaxDegree>* domain() const {
+  const math::UnivariateEvaluationDomain<F, kMaxSize>* domain() const {
     return domain_.get();
   }
 
@@ -51,7 +51,7 @@ class VerifyingKey {
   const F& transcript_repr() const { return transcript_repr_; }
 
  private:
-  std::unique_ptr<math::UnivariateEvaluationDomain<F, kMaxDegree>> domain_;
+  std::unique_ptr<math::UnivariateEvaluationDomain<F, kMaxSize>> domain_;
   Commitments fixed_commitments_;
   PermutationVerifyingKey<PCSTy> permutation_verifying_Key_;
   ConstraintSystem<F> constraint_system_;

--- a/tachyon/zk/plonk/permutation/lookup_table.h
+++ b/tachyon/zk/plonk/permutation/lookup_table.h
@@ -25,7 +25,7 @@ namespace tachyon::zk {
 // Let modulus = 2ˢ * T + 1, then
 // |LookupTable|
 // = [[𝛿ⁱw⁰, 𝛿ⁱw¹, 𝛿ⁱw², ..., 𝛿ⁱwⁿ⁻¹] for i in range(0..T-1)]
-template <typename F, size_t MaxDegree>
+template <typename F, size_t N>
 class LookupTable {
  public:
   using Rows = std::vector<F>;
@@ -39,11 +39,10 @@ class LookupTable {
   F& operator[](const Label& label) { return table_[label.col][label.row]; }
 
   static LookupTable Construct(
-      size_t size,
-      const math::UnivariateEvaluationDomain<F, MaxDegree>* domain) {
+      size_t size, const math::UnivariateEvaluationDomain<F, N>* domain) {
     // The w is gᵀ with order 2ˢ where modulus = 2ˢ * T + 1.
     std::vector<F> omega_powers =
-        domain->GetRootsOfUnity(MaxDegree + 1, domain->group_gen());
+        domain->GetRootsOfUnity(N, domain->group_gen());
 
     // The 𝛿 is g^2ˢ with order T where modulus = 2ˢ * T + 1.
     F delta = GetDelta();
@@ -55,10 +54,10 @@ class LookupTable {
 
     // Assign [𝛿ⁱw⁰, 𝛿ⁱw¹, 𝛿ⁱw², ..., 𝛿ⁱwⁿ⁻¹] to each row.
     for (size_t i = 1; i < size; ++i) {
-      Rows rows = base::CreateVector(MaxDegree + 1, F::Zero());
+      Rows rows = base::CreateVector(N, F::Zero());
       // TODO(dongchangYoo): Optimize this with
       // https://github.com/kroma-network/tachyon/pull/115.
-      for (size_t j = 0; j <= MaxDegree; ++j) {
+      for (size_t j = 0; j < N; ++j) {
         rows[j] = lookup_table[i - 1][j] * delta;
       }
       lookup_table.push_back(std::move(rows));

--- a/tachyon/zk/plonk/permutation/lookup_table_unittest.cc
+++ b/tachyon/zk/plonk/permutation/lookup_table_unittest.cc
@@ -25,24 +25,23 @@ class LookupTableTest : public testing::Test {
 }  // namespace
 
 TEST_F(LookupTableTest, Construct) {
-  constexpr size_t kMaxDegree = 7;
+  constexpr size_t kMaxSize = 8;
   constexpr size_t kCols = 4;
 
   using F = math::bn254::G1Curve::ScalarField;
 
-  std::unique_ptr<math::UnivariateEvaluationDomain<F, kMaxDegree>> domain =
-      math::UnivariateEvaluationDomainFactory<F, kMaxDegree>::Create(
-          kMaxDegree + 1);
-  LookupTable<F, kMaxDegree> lookup_table =
-      LookupTable<F, kMaxDegree>::Construct(kCols, domain.get());
+  std::unique_ptr<math::UnivariateEvaluationDomain<F, kMaxSize>> domain =
+      math::UnivariateEvaluationDomainFactory<F, kMaxSize>::Create(kMaxSize);
+  LookupTable<F, kMaxSize> lookup_table =
+      LookupTable<F, kMaxSize>::Construct(kCols, domain.get());
   F omega = domain->group_gen();
-  std::vector<F> omega_powers = domain->GetRootsOfUnity(kMaxDegree + 1, omega);
+  std::vector<F> omega_powers = domain->GetRootsOfUnity(kMaxSize, omega);
 
   F delta = lookup_table.GetDelta();
   EXPECT_NE(delta, F::One());
   EXPECT_EQ(delta.Pow(F::Config::kTrace), F::One());
   for (size_t i = 1; i < kCols; ++i) {
-    for (size_t j = 0; j < kMaxDegree + 1; ++j) {
+    for (size_t j = 0; j < kMaxSize; ++j) {
       omega_powers[j] *= delta;
       EXPECT_EQ(omega_powers[j], lookup_table[Label(i, j)]);
     }

--- a/tachyon/zk/plonk/permutation/permutation_assembly_unittest.cc
+++ b/tachyon/zk/plonk/permutation/permutation_assembly_unittest.cc
@@ -15,14 +15,13 @@ namespace {
 
 class PermutationAssemblyTest : public testing::Test {
  public:
-  constexpr static size_t kSmallDegree = 7;
-  constexpr static size_t kRows = kSmallDegree + 1;
+  constexpr static size_t kSize = 7;
 
   using PCS = crypto::KZGCommitmentScheme<math::bn254::G1AffinePoint,
                                           math::bn254::G2AffinePoint,
                                           math::bn254::G1AffinePoint>;
   using F = PCS::Field;
-  using Evals = math::UnivariateEvaluations<F, kSmallDegree>;
+  using Evals = math::UnivariateEvaluations<F, kSize>;
 
   static void SetUpTestSuite() { math::bn254::G1Curve::Init(); }
 
@@ -31,16 +30,15 @@ class PermutationAssemblyTest : public testing::Test {
                 InstanceColumn(3)};
     argment_ = PermutationArgument(columns_);
     assembly_ = PermutationAssembly<PCS>::CreateForTesting(
-        columns_, CycleStore(columns_.size(), kRows));
-    domain_ =
-        math::UnivariateEvaluationDomainFactory<F, kSmallDegree>::Create(kRows);
+        columns_, CycleStore(columns_.size(), kSize));
+    domain_ = math::UnivariateEvaluationDomainFactory<F, kSize>::Create(kSize);
   }
 
  protected:
   std::vector<AnyColumn> columns_;
   PermutationArgument argment_;
   PermutationAssembly<PCS> assembly_;
-  std::unique_ptr<math::UnivariateEvaluationDomain<F, kSmallDegree>> domain_;
+  std::unique_ptr<math::UnivariateEvaluationDomain<F, kSize>> domain_;
 };
 
 }  // namespace
@@ -50,11 +48,11 @@ TEST_F(PermutationAssemblyTest, GeneratePermutation) {
   std::vector<Evals> permutations =
       assembly_.GeneratePermutations(domain_.get());
 
-  LookupTable<F, kSmallDegree> lookup_table =
-      LookupTable<F, kSmallDegree>::Construct(columns_.size(), domain_.get());
+  LookupTable<F, kSize> lookup_table =
+      LookupTable<F, kSize>::Construct(columns_.size(), domain_.get());
 
   for (size_t i = 0; i < columns_.size(); ++i) {
-    for (size_t j = 0; j <= kSmallDegree; ++j) {
+    for (size_t j = 0; j < kSize; ++j) {
       EXPECT_EQ(*permutations[i][j], lookup_table[Label(i, j)]);
     }
   }

--- a/tachyon/zk/plonk/permutation/permutation_proving_key.h
+++ b/tachyon/zk/plonk/permutation/permutation_proving_key.h
@@ -20,11 +20,11 @@ namespace zk {
 template <typename PCSTy>
 class PermutationProvingKey {
  public:
-  constexpr static size_t kMaxDegree = PCSTy::kMaxDegree;
+  constexpr static size_t kMaxSize = PCSTy::kMaxSize;
 
   using F = typename PCSTy::Field;
-  using DensePoly = math::UnivariateDensePolynomial<F, kMaxDegree>;
-  using Evals = math::UnivariateEvaluations<F, kMaxDegree>;
+  using DensePoly = math::UnivariateDensePolynomial<F, kMaxSize>;
+  using Evals = math::UnivariateEvaluations<F, kMaxSize>;
 
   PermutationProvingKey() = default;
   PermutationProvingKey(const std::vector<Evals>& permutations,


### PR DESCRIPTION
# Description

Previously, for example, when creating coefficients, you need to pass arguments in terms of degree.

```c++
KZGCommitmentScheme kzg;
DensePoly::Random(kzg.n() - 1); // This accepts degree not a size.
```

To reduce such a confusion, this commit use size throughout the codes.
