### PR TITLE
feat(zk): implement auxiliary classes related to permutation

### DIFF
--- a/tachyon/zk/plonk/lookup/BUILD.bazel
+++ b/tachyon/zk/plonk/lookup/BUILD.bazel
@@ -32,7 +32,6 @@ tachyon_cc_library(
     hdrs = ["lookup_committed.h"],
     deps = [
         ":lookup_evaluated",
-        "//tachyon/zk/base:prover",
         "//tachyon/zk/plonk/circuit:rotation",
     ],
 )
@@ -42,6 +41,7 @@ tachyon_cc_library(
     hdrs = ["lookup_evaluated.h"],
     deps = [
         "//tachyon/zk/base:blinded_polynomial",
+        "//tachyon/zk/base:prover",
         "//tachyon/zk/base:prover_query",
     ],
 )
@@ -63,6 +63,7 @@ tachyon_cc_library(
     deps = [
         "//tachyon/base/containers:container_util",
         "//tachyon/zk/base:evals_pair",
+        "//tachyon/zk/base:prover",
         "//tachyon/zk/plonk:error",
         "@com_google_absl//absl/container:btree",
     ],

--- a/tachyon/zk/plonk/lookup/lookup_argument.h
+++ b/tachyon/zk/plonk/lookup/lookup_argument.h
@@ -15,6 +15,7 @@
 #include <utility>
 #include <vector>
 
+#include "tachyon/zk/base/prover.h"
 #include "tachyon/zk/plonk/lookup/compress_expression.h"
 #include "tachyon/zk/plonk/lookup/lookup_permuted.h"
 
@@ -75,20 +76,20 @@ class LookupArgument {
     return 2 + max_input_degree + max_table_degree;
   }
 
-  template <typename ProverTy, typename Evals,
-            typename Poly = typename ProverTy::Poly>
+  template <typename PCSTy, typename Evals,
+            typename Poly = typename PCSTy::Poly>
   LookupPermuted<Poly, Evals> CommitPermuted(
-      ProverTy& prover, const F& theta,
+      Prover<PCSTy>* prover, const F& theta,
       const SimpleEvaluator<Evals>& evaluator_tpl) {
     // A_compressed(X) = θᵐ⁻¹A₀(X) + θᵐ⁻²A₁(X) + ... + θAₘ₋₂(X) + Aₘ₋₁(X)
     Evals compressed_input_expression;
-    CHECK(CompressExpressions(input_expressions_, prover.domain()->size(),
+    CHECK(CompressExpressions(input_expressions_, prover->domain()->size(),
                               theta, evaluator_tpl,
                               &compressed_input_expression));
 
     // S_compressed(X) = θᵐ⁻¹S₀(X) + θᵐ⁻²S₁(X) + ... + θSₘ₋₂(X) + Sₘ₋₁(X)
     Evals compressed_table_expression;
-    CHECK(CompressExpressions(table_expressions_, prover.domain()->size(),
+    CHECK(CompressExpressions(table_expressions_, prover->domain()->size(),
                               theta, evaluator_tpl,
                               &compressed_table_expression));
 
@@ -105,13 +106,13 @@ class LookupArgument {
 
     // Commit(A'(X))
     BlindedPolynomial<Poly> permuted_input_poly;
-    CHECK(prover.CommitEvalsWithBlind(permuted_evals_pair.input(),
-                                      &permuted_input_poly));
+    CHECK(prover->CommitEvalsWithBlind(permuted_evals_pair.input(),
+                                       &permuted_input_poly));
 
     // Commit(S'(X))
     BlindedPolynomial<Poly> permuted_table_poly;
-    CHECK(prover.CommitEvalsWithBlind(permuted_evals_pair.table(),
-                                      &permuted_table_poly));
+    CHECK(prover->CommitEvalsWithBlind(permuted_evals_pair.table(),
+                                       &permuted_table_poly));
 
     return {std::move(compressed_evals_pair), std::move(permuted_evals_pair),
             std::move(permuted_input_poly), std::move(permuted_table_poly)};

--- a/tachyon/zk/plonk/lookup/lookup_committed.h
+++ b/tachyon/zk/plonk/lookup/lookup_committed.h
@@ -36,16 +36,16 @@ class LookupCommitted {
   }
   const BlindedPolynomial<Poly>& product_poly() const { return product_poly_; }
 
-  template <typename ProverTy>
-  LookupEvaluated<Poly> Evaluate(ProverTy& prover, const F& x) && {
-    F x_inv = Rotation::Prev().RotateOmega(prover.domain(), x);
-    F x_next = Rotation::Next().RotateOmega(prover.domain(), x);
+  template <typename PCSTy>
+  LookupEvaluated<Poly> Evaluate(Prover<PCSTy>* prover, const F& x) && {
+    F x_inv = Rotation::Prev().RotateOmega(prover->domain(), x);
+    F x_next = Rotation::Next().RotateOmega(prover->domain(), x);
 
-    prover.Evaluate(product_poly_.poly(), x);
-    prover.Evaluate(product_poly_.poly(), x_next);
-    prover.Evaluate(permuted_input_poly_.poly(), x);
-    prover.Evaluate(permuted_input_poly_.poly(), x_inv);
-    prover.Evaluate(permuted_table_poly_.poly(), x);
+    prover->Evaluate(product_poly_.poly(), x);
+    prover->Evaluate(product_poly_.poly(), x_next);
+    prover->Evaluate(permuted_input_poly_.poly(), x);
+    prover->Evaluate(permuted_input_poly_.poly(), x_inv);
+    prover->Evaluate(permuted_table_poly_.poly(), x);
 
     return {
         std::move(permuted_input_poly_),

--- a/tachyon/zk/plonk/lookup/lookup_committed.h
+++ b/tachyon/zk/plonk/lookup/lookup_committed.h
@@ -37,7 +37,7 @@ class LookupCommitted {
   const BlindedPolynomial<Poly>& product_poly() const { return product_poly_; }
 
   template <typename PCSTy>
-  LookupEvaluated<Poly> Evaluate(Prover<PCSTy>* prover, const F& x) && {
+  LookupEvaluated<Poly> Evaluate(const Prover<PCSTy>* prover, const F& x) && {
     F x_inv = Rotation::Prev().RotateOmega(prover->domain(), x);
     F x_next = Rotation::Next().RotateOmega(prover->domain(), x);
 

--- a/tachyon/zk/plonk/lookup/lookup_evaluated.h
+++ b/tachyon/zk/plonk/lookup/lookup_evaluated.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "tachyon/zk/base/blinded_polynomial.h"
+#include "tachyon/zk/base/prover.h"
 #include "tachyon/zk/base/prover_query.h"
 
 namespace tachyon::zk {
@@ -36,11 +37,11 @@ class LookupEvaluated {
   }
   const BlindedPolynomial<Poly>& product_poly() const { return product_poly_; }
 
-  template <typename ProverTy, typename PCSTy = typename ProverTy::PCSTy>
-  std::vector<ProverQuery<PCSTy>> Open(const ProverTy& prover,
+  template <typename PCSTy>
+  std::vector<ProverQuery<PCSTy>> Open(Prover<PCSTy>* prover,
                                        const F& x) const {
-    F x_inv = Rotation::Prev().RotateOmega(prover.domain(), x);
-    F x_next = Rotation::Next().RotateOmega(prover.domain(), x);
+    F x_inv = Rotation::Prev().RotateOmega(prover->domain(), x);
+    F x_next = Rotation::Next().RotateOmega(prover->domain(), x);
 
     return {ProverQuery<PCSTy>(x, product_poly_.ToRef()),
             ProverQuery<PCSTy>(x, permuted_input_poly_.ToRef()),

--- a/tachyon/zk/plonk/lookup/lookup_evaluated.h
+++ b/tachyon/zk/plonk/lookup/lookup_evaluated.h
@@ -38,7 +38,7 @@ class LookupEvaluated {
   const BlindedPolynomial<Poly>& product_poly() const { return product_poly_; }
 
   template <typename PCSTy>
-  std::vector<ProverQuery<PCSTy>> Open(Prover<PCSTy>* prover,
+  std::vector<ProverQuery<PCSTy>> Open(const Prover<PCSTy>* prover,
                                        const F& x) const {
     F x_inv = Rotation::Prev().RotateOmega(prover->domain(), x);
     F x_next = Rotation::Next().RotateOmega(prover->domain(), x);

--- a/tachyon/zk/plonk/lookup/lookup_permuted_unittest.cc
+++ b/tachyon/zk/plonk/lookup/lookup_permuted_unittest.cc
@@ -48,7 +48,7 @@ TEST_F(LookupPermutedTest, ComputePermutationProduct) {
       std::move(compressed_table_expression));
 
   EvalsPair<Evals> permuted_evals_pair;
-  Error err = PermuteExpressionPair(*prover_, compressed_evals_pair,
+  Error err = PermuteExpressionPair(prover_.get(), compressed_evals_pair,
                                     &permuted_evals_pair);
   ASSERT_EQ(err, Error::kNone);
 

--- a/tachyon/zk/plonk/lookup/permute_expression_pair.h
+++ b/tachyon/zk/plonk/lookup/permute_expression_pair.h
@@ -15,6 +15,7 @@
 
 #include "tachyon/base/containers/container_util.h"
 #include "tachyon/zk/base/evals_pair.h"
+#include "tachyon/zk/base/prover.h"
 #include "tachyon/zk/plonk/error.h"
 
 namespace tachyon::zk {
@@ -25,11 +26,11 @@ namespace tachyon::zk {
 // - the first row in a sequence of like values in A' is the row
 //   that has the corresponding value in S'.
 // This method returns (A', S') if no errors are encountered.
-template <typename ProverTy, typename Evals, typename F = typename Evals::Field>
-Error PermuteExpressionPair(ProverTy& prover, const EvalsPair<Evals>& in,
+template <typename PCSTy, typename Evals, typename F = typename Evals::Field>
+Error PermuteExpressionPair(Prover<PCSTy>* prover, const EvalsPair<Evals>& in,
                             EvalsPair<Evals>* out) {
-  size_t domain_size = prover.domain()->size();
-  size_t blinding_factors = prover.blinder().blinding_factors();
+  size_t domain_size = prover->domain()->size();
+  size_t blinding_factors = prover->blinder().blinding_factors();
   if (domain_size == 0) return Error::kConstraintSystemFailure;
   if (domain_size - 1 < blinding_factors)
     return Error::kConstraintSystemFailure;
@@ -134,8 +135,8 @@ Error PermuteExpressionPair(ProverTy& prover, const EvalsPair<Evals>& in,
   Evals input(std::move(permuted_input_expressions));
   Evals table(std::move(permuted_table_expressions));
 
-  prover.blinder().Blind(input);
-  prover.blinder().Blind(table);
+  prover->blinder().Blind(input);
+  prover->blinder().Blind(table);
 
   *out = {std::move(input), std::move(table)};
 

--- a/tachyon/zk/plonk/lookup/permute_expression_pair_unittest.cc
+++ b/tachyon/zk/plonk/lookup/permute_expression_pair_unittest.cc
@@ -35,7 +35,7 @@ TEST_F(PermuteExpressionPairTest, PermuteExpressionPairTest) {
                          Evals(std::move(table_evals)));
   EvalsPair<Evals> output;
 
-  Error err = PermuteExpressionPair(*prover_, input, &output);
+  Error err = PermuteExpressionPair(prover_.get(), input, &output);
   ASSERT_EQ(err, Error::kNone);
 
   // sanity check brought from halo2
@@ -62,7 +62,7 @@ TEST_F(PermuteExpressionPairTest, PermuteExpressionPairTestWrong) {
   EvalsPair<Evals> input = {Evals(std::move(input_evals)),
                             Evals(std::move(table_evals))};
   EvalsPair<Evals> output;
-  Error err = PermuteExpressionPair(*prover_, input, &output);
+  Error err = PermuteExpressionPair(prover_.get(), input, &output);
   ASSERT_EQ(err, Error::kConstraintSystemFailure);
 }
 

--- a/tachyon/zk/plonk/permutation/BUILD.bazel
+++ b/tachyon/zk/plonk/permutation/BUILD.bazel
@@ -57,6 +57,15 @@ tachyon_cc_library(
 tachyon_cc_library(
     name = "permutation_committed",
     hdrs = ["permutation_committed.h"],
+    deps = [
+        ":permutation_evaluated",
+        "//tachyon/zk/base:prover",
+    ],
+)
+
+tachyon_cc_library(
+    name = "permutation_evaluated",
+    hdrs = ["permutation_evaluated.h"],
     deps = ["//tachyon/zk/base:blinded_polynomial"],
 )
 

--- a/tachyon/zk/plonk/permutation/BUILD.bazel
+++ b/tachyon/zk/plonk/permutation/BUILD.bazel
@@ -57,16 +57,18 @@ tachyon_cc_library(
 tachyon_cc_library(
     name = "permutation_committed",
     hdrs = ["permutation_committed.h"],
-    deps = [
-        ":permutation_evaluated",
-        "//tachyon/zk/base:prover",
-    ],
+    deps = [":permutation_evaluated"],
 )
 
 tachyon_cc_library(
     name = "permutation_evaluated",
     hdrs = ["permutation_evaluated.h"],
-    deps = ["//tachyon/zk/base:blinded_polynomial"],
+    deps = [
+        "//tachyon/zk/base:blinded_polynomial",
+        "//tachyon/zk/base:prover",
+        "//tachyon/zk/base:prover_query",
+        "//tachyon/zk/plonk/circuit:rotation",
+    ],
 )
 
 tachyon_cc_library(

--- a/tachyon/zk/plonk/permutation/BUILD.bazel
+++ b/tachyon/zk/plonk/permutation/BUILD.bazel
@@ -130,6 +130,7 @@ tachyon_cc_library(
         "//tachyon/base:openmp_util",
         "//tachyon/base:parallelize",
         "//tachyon/base/containers:container_util",
+        "//tachyon/zk/base:prover",
     ],
 )
 

--- a/tachyon/zk/plonk/permutation/permutation_argument_unittest.cc
+++ b/tachyon/zk/plonk/permutation/permutation_argument_unittest.cc
@@ -75,7 +75,7 @@ TEST_F(PermutationArgumentTest, Commit) {
       PermutationAssembly<PCS>::CreateForTesting(
           column_keys_, CycleStore(column_keys_.size(), kDomainSize));
 
-  PermutationProvingKey<PCS> pk = assembly.BuildProvingKey(prover_->domain());
+  PermutationProvingKey<PCS> pk = assembly.BuildProvingKey(prover_.get());
 
   F beta = F::Random();
   F gamma = F::Random();

--- a/tachyon/zk/plonk/permutation/permutation_assembly_unittest.cc
+++ b/tachyon/zk/plonk/permutation/permutation_assembly_unittest.cc
@@ -45,13 +45,12 @@ TEST_F(PermutationAssemblyTest, GeneratePermutation) {
 }
 
 TEST_F(PermutationAssemblyTest, BuildKeys) {
-  const Domain* domain = prover_->domain();
   const PCS& pcs = prover_->pcs();
 
-  PermutationProvingKey<PCS> pk = assembly_.BuildProvingKey(domain);
+  PermutationProvingKey<PCS> pk = assembly_.BuildProvingKey(prover_.get());
   EXPECT_EQ(pk.permutations().size(), pk.polys().size());
 
-  PermutationVerifyingKey<PCS> vk = assembly_.BuildVerifyingKey(pcs, domain);
+  PermutationVerifyingKey<PCS> vk = assembly_.BuildVerifyingKey(prover_.get());
   EXPECT_EQ(pk.permutations().size(), vk.commitments().size());
 
   for (size_t i = 0; i < columns_.size(); ++i) {

--- a/tachyon/zk/plonk/permutation/permutation_committed.h
+++ b/tachyon/zk/plonk/permutation/permutation_committed.h
@@ -11,6 +11,8 @@
 #include <vector>
 
 #include "tachyon/zk/base/blinded_polynomial.h"
+#include "tachyon/zk/base/prover.h"
+#include "tachyon/zk/plonk/permutation/permutation_evaluated.h"
 
 namespace tachyon::zk {
 
@@ -24,6 +26,32 @@ class PermutationCommitted {
 
   const std::vector<BlindedPolynomial<Poly>>& product_polys() const {
     return product_polys_;
+  }
+
+  template <typename PCSTy, typename F>
+  PermutationEvaluated<Poly> Evaluate(Prover<PCSTy>* prover, const F& x) && {
+    int32_t blinding_factors =
+        static_cast<int32_t>(prover->blinder().blinding_factors());
+
+    for (size_t i = 0; i < product_polys_.size(); ++i) {
+      const Poly& poly = product_polys_[i].poly();
+
+      prover->Evaluate(poly, x);
+
+      F x_next = Rotation::Next().RotateOmega(prover->domain(), x);
+      prover->Evaluate(poly, x_next);
+
+      // If we have any remaining sets to process, evaluate this set at ωᵘ
+      // so we can constrain the last value of its running product to equal the
+      // first value of the next set's running product, chaining them together.
+      if (i != product_polys_.size() - 1) {
+        F x_last =
+            Rotation(-(blinding_factors + 1)).RotateOmega(prover->domain(), x);
+        prover->Evaluate(poly, x_last);
+      }
+    }
+
+    return PermutationEvaluated<Poly>(std::move(product_polys_));
   }
 
  private:

--- a/tachyon/zk/plonk/permutation/permutation_evaluated.h
+++ b/tachyon/zk/plonk/permutation/permutation_evaluated.h
@@ -11,6 +11,9 @@
 #include <vector>
 
 #include "tachyon/zk/base/blinded_polynomial.h"
+#include "tachyon/zk/base/prover.h"
+#include "tachyon/zk/base/prover_query.h"
+#include "tachyon/zk/plonk/circuit/rotation.h"
 
 namespace tachyon::zk {
 
@@ -24,6 +27,29 @@ class PermutationEvaluated {
 
   const std::vector<BlindedPolynomial<Poly>>& product_polys() const {
     return product_polys_;
+  }
+
+  template <typename PCSTy, typename F>
+  std::vector<ProverQuery<PCSTy>> Open(const Prover<PCSTy>* prover,
+                                       const F& x) const {
+    std::vector<ProverQuery<PCSTy>> ret;
+    ret.reserve(product_polys_.size() * 3 - 1);
+
+    F x_next = Rotation::Next().RotateOmega(prover->domain(), x);
+    for (const BlindedPolynomial<Poly>& blinded_poly : product_polys_) {
+      ret.emplace_back(x, blinded_poly.ToRef());
+      ret.emplace_back(x_next, blinded_poly.ToRef());
+    }
+
+    int32_t blinding_factors =
+        static_cast<int32_t>(prover->blinder().blinding_factors());
+    F x_last =
+        Rotation(-(blinding_factors + 1)).RotateOmega(prover->domain(), x);
+    for (auto it = product_polys_.rbegin() + 1; it != product_polys_.rend();
+         ++it) {
+      ret.emplace_back(x_last, it->ToRef());
+    }
+    return ret;
   }
 
  private:

--- a/tachyon/zk/plonk/permutation/permutation_evaluated.h
+++ b/tachyon/zk/plonk/permutation/permutation_evaluated.h
@@ -1,0 +1,35 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
+#ifndef TACHYON_ZK_PLONK_PERMUTATION_PERMUTATION_EVALUATED_H_
+#define TACHYON_ZK_PLONK_PERMUTATION_PERMUTATION_EVALUATED_H_
+
+#include <utility>
+#include <vector>
+
+#include "tachyon/zk/base/blinded_polynomial.h"
+
+namespace tachyon::zk {
+
+template <typename Poly>
+class PermutationEvaluated {
+ public:
+  PermutationEvaluated() = default;
+  explicit PermutationEvaluated(
+      std::vector<BlindedPolynomial<Poly>> product_polys)
+      : product_polys_(std::move(product_polys)) {}
+
+  const std::vector<BlindedPolynomial<Poly>>& product_polys() const {
+    return product_polys_;
+  }
+
+ private:
+  std::vector<BlindedPolynomial<Poly>> product_polys_;
+};
+
+}  // namespace tachyon::zk
+
+#endif  // TACHYON_ZK_PLONK_PERMUTATION_PERMUTATION_EVALUATED_H_


### PR DESCRIPTION
This PR implements `Open()` and `Evaluate()` functions of  classes related to permutation.

- [evaluate()](https://github.com/kroma-network/halo2/blob/7d0a36990452c8e7ebd600de258420781a9b7917/halo2_proofs/src/plonk/permutation/prover.rs#L231-L276)
- [open()](https://github.com/kroma-network/halo2/blob/7d0a36990452c8e7ebd600de258420781a9b7917/halo2_proofs/src/plonk/permutation/prover.rs#L278-L324)