### PR TITLE
feat(zk): apply `KZGCommitmentScheme` to `PermutationAssembly`

### DIFF
--- a/tachyon/crypto/commitments/kzg/kzg_commitment_scheme.h
+++ b/tachyon/crypto/commitments/kzg/kzg_commitment_scheme.h
@@ -7,6 +7,7 @@
 #ifndef TACHYON_CRYPTO_COMMITMENTS_KZG_KZG_COMMITMENT_SCHEME_H_
 #define TACHYON_CRYPTO_COMMITMENTS_KZG_KZG_COMMITMENT_SCHEME_H_
 
+#include <algorithm>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -134,11 +135,13 @@ class KZGCommitmentScheme
     using Bucket = typename math::Pippenger<G1PointTy>::Bucket;
 
     math::VariableBaseMSM<G1PointTy> msm;
+    absl::Span<const G1PointTy> bases_span = absl::Span<const G1PointTy>(
+        bases.data(), std::min(bases.size(), scalars.size()));
     if constexpr (std::is_same_v<Commitment, Bucket>) {
-      return msm.Run(bases, scalars, out);
+      return msm.Run(bases_span, scalars, out);
     } else {
       Bucket result;
-      if (!msm.Run(bases, scalars, &result)) return false;
+      if (!msm.Run(bases_span, scalars, &result)) return false;
       *out = math::ConvertPoint<Commitment>(result);
       return true;
     }

