### PR TITLE
fix: fix broken binding build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,12 +48,12 @@ jobs:
       - name: Test Node Binding
         run: |
           cd tachyon/node/test
-          bazel test --config ${{ matrix.bazel_config }} //...
+          bazel test --config ${{ matrix.bazel_config }} --test_output=errors //...
 
       - name: Test Py Binding
         run: |
           cd tachyon/py/test
-          bazel test --config ${{ matrix.bazel_config }} //...
+          bazel test --config ${{ matrix.bazel_config }} --test_output=errors //...
 
   lint:
     runs-on: ubuntu-latest
@@ -85,5 +85,5 @@ jobs:
       - name: Run clang-format lint
         uses: jidicula/clang-format-action@v4.11.0
         with:
-          clang-format-version: '17'
-          check-path: '.'
+          clang-format-version: "17"
+          check-path: "."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Python and Install numpy
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11.6"
+          python-version: "3.10.12"
 
       - name: Install numpy
         run: python -m pip install numpy
@@ -73,7 +73,7 @@ jobs:
       - name: Setup Python for cpplint
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11.6"
+          python-version: "3.10.12"
 
       - name: Install cpplint
         run: pip install cpplint

--- a/tachyon/c/math/elliptic_curves/generator/generator.cc
+++ b/tachyon/c/math/elliptic_curves/generator/generator.cc
@@ -559,13 +559,12 @@ int GenerationConfig::GenerateG1Src() const {
         binary_arithmetic_ops_components.push_back(absl::Substitute(
             // clang-format off
               "  using namespace tachyon::cc::math;\n"
-              "  return ToC$0(To$1(*a).$2(To$3(*b)$4));\n"
+              "  return ToC$0(To$1(*a).$2($3To$4(*b)));\n"
               "}",
             // clang-format on
             j == 0 ? "JacobianPoint" : kUpperPointKinds[j], kUpperPointKinds[j],
-            j == 0 ? "Add" : "AddInPlace",
-            k == 0 ? kUpperPointKinds[j] : "AffinePoint",
-            i == 0 ? "" : ".Negative()"));
+            j == 0 ? "Add" : "AddInPlace", i == 0 ? "" : "-",
+            k == 0 ? kUpperPointKinds[j] : "AffinePoint"));
         binary_arithmetic_ops_components.push_back("");
       }
     }

--- a/tachyon/math/base/groups.h
+++ b/tachyon/math/base/groups.h
@@ -213,7 +213,7 @@ class AdditiveGroup : public AdditiveSemigroup<G> {
       G g = *static_cast<const G*>(this);
       return g.SubInPlace(other);
     } else {
-      return this->operator+(other.Negative());
+      return this->operator+(-other);
     }
   }
 
@@ -230,7 +230,7 @@ class AdditiveGroup : public AdditiveSemigroup<G> {
       return g->SubInPlace(other);
     } else if constexpr (internal::SupportsAddInPlace<G, G2>::value) {
       G* g = static_cast<G*>(this);
-      return g->AddInPlace(other.Negative());
+      return g->AddInPlace(-other);
     } else {
       static_assert(base::AlwaysFalse<G>);
     }
@@ -245,14 +245,6 @@ class AdditiveGroup : public AdditiveSemigroup<G> {
       const G* g = static_cast<const G*>(this);
       return g->Negative();
     }
-  }
-
-  template <
-      typename G2 = G,
-      std::enable_if_t<internal::SupportsNegInPlace<G2>::value>* = nullptr>
-  [[nodiscard]] constexpr auto Negative() const {
-    G ret = *static_cast<const G*>(this);
-    return ret.NegInPlace();
   }
 };
 

