### PR TITLE
refac(zk): unify query method names

### DIFF
--- a/tachyon/zk/base/prover_query.h
+++ b/tachyon/zk/base/prover_query.h
@@ -28,7 +28,7 @@ class ProverQuery {
   const F& point() const { return point_; }
   Ref<const BlindedPolynomial<Poly>> poly() const { return poly_; }
 
-  F Evaluate() const { return poly_->poly().Evaluate(*point_); }
+  F Evaluate() const { return poly_->poly().Evaluate(point_); }
 
  private:
   F point_;

--- a/tachyon/zk/base/prover_query.h
+++ b/tachyon/zk/base/prover_query.h
@@ -18,6 +18,7 @@ class ProverQuery {
  public:
   using F = typename PCSTy::Field;
   using Poly = typename PCSTy::Poly;
+  using Commitment = Ref<const BlindedPolynomial<Poly>>;
 
   ProverQuery(const F& point, Ref<const BlindedPolynomial<Poly>> poly)
       : point_(point), poly_(poly) {}
@@ -25,10 +26,11 @@ class ProverQuery {
   ProverQuery(F&& point, Ref<const BlindedPolynomial<Poly>> poly)
       : point_(std::move(point)), poly_(poly) {}
 
-  const F& point() const { return point_; }
-  Ref<const BlindedPolynomial<Poly>> poly() const { return poly_; }
+  const F& GetPoint() const { return point_; }
 
-  F Evaluate() const { return poly_->poly().Evaluate(point_); }
+  Ref<const BlindedPolynomial<Poly>> GetCommitment() const { return poly_; }
+
+  F GetEval() const { return poly_->poly().Evaluate(point_); }
 
  private:
   F point_;

--- a/tachyon/zk/base/verifier_query.h
+++ b/tachyon/zk/base/verifier_query.h
@@ -28,9 +28,11 @@ class VerifierQuery {
         commitment_(commitment),
         evaluated_(std::move(evaluated)) {}
 
-  const F& point() const { return point_; }
-  Ref<const Commitment> commitment() const { return commitment_; }
-  const F& evaluated() const { return evaluated_; }
+  const F& GetPoint() const { return point_; }
+
+  Ref<const Commitment> GetCommitment() const { return commitment_; }
+
+  const F& GetEval() const { return evaluated_; }
 
  private:
   F point_;


### PR DESCRIPTION
# Description

Unify the method names so that each `ProverQuery` and `VerifierQuery` can be used in common functions like `ConstructIntermediateSets` in a multi-point opening scheme on the prover and verifier sides.

`ConstructIntermediateSets` function is a function commonly used by Prover and Verifier.
IntermediateSets are created independently from each other with its own Query.