### PR TITLE
feat: enhance abstraction of pcs

### DIFF
--- a/tachyon/crypto/commitments/kzg/kzg_commitment_scheme.h
+++ b/tachyon/crypto/commitments/kzg/kzg_commitment_scheme.h
@@ -78,9 +78,7 @@ class KZGCommitmentScheme
     }
 
     // Get |g1_powers_of_tau_lagrange_| from 𝜏 and g₁.
-    std::unique_ptr<DomainTy> domain =
-        math::UnivariateEvaluationDomainFactory<Field, kMaxDegree>::Create(
-            size);
+    std::unique_ptr<DomainTy> domain = DomainTy::Create(size);
     typename DomainTy::DenseCoeffs lagrange_coeffs =
         domain->EvaluateAllLagrangeCoefficients(tau);
     std::vector<G1JacobianPointTy> g1_powers_of_tau_lagrange_jacobian;

--- a/tachyon/crypto/commitments/kzg/kzg_commitment_scheme.h
+++ b/tachyon/crypto/commitments/kzg/kzg_commitment_scheme.h
@@ -21,14 +21,15 @@ namespace tachyon {
 namespace crypto {
 
 template <typename G1PointTy, typename G2PointTy,
-          typename ResultTy = typename math::Pippenger<G1PointTy>::Bucket>
+          typename _Commitment = typename math::Pippenger<G1PointTy>::Bucket>
 class KZGCommitmentScheme
     : public UnivariatePolynomialCommitmentScheme<
-          KZGCommitmentScheme<G1PointTy, G2PointTy, ResultTy>> {
+          KZGCommitmentScheme<G1PointTy, G2PointTy, _Commitment>> {
  public:
   using Base = UnivariatePolynomialCommitmentScheme<
-      KZGCommitmentScheme<G1PointTy, G2PointTy, ResultTy>>;
+      KZGCommitmentScheme<G1PointTy, G2PointTy, _Commitment>>;
   using Field = typename G1PointTy::ScalarField;
+  using Commitment = _Commitment;
 
   static constexpr size_t kMaxDegree = Base::kMaxSize - 1;
 
@@ -112,35 +113,35 @@ class KZGCommitmentScheme
 
  private:
   friend class VectorCommitmentScheme<
-      KZGCommitmentScheme<G1PointTy, G2PointTy, ResultTy>>;
+      KZGCommitmentScheme<G1PointTy, G2PointTy, Commitment>>;
   friend class UnivariatePolynomialCommitmentScheme<
-      KZGCommitmentScheme<G1PointTy, G2PointTy, ResultTy>>;
+      KZGCommitmentScheme<G1PointTy, G2PointTy, Commitment>>;
 
   bool DoUnsafeSetup(size_t size) {
     return UnsafeSetupWithTau(size, Field::Random());
   }
 
   [[nodiscard]] bool DoCommit(const std::vector<Field>& v,
-                              ResultTy* out) const {
+                              Commitment* out) const {
     return DoMSM(g1_powers_of_tau_, v, out);
   }
 
   [[nodiscard]] bool DoCommitLagrange(const std::vector<Field>& v,
-                                      ResultTy* out) const {
+                                      Commitment* out) const {
     return DoMSM(g1_powers_of_tau_lagrange_, v, out);
   }
 
   static bool DoMSM(const std::vector<G1PointTy>& bases,
-                    const std::vector<Field>& scalars, ResultTy* out) {
+                    const std::vector<Field>& scalars, Commitment* out) {
     using Bucket = typename math::Pippenger<G1PointTy>::Bucket;
 
     math::VariableBaseMSM<G1PointTy> msm;
-    if constexpr (std::is_same_v<ResultTy, Bucket>) {
+    if constexpr (std::is_same_v<Commitment, Bucket>) {
       return msm.Run(bases, scalars, out);
     } else {
       Bucket result;
       if (!msm.Run(bases, scalars, &result)) return false;
-      *out = math::ConvertPoint<ResultTy>(result);
+      *out = math::ConvertPoint<Commitment>(result);
       return true;
     }
   }
@@ -150,12 +151,12 @@ class KZGCommitmentScheme
   G2PointTy tau_g2_;
 };
 
-template <typename G1PointTy, typename G2PointTy, typename CommitmentTy>
+template <typename G1PointTy, typename G2PointTy, typename _Commitment>
 struct VectorCommitmentSchemeTraits<
-    KZGCommitmentScheme<G1PointTy, G2PointTy, CommitmentTy>> {
+    KZGCommitmentScheme<G1PointTy, G2PointTy, _Commitment>> {
  public:
   using Field = typename G1PointTy::ScalarField;
-  using ResultTy = CommitmentTy;
+  using Commitment = _Commitment;
 
   constexpr static size_t kMaxSize = size_t{1} << Field::Config::kTwoAdicity;
   constexpr static bool kIsTransparent = false;
@@ -165,10 +166,10 @@ struct VectorCommitmentSchemeTraits<
 
 namespace base {
 
-template <typename G1PointTy, typename G2PointTy, typename ResultTy>
-class Copyable<crypto::KZGCommitmentScheme<G1PointTy, G2PointTy, ResultTy>> {
+template <typename G1PointTy, typename G2PointTy, typename Commitment>
+class Copyable<crypto::KZGCommitmentScheme<G1PointTy, G2PointTy, Commitment>> {
  public:
-  using PCS = crypto::KZGCommitmentScheme<G1PointTy, G2PointTy, ResultTy>;
+  using PCS = crypto::KZGCommitmentScheme<G1PointTy, G2PointTy, Commitment>;
 
   static bool WriteTo(const PCS& pcs, Buffer* buffer) {
     return buffer->WriteMany(pcs.g1_powers_of_tau(),

--- a/tachyon/crypto/commitments/kzg/kzg_commitment_scheme_unittest.cc
+++ b/tachyon/crypto/commitments/kzg/kzg_commitment_scheme_unittest.cc
@@ -37,20 +37,19 @@ TEST_F(KZGCommitmentSchemeTest, UnsafeSetup) {
 }
 
 TEST_F(KZGCommitmentSchemeTest, CommitLagrange) {
-  using Field = math::bn254::G1AffinePoint::ScalarField;
-  using DomainTy = math::UnivariateEvaluationDomain<Field, PCS::kMaxDegree>;
-  using DensePoly = DomainTy::DensePoly;
-  using Evals = DomainTy::Evals;
+  using Domain = typename PCS::Domain;
+  using Poly = typename PCS::Poly;
+  using Evals = typename PCS::Evals;
 
   PCS kzg;
   ASSERT_TRUE(kzg.UnsafeSetup(N));
 
-  DensePoly poly = DensePoly::Random(N - 1);
+  Poly poly = Poly::Random(N - 1);
 
   math::bn254::G1AffinePoint commit;
   ASSERT_TRUE(kzg.Commit(poly, &commit));
 
-  std::unique_ptr<DomainTy> domain = DomainTy::Create(N);
+  std::unique_ptr<Domain> domain = Domain::Create(N);
   Evals poly_evals = domain->FFT(poly);
 
   math::bn254::G1AffinePoint commit_lagrange;

--- a/tachyon/crypto/commitments/kzg/kzg_commitment_scheme_unittest.cc
+++ b/tachyon/crypto/commitments/kzg/kzg_commitment_scheme_unittest.cc
@@ -50,9 +50,7 @@ TEST_F(KZGCommitmentSchemeTest, CommitLagrange) {
   math::bn254::G1AffinePoint commit;
   ASSERT_TRUE(kzg.Commit(poly, &commit));
 
-  std::unique_ptr<DomainTy> domain =
-      math::UnivariateEvaluationDomainFactory<Field, PCS::kMaxDegree>::Create(
-          N);
+  std::unique_ptr<DomainTy> domain = DomainTy::Create(N);
   Evals poly_evals = domain->FFT(poly);
 
   math::bn254::G1AffinePoint commit_lagrange;

--- a/tachyon/crypto/commitments/kzg/kzg_commitment_scheme_unittest.cc
+++ b/tachyon/crypto/commitments/kzg/kzg_commitment_scheme_unittest.cc
@@ -13,8 +13,12 @@ namespace {
 
 class KZGCommitmentSchemeTest : public testing::Test {
  public:
+  constexpr static size_t K = 3;
+  constexpr static size_t N = size_t{1} << K;
+  constexpr static size_t kMaxDegree = N - 1;
+
   using PCS = KZGCommitmentScheme<math::bn254::G1AffinePoint,
-                                  math::bn254::G2AffinePoint,
+                                  math::bn254::G2AffinePoint, kMaxDegree,
                                   math::bn254::G1AffinePoint>;
 
   static void SetUpTestSuite() { math::bn254::G1Curve::Init(); }
@@ -24,12 +28,12 @@ class KZGCommitmentSchemeTest : public testing::Test {
 
 TEST_F(KZGCommitmentSchemeTest, UnsafeSetup) {
   PCS kzg;
-  ASSERT_TRUE(kzg.UnsafeSetup(32));
+  ASSERT_TRUE(kzg.UnsafeSetup(N));
 
-  EXPECT_EQ(kzg.K(), size_t{5});
-  EXPECT_EQ(kzg.N(), size_t{32});
-  EXPECT_EQ(kzg.g1_powers_of_tau().size(), size_t{32});
-  EXPECT_EQ(kzg.g1_powers_of_tau_lagrange().size(), size_t{32});
+  EXPECT_EQ(kzg.K(), K);
+  EXPECT_EQ(kzg.N(), N);
+  EXPECT_EQ(kzg.g1_powers_of_tau().size(), size_t{N});
+  EXPECT_EQ(kzg.g1_powers_of_tau_lagrange().size(), size_t{N});
 }
 
 TEST_F(KZGCommitmentSchemeTest, CommitLagrange) {
@@ -39,16 +43,16 @@ TEST_F(KZGCommitmentSchemeTest, CommitLagrange) {
   using Evals = DomainTy::Evals;
 
   PCS kzg;
-  ASSERT_TRUE(kzg.UnsafeSetup(32));
+  ASSERT_TRUE(kzg.UnsafeSetup(N));
 
-  DensePoly poly = DensePoly::Random(31);
+  DensePoly poly = DensePoly::Random(N - 1);
 
   math::bn254::G1AffinePoint commit;
   ASSERT_TRUE(kzg.Commit(poly, &commit));
 
   std::unique_ptr<DomainTy> domain =
       math::UnivariateEvaluationDomainFactory<Field, PCS::kMaxDegree>::Create(
-          32);
+          N);
   Evals poly_evals = domain->FFT(poly);
 
   math::bn254::G1AffinePoint commit_lagrange;
@@ -59,15 +63,15 @@ TEST_F(KZGCommitmentSchemeTest, CommitLagrange) {
 
 TEST_F(KZGCommitmentSchemeTest, Downsize) {
   PCS kzg;
-  ASSERT_TRUE(kzg.UnsafeSetup(64));
-  ASSERT_FALSE(kzg.Downsize(kzg.N()));
-  ASSERT_TRUE(kzg.Downsize(32));
-  EXPECT_EQ(kzg.N(), size_t{32});
+  ASSERT_TRUE(kzg.UnsafeSetup(N));
+  ASSERT_FALSE(kzg.Downsize(N));
+  ASSERT_TRUE(kzg.Downsize(N / 2));
+  EXPECT_EQ(kzg.N(), N / 2);
 }
 
 TEST_F(KZGCommitmentSchemeTest, Copyable) {
   PCS expected;
-  ASSERT_TRUE(expected.UnsafeSetup(32));
+  ASSERT_TRUE(expected.UnsafeSetup(N));
 
   base::VectorBuffer write_buf;
   EXPECT_TRUE(write_buf.Write(expected));

--- a/tachyon/crypto/commitments/univariate_polynomial_commitment_scheme.h
+++ b/tachyon/crypto/commitments/univariate_polynomial_commitment_scheme.h
@@ -15,13 +15,13 @@ class UnivariatePolynomialCommitmentScheme : public VectorCommitmentScheme<C> {
   constexpr static size_t kMaxDegree = VectorCommitmentScheme<C>::kMaxSize - 1;
 
   using Field = typename VectorCommitmentScheme<C>::Field;
-  using ResultTy = typename VectorCommitmentScheme<C>::ResultTy;
+  using Commitment = typename VectorCommitmentScheme<C>::Commitment;
 
   // Commit to |poly| and populates |result| with the commitment.
   // Return false if the degree of |poly| exceeds |kMaxDegree|.
   [[nodiscard]] bool Commit(
       const math::UnivariateDensePolynomial<Field, kMaxDegree>& poly,
-      ResultTy* result) const {
+      Commitment* result) const {
     const C* c = static_cast<const C*>(this);
     return c->DoCommit(poly.coefficients().coefficients(), result);
   }
@@ -30,7 +30,7 @@ class UnivariatePolynomialCommitmentScheme : public VectorCommitmentScheme<C> {
   // Return false if the degree of |poly| exceeds |kMaxDegree|.
   [[nodiscard]] bool CommitLagrange(
       const math::UnivariateEvaluations<Field, kMaxDegree>& evals,
-      ResultTy* result) const {
+      Commitment* result) const {
     const C* c = static_cast<const C*>(this);
     return c->DoCommitLagrange(evals.evaluations(), result);
   }

--- a/tachyon/crypto/commitments/univariate_polynomial_commitment_scheme.h
+++ b/tachyon/crypto/commitments/univariate_polynomial_commitment_scheme.h
@@ -9,21 +9,23 @@
 
 namespace tachyon::crypto {
 
-template <typename C>
-class UnivariatePolynomialCommitmentScheme : public VectorCommitmentScheme<C> {
+template <typename Derived>
+class UnivariatePolynomialCommitmentScheme
+    : public VectorCommitmentScheme<Derived> {
  public:
-  constexpr static size_t kMaxDegree = VectorCommitmentScheme<C>::kMaxSize - 1;
+  constexpr static size_t kMaxDegree =
+      VectorCommitmentScheme<Derived>::kMaxSize - 1;
 
-  using Field = typename VectorCommitmentScheme<C>::Field;
-  using Commitment = typename VectorCommitmentScheme<C>::Commitment;
+  using Field = typename VectorCommitmentScheme<Derived>::Field;
+  using Commitment = typename VectorCommitmentScheme<Derived>::Commitment;
 
   // Commit to |poly| and populates |result| with the commitment.
   // Return false if the degree of |poly| exceeds |kMaxDegree|.
   [[nodiscard]] bool Commit(
       const math::UnivariateDensePolynomial<Field, kMaxDegree>& poly,
       Commitment* result) const {
-    const C* c = static_cast<const C*>(this);
-    return c->DoCommit(poly.coefficients().coefficients(), result);
+    const Derived* derived = static_cast<const Derived*>(this);
+    return derived->DoCommit(poly.coefficients().coefficients(), result);
   }
 
   // Commit to |poly| and populates |result| with the commitment.
@@ -31,8 +33,8 @@ class UnivariatePolynomialCommitmentScheme : public VectorCommitmentScheme<C> {
   [[nodiscard]] bool CommitLagrange(
       const math::UnivariateEvaluations<Field, kMaxDegree>& evals,
       Commitment* result) const {
-    const C* c = static_cast<const C*>(this);
-    return c->DoCommitLagrange(evals.evaluations(), result);
+    const Derived* derived = static_cast<const Derived*>(this);
+    return derived->DoCommitLagrange(evals.evaluations(), result);
   }
 };
 

--- a/tachyon/crypto/commitments/univariate_polynomial_commitment_scheme.h
+++ b/tachyon/crypto/commitments/univariate_polynomial_commitment_scheme.h
@@ -18,21 +18,21 @@ class UnivariatePolynomialCommitmentScheme
 
   using Field = typename VectorCommitmentScheme<Derived>::Field;
   using Commitment = typename VectorCommitmentScheme<Derived>::Commitment;
+  using Poly = math::UnivariateDensePolynomial<Field, kMaxDegree>;
+  using Evals = math::UnivariateEvaluations<Field, kMaxDegree>;
+  using Domain = math::UnivariateEvaluationDomain<Field, kMaxDegree>;
 
   // Commit to |poly| and populates |result| with the commitment.
   // Return false if the degree of |poly| exceeds |kMaxDegree|.
-  [[nodiscard]] bool Commit(
-      const math::UnivariateDensePolynomial<Field, kMaxDegree>& poly,
-      Commitment* result) const {
+  [[nodiscard]] bool Commit(const Poly& poly, Commitment* result) const {
     const Derived* derived = static_cast<const Derived*>(this);
     return derived->DoCommit(poly.coefficients().coefficients(), result);
   }
 
   // Commit to |poly| and populates |result| with the commitment.
   // Return false if the degree of |poly| exceeds |kMaxDegree|.
-  [[nodiscard]] bool CommitLagrange(
-      const math::UnivariateEvaluations<Field, kMaxDegree>& evals,
-      Commitment* result) const {
+  [[nodiscard]] bool CommitLagrange(const Evals& evals,
+                                    Commitment* result) const {
     const Derived* derived = static_cast<const Derived*>(this);
     return derived->DoCommitLagrange(evals.evaluations(), result);
   }

--- a/tachyon/crypto/commitments/vector_commitment_scheme.h
+++ b/tachyon/crypto/commitments/vector_commitment_scheme.h
@@ -6,47 +6,52 @@
 
 namespace tachyon::crypto {
 
-template <typename C>
+template <typename Derived>
 class VectorCommitmentScheme {
  public:
-  constexpr static size_t kMaxSize = VectorCommitmentSchemeTraits<C>::kMaxSize;
+  constexpr static size_t kMaxSize =
+      VectorCommitmentSchemeTraits<Derived>::kMaxSize;
   constexpr static bool kIsTransparent =
-      VectorCommitmentSchemeTraits<C>::kIsTransparent;
+      VectorCommitmentSchemeTraits<Derived>::kIsTransparent;
 
-  using Field = typename VectorCommitmentSchemeTraits<C>::Field;
-  using Commitment = typename VectorCommitmentSchemeTraits<C>::Commitment;
+  using Field = typename VectorCommitmentSchemeTraits<Derived>::Field;
+  using Commitment = typename VectorCommitmentSchemeTraits<Derived>::Commitment;
 
   size_t K() const {
-    const C* c = static_cast<const C*>(this);
-    return base::bits::SafeLog2Ceiling(c->N());
+    const Derived* derived = static_cast<const Derived*>(this);
+    return base::bits::SafeLog2Ceiling(derived->N());
   }
 
   // Initialize parameters.
-  template <typename C2 = C, std::enable_if_t<VectorCommitmentSchemeTraits<
-                                 C2>::kIsTransparent>* = nullptr>
+  template <typename T = Derived,
+            std::enable_if_t<VectorCommitmentSchemeTraits<T>::kIsTransparent>* =
+                nullptr>
   [[nodiscard]] bool Setup() {
     return Setup(kMaxSize);
   }
 
-  template <typename C2 = C, std::enable_if_t<VectorCommitmentSchemeTraits<
-                                 C2>::kIsTransparent>* = nullptr>
+  template <typename T = Derived,
+            std::enable_if_t<VectorCommitmentSchemeTraits<T>::kIsTransparent>* =
+                nullptr>
   [[nodiscard]] bool Setup(size_t size) {
-    C* c = static_cast<C*>(this);
-    return c->DoSetup(size);
+    Derived* derived = static_cast<Derived*>(this);
+    return derived->DoSetup(size);
   }
 
   // Initialize parameters.
-  template <typename C2 = C, std::enable_if_t<!VectorCommitmentSchemeTraits<
-                                 C2>::kIsTransparent>* = nullptr>
+  template <typename T = Derived,
+            std::enable_if_t<
+                !VectorCommitmentSchemeTraits<T>::kIsTransparent>* = nullptr>
   [[nodiscard]] bool UnsafeSetup() {
     return UnsafeSetup(kMaxSize);
   }
 
-  template <typename C2 = C, std::enable_if_t<!VectorCommitmentSchemeTraits<
-                                 C2>::kIsTransparent>* = nullptr>
+  template <typename T = Derived,
+            std::enable_if_t<
+                !VectorCommitmentSchemeTraits<T>::kIsTransparent>* = nullptr>
   [[nodiscard]] bool UnsafeSetup(size_t size) {
-    C* c = static_cast<C*>(this);
-    return c->DoUnsafeSetup(size);
+    Derived* derived = static_cast<Derived*>(this);
+    return derived->DoUnsafeSetup(size);
   }
 
   // Commit to |container| and populates |result| with the commitment.
@@ -55,8 +60,8 @@ class VectorCommitmentScheme {
   template <typename ContainerTy>
   [[nodiscard]] bool Commit(const ContainerTy& container,
                             Commitment* result) const {
-    const C* c = static_cast<const C*>(this);
-    return c->DoCommit(container, result);
+    const Derived* derived = static_cast<const Derived*>(this);
+    return derived->DoCommit(container, result);
   }
 
   // Commit to |container| with a |random_value| and populates |result| with the
@@ -65,8 +70,8 @@ class VectorCommitmentScheme {
   template <typename ContainerTy>
   [[nodiscard]] bool Commit(const ContainerTy& container,
                             const Field& random_value, Commitment* result) const {
-    const C* c = static_cast<const C*>(this);
-    return c->DoCommit(container, random_value, result);
+    const Derived* derived = static_cast<const Derived*>(this);
+    return derived->DoCommit(container, random_value, result);
   }
 };
 

--- a/tachyon/crypto/commitments/vector_commitment_scheme.h
+++ b/tachyon/crypto/commitments/vector_commitment_scheme.h
@@ -14,7 +14,7 @@ class VectorCommitmentScheme {
       VectorCommitmentSchemeTraits<C>::kIsTransparent;
 
   using Field = typename VectorCommitmentSchemeTraits<C>::Field;
-  using ResultTy = typename VectorCommitmentSchemeTraits<C>::ResultTy;
+  using Commitment = typename VectorCommitmentSchemeTraits<C>::Commitment;
 
   size_t K() const {
     const C* c = static_cast<const C*>(this);
@@ -54,7 +54,7 @@ class VectorCommitmentScheme {
   // parameters.
   template <typename ContainerTy>
   [[nodiscard]] bool Commit(const ContainerTy& container,
-                            ResultTy* result) const {
+                            Commitment* result) const {
     const C* c = static_cast<const C*>(this);
     return c->DoCommit(container, result);
   }
@@ -64,7 +64,7 @@ class VectorCommitmentScheme {
   // size of parameters.
   template <typename ContainerTy>
   [[nodiscard]] bool Commit(const ContainerTy& container,
-                            const Field& random_value, ResultTy* result) const {
+                            const Field& random_value, Commitment* result) const {
     const C* c = static_cast<const C*>(this);
     return c->DoCommit(container, random_value, result);
   }

--- a/tachyon/math/polynomials/univariate/univariate_evaluation_domain.h
+++ b/tachyon/math/polynomials/univariate/univariate_evaluation_domain.h
@@ -22,6 +22,9 @@
 namespace tachyon::math {
 
 template <typename F, size_t MaxDegree>
+class UnivariateEvaluationDomainFactory;
+
+template <typename F, size_t MaxDegree>
 class UnivariateEvaluationDomain : public EvaluationDomain<F, MaxDegree> {
  public:
   static_assert(F::HasRootOfUnity(),
@@ -35,8 +38,6 @@ class UnivariateEvaluationDomain : public EvaluationDomain<F, MaxDegree> {
 
   constexpr UnivariateEvaluationDomain() = default;
 
-  virtual ~UnivariateEvaluationDomain() = default;
-
   constexpr UnivariateEvaluationDomain(size_t size, uint32_t log_size_of_group)
       : size_(size), log_size_of_group_(log_size_of_group) {
     size_as_field_element_ = F::FromBigInt(typename F::BigIntTy(size_));
@@ -48,6 +49,13 @@ class UnivariateEvaluationDomain : public EvaluationDomain<F, MaxDegree> {
     // Check that it is indeed the 2^(log_size_of_group) root of unity.
     DCHECK_EQ(group_gen_.Pow(BigInt<1>(size_)), F::One());
     group_gen_inv_ = group_gen_.Inverse();
+  }
+
+  virtual ~UnivariateEvaluationDomain() = default;
+
+  constexpr static std::unique_ptr<UnivariateEvaluationDomain> Create(
+      size_t num_coeffs) {
+    return UnivariateEvaluationDomainFactory<F, MaxDegree>::Create(num_coeffs);
   }
 
   constexpr size_t size() const { return size_; }

--- a/tachyon/math/polynomials/univariate/univariate_evaluation_domain.h
+++ b/tachyon/math/polynomials/univariate/univariate_evaluation_domain.h
@@ -30,6 +30,7 @@ class UnivariateEvaluationDomain : public EvaluationDomain<F, MaxDegree> {
   static_assert(F::HasRootOfUnity(),
                 "UnivariateEvaluationDomain should have root of unity");
 
+  using Field = F;
   using Evals = UnivariateEvaluations<F, MaxDegree>;
   using DensePoly = UnivariateDensePolynomial<F, MaxDegree>;
   using DenseCoeffs = UnivariateDenseCoefficients<F, MaxDegree>;

--- a/tachyon/math/polynomials/univariate/univariate_evaluation_domain_factory.h
+++ b/tachyon/math/polynomials/univariate/univariate_evaluation_domain_factory.h
@@ -30,8 +30,8 @@ class UnivariateEvaluationDomainFactory {
  public:
   // Construct a domain that is large enough for evaluations of a polynomial
   // having |num_coeffs| coefficients.
-  static std::unique_ptr<UnivariateEvaluationDomain<F, MaxDegree>> Create(
-      size_t num_coeffs) {
+  constexpr static std::unique_ptr<UnivariateEvaluationDomain<F, MaxDegree>>
+  Create(size_t num_coeffs) {
     if (Radix2EvaluationDomain<F, MaxDegree>::IsValidNumCoeffs(num_coeffs)) {
       return Radix2EvaluationDomain<F, MaxDegree>::Create(num_coeffs);
     } else if (MixedRadixEvaluationDomain<F, MaxDegree>::IsValidNumCoeffs(

--- a/tachyon/zk/plonk/circuit/rotation.h
+++ b/tachyon/zk/plonk/circuit/rotation.h
@@ -50,9 +50,8 @@ class TACHYON_EXPORT Rotation {
     return size_t{base::bit_cast<uint32_t>(value % size)};
   }
 
-  template <typename F, size_t MaxDegree>
-  F RotateOmega(const math::UnivariateEvaluationDomain<F, MaxDegree>* domain,
-                const F& point) const {
+  template <typename Domain, typename F = typename Domain::F>
+  F RotateOmega(const Domain* domain, const F& point) const {
     if (value_ >= 0) {
       return point * domain->group_gen().Pow(math::BigInt<1>(value_));
     } else {

--- a/tachyon/zk/plonk/keys/proving_key.h
+++ b/tachyon/zk/plonk/keys/proving_key.h
@@ -4,8 +4,6 @@
 #include <utility>
 #include <vector>
 
-#include "tachyon/math/polynomials/univariate/univariate_evaluations.h"
-#include "tachyon/math/polynomials/univariate/univariate_polynomial.h"
 #include "tachyon/zk/plonk/keys/verifying_key.h"
 #include "tachyon/zk/plonk/permutation/permutation_proving_key.h"
 
@@ -17,11 +15,11 @@ class ProvingKey {
   static constexpr size_t kMaxDegree = PCSTy::kMaxDegree;
 
   using F = typename PCSTy::Field;
-  using DensePoly = math::UnivariateDensePolynomial<F, kMaxDegree>;
-  using Evals = math::UnivariateEvaluations<F, kMaxDegree>;
+  using Poly = typename PCSTy::Poly;
+  using Evals = typename PCSTy::Evals;
 
-  ProvingKey(VerifyingKey<PCSTy> verifying_key, DensePoly l0, DensePoly l_last,
-             DensePoly l_active_row, Evals fixed_values, Evals fixed_polys,
+  ProvingKey(VerifyingKey<PCSTy> verifying_key, Poly l0, Poly l_last,
+             Poly l_active_row, Evals fixed_values, Evals fixed_polys,
              PermutationProvingKey<PCSTy> permutation_proving_key)
       : verifying_key_(std::move(verifying_key)),
         l0_(std::move(l0)),
@@ -32,9 +30,9 @@ class ProvingKey {
         permutation_proving_key_(std::move(permutation_proving_key)) {}
 
   const VerifyingKey<PCSTy>& verifying_key() const { return verifying_key_; }
-  const DensePoly& l0() const { return l0_; }
-  const DensePoly& l_last() const { return l_last_; }
-  const DensePoly& l_active_row() const { return l_active_row_; }
+  const Poly& l0() const { return l0_; }
+  const Poly& l_last() const { return l_last_; }
+  const Poly& l_active_row() const { return l_active_row_; }
   const std::vector<Evals>& fixed_values() const { return fixed_values_; }
   const std::vector<Evals>& fixed_polys() const { return fixed_polys_; }
   const PermutationProvingKey<PCSTy>& permutation_proving_key() const {
@@ -43,9 +41,9 @@ class ProvingKey {
 
  private:
   VerifyingKey<PCSTy> verifying_key_;
-  DensePoly l0_;
-  DensePoly l_last_;
-  DensePoly l_active_row_;
+  Poly l0_;
+  Poly l_last_;
+  Poly l_active_row_;
   std::vector<Evals> fixed_values_;
   std::vector<Evals> fixed_polys_;
   PermutationProvingKey<PCSTy> permutation_proving_key_;

--- a/tachyon/zk/plonk/keys/verifying_key.h
+++ b/tachyon/zk/plonk/keys/verifying_key.h
@@ -20,7 +20,8 @@ class VerifyingKey {
   constexpr static size_t kMaxDegree = PCSTy::kMaxDegree;
 
   using F = typename PCSTy::Field;
-  using Commitment = typename PCSTy::ResultTy;
+  using Domain = typename PCSTy::Domain;
+  using Commitment = typename PCSTy::Commitment;
   using Commitments = std::vector<Commitment>;
 
   VerifyingKey() = default;
@@ -69,7 +70,7 @@ class VerifyingKey {
   const F& transcript_repr() const { return transcript_repr_; }
 
  private:
-  std::unique_ptr<math::UnivariateEvaluationDomain<F, kMaxDegree>> domain_;
+  std::unique_ptr<Domain> domain_;
   Commitments fixed_commitments_;
   PermutationVerifyingKey<PCSTy> permutation_verifying_Key_;
   ConstraintSystem<F> constraint_system_;

--- a/tachyon/zk/plonk/keys/verifying_key_unittest.cc
+++ b/tachyon/zk/plonk/keys/verifying_key_unittest.cc
@@ -12,9 +12,12 @@ namespace {
 
 class VerifyingKeyTest : public testing::Test {
  public:
-  using PCS = crypto::KZGCommitmentScheme<math::bn254::G1AffinePoint,
-                                          math::bn254::G2AffinePoint,
-                                          math::bn254::G1AffinePoint>;
+  constexpr static size_t kMaxDegree = 7;
+
+  using PCS =
+      crypto::KZGCommitmentScheme<math::bn254::G1AffinePoint,
+                                  math::bn254::G2AffinePoint, kMaxDegree,
+                                  math::bn254::G1AffinePoint>;
 
   static void SetUpTestSuite() { math::bn254::G1Curve::Init(); }
 };

--- a/tachyon/zk/plonk/permutation/BUILD.bazel
+++ b/tachyon/zk/plonk/permutation/BUILD.bazel
@@ -24,7 +24,6 @@ tachyon_cc_library(
     deps = [
         ":label",
         "//tachyon/base/containers:container_util",
-        "//tachyon/math/polynomials/univariate:univariate_evaluation_domain",
         "@com_google_googletest//:gtest_prod",
     ],
 )
@@ -49,8 +48,6 @@ tachyon_cc_library(
     hdrs = ["permutation_verifying_key.h"],
     deps = [
         "//tachyon/base/buffer:copyable",
-        "//tachyon/math/polynomials/univariate:univariate_evaluations",
-        "//tachyon/math/polynomials/univariate:univariate_polynomial",
     ],
 )
 
@@ -67,7 +64,6 @@ tachyon_cc_library(
         "//tachyon/base:openmp_util",
         "//tachyon/base:parallelize",
         "//tachyon/base/containers:container_util",
-        "//tachyon/math/polynomials/univariate:univariate_evaluation_domain",
     ],
 )
 

--- a/tachyon/zk/plonk/permutation/lookup_table_unittest.cc
+++ b/tachyon/zk/plonk/permutation/lookup_table_unittest.cc
@@ -10,7 +10,9 @@
 
 #include "gtest/gtest.h"
 
+#include "tachyon/crypto/commitments/kzg/kzg_commitment_scheme.h"
 #include "tachyon/math/elliptic_curves/bn/bn254/g1.h"
+#include "tachyon/math/elliptic_curves/bn/bn254/g2.h"
 #include "tachyon/math/polynomials/univariate/univariate_evaluation_domain_factory.h"
 
 namespace tachyon::zk {
@@ -19,6 +21,13 @@ namespace {
 
 class LookupTableTest : public testing::Test {
  public:
+  constexpr static size_t kMaxDegree = 7;
+
+  using PCS =
+      crypto::KZGCommitmentScheme<math::bn254::G1AffinePoint,
+                                  math::bn254::G2AffinePoint, kMaxDegree,
+                                  math::bn254::G1AffinePoint>;
+
   static void SetUpTestSuite() { math::bn254::G1Curve::Init(); }
 };
 
@@ -32,8 +41,8 @@ TEST_F(LookupTableTest, Construct) {
 
   std::unique_ptr<math::UnivariateEvaluationDomain<F, kMaxDegree>> domain =
       math::UnivariateEvaluationDomain<F, kMaxDegree>::Create(kMaxDegree + 1);
-  LookupTable<F, kMaxDegree> lookup_table =
-      LookupTable<F, kMaxDegree>::Construct(kCols, domain.get());
+  LookupTable<PCS> lookup_table =
+      LookupTable<PCS>::Construct(kCols, domain.get());
   F omega = domain->group_gen();
   std::vector<F> omega_powers = domain->GetRootsOfUnity(kMaxDegree + 1, omega);
 

--- a/tachyon/zk/plonk/permutation/lookup_table_unittest.cc
+++ b/tachyon/zk/plonk/permutation/lookup_table_unittest.cc
@@ -31,8 +31,7 @@ TEST_F(LookupTableTest, Construct) {
   using F = math::bn254::G1Curve::ScalarField;
 
   std::unique_ptr<math::UnivariateEvaluationDomain<F, kMaxDegree>> domain =
-      math::UnivariateEvaluationDomainFactory<F, kMaxDegree>::Create(
-          kMaxDegree + 1);
+      math::UnivariateEvaluationDomain<F, kMaxDegree>::Create(kMaxDegree + 1);
   LookupTable<F, kMaxDegree> lookup_table =
       LookupTable<F, kMaxDegree>::Construct(kCols, domain.get());
   F omega = domain->group_gen();

--- a/tachyon/zk/plonk/permutation/permutation_assembly.h
+++ b/tachyon/zk/plonk/permutation/permutation_assembly.h
@@ -32,7 +32,7 @@ class PermutationAssembly {
   constexpr static size_t kRows = kMaxDegree + 1;
 
   using F = typename PCSTy::Field;
-  using Commitment = typename PCSTy::ResultTy;
+  using Commitment = typename PCSTy::Commitment;
   using Commitments = std::vector<Commitment>;
   using Evals = math::UnivariateEvaluations<F, kMaxDegree>;
   using DensePoly = math::UnivariateDensePolynomial<F, kMaxDegree>;

--- a/tachyon/zk/plonk/permutation/permutation_assembly_unittest.cc
+++ b/tachyon/zk/plonk/permutation/permutation_assembly_unittest.cc
@@ -18,9 +18,10 @@ class PermutationAssemblyTest : public testing::Test {
   constexpr static size_t kSmallDegree = 7;
   constexpr static size_t kRows = kSmallDegree + 1;
 
-  using PCS = crypto::KZGCommitmentScheme<math::bn254::G1AffinePoint,
-                                          math::bn254::G2AffinePoint,
-                                          math::bn254::G1AffinePoint>;
+  using PCS =
+      crypto::KZGCommitmentScheme<math::bn254::G1AffinePoint,
+                                  math::bn254::G2AffinePoint, kSmallDegree,
+                                  math::bn254::G1AffinePoint>;
   using F = PCS::Field;
   using Evals = math::UnivariateEvaluations<F, kSmallDegree>;
 

--- a/tachyon/zk/plonk/permutation/permutation_assembly_unittest.cc
+++ b/tachyon/zk/plonk/permutation/permutation_assembly_unittest.cc
@@ -23,7 +23,8 @@ class PermutationAssemblyTest : public testing::Test {
                                   math::bn254::G2AffinePoint, kMaxDegree,
                                   math::bn254::G1AffinePoint>;
   using F = PCS::Field;
-  using Evals = math::UnivariateEvaluations<F, kMaxDegree>;
+  using Evals = PCS::Evals;
+  using Domain = PCS::Domain;
 
   static void SetUpTestSuite() { math::bn254::G1Curve::Init(); }
 
@@ -41,7 +42,7 @@ class PermutationAssemblyTest : public testing::Test {
   std::vector<AnyColumn> columns_;
   PermutationArgument argment_;
   PermutationAssembly<PCS> assembly_;
-  std::unique_ptr<math::UnivariateEvaluationDomain<F, kMaxDegree>> domain_;
+  std::unique_ptr<Domain> domain_;
 };
 
 }  // namespace
@@ -51,8 +52,8 @@ TEST_F(PermutationAssemblyTest, GeneratePermutation) {
   std::vector<Evals> permutations =
       assembly_.GeneratePermutations(domain_.get());
 
-  LookupTable<F, kMaxDegree> lookup_table =
-      LookupTable<F, kMaxDegree>::Construct(columns_.size(), domain_.get());
+  LookupTable<PCS> lookup_table =
+      LookupTable<PCS>::Construct(columns_.size(), domain_.get());
 
   for (size_t i = 0; i < columns_.size(); ++i) {
     for (size_t j = 0; j <= kMaxDegree; ++j) {

--- a/tachyon/zk/plonk/permutation/permutation_assembly_unittest.cc
+++ b/tachyon/zk/plonk/permutation/permutation_assembly_unittest.cc
@@ -15,15 +15,15 @@ namespace {
 
 class PermutationAssemblyTest : public testing::Test {
  public:
-  constexpr static size_t kSmallDegree = 7;
-  constexpr static size_t kRows = kSmallDegree + 1;
+  constexpr static size_t kMaxDegree = 7;
+  constexpr static size_t kRows = kMaxDegree + 1;
 
   using PCS =
       crypto::KZGCommitmentScheme<math::bn254::G1AffinePoint,
-                                  math::bn254::G2AffinePoint, kSmallDegree,
+                                  math::bn254::G2AffinePoint, kMaxDegree,
                                   math::bn254::G1AffinePoint>;
   using F = PCS::Field;
-  using Evals = math::UnivariateEvaluations<F, kSmallDegree>;
+  using Evals = math::UnivariateEvaluations<F, kMaxDegree>;
 
   static void SetUpTestSuite() { math::bn254::G1Curve::Init(); }
 
@@ -34,14 +34,14 @@ class PermutationAssemblyTest : public testing::Test {
     assembly_ = PermutationAssembly<PCS>::CreateForTesting(
         columns_, CycleStore(columns_.size(), kRows));
     domain_ =
-        math::UnivariateEvaluationDomainFactory<F, kSmallDegree>::Create(kRows);
+        math::UnivariateEvaluationDomainFactory<F, kMaxDegree>::Create(kRows);
   }
 
  protected:
   std::vector<AnyColumn> columns_;
   PermutationArgument argment_;
   PermutationAssembly<PCS> assembly_;
-  std::unique_ptr<math::UnivariateEvaluationDomain<F, kSmallDegree>> domain_;
+  std::unique_ptr<math::UnivariateEvaluationDomain<F, kMaxDegree>> domain_;
 };
 
 }  // namespace
@@ -51,11 +51,11 @@ TEST_F(PermutationAssemblyTest, GeneratePermutation) {
   std::vector<Evals> permutations =
       assembly_.GeneratePermutations(domain_.get());
 
-  LookupTable<F, kSmallDegree> lookup_table =
-      LookupTable<F, kSmallDegree>::Construct(columns_.size(), domain_.get());
+  LookupTable<F, kMaxDegree> lookup_table =
+      LookupTable<F, kMaxDegree>::Construct(columns_.size(), domain_.get());
 
   for (size_t i = 0; i < columns_.size(); ++i) {
-    for (size_t j = 0; j <= kSmallDegree; ++j) {
+    for (size_t j = 0; j <= kMaxDegree; ++j) {
       EXPECT_EQ(*permutations[i][j], lookup_table[Label(i, j)]);
     }
   }

--- a/tachyon/zk/plonk/permutation/permutation_proving_key.h
+++ b/tachyon/zk/plonk/permutation/permutation_proving_key.h
@@ -11,8 +11,6 @@
 #include <vector>
 
 #include "tachyon/base/buffer/copyable.h"
-#include "tachyon/math/polynomials/univariate/univariate_evaluations.h"
-#include "tachyon/math/polynomials/univariate/univariate_polynomial.h"
 
 namespace tachyon {
 namespace zk {
@@ -23,19 +21,19 @@ class PermutationProvingKey {
   constexpr static size_t kMaxDegree = PCSTy::kMaxDegree;
 
   using F = typename PCSTy::Field;
-  using DensePoly = math::UnivariateDensePolynomial<F, kMaxDegree>;
-  using Evals = math::UnivariateEvaluations<F, kMaxDegree>;
+  using Poly = typename PCSTy::Poly;
+  using Evals = typename PCSTy::Evals;
 
   PermutationProvingKey() = default;
   PermutationProvingKey(const std::vector<Evals>& permutations,
-                        const std::vector<DensePoly>& polys)
+                        const std::vector<Poly>& polys)
       : permutations_(permutations), polys_(polys) {}
   PermutationProvingKey(std::vector<Evals>&& permutations,
-                        std::vector<DensePoly>&& polys)
+                        std::vector<Poly>&& polys)
       : permutations_(std::move(permutations)), polys_(std::move(polys)) {}
 
   const std::vector<Evals>& permutations() const { return permutations_; }
-  const std::vector<DensePoly>& polys() const { return polys_; }
+  const std::vector<Poly>& polys() const { return polys_; }
 
   size_t BytesLength() const { return base::EstimateSize(this); }
 
@@ -48,7 +46,7 @@ class PermutationProvingKey {
 
  private:
   std::vector<Evals> permutations_;
-  std::vector<DensePoly> polys_;
+  std::vector<Poly> polys_;
 };
 
 }  // namespace zk
@@ -58,6 +56,9 @@ namespace base {
 template <typename PCSTy>
 class Copyable<zk::PermutationProvingKey<PCSTy>> {
  public:
+  using Poly = typename PCSTy::Poly;
+  using Evals = typename PCSTy::Evals;
+
   static bool WriteTo(const zk::PermutationProvingKey<PCSTy>& pk,
                       Buffer* buffer) {
     return buffer->WriteMany(pk.permutations(), pk.polys());
@@ -65,8 +66,8 @@ class Copyable<zk::PermutationProvingKey<PCSTy>> {
 
   static bool ReadFrom(const Buffer& buffer,
                        zk::PermutationProvingKey<PCSTy>* pk) {
-    std::vector<typename zk::PermutationProvingKey<PCSTy>::Evals> perms;
-    std::vector<typename zk::PermutationProvingKey<PCSTy>::DensePoly> poly;
+    std::vector<Evals> perms;
+    std::vector<Poly> poly;
     if (!buffer.ReadMany(&perms, &poly)) return false;
 
     *pk = zk::PermutationProvingKey<PCSTy>(std::move(perms), std::move(poly));

--- a/tachyon/zk/plonk/permutation/permutation_proving_key_unittest.cc
+++ b/tachyon/zk/plonk/permutation/permutation_proving_key_unittest.cc
@@ -19,9 +19,12 @@ namespace {
 
 class PermutationProvingKeyTest : public testing::Test {
  public:
-  using PCS = crypto::KZGCommitmentScheme<math::bn254::G1AffinePoint,
-                                          math::bn254::G2AffinePoint,
-                                          math::bn254::G1AffinePoint>;
+  constexpr static size_t kMaxDegree = 7;
+
+  using PCS =
+      crypto::KZGCommitmentScheme<math::bn254::G1AffinePoint,
+                                  math::bn254::G2AffinePoint, kMaxDegree,
+                                  math::bn254::G1AffinePoint>;
   using ProvingKey = PermutationProvingKey<PCS>;
   using DensePoly = ProvingKey::DensePoly;
   using Evals = ProvingKey::Evals;

--- a/tachyon/zk/plonk/permutation/permutation_proving_key_unittest.cc
+++ b/tachyon/zk/plonk/permutation/permutation_proving_key_unittest.cc
@@ -26,8 +26,8 @@ class PermutationProvingKeyTest : public testing::Test {
                                   math::bn254::G2AffinePoint, kMaxDegree,
                                   math::bn254::G1AffinePoint>;
   using ProvingKey = PermutationProvingKey<PCS>;
-  using DensePoly = ProvingKey::DensePoly;
-  using Evals = ProvingKey::Evals;
+  using Poly = ProvingKey::Poly;
+  using Evals = PCS::Evals;
 
   static void SetUpTestSuite() { math::bn254::G1Curve::Init(); }
 };
@@ -36,7 +36,7 @@ class PermutationProvingKeyTest : public testing::Test {
 
 TEST_F(PermutationProvingKeyTest, Copyable) {
   constexpr size_t kDegree = 5;
-  ProvingKey expected({Evals::Random(kDegree)}, {DensePoly::Random(kDegree)});
+  ProvingKey expected({Evals::Random(kDegree)}, {Poly::Random(kDegree)});
   ProvingKey value;
 
   base::VectorBuffer write_buf;

--- a/tachyon/zk/plonk/permutation/permutation_verifying_key.h
+++ b/tachyon/zk/plonk/permutation/permutation_verifying_key.h
@@ -18,7 +18,7 @@ namespace zk {
 template <typename PCSTy>
 class PermutationVerifyingKey {
  public:
-  using Commitment = typename PCSTy::ResultTy;
+  using Commitment = typename PCSTy::Commitment;
   using Commitments = std::vector<Commitment>;
 
   PermutationVerifyingKey() = default;

--- a/tachyon/zk/plonk/permutation/permutation_verifying_key_unittest.cc
+++ b/tachyon/zk/plonk/permutation/permutation_verifying_key_unittest.cc
@@ -19,9 +19,12 @@ namespace {
 
 class PermutationVerifyingKeyTest : public testing::Test {
  public:
-  using PCS = crypto::KZGCommitmentScheme<math::bn254::G1AffinePoint,
-                                          math::bn254::G2AffinePoint,
-                                          math::bn254::G1AffinePoint>;
+  constexpr static size_t kMaxDegree = 7;
+
+  using PCS =
+      crypto::KZGCommitmentScheme<math::bn254::G1AffinePoint,
+                                  math::bn254::G2AffinePoint, kMaxDegree,
+                                  math::bn254::G1AffinePoint>;
   using VerifyingKey = PermutationVerifyingKey<PCS>;
 
   static void SetUpTestSuite() { math::bn254::G1Curve::Init(); }


### PR DESCRIPTION
1. The level of abstraction for `UnivariatePolynomialCommitmentScheme`(`PCS`) was elevated  to allow proofs based on various PCS. In this PR, PCSs have been modified to provide the types of `Evals`, `DensePoly` and `Domain`.

2. If a radix 2 domain is used with Modulus = 2^s * T + 1, the maximum degree of the polynomial is 2^s - 1. However, the degree of the polynomial should be chosen appropriately small as it affects performance. Therefore, in this PR, The `MaxDegree` of `Polynomial` was updated  to be used as the polynomial's degree.
(related to https://github.com/kroma-network/tachyon/pull/137 )