### PR TITLE
refac: allow call `Pow()` with `BigInt<1>` convertible

### DIFF
--- a/tachyon/crypto/hashes/sponge/poseidon/poseidon.h
+++ b/tachyon/crypto/hashes/sponge/poseidon/poseidon.h
@@ -69,12 +69,12 @@ struct PoseidonSponge
     if (is_full_round) {
       // Full rounds apply the S-Box (xᵅ) to every element of |state|.
       for (F& elem : state.elements) {
-        elem = elem.Pow(math::BigInt<1>(config.alpha));
+        elem = elem.Pow(config.alpha);
       }
     } else {
       // Partial rounds apply the S-Box (xᵅ) to just the first element of
       // |state|.
-      state[0] = state[0].Pow(math::BigInt<1>(config.alpha));
+      state[0] = state[0].Pow(config.alpha);
     }
   }
 

--- a/tachyon/math/base/rational_field_unittest.cc
+++ b/tachyon/math/base/rational_field_unittest.cc
@@ -176,7 +176,7 @@ TEST_F(RationalFieldTest, MultiplicativeGroupOperators) {
   EXPECT_EQ(r, expected);
 
   r = R(GF7(3), GF7(2));
-  EXPECT_EQ(r.Pow(BigInt<1>(5)), R(GF7(5), GF7(4)));
+  EXPECT_EQ(r.Pow(5), R(GF7(5), GF7(4)));
 }
 
 TEST_F(RationalFieldTest, BatchEvaluate) {

--- a/tachyon/math/base/semigroups.h
+++ b/tachyon/math/base/semigroups.h
@@ -335,14 +335,8 @@ class AdditiveSemigroup {
 
   template <typename ScalarTy>
   [[nodiscard]] constexpr auto ScalarMul(const ScalarTy& scalar) const {
-    if constexpr (std::is_integral_v<ScalarTy> && sizeof(ScalarTy) <= 8) {
-      // TODO(chokobole): Remove this branch if |BigInt| supports sign.
-      if constexpr (std::is_signed_v<ScalarTy>) {
-        return scalar > 0 ? DoScalarMul(BigInt<1>(scalar))
-                          : -DoScalarMul(BigInt<1>(-scalar));
-      } else {
-        return DoScalarMul(BigInt<1>(scalar));
-      }
+    if constexpr (std::is_constructible_v<BigInt<1>, ScalarTy>) {
+      return DoScalarMul(BigInt<1>(scalar));
     } else if constexpr (internal::SupportsToBigInt<ScalarTy>::value) {
       return DoScalarMul(scalar.ToBigInt());
     } else {

--- a/tachyon/math/elliptic_curves/msm/glv_unittest.cc
+++ b/tachyon/math/elliptic_curves/msm/glv_unittest.cc
@@ -34,8 +34,7 @@ TYPED_TEST(GLVTest, Endomorphism) {
   using ReturnTy =
       typename internal::AdditiveSemigroupTraits<PointTy>::ReturnTy;
 
-  EXPECT_TRUE(PointTy::Curve::Config::kEndomorphismCoefficient.Pow(BigInt<1>(3))
-                  .IsOne());
+  EXPECT_TRUE(PointTy::Curve::Config::kEndomorphismCoefficient.Pow(3).IsOne());
   PointTy base = PointTy::Random();
   EXPECT_EQ(base * PointTy::Curve::Config::kLambda,
             ConvertPoint<ReturnTy>(PointTy::Endomorphism(base)));

--- a/tachyon/math/finite_fields/goldilocks_prime/prime_field_goldilocks_unittest.cc
+++ b/tachyon/math/finite_fields/goldilocks_prime/prime_field_goldilocks_unittest.cc
@@ -137,7 +137,7 @@ TEST(PrimeFieldGoldilocksTest, MultiplicativeGroupOperators) {
   f.SquareInPlace();
   EXPECT_EQ(f, f_sqr);
 
-  Goldilocks f_pow = f.Pow(BigInt<1>(5));
+  Goldilocks f_pow = f.Pow(5);
   EXPECT_EQ(f * f * f * f * f, f_pow);
 }
 

--- a/tachyon/math/finite_fields/prime_field_base.h
+++ b/tachyon/math/finite_fields/prime_field_base.h
@@ -91,7 +91,7 @@ class PrimeFieldBase : public FiniteField<F> {
       omega = F::FromMontgomery(Config::kLargeSubgroupRootOfUnity);
       for (size_t i = factors.q_adicity; i < Config::kSmallSubgroupAdicity;
            ++i) {
-        omega = omega.Pow(BigInt<1>(Config::kSmallSubgroupBase));
+        omega = omega.Pow(Config::kSmallSubgroupBase);
       }
 
       for (size_t i = factors.two_adicity; i < Config::kTwoAdicity; ++i) {

--- a/tachyon/math/finite_fields/prime_field_base_unittest.cc
+++ b/tachyon/math/finite_fields/prime_field_base_unittest.cc
@@ -41,7 +41,7 @@ TYPED_TEST(PrimeFieldBaseTest, Decompose) {
 TYPED_TEST(PrimeFieldBaseTest, TwoAdicRootOfUnity) {
   using F = TypeParam;
 
-  F n = F(2).Pow(BigInt<1>(F::Config::kTwoAdicity));
+  F n = F(2).Pow(F::Config::kTwoAdicity);
   EXPECT_EQ(F::FromMontgomery(F::Config::kTwoAdicRootOfUnity).Pow(n.ToBigInt()),
             F::One());
 }
@@ -50,9 +50,9 @@ TYPED_TEST(PrimeFieldBaseTest, LargeSubgroupOfUnity) {
   using F = TypeParam;
 
   if constexpr (F::Config::kHasLargeSubgroupRootOfUnity) {
-    F n = F(2).Pow(BigInt<1>(F::Config::kTwoAdicity)) *
-          F(F::Config::kSmallSubgroupBase)
-              .Pow(BigInt<1>(F::Config::kSmallSubgroupAdicity));
+    F n =
+        F(2).Pow(F::Config::kTwoAdicity) *
+        F(F::Config::kSmallSubgroupBase).Pow(F::Config::kSmallSubgroupAdicity);
     EXPECT_EQ(F::FromMontgomery(F::Config::kLargeSubgroupRootOfUnity)
                   .Pow(n.ToBigInt()),
               F::One());
@@ -71,7 +71,7 @@ TYPED_TEST(PrimeFieldBaseTest, GetRootOfUnity) {
                    std::pow(size_t{F::Config::kSmallSubgroupBase}, j);
         F root;
         ASSERT_TRUE(F::GetRootOfUnity(n, &root));
-        ASSERT_EQ(root.Pow(BigInt<1>(n)), F::One());
+        ASSERT_EQ(root.Pow(n), F::One());
       }
     }
   } else {
@@ -79,7 +79,7 @@ TYPED_TEST(PrimeFieldBaseTest, GetRootOfUnity) {
       size_t n = size_t{1} << i;
       F root;
       ASSERT_TRUE(F::GetRootOfUnity(n, &root));
-      ASSERT_EQ(root.Pow(BigInt<1>(n)), F::One());
+      ASSERT_EQ(root.Pow(n), F::One());
     }
   }
 }

--- a/tachyon/math/finite_fields/prime_field_unittest.cc
+++ b/tachyon/math/finite_fields/prime_field_unittest.cc
@@ -187,7 +187,7 @@ TYPED_TEST(PrimeFieldTest, MultiplicativeGroupOperators) {
   EXPECT_EQ(f, F(2));
 
   f = F(3);
-  EXPECT_EQ(f.Pow(BigInt<1>(5)), F(5));
+  EXPECT_EQ(f.Pow(5), F(5));
 }
 
 TYPED_TEST(PrimeFieldTest, SumOfProducts) {

--- a/tachyon/math/polynomials/multivariate/multivariate_sparse_coefficients.h
+++ b/tachyon/math/polynomials/multivariate/multivariate_sparse_coefficients.h
@@ -122,11 +122,11 @@ class MultivariateSparseCoefficients {
    private:
     static F EvaluateSerial(absl::Span<const Element> elements,
                             const std::vector<F>& points) {
-      return std::accumulate(
-          elements.begin(), elements.end(), F::One(),
-          [&points](const F& acc, const Element& elem) {
-            return acc * points[elem.variable].Pow(BigInt<1>(elem.exponent));
-          });
+      return std::accumulate(elements.begin(), elements.end(), F::One(),
+                             [&points](const F& acc, const Element& elem) {
+                               return acc *
+                                      points[elem.variable].Pow(elem.exponent);
+                             });
     }
   };
 

--- a/tachyon/math/polynomials/univariate/mixed_radix_evaluation_domain.h
+++ b/tachyon/math/polynomials/univariate/mixed_radix_evaluation_domain.h
@@ -233,7 +233,7 @@ class MixedRadixEvaluationDomain
         }
       }
 
-      F omega_q = omega.Pow(BigInt<1>(n / q));
+      F omega_q = omega.Pow(n / q);
       std::vector<F> qth_roots(q, F::One());
       for (size_t i = 1; i < q; ++i) {
         qth_roots[i] = qth_roots[i - 1] * omega_q;
@@ -243,7 +243,7 @@ class MixedRadixEvaluationDomain
 
       // Doing the q_adicity passes.
       for (size_t i = 0; i < q_adicity; ++i) {
-        F w_m = omega.Pow(BigInt<1>(n / (q * m)));
+        F w_m = omega.Pow(n / (q * m));
         for (size_t k = 0; k < n; k += q * m) {
           F w_j = F::One();  // ωⱼ is ωₘʲ
           for (size_t j = 0; j < m; ++j) {
@@ -276,7 +276,7 @@ class MixedRadixEvaluationDomain
 
     for (size_t i = 0; i < two_adicity; ++i) {
       // ωₘ is 2ˢ-th root of unity now
-      F w_m = omega.Pow(BigInt<1>(n / (2 * m)));
+      F w_m = omega.Pow(n / (2 * m));
       for (size_t k = 0; k < n; k += 2 * m) {
         F w = F::One();
         for (size_t j = 0; j < m; ++j) {
@@ -314,7 +314,7 @@ class MixedRadixEvaluationDomain
     // g^{|num_cosets|}, and varying shifts.
     std::vector<PolyOrEvals> tmp =
         base::CreateVector(num_cosets, PolyOrEvals::UnsafeZero(coset_size - 1));
-    F new_omega = omega.Pow(BigInt<1>(num_cosets));
+    F new_omega = omega.Pow(num_cosets);
     uint32_t new_two_adicity =
         ComputeAdicity(2, gmp::FromUnsignedInt(coset_size));
 
@@ -325,8 +325,8 @@ class MixedRadixEvaluationDomain
     for (size_t k = 0; k < tmp.size(); ++k) {
       PolyOrEvals& kth_poly_coeffs = tmp[k];
       // Shuffle into a sub-FFT
-      F omega_k = omega.Pow(BigInt<1>(uint64_t{k}));
-      F omega_step = omega.Pow(BigInt<1>(uint64_t{k} * coset_size));
+      F omega_k = omega.Pow(k);
+      F omega_step = omega.Pow(k * coset_size);
 
       F elt = F::One();
       // Construct |kth_poly_coeffs|, which is a polynomial whose evaluations on

--- a/tachyon/math/polynomials/univariate/univariate_dense_coefficients.h
+++ b/tachyon/math/polynomials/univariate/univariate_dense_coefficients.h
@@ -163,7 +163,7 @@ class UnivariateDenseCoefficients {
         coefficients_, [&point](absl::Span<const F> chunk, size_t chunk_offset,
                                 size_t chunk_size) {
           F result = HornerEvaluate(chunk, point);
-          result *= point.Pow(BigInt<1>(chunk_offset * chunk_size));
+          result *= point.Pow(chunk_offset * chunk_size);
           return result;
         });
     return std::accumulate(results.begin(), results.end(), F::Zero(),

--- a/tachyon/math/polynomials/univariate/univariate_evaluation_domain_unittest.cc
+++ b/tachyon/math/polynomials/univariate/univariate_evaluation_domain_unittest.cc
@@ -164,14 +164,14 @@ TYPED_TEST(UnivariateEvaluationDomainTest, ContentsOfElements) {
 
   for (size_t coeffs = 0; coeffs < kNumCoeffs; ++coeffs) {
     size_t size = size_t{1} << coeffs;
-    this->TestDomains(size, [size](
-                                const BaseUnivariateEvaluationDomainType& d) {
-      std::vector<F> elements = d.GetElements();
-      for (size_t i = 0; i < size; ++i) {
-        EXPECT_EQ(elements[i], d.offset() * d.group_gen().Pow(BigInt<1>(i)));
-        EXPECT_EQ(elements[i], d.GetElement(i));
-      }
-    });
+    this->TestDomains(
+        size, [size](const BaseUnivariateEvaluationDomainType& d) {
+          std::vector<F> elements = d.GetElements();
+          for (size_t i = 0; i < size; ++i) {
+            EXPECT_EQ(elements[i], d.offset() * d.group_gen().Pow(i));
+            EXPECT_EQ(elements[i], d.GetElement(i));
+          }
+        });
   }
 }
 

--- a/tachyon/zk/plonk/circuit/rotation.h
+++ b/tachyon/zk/plonk/circuit/rotation.h
@@ -54,9 +54,9 @@ class TACHYON_EXPORT Rotation {
   F RotateOmega(const math::UnivariateEvaluationDomain<F, MaxDegree>* domain,
                 const F& point) const {
     if (value_ >= 0) {
-      return point * domain->group_gen().Pow(math::BigInt<1>(value_));
+      return point * domain->group_gen().Pow(value_);
     } else {
-      return point * domain->group_gen_inv().Pow(math::BigInt<1>(-1 * value_));
+      return point * domain->group_gen_inv().Pow(-1 * value_);
     }
   }
 

--- a/tachyon/zk/plonk/permutation/lookup_table.h
+++ b/tachyon/zk/plonk/permutation/lookup_table.h
@@ -75,8 +75,7 @@ class LookupTable {
   // where T = F::Config::kTrace.
   constexpr static F GetDelta() {
     F g = F::FromMontgomery(F::Config::kSubgroupGenerator);
-    typename F::BigIntTy s(F::Config::kTwoAdicity);
-    F adicity = F(2).Pow(s);
+    F adicity = F(2).Pow(F::Config::kTwoAdicity);
     return g.Pow(adicity.ToBigInt());
   }
 

--- a/tachyon/zk/value_unittest.cc
+++ b/tachyon/zk/value_unittest.cc
@@ -170,7 +170,7 @@ TEST(ValueTest, MultiplicativeGroupOperators) {
           Value<math::GF7>::Known(a),
           Value<math::GF7>::Known(a.Inverse()),
           Value<math::GF7>::Known(a.Square()),
-          Value<math::GF7>::Known(a.Pow(math::BigInt<1>(5))),
+          Value<math::GF7>::Known(a.Pow(5)),
       },
       {
           Value<math::GF7>::Unknown(),
@@ -186,7 +186,7 @@ TEST(ValueTest, MultiplicativeGroupOperators) {
       EXPECT_DEATH(test.a.InverseInPlace(), "");
       EXPECT_DEATH(std::ignore = test.a.Square(), "");
       EXPECT_DEATH(test.a.SquareInPlace(), "");
-      EXPECT_DEATH(std::ignore = test.a.Pow(math::BigInt<1>(5)), "");
+      EXPECT_DEATH(std::ignore = test.a.Pow(5), "");
     } else {
       EXPECT_EQ(test.a.Inverse(), test.inverse);
       Value<math::GF7> a_tmp = test.a;
@@ -198,7 +198,7 @@ TEST(ValueTest, MultiplicativeGroupOperators) {
       a_tmp.SquareInPlace();
       EXPECT_EQ(a_tmp, test.sqr);
 
-      EXPECT_EQ(test.a.Pow(math::BigInt<1>(5)), test.pow);
+      EXPECT_EQ(test.a.Pow(5), test.pow);
     }
   }
 }


### PR DESCRIPTION
# Description

This PR allows to call `ScalarMul` and `Pow()` with a `BigInt<1>` convertible type.
