### PR TITLE
feat(zk): add committing permutations

### DIFF
--- a/tachyon/math/polynomials/univariate/univariate_evaluation_domain.h
+++ b/tachyon/math/polynomials/univariate/univariate_evaluation_domain.h
@@ -37,6 +37,8 @@ class UnivariateEvaluationDomain : public EvaluationDomain<F, MaxDegree> {
   using SparseCoeffs = UnivariateSparseCoefficients<F, MaxDegree>;
   using SparsePoly = UnivariateSparsePolynomial<F, MaxDegree>;
 
+  constexpr static size_t kMaxDegree = MaxDegree;
+
   constexpr UnivariateEvaluationDomain() = default;
 
   constexpr UnivariateEvaluationDomain(size_t size, uint32_t log_size_of_group)

--- a/tachyon/zk/base/blinder.h
+++ b/tachyon/zk/base/blinder.h
@@ -31,9 +31,8 @@ class Blinder {
     size_t size = evals.NumElements();
     if (size < blinding_factors_) return false;
     size_t start = size - blinding_factors_;
-    std::vector<F>& values = evals.evaluations();
     for (size_t i = start; i < size; ++i) {
-      values[i] = random_field_generator_->Generate();
+      *evals[i] = random_field_generator_->Generate();
     }
     return true;
   }

--- a/tachyon/zk/base/blinder_unittest.cc
+++ b/tachyon/zk/base/blinder_unittest.cc
@@ -19,6 +19,9 @@ class FakeEvals {
   const std::vector<math::GF7>& evaluations() const { return evaluations_; }
   std::vector<math::GF7>& evaluations() { return evaluations_; }
 
+  math::GF7* operator[](size_t i) { return &evaluations_[i]; }
+  const math::GF7* operator[](size_t i) const { return &evaluations_[i]; }
+
   size_t NumElements() const { return evaluations_.size(); }
 
  private:

--- a/tachyon/zk/plonk/circuit/table.h
+++ b/tachyon/zk/plonk/circuit/table.h
@@ -47,11 +47,11 @@ class Table {
     return Ref<const Evals>();
   }
 
-  std::vector<Ref<const Evals>> GetColumns(
-      const std::vector<ColumnKeyBase>& column_keys) const {
+  template <typename Container>
+  std::vector<Ref<const Evals>> GetColumns(const Container& column_keys) const {
     std::vector<Ref<const Evals>> ret;
-    ret.reserve(column_keys.size());
-    for (const ColumnKeyBase& column_key : column_keys) {
+    ret.reserve(std::size(column_keys));
+    for (const auto& column_key : column_keys) {
       ret.push_back(GetColumn(column_key));
     }
     return ret;

--- a/tachyon/zk/plonk/circuit/table_unittest.cc
+++ b/tachyon/zk/plonk/circuit/table_unittest.cc
@@ -9,6 +9,7 @@
 
 namespace tachyon::zk {
 
+template <typename ColumnKeyType>
 class TableTest : public testing::Test {
  public:
   constexpr static size_t kMaxDegree = (size_t{1} << 3) - 1;
@@ -36,24 +37,30 @@ class TableTest : public testing::Test {
   std::vector<Evals> instance_columns_;
 };
 
-TEST_F(TableTest, FindColumns) {
-  std::vector<ColumnKeyBase> targets = {
+using ColumnKeyTypes = testing::Types<ColumnKeyBase, AnyColumnKey>;
+TYPED_TEST_SUITE(TableTest, ColumnKeyTypes);
+
+TYPED_TEST(TableTest, GetColumns) {
+  using ColumnKeyType = TypeParam;
+  using Evals = typename TableTest<ColumnKeyType>::Evals;
+
+  std::vector<ColumnKeyType> targets = {
       FixedColumnKey(1), AdviceColumnKey(1, kFirstPhase), InstanceColumnKey(1),
       FixedColumnKey(2), AdviceColumnKey(2, kFirstPhase), InstanceColumnKey(2),
   };
 
-  Table<Evals> table(absl::MakeConstSpan(fixed_columns_),
-                     absl::MakeConstSpan(advice_columns_),
-                     absl::MakeConstSpan(instance_columns_));
+  Table<Evals> table(absl::MakeConstSpan(this->fixed_columns_),
+                     absl::MakeConstSpan(this->advice_columns_),
+                     absl::MakeConstSpan(this->instance_columns_));
 
   std::vector<Ref<const Evals>> evals_refs = table.GetColumns(targets);
 
-  EXPECT_EQ(*evals_refs[0], fixed_columns_[1]);
-  EXPECT_EQ(*evals_refs[1], advice_columns_[1]);
-  EXPECT_EQ(*evals_refs[2], instance_columns_[1]);
-  EXPECT_EQ(*evals_refs[3], fixed_columns_[2]);
-  EXPECT_EQ(*evals_refs[4], advice_columns_[2]);
-  EXPECT_EQ(*evals_refs[5], instance_columns_[2]);
+  EXPECT_EQ(*evals_refs[0], this->fixed_columns_[1]);
+  EXPECT_EQ(*evals_refs[1], this->advice_columns_[1]);
+  EXPECT_EQ(*evals_refs[2], this->instance_columns_[1]);
+  EXPECT_EQ(*evals_refs[3], this->fixed_columns_[2]);
+  EXPECT_EQ(*evals_refs[4], this->advice_columns_[2]);
+  EXPECT_EQ(*evals_refs[5], this->instance_columns_[2]);
 }
 
 }  // namespace tachyon::zk

--- a/tachyon/zk/plonk/permutation/BUILD.bazel
+++ b/tachyon/zk/plonk/permutation/BUILD.bazel
@@ -33,7 +33,13 @@ tachyon_cc_library(
     name = "permutation_argument",
     hdrs = ["permutation_argument.h"],
     deps = [
+        ":grand_product_argument",
+        ":permutation_committed",
+        ":permutation_proving_key",
+        ":permutation_table_store",
         "//tachyon/base/containers:contains",
+        "//tachyon/zk/base:blinded_polynomial",
+        "//tachyon/zk/base:prover",
         "//tachyon/zk/plonk/circuit:column_key",
     ],
 )
@@ -46,6 +52,12 @@ tachyon_cc_library(
         "//tachyon/base/strings:rust_stringifier",
         "//tachyon/zk/plonk/circuit:column_key_stringifier",
     ],
+)
+
+tachyon_cc_library(
+    name = "permutation_committed",
+    hdrs = ["permutation_committed.h"],
+    deps = ["//tachyon/zk/base:blinded_polynomial"],
 )
 
 tachyon_cc_library(

--- a/tachyon/zk/plonk/permutation/BUILD.bazel
+++ b/tachyon/zk/plonk/permutation/BUILD.bazel
@@ -55,6 +55,18 @@ tachyon_cc_library(
 )
 
 tachyon_cc_library(
+    name = "permutation_table_store",
+    hdrs = ["permutation_table_store.h"],
+    deps = [
+        ":permuted_table",
+        ":unpermuted_table",
+        "//tachyon/zk/plonk/circuit:table",
+        "@com_google_absl//absl/types:span",
+        "@com_google_googletest//:gtest_prod",
+    ],
+)
+
+tachyon_cc_library(
     name = "permutation_verifying_key",
     hdrs = ["permutation_verifying_key.h"],
     deps = [
@@ -69,6 +81,16 @@ tachyon_cc_library(
         ":permutation_verifying_key",
         "//tachyon/base/strings:rust_stringifier",
         "//tachyon/zk/base:point_stringifier",
+    ],
+)
+
+tachyon_cc_library(
+    name = "permuted_table",
+    hdrs = ["permuted_table.h"],
+    deps = [
+        ":label",
+        "//tachyon/base:range",
+        "//tachyon/zk/base:ref",
     ],
 )
 
@@ -107,11 +129,13 @@ tachyon_cc_unittest(
         "permutation_argument_unittest.cc",
         "permutation_assembly_unittest.cc",
         "permutation_proving_key_unittest.cc",
+        "permutation_table_store_unittest.cc",
         "permutation_verifying_key_unittest.cc",
         "unpermuted_table_unittest.cc",
     ],
     deps = [
         ":permutation_assembly",
+        ":permutation_table_store",
         "//tachyon/base/buffer:vector_buffer",
         "//tachyon/zk/base:halo2_prover_test",
     ],

--- a/tachyon/zk/plonk/permutation/BUILD.bazel
+++ b/tachyon/zk/plonk/permutation/BUILD.bazel
@@ -93,7 +93,9 @@ tachyon_cc_library(
     hdrs = ["unpermuted_table.h"],
     deps = [
         ":label",
+        "//tachyon/base:range",
         "//tachyon/base/containers:container_util",
+        "//tachyon/zk/base:ref",
         "@com_google_googletest//:gtest_prod",
     ],
 )

--- a/tachyon/zk/plonk/permutation/grand_product_argument.h
+++ b/tachyon/zk/plonk/permutation/grand_product_argument.h
@@ -22,7 +22,7 @@ class GrandProductArgument {
     using Evals = typename PCSTy::Evals;
 
     size_t size = prover->pcs().N();
-    size_t blinding_factors = prover->blinder().blinded_factors();
+    size_t blinding_factors = prover->blinder().blinding_factors();
     Evals z = CreatePolynomial<Evals>(size, blinding_factors,
                                       std::move(numerator_callback),
                                       std::move(denominator_callback));

--- a/tachyon/zk/plonk/permutation/grand_product_argument.h
+++ b/tachyon/zk/plonk/permutation/grand_product_argument.h
@@ -14,6 +14,9 @@ namespace tachyon::zk {
 
 class GrandProductArgument {
  public:
+  // If the number of rows is within than the supported size of polynomial
+  // commitment scheme, you should use this version. See lookup argument for use
+  // case.
   template <typename PCSTy, typename Callable,
             typename Poly = typename PCSTy::Poly>
   static BlindedPolynomial<Poly> Commit(Prover<PCSTy>* prover,
@@ -26,6 +29,31 @@ class GrandProductArgument {
     Evals z = CreatePolynomial<Evals>(size, blinding_factors,
                                       std::move(numerator_callback),
                                       std::move(denominator_callback));
+    CHECK(prover->blinder().Blind(z));
+
+    BlindedPolynomial<Poly> ret;
+    CHECK(prover->CommitEvalsWithBlind(z, &ret));
+    return ret;
+  }
+
+  // If the number of rows is out of the supported size of polynomial
+  // commitment scheme, you should use this version. See permutation argument
+  // for use case.
+  // See
+  // https://zcash.github.io/halo2/design/proving-system/permutation.html#spanning-a-large-number-of-columns
+  template <typename PCSTy, typename Callable, typename F,
+            typename Poly = typename PCSTy::Poly>
+  static BlindedPolynomial<Poly> CommitExcessive(Prover<PCSTy>* prover,
+                                                 Callable numerator_callback,
+                                                 Callable denominator_callback,
+                                                 size_t num_cols, F& last_z) {
+    using Evals = typename PCSTy::Evals;
+
+    size_t size = prover->pcs().N();
+    size_t blinding_factors = prover->blinder().blinding_factors();
+    Evals z = CreatePolynomialExcessive<Evals>(
+        size, blinding_factors, num_cols, last_z, std::move(numerator_callback),
+        std::move(denominator_callback));
     CHECK(prover->blinder().Blind(z));
 
     BlindedPolynomial<Poly> ret;
@@ -50,12 +78,43 @@ class GrandProductArgument {
 
     base::Parallelize(grand_product, std::move(numerator_callback));
 
+    F last_z = F::One();
+    return DoCreatePolynomial<Evals>(last_z, size, grand_product,
+                                     blinding_factors);
+  }
+
+  template <typename Evals, typename F, typename Callable>
+  static Evals CreatePolynomialExcessive(size_t size, size_t blinding_factors,
+                                         size_t num_cols, F& last_z,
+                                         Callable numerator_callback,
+                                         Callable denominator_callback) {
+    std::vector<F> grand_product(size, F::Zero());
+
+    for (size_t i = 0; i < num_cols; ++i) {
+      base::Parallelize(grand_product, denominator_callback(i));
+    }
+
+    F::BatchInverseInPlace(grand_product);
+
+    for (size_t i = 0; i < num_cols; ++i) {
+      base::Parallelize(grand_product, numerator_callback(i));
+    }
+
+    return DoCreatePolynomial<Evals>(last_z, size, grand_product,
+                                     blinding_factors);
+  }
+
+  template <typename Evals, typename F>
+  static Evals DoCreatePolynomial(F& last_z, size_t size,
+                                  const std::vector<F>& grand_product,
+                                  size_t blinding_factors) {
     std::vector<F> z;
     z.resize(size);
-    z[0] = F::One();
+    z[0] = last_z;
     for (size_t i = 0; i < size - blinding_factors - 1; ++i) {
       z[i + 1] = z[i] * grand_product[i];
     }
+    last_z = z[size - blinding_factors - 1];
     return Evals(std::move(z));
   }
 };

--- a/tachyon/zk/plonk/permutation/permutation_argument.h
+++ b/tachyon/zk/plonk/permutation/permutation_argument.h
@@ -11,7 +11,13 @@
 #include <vector>
 
 #include "tachyon/base/containers/contains.h"
+#include "tachyon/zk/base/blinded_polynomial.h"
+#include "tachyon/zk/base/prover.h"
 #include "tachyon/zk/plonk/circuit/column_key.h"
+#include "tachyon/zk/plonk/permutation/grand_product_argument.h"
+#include "tachyon/zk/plonk/permutation/permutation_committed.h"
+#include "tachyon/zk/plonk/permutation/permutation_proving_key.h"
+#include "tachyon/zk/plonk/permutation/permutation_table_store.h"
 
 namespace tachyon::zk {
 
@@ -68,7 +74,110 @@ class PermutationArgument {
     return 3;
   }
 
+  // Returns commitments of Zₚ,ᵢ for chunk index i.
+  //
+  // See Halo2 book to figure out logic in detail.
+  // https://zcash.github.io/halo2/design/proving-system/permutation.html
+  template <typename PCSTy, typename Evals = typename PCSTy::Evals,
+            typename Poly = typename PCSTy::Poly,
+            typename F = typename PCSTy::Field>
+  PermutationCommitted<Poly> Commit(
+      Prover<PCSTy>* prover, Table<Evals>& table,
+      size_t constraint_system_degree,
+      const PermutationProvingKey<PCSTy>& permutation_proving_key,
+      const F& beta, const F& gamma) {
+    // How many columns can be included in a single permutation polynomial?
+    // We need to multiply by z(X) and (1 - (l_last(X) + l_blind(X))). This
+    // will never underflow because of the requirement of at least a degree
+    // 3 circuit for the permutation argument.
+    CHECK_GE(constraint_system_degree, RequiredDegree());
+
+    size_t chunk_size = constraint_system_degree - 2;
+    size_t chunk_num = (columns_.size() + chunk_size - 1) / chunk_size;
+
+    UnpermutedTable<Evals> unpermuted_table =
+        UnpermutedTable<Evals>::Construct(columns_.size(), prover->domain());
+    PermutedTable<Evals> permuted_table(
+        &permutation_proving_key.permutations());
+    PermutationTableStore<Evals> table_store(columns_, table, permuted_table,
+                                             unpermuted_table, chunk_size);
+
+    std::vector<BlindedPolynomial<Poly>> grand_product_polys;
+    grand_product_polys.reserve(chunk_num);
+
+    // Track the "last" value from the previous column set.
+    F last_z = F::One();
+
+    for (size_t i = 0; i < chunk_num; ++i) {
+      std::vector<Ref<const Evals>> permuted_columns =
+          table_store.GetPermutedColumns(i);
+      std::vector<Ref<const Evals>> unpermuted_columns =
+          table_store.GetUnpermutedColumns(i);
+      std::vector<Ref<const Evals>> value_columns =
+          table_store.GetValueColumns(i);
+
+      size_t chunk_size = table_store.GetChunkSize(i);
+      BlindedPolynomial<Poly> grand_product_poly =
+          GrandProductArgument::CommitExcessive(
+              prover,
+              CreateNumeratorCallback<Evals>(unpermuted_columns, value_columns,
+                                             beta, gamma),
+              CreateDenominatorCallback<Evals>(permuted_columns, value_columns,
+                                               beta, gamma),
+              chunk_size, last_z);
+
+      grand_product_polys.push_back(std::move(grand_product_poly));
+    }
+
+    return PermutationCommitted<Poly>(std::move(grand_product_polys));
+  }
+
  private:
+  template <typename Evals, typename F = typename Evals::Field>
+  std::function<base::ParallelizeCallback3<F>(size_t)> CreateNumeratorCallback(
+      const std::vector<Ref<const Evals>>& unpermuted_columns,
+      const std::vector<Ref<const Evals>>& value_columns, const F& beta,
+      const F& gamma) {
+    // vᵢ(ωʲ) + β * δⁱ * ωʲ + γ
+    return [&unpermuted_columns, &value_columns, &beta,
+            &gamma](size_t column_index) {
+      const Evals& unpermuted_values = *unpermuted_columns[column_index];
+      const Evals& values = *value_columns[column_index];
+      return
+          [&unpermuted_values, &values, &beta, &gamma](
+              absl::Span<F> chunk, size_t chunk_index, size_t chunk_size_in) {
+            size_t i = chunk_index * chunk_size_in;
+            for (F& result : chunk) {
+              result *= *values[i] + beta * *unpermuted_values[i] + gamma;
+              ++i;
+            }
+          };
+    };
+  }
+
+  template <typename Evals, typename F = typename Evals::Field>
+  std::function<base::ParallelizeCallback3<F>(size_t)>
+  CreateDenominatorCallback(
+      const std::vector<Ref<const Evals>>& permuted_columns,
+      const std::vector<Ref<const Evals>>& value_columns, const F& beta,
+      const F& gamma) {
+    // vᵢ(ωʲ) + β * sᵢ(ωʲ) + γ
+    return [&permuted_columns, &value_columns, &beta,
+            &gamma](size_t column_index) {
+      const Evals& permuted_values = *permuted_columns[column_index];
+      const Evals& values = *value_columns[column_index];
+      return
+          [&permuted_values, &values, &beta, &gamma](
+              absl::Span<F> chunk, size_t chunk_index, size_t chunk_size_in) {
+            size_t i = chunk_index * chunk_size_in;
+            for (F& result : chunk) {
+              result *= *values[i] + beta * *permuted_values[i] + gamma;
+              ++i;
+            }
+          };
+    };
+  }
+
   std::vector<AnyColumnKey> columns_;
 };
 

--- a/tachyon/zk/plonk/permutation/permutation_argument.h
+++ b/tachyon/zk/plonk/permutation/permutation_argument.h
@@ -44,7 +44,7 @@ class PermutationArgument {
     // this middleware.
     //
     // clang-format off
-    // (1 - (l_last(X) + l_blind(X))) * (z(ω * X) Π (p(X) + β * sᵢ(X) + γ) - z(X) Π (p(X) + \delta^i β * X + γ))
+    // (1 - (l_last(X) + l_blind(X))) * (z(ω * X) Π (p(X) + β * sᵢ(X) + γ) - z(X) Π (p(X) + β * δⁱ * X + γ))
     // clang-format on
     //
     // On the first sets of columns, except the first

--- a/tachyon/zk/plonk/permutation/permutation_argument_unittest.cc
+++ b/tachyon/zk/plonk/permutation/permutation_argument_unittest.cc
@@ -10,34 +10,77 @@
 
 #include "tachyon/base/random.h"
 #include "tachyon/zk/base/halo2_prover_test.h"
+#include "tachyon/zk/plonk/permutation/permutation_assembly.h"
 
 namespace tachyon::zk {
 
-class PermutationArgumentTest : public Halo2ProverTest {};
+class PermutationArgumentTest : public Halo2ProverTest {
+ public:
+  void SetUp() override {
+    Halo2ProverTest::SetUp();
+
+    Evals cycled_column = Evals::Random();
+    fixed_columns_ = {cycled_column, Evals::Random(), Evals::Random()};
+    advice_columns_ = {Evals::Random(), cycled_column, Evals::Random()};
+    instance_columns_ = {cycled_column, Evals::Random(), Evals::Random()};
+
+    table_ = Table<Evals>(absl::MakeConstSpan(fixed_columns_),
+                          absl::MakeConstSpan(advice_columns_),
+                          absl::MakeConstSpan(instance_columns_));
+
+    column_keys_ = {
+        FixedColumnKey(0), AdviceColumnKey(0), InstanceColumnKey(0),
+        FixedColumnKey(1), AdviceColumnKey(1), InstanceColumnKey(1),
+        FixedColumnKey(2), AdviceColumnKey(2), InstanceColumnKey(2),
+    };
+    argument_ = PermutationArgument(column_keys_);
+
+    unpermuted_table_ = UnpermutedTable<Evals>::Construct(column_keys_.size(),
+                                                          prover_->domain());
+  }
+
+ protected:
+  std::vector<Evals> fixed_columns_;
+  std::vector<Evals> advice_columns_;
+  std::vector<Evals> instance_columns_;
+  Table<Evals> table_;
+
+  std::vector<AnyColumnKey> column_keys_;
+  PermutationArgument argument_;
+  UnpermutedTable<Evals> unpermuted_table_;
+};
 
 TEST_F(PermutationArgumentTest, AddColumn) {
-  std::vector<AnyColumnKey> columns = {FixedColumnKey(0),
-                                       AdviceColumnKey(1, kSecondPhase),
-                                       InstanceColumnKey(2)};
-  PermutationArgument argument(columns);
-  EXPECT_EQ(argument.columns(), columns);
-
   // Already included column should not be added.
-  AnyColumnKey col = base::UniformElement(columns);
-  argument.AddColumn(col);
-  EXPECT_EQ(argument.columns(), columns);
+  AnyColumnKey col = base::UniformElement(column_keys_);
+  argument_.AddColumn(col);
+  EXPECT_EQ(argument_.columns(), column_keys_);
 
   // Advice column whose phase is different should be added.
   AdviceColumnKey col2(1, Phase(3));
-  argument.AddColumn(col2);
-  columns.push_back(col2);
-  EXPECT_EQ(argument.columns(), columns);
+  argument_.AddColumn(col2);
+  column_keys_.push_back(col2);
+  EXPECT_EQ(argument_.columns(), column_keys_);
 
   // New Instance column should be added.
   InstanceColumnKey col3(3);
-  argument.AddColumn(col3);
-  columns.push_back(col3);
-  EXPECT_EQ(argument.columns(), columns);
+  argument_.AddColumn(col3);
+  column_keys_.push_back(col3);
+  EXPECT_EQ(argument_.columns(), column_keys_);
+}
+
+// TODO(chokobole): Implement test codes correctly. This just test compilation.
+TEST_F(PermutationArgumentTest, Commit) {
+  PermutationAssembly<PCS> assembly =
+      PermutationAssembly<PCS>::CreateForTesting(
+          column_keys_, CycleStore(column_keys_.size(), kDomainSize));
+
+  PermutationProvingKey<PCS> pk = assembly.BuildProvingKey(prover_->domain());
+
+  F beta = F::Random();
+  F gamma = F::Random();
+
+  argument_.Commit(prover_.get(), table_, prover_->pcs().N(), pk, beta, gamma);
 }
 
 }  // namespace tachyon::zk

--- a/tachyon/zk/plonk/permutation/permutation_argument_unittest.cc
+++ b/tachyon/zk/plonk/permutation/permutation_argument_unittest.cc
@@ -9,10 +9,13 @@
 #include "gtest/gtest.h"
 
 #include "tachyon/base/random.h"
+#include "tachyon/zk/base/halo2_prover_test.h"
 
 namespace tachyon::zk {
 
-TEST(PermutationArgumentTest, AddColumn) {
+class PermutationArgumentTest : public Halo2ProverTest {};
+
+TEST_F(PermutationArgumentTest, AddColumn) {
   std::vector<AnyColumnKey> columns = {FixedColumnKey(0),
                                        AdviceColumnKey(1, kSecondPhase),
                                        InstanceColumnKey(2)};

--- a/tachyon/zk/plonk/permutation/permutation_assembly.h
+++ b/tachyon/zk/plonk/permutation/permutation_assembly.h
@@ -115,8 +115,8 @@ class PermutationAssembly {
   // permutations. Note that the permutation polynomials are in evaluation
   // form.
   std::vector<Evals> GeneratePermutations(const Domain* domain) const {
-    UnpermutedTable<PCSTy> unpermuted_table =
-        UnpermutedTable<PCSTy>::Construct(columns_.size(), domain);
+    UnpermutedTable<Evals> unpermuted_table =
+        UnpermutedTable<Evals>::Construct(columns_.size(), domain);
 
     // Init evaluation formed polynomials with all-zero coefficients.
     std::vector<Evals> permutations =

--- a/tachyon/zk/plonk/permutation/permutation_assembly_unittest.cc
+++ b/tachyon/zk/plonk/permutation/permutation_assembly_unittest.cc
@@ -34,8 +34,8 @@ TEST_F(PermutationAssemblyTest, GeneratePermutation) {
   const Domain* domain = prover_->domain();
   std::vector<Evals> permutations = assembly_.GeneratePermutations(domain);
 
-  UnpermutedTable<PCS> unpermuted_table =
-      UnpermutedTable<PCS>::Construct(columns_.size(), domain);
+  UnpermutedTable<Evals> unpermuted_table =
+      UnpermutedTable<Evals>::Construct(columns_.size(), domain);
 
   for (size_t i = 0; i < columns_.size(); ++i) {
     for (size_t j = 0; j <= kMaxDegree; ++j) {

--- a/tachyon/zk/plonk/permutation/permutation_committed.h
+++ b/tachyon/zk/plonk/permutation/permutation_committed.h
@@ -1,0 +1,35 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
+#ifndef TACHYON_ZK_PLONK_PERMUTATION_PERMUTATION_COMMITTED_H_
+#define TACHYON_ZK_PLONK_PERMUTATION_PERMUTATION_COMMITTED_H_
+
+#include <utility>
+#include <vector>
+
+#include "tachyon/zk/base/blinded_polynomial.h"
+
+namespace tachyon::zk {
+
+// Committed polynomials for chunks of columns.
+template <typename Poly>
+class PermutationCommitted {
+ public:
+  explicit PermutationCommitted(
+      std::vector<BlindedPolynomial<Poly>> product_polys)
+      : product_polys_(std::move(product_polys)) {}
+
+  const std::vector<BlindedPolynomial<Poly>>& product_polys() const {
+    return product_polys_;
+  }
+
+ private:
+  std::vector<BlindedPolynomial<Poly>> product_polys_;
+};
+
+}  // namespace tachyon::zk
+
+#endif  // TACHYON_ZK_PLONK_PERMUTATION_PERMUTATION_COMMITTED_H_

--- a/tachyon/zk/plonk/permutation/permutation_proving_key_unittest.cc
+++ b/tachyon/zk/plonk/permutation/permutation_proving_key_unittest.cc
@@ -9,27 +9,15 @@
 #include "gtest/gtest.h"
 
 #include "tachyon/base/buffer/vector_buffer.h"
-#include "tachyon/crypto/commitments/kzg/kzg_commitment_scheme.h"
-#include "tachyon/math/elliptic_curves/bn/bn254/g1.h"
-#include "tachyon/math/elliptic_curves/bn/bn254/g2.h"
+#include "tachyon/zk/base/halo2_prover_test.h"
 
 namespace tachyon::zk {
 
 namespace {
 
-class PermutationProvingKeyTest : public testing::Test {
+class PermutationProvingKeyTest : public Halo2ProverTest {
  public:
-  constexpr static size_t kMaxDegree = 7;
-
-  using PCS =
-      crypto::KZGCommitmentScheme<math::bn254::G1AffinePoint,
-                                  math::bn254::G2AffinePoint, kMaxDegree,
-                                  math::bn254::G1AffinePoint>;
   using ProvingKey = PermutationProvingKey<PCS>;
-  using Poly = ProvingKey::Poly;
-  using Evals = PCS::Evals;
-
-  static void SetUpTestSuite() { math::bn254::G1Curve::Init(); }
 };
 
 }  // namespace

--- a/tachyon/zk/plonk/permutation/permutation_table_store.h
+++ b/tachyon/zk/plonk/permutation/permutation_table_store.h
@@ -1,0 +1,94 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
+#ifndef TACHYON_ZK_PLONK_PERMUTATION_PERMUTATION_TABLE_STORE_H_
+#define TACHYON_ZK_PLONK_PERMUTATION_PERMUTATION_TABLE_STORE_H_
+
+#include <vector>
+
+#include "absl/types/span.h"
+#include "gtest/gtest_prod.h"
+
+#include "tachyon/zk/plonk/circuit/table.h"
+#include "tachyon/zk/plonk/permutation/permuted_table.h"
+#include "tachyon/zk/plonk/permutation/unpermuted_table.h"
+
+namespace tachyon::zk {
+
+template <typename Evals>
+class PermutationTableStore {
+ public:
+  using F = typename Evals::Field;
+
+  PermutationTableStore(const std::vector<AnyColumnKey>& column_keys,
+                        const Table<Evals>& table,
+                        const PermutedTable<Evals>& permuted_table,
+                        const UnpermutedTable<Evals>& unpermuted_table,
+                        size_t chunk_size)
+      : column_keys_(column_keys),
+        table_(table),
+        permuted_table_(permuted_table),
+        unpermuted_table_(unpermuted_table),
+        chunk_size_(chunk_size) {}
+
+  size_t GetChunkSize(size_t chunk_idx) const {
+    size_t total_size = column_keys_.size();
+    size_t chunk_num = GetChunkNum();
+    CHECK_LT(chunk_idx, chunk_num);
+
+    if (chunk_idx < chunk_num - 1) {
+      return chunk_size_;
+    } else {
+      return total_size - (chunk_num - 1) * chunk_size_;
+    }
+  }
+
+  std::vector<Ref<const Evals>> GetValueColumns(size_t chunk_idx) const {
+    size_t chunk_offset = GetChunkOffset(chunk_idx);
+    size_t chunk_size = GetChunkSize(chunk_idx);
+    absl::Span<const AnyColumnKey> keys =
+        absl::MakeConstSpan(column_keys_.data() + chunk_offset, chunk_size);
+    return table_.GetColumns(keys);
+  }
+
+  std::vector<Ref<const Evals>> GetPermutedColumns(size_t chunk_idx) const {
+    return GetColumns(permuted_table_, chunk_idx);
+  }
+
+  std::vector<Ref<const Evals>> GetUnpermutedColumns(size_t chunk_idx) const {
+    return GetColumns(unpermuted_table_, chunk_idx);
+  }
+
+ private:
+  FRIEND_TEST(PermutationTableStoreTest, GetColumns);
+
+  size_t GetChunkNum() const {
+    return (column_keys_.size() + chunk_size_ - 1) / chunk_size_;
+  }
+
+  size_t GetChunkOffset(size_t chunk_idx) const {
+    return chunk_idx * chunk_size_;
+  }
+
+  template <typename T>
+  auto GetColumns(const T& table, size_t chunk_idx) const {
+    size_t chunk_offset = GetChunkOffset(chunk_idx);
+    size_t chunk_size = GetChunkSize(chunk_idx);
+    return table.GetColumns(
+        base::Range<size_t>(chunk_offset, chunk_offset + chunk_size));
+  }
+
+  const std::vector<AnyColumnKey>& column_keys_;
+  const Table<Evals>& table_;
+  const PermutedTable<Evals>& permuted_table_;
+  const UnpermutedTable<Evals>& unpermuted_table_;
+  // The number of element in a chunk.
+  size_t chunk_size_ = 0;
+};
+
+}  // namespace tachyon::zk
+
+#endif  // TACHYON_ZK_PLONK_PERMUTATION_PERMUTATION_TABLE_STORE_H_

--- a/tachyon/zk/plonk/permutation/permutation_table_store_unittest.cc
+++ b/tachyon/zk/plonk/permutation/permutation_table_store_unittest.cc
@@ -1,0 +1,83 @@
+#include "tachyon/zk/plonk/permutation/permutation_table_store.h"
+
+#include <utility>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "tachyon/zk/base/halo2_prover_test.h"
+
+namespace tachyon::zk {
+namespace {
+
+class PermutationTableStoreTest : public Halo2ProverTest {
+ public:
+  static constexpr size_t kChunkSize = 4;
+
+  void SetUp() override {
+    Halo2ProverTest::SetUp();
+
+    fixed_columns_ = {Evals::Random(), Evals::Random(), Evals::Random()};
+    advice_columns_ = {Evals::Random(), Evals::Random(), Evals::Random()};
+    instance_columns_ = {Evals::Random(), Evals::Random(), Evals::Random()};
+
+    table_ = Table<Evals>(absl::MakeConstSpan(fixed_columns_),
+                          absl::MakeConstSpan(advice_columns_),
+                          absl::MakeConstSpan(instance_columns_));
+
+    column_keys_ = {
+        FixedColumnKey(0),  InstanceColumnKey(0), AdviceColumnKey(0),
+        AdviceColumnKey(1), FixedColumnKey(1),    FixedColumnKey(2),
+        AdviceColumnKey(2), InstanceColumnKey(1), InstanceColumnKey(2)};
+
+    unpermuted_table_ = UnpermutedTable<Evals>::Construct(column_keys_.size(),
+                                                          prover_->domain());
+    for (const Evals& column : unpermuted_table_.table()) {
+      permutations_.push_back(column);
+    }
+    permuted_table_ = PermutedTable<Evals>(&permutations_);
+  }
+
+ protected:
+  std::vector<Evals> fixed_columns_;
+  std::vector<Evals> advice_columns_;
+  std::vector<Evals> instance_columns_;
+  Table<Evals> table_;
+
+  std::vector<AnyColumnKey> column_keys_;
+  std::vector<Evals> permutations_;
+  PermutedTable<Evals> permuted_table_;
+  UnpermutedTable<Evals> unpermuted_table_;
+};
+
+}  // namespace
+
+TEST_F(PermutationTableStoreTest, GetColumns) {
+  PermutationTableStore<Evals> permutation_table_store(
+      column_keys_, table_, permuted_table_, unpermuted_table_, kChunkSize);
+
+  // Prepare columns sorted in the order of |column_keys_|
+  std::vector<Evals> expected_value_columns = {
+      fixed_columns_[0],  instance_columns_[0], advice_columns_[0],
+      advice_columns_[1], fixed_columns_[1],    fixed_columns_[2],
+      advice_columns_[2], instance_columns_[1], instance_columns_[2],
+  };
+
+  for (size_t i = 0; i < permutation_table_store.GetChunkNum(); ++i) {
+    std::vector<Ref<const Evals>> value_columns =
+        permutation_table_store.GetValueColumns(i);
+    std::vector<Ref<const Evals>> permuted_columns =
+        permutation_table_store.GetPermutedColumns(i);
+    std::vector<Ref<const Evals>> unpermuted_columns =
+        permutation_table_store.GetUnpermutedColumns(i);
+
+    size_t start = permutation_table_store.GetChunkOffset(i);
+    size_t chunk_size = permutation_table_store.GetChunkSize(i);
+    for (size_t j = 0; j < chunk_size; ++j) {
+      EXPECT_EQ(*permuted_columns[j], *unpermuted_columns[j]);
+      EXPECT_EQ(*value_columns[j], expected_value_columns[start + j]);
+    }
+  }
+}
+
+}  // namespace tachyon::zk

--- a/tachyon/zk/plonk/permutation/permutation_verifying_key_unittest.cc
+++ b/tachyon/zk/plonk/permutation/permutation_verifying_key_unittest.cc
@@ -9,25 +9,15 @@
 #include "gtest/gtest.h"
 
 #include "tachyon/base/buffer/vector_buffer.h"
-#include "tachyon/crypto/commitments/kzg/kzg_commitment_scheme.h"
-#include "tachyon/math/elliptic_curves/bn/bn254/g1.h"
-#include "tachyon/math/elliptic_curves/bn/bn254/g2.h"
+#include "tachyon/zk/base/halo2_prover_test.h"
 
 namespace tachyon::zk {
 
 namespace {
 
-class PermutationVerifyingKeyTest : public testing::Test {
+class PermutationVerifyingKeyTest : public Halo2ProverTest {
  public:
-  constexpr static size_t kMaxDegree = 7;
-
-  using PCS =
-      crypto::KZGCommitmentScheme<math::bn254::G1AffinePoint,
-                                  math::bn254::G2AffinePoint, kMaxDegree,
-                                  math::bn254::G1AffinePoint>;
   using VerifyingKey = PermutationVerifyingKey<PCS>;
-
-  static void SetUpTestSuite() { math::bn254::G1Curve::Init(); }
 };
 
 }  // namespace

--- a/tachyon/zk/plonk/permutation/permuted_table.h
+++ b/tachyon/zk/plonk/permutation/permuted_table.h
@@ -1,0 +1,55 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
+#ifndef TACHYON_ZK_PLONK_PERMUTATION_PERMUTED_TABLE_H_
+#define TACHYON_ZK_PLONK_PERMUTATION_PERMUTED_TABLE_H_
+
+#include <utility>
+#include <vector>
+
+#include "tachyon/base/range.h"
+#include "tachyon/zk/base/ref.h"
+#include "tachyon/zk/plonk/permutation/label.h"
+
+namespace tachyon::zk {
+
+template <typename Evals>
+class PermutedTable {
+ public:
+  using F = typename Evals::Field;
+  using Table = std::vector<Evals>;
+
+  PermutedTable() = default;
+  explicit PermutedTable(const Table* table) : table_(table) {}
+
+  const F& operator[](const Label& label) const {
+    return (*table_)[label.col][label.row];
+  }
+
+  Ref<const Evals> GetColumn(size_t i) const {
+    return Ref<const Evals>(&(*table_)[i]);
+  }
+
+  std::vector<Ref<const Evals>> GetColumns(base::Range<size_t> range) const {
+    CHECK_EQ(range.Intersect(base::Range<size_t>::Until(table_->size())),
+             range);
+
+    std::vector<Ref<const Evals>> ret;
+    ret.reserve(range.GetSize());
+    for (size_t i : range) {
+      ret.push_back(GetColumn(i));
+    }
+    return ret;
+  }
+
+ private:
+  // not owned
+  const Table* table_ = nullptr;
+};
+
+}  // namespace tachyon::zk
+
+#endif  // TACHYON_ZK_PLONK_PERMUTATION_PERMUTED_TABLE_H_

--- a/tachyon/zk/plonk/permutation/unpermuted_table.h
+++ b/tachyon/zk/plonk/permutation/unpermuted_table.h
@@ -37,7 +37,6 @@ class UnpermutedTable {
   const F& operator[](const Label& label) const {
     return *table_[label.col][label.row];
   }
-  F& operator[](const Label& label) { return *table_[label.col][label.row]; }
 
   Ref<const Evals> GetColumn(size_t i) const {
     return Ref<const Evals>(&table_[i]);

--- a/tachyon/zk/plonk/permutation/unpermuted_table.h
+++ b/tachyon/zk/plonk/permutation/unpermuted_table.h
@@ -34,6 +34,8 @@ class UnpermutedTable {
 
   UnpermutedTable() = default;
 
+  const Table& table() const& { return table_; }
+
   const F& operator[](const Label& label) const {
     return *table_[label.col][label.row];
   }

--- a/tachyon/zk/plonk/permutation/unpermuted_table_unittest.cc
+++ b/tachyon/zk/plonk/permutation/unpermuted_table_unittest.cc
@@ -10,39 +10,22 @@
 
 #include "gtest/gtest.h"
 
-#include "tachyon/crypto/commitments/kzg/kzg_commitment_scheme.h"
-#include "tachyon/math/elliptic_curves/bn/bn254/g1.h"
-#include "tachyon/math/elliptic_curves/bn/bn254/g2.h"
-#include "tachyon/math/polynomials/univariate/univariate_evaluation_domain_factory.h"
+#include "tachyon/zk/base/halo2_prover_test.h"
 
 namespace tachyon::zk {
 
 namespace {
 
-class UnpermutedTableTest : public testing::Test {
- public:
-  constexpr static size_t kMaxDegree = 7;
-
-  using PCS =
-      crypto::KZGCommitmentScheme<math::bn254::G1AffinePoint,
-                                  math::bn254::G2AffinePoint, kMaxDegree,
-                                  math::bn254::G1AffinePoint>;
-
-  static void SetUpTestSuite() { math::bn254::G1Curve::Init(); }
-};
+class UnpermutedTableTest : public Halo2ProverTest {};
 
 }  // namespace
 
 TEST_F(UnpermutedTableTest, Construct) {
-  constexpr size_t kMaxDegree = 7;
   constexpr size_t kCols = 4;
+  const Domain* domain = prover_->domain();
 
-  using F = math::bn254::G1Curve::ScalarField;
-
-  std::unique_ptr<math::UnivariateEvaluationDomain<F, kMaxDegree>> domain =
-      math::UnivariateEvaluationDomain<F, kMaxDegree>::Create(kMaxDegree + 1);
   UnpermutedTable<PCS> unpermuted_table =
-      UnpermutedTable<PCS>::Construct(kCols, domain.get());
+      UnpermutedTable<PCS>::Construct(kCols, domain);
   F omega = domain->group_gen();
   std::vector<F> omega_powers = domain->GetRootsOfUnity(kMaxDegree + 1, omega);
 

--- a/tachyon/zk/plonk/permutation/unpermuted_table_unittest.cc
+++ b/tachyon/zk/plonk/permutation/unpermuted_table_unittest.cc
@@ -16,27 +16,64 @@ namespace tachyon::zk {
 
 namespace {
 
-class UnpermutedTableTest : public Halo2ProverTest {};
+class UnpermutedTableTest : public Halo2ProverTest {
+ public:
+  constexpr static size_t kCols = 4;
+
+  void SetUp() override {
+    Halo2ProverTest::SetUp();
+    unpermuted_table_ =
+        UnpermutedTable<PCS>::Construct(kCols, prover_->domain());
+  }
+
+ protected:
+  UnpermutedTable<PCS> unpermuted_table_;
+};
 
 }  // namespace
 
 TEST_F(UnpermutedTableTest, Construct) {
-  constexpr size_t kCols = 4;
   const Domain* domain = prover_->domain();
 
-  UnpermutedTable<PCS> unpermuted_table =
-      UnpermutedTable<PCS>::Construct(kCols, domain);
   const F& omega = domain->group_gen();
   std::vector<F> omega_powers = domain->GetRootsOfUnity(kMaxDegree + 1, omega);
 
-  const F delta = unpermuted_table.GetDelta();
+  const F delta = unpermuted_table_.GetDelta();
   EXPECT_NE(delta, F::One());
   EXPECT_EQ(delta.Pow(F::Config::kTrace), F::One());
   for (size_t i = 1; i < kCols; ++i) {
     for (size_t j = 0; j < kMaxDegree + 1; ++j) {
       omega_powers[j] *= delta;
-      EXPECT_EQ(omega_powers[j], unpermuted_table[Label(i, j)]);
+      EXPECT_EQ(omega_powers[j], unpermuted_table_[Label(i, j)]);
     }
   }
 }
+
+TEST_F(UnpermutedTableTest, GetColumns) {
+  using Col = UnpermutedTable<PCS>::Col;
+
+  const Domain* domain = prover_->domain();
+
+  const F& omega = domain->group_gen();
+  const F delta = unpermuted_table_.GetDelta();
+  std::vector<F> omega_powers = domain->GetRootsOfUnity(kMaxDegree + 1, omega);
+  for (F& omega_power : omega_powers) {
+    omega_power *= delta;
+  }
+
+  Ref<const Col> column = unpermuted_table_.GetColumn(1);
+  for (size_t i = 0; i < kMaxDegree + 1; ++i) {
+    EXPECT_EQ(omega_powers[i], column[i]);
+  }
+
+  std::vector<Ref<const Col>> columns =
+      unpermuted_table_.GetColumns(base::Range<size_t>(2, 4));
+  for (size_t i = 0; i < 2; ++i) {
+    for (size_t j = 0; j < kMaxDegree + 1; ++j) {
+      omega_powers[j] *= delta;
+      EXPECT_EQ(omega_powers[j], columns[i][j]);
+    }
+  }
+}
+
 }  // namespace tachyon::zk

--- a/tachyon/zk/plonk/permutation/unpermuted_table_unittest.cc
+++ b/tachyon/zk/plonk/permutation/unpermuted_table_unittest.cc
@@ -23,11 +23,11 @@ class UnpermutedTableTest : public Halo2ProverTest {
   void SetUp() override {
     Halo2ProverTest::SetUp();
     unpermuted_table_ =
-        UnpermutedTable<PCS>::Construct(kCols, prover_->domain());
+        UnpermutedTable<Evals>::Construct(kCols, prover_->domain());
   }
 
  protected:
-  UnpermutedTable<PCS> unpermuted_table_;
+  UnpermutedTable<Evals> unpermuted_table_;
 };
 
 }  // namespace
@@ -50,8 +50,6 @@ TEST_F(UnpermutedTableTest, Construct) {
 }
 
 TEST_F(UnpermutedTableTest, GetColumns) {
-  using Col = UnpermutedTable<PCS>::Col;
-
   const Domain* domain = prover_->domain();
 
   const F& omega = domain->group_gen();
@@ -61,17 +59,17 @@ TEST_F(UnpermutedTableTest, GetColumns) {
     omega_power *= delta;
   }
 
-  Ref<const Col> column = unpermuted_table_.GetColumn(1);
+  Ref<const Evals> column = unpermuted_table_.GetColumn(1);
   for (size_t i = 0; i < kMaxDegree + 1; ++i) {
-    EXPECT_EQ(omega_powers[i], column[i]);
+    EXPECT_EQ(omega_powers[i], *(*column)[i]);
   }
 
-  std::vector<Ref<const Col>> columns =
+  std::vector<Ref<const Evals>> columns =
       unpermuted_table_.GetColumns(base::Range<size_t>(2, 4));
   for (size_t i = 0; i < 2; ++i) {
     for (size_t j = 0; j < kMaxDegree + 1; ++j) {
       omega_powers[j] *= delta;
-      EXPECT_EQ(omega_powers[j], columns[i][j]);
+      EXPECT_EQ(omega_powers[j], *(*columns[i])[j]);
     }
   }
 }

--- a/tachyon/zk/plonk/permutation/unpermuted_table_unittest.cc
+++ b/tachyon/zk/plonk/permutation/unpermuted_table_unittest.cc
@@ -26,10 +26,10 @@ TEST_F(UnpermutedTableTest, Construct) {
 
   UnpermutedTable<PCS> unpermuted_table =
       UnpermutedTable<PCS>::Construct(kCols, domain);
-  F omega = domain->group_gen();
+  const F& omega = domain->group_gen();
   std::vector<F> omega_powers = domain->GetRootsOfUnity(kMaxDegree + 1, omega);
 
-  F delta = unpermuted_table.GetDelta();
+  const F delta = unpermuted_table.GetDelta();
   EXPECT_NE(delta, F::One());
   EXPECT_EQ(delta.Pow(F::Config::kTrace), F::One());
   for (size_t i = 1; i < kCols; ++i) {


### PR DESCRIPTION
This PR implements `Commit()` function of `PermutationArgument` and its output structure
See [PermutationArgument::Commit](https://github.com/kroma-network/halo2/blob/7d0a36990452c8e7ebd600de258420781a9b7917/halo2_proofs/src/plonk/permutation/prover.rs#L43-L188), and [PermutationCommitted](https://github.com/kroma-network/halo2/blob/7d0a36990452c8e7ebd600de258420781a9b7917/halo2_proofs/src/plonk/permutation/prover.rs#L21-L28) and its [Construct](https://github.com/kroma-network/halo2/blob/7d0a36990452c8e7ebd600de258420781a9b7917/halo2_proofs/src/plonk/permutation/prover.rs#L190-L203) method.