--- a/tachyon/zk/base/halo2_prover_test.h
+++ b/tachyon/zk/base/halo2_prover_test.h
@@ -28,6 +28,7 @@ class Halo2ProverTest : public testing::Test {
                                   math::bn254::G2AffinePoint, kMaxDegree,
                                   math::bn254::G1AffinePoint>;
   using F = PCS::Field;
+  using Commitment = PCS::Commitment;
   using Poly = PCS::Poly;
   using Evals = PCS::Evals;
   using Domain = PCS::Domain;

--- a/tachyon/zk/plonk/permutation/BUILD.bazel
+++ b/tachyon/zk/plonk/permutation/BUILD.bazel
@@ -80,9 +80,6 @@ tachyon_cc_unittest(
     deps = [
         ":permutation_assembly",
         "//tachyon/base/buffer:vector_buffer",
-        "//tachyon/crypto/commitments/kzg:kzg_commitment_scheme",
-        "//tachyon/math/elliptic_curves/bn/bn254:g1",
-        "//tachyon/math/elliptic_curves/bn/bn254:g2",
-        "//tachyon/math/polynomials/univariate:univariate_evaluation_domain_factory",
+        "//tachyon/zk/base:halo2_prover_test",
     ],
 )

--- a/tachyon/zk/plonk/permutation/permutation_assembly.h
+++ b/tachyon/zk/plonk/permutation/permutation_assembly.h
@@ -78,7 +78,7 @@ class PermutationAssembly {
 
   // Returns |PermutationVerifyingKey| which has commitments for permutations.
   constexpr PermutationVerifyingKey<PCSTy> BuildVerifyingKey(
-      Domain* domain) const {
+      const PCSTy& kzg_params, const Domain* domain) const {
     std::vector<Evals> permutations = GeneratePermutations(domain);
 
     // TODO(dongchangYoo): calculate commitments after complete Params. See
@@ -90,7 +90,8 @@ class PermutationAssembly {
 
   // Returns the |PermutationProvingKey| that has the coefficient form and
   // evaluation form of the permutation.
-  constexpr PermutationProvingKey<PCSTy> BuildProvingKey(Domain* domain) const {
+  constexpr PermutationProvingKey<PCSTy> BuildProvingKey(
+      const Domain* domain) const {
     // The polynomials of permutations in evaluation form.
     std::vector<Evals> permutations = GeneratePermutations(domain);
 
@@ -109,7 +110,7 @@ class PermutationAssembly {
   // Generate the permutation polynomials based on the accumulated copy
   // permutations. Note that the permutation polynomials are in evaluation
   // form.
-  std::vector<Evals> GeneratePermutations(Domain* domain) const {
+  std::vector<Evals> GeneratePermutations(const Domain* domain) const {
     LookupTable<PCSTy> lookup_table =
         LookupTable<PCSTy>::Construct(columns_.size(), domain);
 

--- a/tachyon/zk/plonk/permutation/permutation_assembly.h
+++ b/tachyon/zk/plonk/permutation/permutation_assembly.h
@@ -78,12 +78,16 @@ class PermutationAssembly {
 
   // Returns |PermutationVerifyingKey| which has commitments for permutations.
   constexpr PermutationVerifyingKey<PCSTy> BuildVerifyingKey(
-      const PCSTy& kzg_params, const Domain* domain) const {
+      const PCSTy& params, const Domain* domain) const {
     std::vector<Evals> permutations = GeneratePermutations(domain);
 
-    // TODO(dongchangYoo): calculate commitments after complete Params. See
-    // https://github.com/kroma-network/halo2/blob/7d0a36990452c8e7ebd600de258420781a9b7917/halo2_proofs/src/plonk/permutation/keygen.rs#L153-L162.
     Commitments commitments;
+    commitments.reserve(columns_.size());
+    for (size_t i = 0; i < columns_.size(); ++i) {
+      Commitment commitment;
+      CHECK(params.CommitLagrange(permutations[i], &commitment));
+      commitments.push_back(commitment);
+    }
 
     return PermutationVerifyingKey<PCSTy>(std::move(commitments));
   }

--- a/tachyon/zk/plonk/permutation/permutation_assembly_unittest.cc
+++ b/tachyon/zk/plonk/permutation/permutation_assembly_unittest.cc
@@ -4,56 +4,38 @@
 
 #include "gtest/gtest.h"
 
-#include "tachyon/base/buffer/vector_buffer.h"
-#include "tachyon/crypto/commitments/kzg/kzg_commitment_scheme.h"
-#include "tachyon/math/elliptic_curves/bn/bn254/g1.h"
-#include "tachyon/math/elliptic_curves/bn/bn254/g2.h"
-#include "tachyon/math/polynomials/univariate/univariate_evaluation_domain_factory.h"
+#include "tachyon/zk/base/halo2_prover_test.h"
 
 namespace tachyon::zk {
 namespace {
 
-class PermutationAssemblyTest : public testing::Test {
+class PermutationAssemblyTest : public Halo2ProverTest {
  public:
-  constexpr static size_t kMaxDegree = 7;
-  constexpr static size_t kRows = kMaxDegree + 1;
-
-  using PCS =
-      crypto::KZGCommitmentScheme<math::bn254::G1AffinePoint,
-                                  math::bn254::G2AffinePoint, kMaxDegree,
-                                  math::bn254::G1AffinePoint>;
-  using F = PCS::Field;
-  using Evals = PCS::Evals;
-  using Domain = PCS::Domain;
-
-  static void SetUpTestSuite() { math::bn254::G1Curve::Init(); }
-
   void SetUp() override {
+    Halo2ProverTest::SetUp();
+
     columns_ = {AnyColumn(0), AdviceColumn(1), FixedColumn(2),
                 InstanceColumn(3)};
     argment_ = PermutationArgument(columns_);
     assembly_ = PermutationAssembly<PCS>::CreateForTesting(
-        columns_, CycleStore(columns_.size(), kRows));
-    domain_ =
-        math::UnivariateEvaluationDomainFactory<F, kMaxDegree>::Create(kRows);
+        columns_, CycleStore(columns_.size(), kDomainSize));
   }
 
  protected:
   std::vector<AnyColumn> columns_;
   PermutationArgument argment_;
   PermutationAssembly<PCS> assembly_;
-  std::unique_ptr<Domain> domain_;
 };
 
 }  // namespace
 
 TEST_F(PermutationAssemblyTest, GeneratePermutation) {
   // Check initial permutation polynomials w/o any copy.
-  std::vector<Evals> permutations =
-      assembly_.GeneratePermutations(domain_.get());
+  const Domain* domain = prover_->domain();
+  std::vector<Evals> permutations = assembly_.GeneratePermutations(domain);
 
   LookupTable<PCS> lookup_table =
-      LookupTable<PCS>::Construct(columns_.size(), domain_.get());
+      LookupTable<PCS>::Construct(columns_.size(), domain);
 
   for (size_t i = 0; i < columns_.size(); ++i) {
     for (size_t j = 0; j <= kMaxDegree; ++j) {


### PR DESCRIPTION
The `PermutationAssembly::BuildVerifyingKey()` completed using the `PolynomialCommitmentScheme`::`CommitLagrange()`.

And this PR also includes a fix for the bug where the commit function fails for polynomials with leading zeros.