### PR TITLE
feat!: contain degree sized elements univariate evalutions

### DIFF
--- a/tachyon/math/elliptic_curves/short_weierstrass/affine_point_unittest.cc
+++ b/tachyon/math/elliptic_curves/short_weierstrass/affine_point_unittest.cc
@@ -68,7 +68,7 @@ TYPED_TEST(AffinePointTest, Random) {
   EXPECT_TRUE(success);
 }
 
-TYPED_TEST(AffinePointTest, EqualityOperator) {
+TYPED_TEST(AffinePointTest, EqualityOperators) {
   using AffinePointTy = TypeParam;
   using BaseField = typename AffinePointTy::BaseField;
 

--- a/tachyon/math/finite_fields/cubic_extension_field_unittest.cc
+++ b/tachyon/math/finite_fields/cubic_extension_field_unittest.cc
@@ -35,7 +35,7 @@ TEST_F(CubicExtensionFieldTest, Random) {
   EXPECT_TRUE(success);
 }
 
-TEST_F(CubicExtensionFieldTest, EqualityOperator) {
+TEST_F(CubicExtensionFieldTest, EqualityOperators) {
   GF7_3 f(GF7(3), GF7(4), GF7(5));
   GF7_3 f2(GF7(4), GF7(4), GF7(5));
   EXPECT_FALSE(f == f2);

--- a/tachyon/math/finite_fields/quadratic_extension_field_unittest.cc
+++ b/tachyon/math/finite_fields/quadratic_extension_field_unittest.cc
@@ -47,7 +47,7 @@ TEST_F(QuadraticExtensionFieldTest, ConjugateInPlace) {
   EXPECT_EQ(f.c1(), -f2.c1());
 }
 
-TEST_F(QuadraticExtensionFieldTest, EqualityOperator) {
+TEST_F(QuadraticExtensionFieldTest, EqualityOperators) {
   GF7_2 f(GF7(3), GF7(4));
   GF7_2 f2(GF7(4), GF7(4));
   EXPECT_FALSE(f == f2);

--- a/tachyon/math/polynomials/univariate/mixed_radix_evaluation_domain.h
+++ b/tachyon/math/polynomials/univariate/mixed_radix_evaluation_domain.h
@@ -197,7 +197,7 @@ class MixedRadixEvaluationDomain
     // Conceptually, this FFT first splits into 2 sub-arrays |two_adicity| many
     // times, and then splits into q sub-arrays |q_adicity| many times.
 
-    size_t n = a.Degree() + 1;
+    size_t n = a.NumElements();
     uint64_t q = uint64_t{F::Config::kSmallSubgroupBase};
     uint64_t n_u64 = n;
 
@@ -299,7 +299,7 @@ class MixedRadixEvaluationDomain
 
     // Partition |a| equally into the number of threads.
     // each partition is then of size m / num_threads.
-    size_t m = a.Degree() + 1;
+    size_t m = a.NumElements();
     size_t num_threads = size_t{1} << (log_num_threads);
     size_t num_cosets = num_threads;
     CHECK_EQ(m % num_threads, size_t{0});
@@ -375,7 +375,7 @@ class MixedRadixEvaluationDomain
 
     // shuffle the values computed above into a
     // The evaluations of a should be ordered as (1, g, g², ...)
-    for (size_t i = 0; i < a.Degree() + 1; ++i) {
+    for (size_t i = 0; i < a.NumElements(); ++i) {
       *a[i] = *tmp[i % num_cosets][i / num_cosets];
     }
   }

--- a/tachyon/math/polynomials/univariate/radix2_evaluation_domain.h
+++ b/tachyon/math/polynomials/univariate/radix2_evaluation_domain.h
@@ -211,7 +211,7 @@ class Radix2EvaluationDomain : public UnivariateEvaluationDomain<F, MaxDegree> {
       static_assert(Order == FFTOrder::kOutIn);
       fn = UnivariateEvaluationDomain<F, MaxDegree>::ButterflyFnOutIn;
     }
-    OPENMP_PARALLEL_FOR(size_t i = 0; i <= poly_or_evals.Degree();
+    OPENMP_PARALLEL_FOR(size_t i = 0; i < poly_or_evals.NumElements();
                         i += chunk_size) {
       // If the chunk is sufficiently big that parallelism helps,
       // we parallelize the butterfly operation within the chunk.

--- a/tachyon/math/polynomials/univariate/univariate_dense_coefficients.h
+++ b/tachyon/math/polynomials/univariate/univariate_dense_coefficients.h
@@ -58,7 +58,7 @@ class UnivariateDenseCoefficients {
 
   // NOTE(chokobole): This doesn't call |RemoveHighDegreeZeros()| internally.
   // So when the returned evaluations is called with |IsZero()|, it returns
-  // false. This is only used at |EvaluationDomain|.
+  // false. So please use it carefully!
   constexpr static UnivariateDenseCoefficients UnsafeZero(size_t degree) {
     UnivariateDenseCoefficients ret;
     ret.coefficients_ = base::CreateVector(degree + 1, F::Zero());
@@ -108,6 +108,8 @@ class UnivariateDenseCoefficients {
     if (IsZero()) return 0;
     return coefficients_.size() - 1;
   }
+
+  constexpr size_t NumElements() const { return coefficients_.size(); }
 
   constexpr F Evaluate(const F& point) const {
     if (IsZero()) return F::Zero();

--- a/tachyon/math/polynomials/univariate/univariate_evaluation_domain.h
+++ b/tachyon/math/polynomials/univariate/univariate_evaluation_domain.h
@@ -301,7 +301,7 @@ class UnivariateEvaluationDomain : public EvaluationDomain<F, MaxDegree> {
     size_t thread_nums = 1;
 #endif
     // Invariant: |pow| = |c|*|g|ⁱ at the i-th iteration of the loop
-    size_t size = poly_or_evals.Degree() + 1;
+    size_t size = poly_or_evals.NumElements();
     size_t num_elems_per_thread = std::max(size / thread_nums, size_t{1024});
     OPENMP_PARALLEL_FOR(size_t i = 0; i < size; i += num_elems_per_thread) {
       F pow = c * g.Pow(BigInt<1>(i));

--- a/tachyon/math/polynomials/univariate/univariate_evaluations_ops.h
+++ b/tachyon/math/polynomials/univariate/univariate_evaluations_ops.h
@@ -25,7 +25,12 @@ class UnivariateEvaluationsOp {
   static Poly& AddInPlace(Poly& self, const Poly& other) {
     std::vector<F>& l_evaluations = self.evaluations_;
     const std::vector<F>& r_evaluations = other.evaluations_;
-    CHECK_EQ(l_evaluations.size(), r_evaluations.size());
+    if (l_evaluations.empty()) {
+      // 0 + g(x)
+      l_evaluations = r_evaluations;
+      return self;
+    }
+    // f(x) + 0 skips this for loop.
     OPENMP_PARALLEL_FOR(size_t i = 0; i < r_evaluations.size(); ++i) {
       l_evaluations[i] += r_evaluations[i];
     }
@@ -35,7 +40,11 @@ class UnivariateEvaluationsOp {
   static Poly& SubInPlace(Poly& self, const Poly& other) {
     std::vector<F>& l_evaluations = self.evaluations_;
     const std::vector<F>& r_evaluations = other.evaluations_;
-    CHECK_EQ(l_evaluations.size(), r_evaluations.size());
+    if (l_evaluations.empty()) {
+      // 0 - g(x)
+      l_evaluations.resize(r_evaluations.size());
+    }
+    // f(x) - 0 skips this for loop.
     OPENMP_PARALLEL_FOR(size_t i = 0; i < r_evaluations.size(); ++i) {
       l_evaluations[i] -= r_evaluations[i];
     }
@@ -55,8 +64,16 @@ class UnivariateEvaluationsOp {
   static Poly& MulInPlace(Poly& self, const Poly& other) {
     std::vector<F>& l_evaluations = self.evaluations_;
     const std::vector<F>& r_evaluations = other.evaluations_;
-    CHECK_EQ(l_evaluations.size(), r_evaluations.size());
-    OPENMP_PARALLEL_FOR(size_t i = 0; i < l_evaluations.size(); ++i) {
+    if (l_evaluations.empty()) {
+      // 0 * g(x)
+      return self;
+    }
+    if (r_evaluations.empty()) {
+      // f(x) * 0
+      l_evaluations.clear();
+      return self;
+    }
+    OPENMP_PARALLEL_FOR(size_t i = 0; i < r_evaluations.size(); ++i) {
       l_evaluations[i] *= r_evaluations[i];
     }
     return self;
@@ -65,8 +82,13 @@ class UnivariateEvaluationsOp {
   static Poly& DivInPlace(Poly& self, const Poly& other) {
     std::vector<F>& l_evaluations = self.evaluations_;
     const std::vector<F>& r_evaluations = other.evaluations_;
-    CHECK_EQ(l_evaluations.size(), r_evaluations.size());
-    OPENMP_PARALLEL_FOR(size_t i = 0; i < l_evaluations.size(); ++i) {
+    if (l_evaluations.empty()) {
+      // 0 / g(x)
+      return self;
+    }
+    // TODO(chokobole): Check division by zero polynomial.
+    // f(x) / 0 skips this for loop.
+    OPENMP_PARALLEL_FOR(size_t i = 0; i < r_evaluations.size(); ++i) {
       l_evaluations[i] /= r_evaluations[i];
     }
     return self;

--- a/tachyon/math/polynomials/univariate/univariate_polynomial.h
+++ b/tachyon/math/polynomials/univariate/univariate_polynomial.h
@@ -81,6 +81,10 @@ class UnivariatePolynomial final
 
   constexpr size_t Degree() const { return coefficients_.Degree(); }
 
+  constexpr const size_t NumElements() const {
+    return coefficients_.NumElements();
+  }
+
   constexpr Field Evaluate(const Field& point) const {
     return coefficients_.Evaluate(point);
   }
@@ -182,7 +186,7 @@ class UnivariatePolynomial final
 
   // NOTE(chokobole): This doesn't call |RemoveHighDegreeZeros()| internally.
   // So when the returned evaluations is called with |IsZero()|, it returns
-  // false. This is only used at |EvaluationDomain|.
+  // false. So please use it carefully!
   constexpr static UnivariatePolynomial UnsafeZero(size_t degree) {
     UnivariatePolynomial ret;
     ret.coefficients_ = Coefficients::UnsafeZero(degree);

--- a/tachyon/math/polynomials/univariate/univariate_sparse_coefficients.h
+++ b/tachyon/math/polynomials/univariate/univariate_sparse_coefficients.h
@@ -131,6 +131,8 @@ class UnivariateSparseCoefficients {
     return terms_.back().degree;
   }
 
+  constexpr size_t NumElements() const { return terms_.size(); }
+
   constexpr F Evaluate(const F& point) const {
     if (IsZero()) return F::Zero();
 

--- a/tachyon/zk/plonk/permutation/permutation_assembly.h
+++ b/tachyon/zk/plonk/permutation/permutation_assembly.h
@@ -115,7 +115,7 @@ class PermutationAssembly {
 
     // Init evaluation formed polynomials with all-zero coefficients
     std::vector<Evals> permutations =
-        base::CreateVector(columns_.size(), Evals::Zero(kMaxDegree));
+        base::CreateVector(columns_.size(), Evals::UnsafeZero(kMaxDegree));
 
     // Assign lookup_table to permutations
     base::Parallelize(

--- a/tachyon/zk/plonk/permutation/permutation_proving_key_unittest.cc
+++ b/tachyon/zk/plonk/permutation/permutation_proving_key_unittest.cc
@@ -35,8 +35,10 @@ class PermutationProvingKeyTest : public testing::Test {
 }  // namespace
 
 TEST_F(PermutationProvingKeyTest, Copyable) {
-  constexpr size_t kDegree = 5;
-  ProvingKey expected({Evals::Random(kDegree)}, {Poly::Random(kDegree)});
+  // NOTE(chokobole): Since https://github.com/kroma-network/tachyon/pull/139,
+  // I intentionally use |Evals::Zero()| instead of |Evals::Random()| due to
+  // performance issues.
+  ProvingKey expected({Evals::Zero()}, {Poly::Random(5)});
   ProvingKey value;
 
   base::VectorBuffer write_buf;


### PR DESCRIPTION
# Description

- To compute degree of `UnivariateEvaluations`, it needs IFFT. Does it really mean anything in evaluation form? So this commit removes `Degree()`. Instead, `UnivariatePolynomial` and `UnivariateEvaluations` have `NumElements()` to count the number of elements. e.g, Considering constant polynomial, the degree of this polynomial should be 0, but previously it returns the number of elements.
- `UnivariateEvaluations` except for zero polynomial have elements of `MaxDegree`. This affects equality operator, arithmetic operators and how it construct `UnivariateEvaluations`. e.g, `Random()` doesn't receive `degree` as an argument.
- For performance reason, zero polynomial is allowed to have an empty vector.
    
BREAKING CHANGE: `UnivariateEvaluations` doesn't allow arbitrary number of evaluation vector any more.