--- a/tachyon/math/base/rational_field_unittest.cc
+++ b/tachyon/math/base/rational_field_unittest.cc
@@ -123,7 +123,7 @@ TEST_F(RationalFieldTest, AdditiveOperators) {
 TEST_F(RationalFieldTest, AdditiveGroupOperators) {
   R r(GF7(3), GF7(2));
   R neg_expected(GF7(4), GF7(2));
-  EXPECT_EQ(r.Negative(), neg_expected);
+  EXPECT_EQ(-r, neg_expected);
   r.NegInPlace();
   EXPECT_EQ(r, neg_expected);
 

--- a/tachyon/math/elliptic_curves/short_weierstrass/affine_point_correctness_gpu_test.cc
+++ b/tachyon/math/elliptic_curves/short_weierstrass/affine_point_correctness_gpu_test.cc
@@ -136,7 +136,7 @@ TEST_F(AffinePointCorrectnessGpuTest, Negative) {
   for (size_t i = 0; i < N; ++i) {
     SCOPED_TRACE(absl::Substitute("a: $0", xs_[i].ToString()));
     auto result = ConvertPoint<bn254::G1AffinePointGmp>(affine_results_[i]);
-    ASSERT_EQ(result, x_gmps_[i].Negative());
+    ASSERT_EQ(result, -x_gmps_[i]);
   }
 }
 

--- a/tachyon/math/elliptic_curves/short_weierstrass/affine_point_unittest.cc
+++ b/tachyon/math/elliptic_curves/short_weierstrass/affine_point_unittest.cc
@@ -107,7 +107,7 @@ TYPED_TEST(AffinePointTest, AdditiveGroupOperators) {
   EXPECT_EQ(ap.DoubleProjective(), ap4.ToProjective());
   EXPECT_EQ(ap.DoubleXYZZ(), ap4.ToXYZZ());
 
-  EXPECT_EQ(ap.Negative(), AffinePointTy(BaseField(5), BaseField(2)));
+  EXPECT_EQ(-ap, AffinePointTy(BaseField(5), BaseField(2)));
   {
     AffinePointTy ap_tmp = ap;
     ap_tmp.NegInPlace();

--- a/tachyon/math/elliptic_curves/short_weierstrass/jacobian_point_unittest.cc
+++ b/tachyon/math/elliptic_curves/short_weierstrass/jacobian_point_unittest.cc
@@ -141,8 +141,7 @@ TYPED_TEST(JacobianPointTest, AdditiveGroupOperators) {
     EXPECT_EQ(jp_tmp, jp4);
   }
 
-  EXPECT_EQ(jp.Negative(),
-            JacobianPointTy(BaseField(5), BaseField(2), BaseField(1)));
+  EXPECT_EQ(-jp, JacobianPointTy(BaseField(5), BaseField(2), BaseField(1)));
   {
     JacobianPointTy jp_tmp = jp;
     jp_tmp.NegInPlace();

--- a/tachyon/math/elliptic_curves/short_weierstrass/kernels/elliptic_curve_ops.cu.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/kernels/elliptic_curve_ops.cu.h
@@ -48,25 +48,37 @@ DEFINE_COMPARISON_OP(Ne, !=, PointXYZZ)
 
 #undef DEFINE_COMPARISON_OP
 
-#define DEFINE_UNARY_OP(method, src_type, dst_type)                           \
+#define DEFINE_DOUBLE_OP(src_type, dst_type)                                  \
   template <typename Config>                                                  \
-  __global__ void method(const src_type<Config>* x, dst_type<Config>* result, \
+  __global__ void Double(const src_type<Config>* x, dst_type<Config>* result, \
                          unsigned int count) {                                \
     unsigned int gid = blockIdx.x * blockDim.x + threadIdx.x;                 \
     if (gid >= count) return;                                                 \
-    result[gid] = x[gid].method();                                            \
+    result[gid] = x[gid].Double();                                            \
   }
 
-DEFINE_UNARY_OP(Double, AffinePoint, JacobianPoint)
-DEFINE_UNARY_OP(Double, JacobianPoint, JacobianPoint)
-DEFINE_UNARY_OP(Double, ProjectivePoint, ProjectivePoint)
-DEFINE_UNARY_OP(Double, PointXYZZ, PointXYZZ)
-DEFINE_UNARY_OP(Negative, AffinePoint, AffinePoint)
-DEFINE_UNARY_OP(Negative, JacobianPoint, JacobianPoint)
-DEFINE_UNARY_OP(Negative, ProjectivePoint, ProjectivePoint)
-DEFINE_UNARY_OP(Negative, PointXYZZ, PointXYZZ)
+DEFINE_DOUBLE_OP(AffinePoint, JacobianPoint)
+DEFINE_DOUBLE_OP(JacobianPoint, JacobianPoint)
+DEFINE_DOUBLE_OP(ProjectivePoint, ProjectivePoint)
+DEFINE_DOUBLE_OP(PointXYZZ, PointXYZZ)
 
-#undef DEFINE_UNARY_OP
+#undef DEFINE_DOUBLE_OP
+
+#define DEFINE_NEGATIVE_OP(src_type, dst_type)                             \
+  template <typename Config>                                               \
+  __global__ void Negative(const src_type<Config>* x,                      \
+                           dst_type<Config>* result, unsigned int count) { \
+    unsigned int gid = blockIdx.x * blockDim.x + threadIdx.x;              \
+    if (gid >= count) return;                                              \
+    result[gid] = -x[gid];                                                 \
+  }
+
+DEFINE_NEGATIVE_OP(AffinePoint, AffinePoint)
+DEFINE_NEGATIVE_OP(JacobianPoint, JacobianPoint)
+DEFINE_NEGATIVE_OP(ProjectivePoint, ProjectivePoint)
+DEFINE_NEGATIVE_OP(PointXYZZ, PointXYZZ)
+
+#undef DEFINE_NEGATIVE_OP
 
 }  // namespace tachyon::math::kernels
 

--- a/tachyon/math/elliptic_curves/short_weierstrass/non_affine_point_correctness_gpu_test.cc
+++ b/tachyon/math/elliptic_curves/short_weierstrass/non_affine_point_correctness_gpu_test.cc
@@ -191,7 +191,7 @@ TYPED_TEST(PointCorrectnessGpuTest, Negative) {
   for (size_t i = 0; i < N; ++i) {
     SCOPED_TRACE(absl::Substitute("a: $0", this->xs_[i].ToString()));
     auto result = ConvertPoint<Expected>(this->results_[i]);
-    ASSERT_EQ(result, this->x_gmps_[i].Negative());
+    ASSERT_EQ(result, -this->x_gmps_[i]);
   }
 }
 

--- a/tachyon/math/elliptic_curves/short_weierstrass/point_xyzz_unittest.cc
+++ b/tachyon/math/elliptic_curves/short_weierstrass/point_xyzz_unittest.cc
@@ -146,8 +146,8 @@ TYPED_TEST(PointXYZZTest, AdditiveGroupOperators) {
     EXPECT_EQ(p_tmp, p4);
   }
 
-  EXPECT_EQ(p.Negative(), PointXYZZTy(BaseField(5), BaseField(2), BaseField(1),
-                                      BaseField(1)));
+  EXPECT_EQ(
+      -p, PointXYZZTy(BaseField(5), BaseField(2), BaseField(1), BaseField(1)));
   {
     PointXYZZTy p_tmp = p;
     p_tmp.NegInPlace();

--- a/tachyon/math/elliptic_curves/short_weierstrass/projective_point_unittest.cc
+++ b/tachyon/math/elliptic_curves/short_weierstrass/projective_point_unittest.cc
@@ -141,8 +141,7 @@ TYPED_TEST(ProjectivePointTest, AdditiveGroupOperators) {
     EXPECT_EQ(pp_tmp, pp4);
   }
 
-  EXPECT_EQ(pp.Negative(),
-            ProjectivePointTy(BaseField(5), BaseField(2), BaseField(1)));
+  EXPECT_EQ(-pp, ProjectivePointTy(BaseField(5), BaseField(2), BaseField(1)));
   {
     ProjectivePointTy pp_tmp = pp;
     pp_tmp.NegInPlace();

--- a/tachyon/math/finite_fields/cubic_extension_field_unittest.cc
+++ b/tachyon/math/finite_fields/cubic_extension_field_unittest.cc
@@ -110,7 +110,7 @@ TEST_F(CubicExtensionFieldTest, AdditiveOperators) {
 TEST_F(CubicExtensionFieldTest, AdditiveGroupOperators) {
   GF7_3 f(GF7(3), GF7(4), GF7(5));
   GF7_3 f_neg(GF7(4), GF7(3), GF7(2));
-  EXPECT_EQ(f.Negative(), f_neg);
+  EXPECT_EQ(-f, f_neg);
   f.NegInPlace();
   EXPECT_EQ(f, f_neg);
 

--- a/tachyon/math/finite_fields/goldilocks_prime/prime_field_goldilocks_unittest.cc
+++ b/tachyon/math/finite_fields/goldilocks_prime/prime_field_goldilocks_unittest.cc
@@ -90,7 +90,7 @@ TEST(PrimeFieldGoldilocksTest, AdditiveOperators) {
 TEST(PrimeFieldGoldilocksTest, AdditiveGroupOperators) {
   Goldilocks f = Goldilocks::Random();
   SCOPED_TRACE(absl::Substitute("f: $0", f.ToString()));
-  Goldilocks f_neg = f.Negative();
+  Goldilocks f_neg = -f;
   EXPECT_TRUE((f_neg + f).IsZero());
   f.NegInPlace();
   EXPECT_EQ(f, f_neg);

--- a/tachyon/math/finite_fields/prime_field_correctness_test.cc
+++ b/tachyon/math/finite_fields/prime_field_correctness_test.cc
@@ -133,7 +133,7 @@ TYPED_TEST(PrimeFieldCorrectnessTest, AdditiveGroupOperators) {
     F a = PrimeFieldCorrectnessTest<F>::as_[i];
     SCOPED_TRACE(absl::Substitute("a: $0", a_gmp.ToString()));
 
-    ASSERT_EQ(ConvertPrimeField<GmpF>(a.Negative()), a_gmp.Negative());
+    ASSERT_EQ(ConvertPrimeField<GmpF>(-a), -a_gmp);
     a.NegInPlace();
     a_gmp.NegInPlace();
     ASSERT_EQ(ConvertPrimeField<GmpF>(a), a_gmp);

--- a/tachyon/math/finite_fields/prime_field_unittest.cc
+++ b/tachyon/math/finite_fields/prime_field_unittest.cc
@@ -132,7 +132,7 @@ TYPED_TEST(PrimeFieldTest, AdditiveGroupOperators) {
   using F = TypeParam;
 
   F f(3);
-  EXPECT_EQ(f.Negative(), F(4));
+  EXPECT_EQ(-f, F(4));
   f.NegInPlace();
   EXPECT_EQ(f, F(4));
 

--- a/tachyon/math/finite_fields/quadratic_extension_field_unittest.cc
+++ b/tachyon/math/finite_fields/quadratic_extension_field_unittest.cc
@@ -111,7 +111,7 @@ TEST_F(QuadraticExtensionFieldTest, AdditiveOperators) {
 TEST_F(QuadraticExtensionFieldTest, AdditiveGroupOperators) {
   GF7_2 f(GF7(3), GF7(4));
   GF7_2 f_neg(GF7(4), GF7(3));
-  EXPECT_EQ(f.Negative(), f_neg);
+  EXPECT_EQ(-f, f_neg);
   f.NegInPlace();
   EXPECT_EQ(f, f_neg);
 

--- a/tachyon/node/math/elliptic_curves/short_weierstrass/affine_point.h
+++ b/tachyon/node/math/elliptic_curves/short_weierstrass/affine_point.h
@@ -27,7 +27,9 @@ void AddAffinePoint(NodeModule& m, std::string_view name) {
                  &AffinePointTy::template operator+ <const AffinePointTy&>)
       .AddMethod("sub",
                  &AffinePointTy::template operator- <const AffinePointTy&>)
-      .AddMethod("negative", &AffinePointTy::Negative)
+      .AddMethod("negative",
+                 static_cast<AffinePointTy (AffinePointTy::*)() const>(
+                     &AffinePointTy::operator-))
       .AddMethod("double", &AffinePointTy::Double);
 }
 

--- a/tachyon/node/math/elliptic_curves/short_weierstrass/jacobian_point.h
+++ b/tachyon/node/math/elliptic_curves/short_weierstrass/jacobian_point.h
@@ -35,7 +35,9 @@ void AddJacobianPoint(NodeModule& m, std::string_view name) {
                  &JacobianPointTy::template operator- <const JacobianPointTy&>)
       .AddMethod("subMixed",
                  &JacobianPointTy::template operator- <const AffinePointTy&>)
-      .AddMethod("negative", &JacobianPointTy::Negative)
+      .AddMethod("negative",
+                 static_cast<JacobianPointTy (JacobianPointTy::*)() const>(
+                     &JacobianPointTy::operator-))
       .AddMethod("double", &JacobianPointTy::Double);
 }
 

--- a/tachyon/node/math/elliptic_curves/short_weierstrass/point_xyzz.h
+++ b/tachyon/node/math/elliptic_curves/short_weierstrass/point_xyzz.h
@@ -34,7 +34,8 @@ void AddPointXYZZ(NodeModule& m, std::string_view name) {
       .AddMethod("sub", &PointXYZZTy::template operator- <const PointXYZZTy&>)
       .AddMethod("subMixed",
                  &PointXYZZTy::template operator- <const AffinePointTy&>)
-      .AddMethod("negative", &PointXYZZTy::Negative)
+      .AddMethod("negative", static_cast<PointXYZZTy (PointXYZZTy::*)() const>(
+                                 &PointXYZZTy::operator-))
       .AddMethod("double", &PointXYZZTy::Double);
 }
 

--- a/tachyon/node/math/elliptic_curves/short_weierstrass/projective_point.h
+++ b/tachyon/node/math/elliptic_curves/short_weierstrass/projective_point.h
@@ -35,7 +35,9 @@ void AddProjectivePoint(NodeModule& m, std::string_view name) {
                         <const ProjectivePointTy&>)
       .AddMethod("subMixed",
                  &ProjectivePointTy::template operator- <const AffinePointTy&>)
-      .AddMethod("negative", &ProjectivePointTy::Negative)
+      .AddMethod("negative",
+                 static_cast<ProjectivePointTy (ProjectivePointTy::*)() const>(
+                     &ProjectivePointTy::operator-))
       .AddMethod("double", &ProjectivePointTy::Double);
 }
 

--- a/tachyon/node/math/finite_fields/prime_field.h
+++ b/tachyon/node/math/finite_fields/prime_field.h
@@ -48,7 +48,9 @@ void AddPrimeField(NodeModule& m, std::string_view name) {
       .AddMethod("sub", &PrimeFieldTy::template operator- <const PrimeFieldTy&>)
       .AddMethod("mul", &PrimeFieldTy::template operator* <const PrimeFieldTy&>)
       .AddMethod("div", &PrimeFieldTy::template operator/ <const PrimeFieldTy&>)
-      .AddMethod("negative", &PrimeFieldTy::Negative)
+      .AddMethod("negative",
+                 static_cast<PrimeFieldTy (PrimeFieldTy::*)() const>(
+                     &PrimeFieldTy::operator-))
       .AddMethod("double", &PrimeFieldTy::Double)
       .AddMethod("square", &PrimeFieldTy::Square);
 }

--- a/tachyon/py/math/elliptic_curves/short_weierstrass/jacobian_point.h
+++ b/tachyon/py/math/elliptic_curves/short_weierstrass/jacobian_point.h
@@ -37,7 +37,14 @@ void AddJacobianPoint(py11::module& m, const std::string& name) {
       .def(py11::self + AffinePointTy())
       .def(py11::self += AffinePointTy())
       .def(py11::self - py11::self)
-      .def(py11::self -= py11::self)
+      // NOTE(chokobole): See https://github.com/pybind/pybind11/issues/1893
+      // .def(py11::self -= py11::self)
+      .def(
+          "__isub__",
+          [](JacobianPointTy& lhs, const JacobianPointTy& rhs) {
+            return lhs -= rhs;
+          },
+          py11::is_operator())
       .def(py11::self - AffinePointTy())
       .def(py11::self -= AffinePointTy())
       .def(py11::self * ScalarField())

--- a/tachyon/py/math/elliptic_curves/short_weierstrass/point_xyzz.h
+++ b/tachyon/py/math/elliptic_curves/short_weierstrass/point_xyzz.h
@@ -39,7 +39,12 @@ void AddPointXYZZ(py11::module& m, const std::string& name) {
       .def(py11::self + AffinePointTy())
       .def(py11::self += AffinePointTy())
       .def(py11::self - py11::self)
-      .def(py11::self -= py11::self)
+      // NOTE(chokobole): See https://github.com/pybind/pybind11/issues/1893
+      // .def(py11::self -= py11::self)
+      .def(
+          "__isub__",
+          [](PointXYZZTy& lhs, const PointXYZZTy& rhs) { return lhs -= rhs; },
+          py11::is_operator())
       .def(py11::self - AffinePointTy())
       .def(py11::self -= AffinePointTy())
       .def(py11::self * ScalarField())

--- a/tachyon/py/math/elliptic_curves/short_weierstrass/projective_point.h
+++ b/tachyon/py/math/elliptic_curves/short_weierstrass/projective_point.h
@@ -37,7 +37,14 @@ void AddProjectivePoint(py11::module& m, const std::string& name) {
       .def(py11::self + AffinePointTy())
       .def(py11::self += AffinePointTy())
       .def(py11::self - py11::self)
-      .def(py11::self -= py11::self)
+      // NOTE(chokobole): See https://github.com/pybind/pybind11/issues/1893
+      // .def(py11::self -= py11::self)
+      .def(
+          "__isub__",
+          [](ProjectivePointTy& lhs, const ProjectivePointTy& rhs) {
+            return lhs -= rhs;
+          },
+          py11::is_operator())
       .def(py11::self - AffinePointTy())
       .def(py11::self -= AffinePointTy())
       .def(py11::self * ScalarField())

--- a/tachyon/py/math/finite_fields/prime_field.h
+++ b/tachyon/py/math/finite_fields/prime_field.h
@@ -32,11 +32,21 @@ void AddPrimeField(py11::module& m, const std::string& name) {
       .def(py11::self + py11::self)
       .def(py11::self += py11::self)
       .def(py11::self - py11::self)
-      .def(py11::self -= py11::self)
+      // NOTE(chokobole): See https://github.com/pybind/pybind11/issues/1893
+      // .def(py11::self -= py11::self)
+      .def(
+          "__isub__",
+          [](PrimeFieldTy& lhs, const PrimeFieldTy& rhs) { return lhs -= rhs; },
+          py11::is_operator())
       .def(py11::self * py11::self)
       .def(py11::self *= py11::self)
       .def(py11::self / py11::self)
-      .def(py11::self /= py11::self)
+      // NOTE(chokobole): See https://github.com/pybind/pybind11/issues/1893
+      // .def(py11::self /= py11::self)
+      .def(
+          "__idiv__",
+          [](PrimeFieldTy& lhs, const PrimeFieldTy& rhs) { return lhs /= rhs; },
+          py11::is_operator())
       .def(-py11::self)
       .def("double", &PrimeFieldTy::Double)
       .def("double_in_place", &PrimeFieldTy::DoubleInPlace)

--- a/tachyon/zk/base/value_unittest.cc
+++ b/tachyon/zk/base/value_unittest.cc
@@ -77,7 +77,7 @@ TEST(ValueTest, AdditiveGroupOperators) {
   } tests[] = {
       {
           Value<math::GF7>::Known(a),
-          Value<math::GF7>::Known(a.Negative()),
+          Value<math::GF7>::Known(-a),
           Value<math::GF7>::Known(a.Double()),
       },
       {
@@ -89,12 +89,12 @@ TEST(ValueTest, AdditiveGroupOperators) {
 
   for (auto& test : tests) {
     if (test.a.IsNone()) {
-      EXPECT_DEATH(std::ignore = test.a.Negative(), "");
+      EXPECT_DEATH(std::ignore = -test.a, "");
       EXPECT_DEATH(test.a.NegInPlace(), "");
       EXPECT_DEATH(std::ignore = test.a.Double(), "");
       EXPECT_DEATH(test.a.DoubleInPlace(), "");
     } else {
-      EXPECT_EQ(test.a.Negative(), test.neg);
+      EXPECT_EQ(-test.a, test.neg);
       Value<math::GF7> a_tmp = test.a;
       a_tmp.NegInPlace();
       EXPECT_EQ(a_tmp, test.neg);


### PR DESCRIPTION
# Description

This PR fixes CI since [this](https://github.com/kroma-network/tachyon/pull/156). The symptom is it can deduce `Negative()` signature. The reason is still unclear to me. I believe this is a bug or lack of feature in `NodeCppConstructor`. This PR doesn't solve the issue directly but rather solve in another way. It binds `operator-()` unary operator directly and removes `Negative()` method, which also might makes user confused since `Negative()` is not supported, even when `operator-()` is supported!

