### PR TITLE
feat(zk): fill `transcript_repr` of `VerifyingKey`

### DIFF
--- a/tachyon/base/strings/BUILD.bazel
+++ b/tachyon/base/strings/BUILD.bazel
@@ -9,6 +9,12 @@ load(
 package(default_visibility = ["//visibility:public"])
 
 tachyon_cc_library(
+    name = "rust_stringifier",
+    hdrs = ["rust_stringifier.h"],
+    deps = ["//tachyon:export"],
+)
+
+tachyon_cc_library(
     name = "string_number_conversions",
     srcs = [
         "string_number_conversions.cc",

--- a/tachyon/base/strings/rust_stringifier.h
+++ b/tachyon/base/strings/rust_stringifier.h
@@ -1,0 +1,146 @@
+#ifndef TACHYON_BASE_STRINGS_RUST_STRINGIFIER_H_
+#define TACHYON_BASE_STRINGS_RUST_STRINGIFIER_H_
+
+#include <optional>
+#include <sstream>
+#include <string>
+#include <type_traits>
+
+#include "tachyon/export.h"
+
+namespace tachyon::base {
+
+class RustFormatter;
+
+namespace internal {
+
+template <typename T, typename SFINAE = void>
+class RustDebugStringifier;
+
+class TACHYON_EXPORT DebugStruct {
+ public:
+  DebugStruct(RustFormatter* fmt, std::string_view name) : fmt_(fmt) {
+    ss_ << name << " { ";
+  }
+
+  template <typename T>
+  DebugStruct& Field(std::string_view name, const T& value) {
+    if (has_field_) {
+      ss_ << ", ";
+    }
+    ss_ << name << ": ";
+    RustDebugStringifier<T>::AppendToStream(ss_, *fmt_, value);
+    has_field_ = true;
+    return *this;
+  }
+
+  std::string Finish() {
+    ss_ << " }";
+    return ss_.str();
+  }
+
+ private:
+  RustFormatter* fmt_ = nullptr;
+  std::stringstream ss_;
+  bool has_field_ = false;
+};
+
+}  // namespace internal
+
+class TACHYON_EXPORT RustFormatter {
+ public:
+  RustFormatter() = default;
+
+  internal::DebugStruct DebugStruct(std::string_view name) {
+    return internal::DebugStruct(this, name);
+  }
+};
+
+namespace internal {
+
+template <>
+class RustDebugStringifier<bool> {
+ public:
+  static std::ostream& AppendToStream(std::ostream& os, RustFormatter& fmt,
+                                      bool value) {
+    if (value) {
+      return os << "true";
+    } else {
+      return os << "false";
+    }
+  }
+};
+
+template <typename T>
+class RustDebugStringifier<T, std::enable_if_t<std::is_arithmetic_v<T>>> {
+ public:
+  static std::ostream& AppendToStream(std::ostream& os, RustFormatter& fmt,
+                                      T value) {
+    return os << value;
+  }
+};
+
+template <typename CharTy>
+class RustDebugStringifier<std::basic_string_view<CharTy>> {
+ public:
+  static std::ostream& AppendToStream(std::ostream& os, RustFormatter& fmt,
+                                      std::basic_string_view<CharTy> value) {
+    return os << "\"" << value << "\"";
+  }
+};
+
+template <typename CharTy>
+class RustDebugStringifier<std::basic_string<CharTy>> {
+ public:
+  static std::ostream& AppendToStream(std::ostream& os, RustFormatter& fmt,
+                                      const std::basic_string<CharTy>& value) {
+    return os << "\"" << value << "\"";
+  }
+};
+
+template <typename CharTy>
+class RustDebugStringifier<
+    const CharTy*,
+    std::enable_if_t<
+        std::is_same_v<CharTy, char> || std::is_same_v<CharTy, wchar_t> ||
+        std::is_same_v<CharTy, char16_t> || std::is_same_v<CharTy, char32_t>>> {
+ public:
+  static std::ostream& AppendToStream(std::ostream& os, RustFormatter& fmt,
+                                      const CharTy* value) {
+    return os << "\"" << value << "\"";
+  }
+};
+
+template <typename T>
+class RustDebugStringifier<std::optional<T>> {
+ public:
+  static std::ostream& AppendToStream(std::ostream& os, RustFormatter& fmt,
+                                      const std::optional<T>& value) {
+    if (value.has_value()) {
+      os << "Some(";
+      RustDebugStringifier<T>::AppendToStream(os, fmt, value.value());
+      return os << ")";
+    } else {
+      return os << "None";
+    }
+  }
+};
+
+}  // namespace internal
+
+template <typename T>
+std::string ToRustDebugString(RustFormatter& fmt, const T& value) {
+  std::stringstream ss;
+  internal::RustDebugStringifier<T>::AppendToStream(ss, fmt, value);
+  return ss.str();
+}
+
+template <typename T>
+std::string ToRustDebugString(const T& value) {
+  RustFormatter fmt;
+  return ToRustDebugString(fmt, value);
+}
+
+}  // namespace tachyon::base
+
+#endif  // TACHYON_BASE_STRINGS_RUST_STRINGIFIER_H_

--- a/tachyon/zk/base/BUILD.bazel
+++ b/tachyon/zk/base/BUILD.bazel
@@ -20,6 +20,15 @@ tachyon_cc_library(
 )
 
 tachyon_cc_library(
+    name = "field_stringifier",
+    hdrs = ["field_stringifier.h"],
+    deps = [
+        "//tachyon/base/strings:rust_stringifier",
+        "//tachyon/math/finite_fields:prime_field_base",
+    ],
+)
+
+tachyon_cc_library(
     name = "halo2_prover",
     hdrs = ["halo2_prover.h"],
     deps = [

--- a/tachyon/zk/base/BUILD.bazel
+++ b/tachyon/zk/base/BUILD.bazel
@@ -64,6 +64,15 @@ tachyon_cc_library(
 )
 
 tachyon_cc_library(
+    name = "point_stringifier",
+    hdrs = ["point_stringifier.h"],
+    deps = [
+        ":field_stringifier",
+        "//tachyon/math/elliptic_curves:points",
+    ],
+)
+
+tachyon_cc_library(
     name = "prover",
     hdrs = ["prover.h"],
     deps = [

--- a/tachyon/zk/base/field_stringifier.h
+++ b/tachyon/zk/base/field_stringifier.h
@@ -1,0 +1,30 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
+#ifndef TACHYON_ZK_BASE_FIELD_STRINGIFIER_H_
+#define TACHYON_ZK_BASE_FIELD_STRINGIFIER_H_
+
+#include <ostream>
+#include <type_traits>
+
+#include "tachyon/base/strings/rust_stringifier.h"
+#include "tachyon/math/finite_fields/prime_field_base.h"
+
+namespace tachyon::base::internal {
+
+template <typename T>
+class RustDebugStringifier<
+    T, std::enable_if_t<std::is_base_of_v<math::PrimeFieldBase<T>, T>>> {
+ public:
+  static std::ostream& AppendToStream(std::ostream& os, RustFormatter& fmt,
+                                      const T& value) {
+    return os << value.ToHexString();
+  }
+};
+
+}  // namespace tachyon::base::internal
+
+#endif  // TACHYON_ZK_BASE_FIELD_STRINGIFIER_H_

--- a/tachyon/zk/base/point_stringifier.h
+++ b/tachyon/zk/base/point_stringifier.h
@@ -1,0 +1,29 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
+#ifndef TACHYON_ZK_BASE_POINT_STRINGIFIER_H_
+#define TACHYON_ZK_BASE_POINT_STRINGIFIER_H_
+
+#include <ostream>
+
+#include "tachyon/base/strings/rust_stringifier.h"
+#include "tachyon/math/elliptic_curves/affine_point.h"
+#include "tachyon/zk/base/field_stringifier.h"
+
+namespace tachyon::base::internal {
+
+template <typename Curve>
+class RustDebugStringifier<math::AffinePoint<Curve>> {
+ public:
+  static std::ostream& AppendToStream(std::ostream& os, RustFormatter& fmt,
+                                      const math::AffinePoint<Curve>& value) {
+    return os << fmt.DebugTuple("").Field(value.x()).Field(value.y()).Finish();
+  }
+};
+
+}  // namespace tachyon::base::internal
+
+#endif  // TACHYON_ZK_BASE_POINT_STRINGIFIER_H_

--- a/tachyon/zk/plonk/circuit/BUILD.bazel
+++ b/tachyon/zk/plonk/circuit/BUILD.bazel
@@ -84,10 +84,28 @@ tachyon_cc_library(
 )
 
 tachyon_cc_library(
+    name = "column_stringifier",
+    hdrs = ["column_stringifier.h"],
+    deps = [
+        ":column",
+        ":column_type_stringifier",
+    ],
+)
+
+tachyon_cc_library(
     name = "column_type",
     srcs = ["column_type.cc"],
     hdrs = ["column_type.h"],
     deps = ["//tachyon/base:logging"],
+)
+
+tachyon_cc_library(
+    name = "column_type_stringifier",
+    hdrs = ["column_type_stringifier.h"],
+    deps = [
+        ":column_type",
+        "//tachyon/base/strings:rust_stringifier",
+    ],
 )
 
 tachyon_cc_library(
@@ -159,6 +177,16 @@ tachyon_cc_library(
     deps = [
         ":column",
         ":rotation",
+    ],
+)
+
+tachyon_cc_library(
+    name = "query_stringifier",
+    hdrs = ["query_stringifier.h"],
+    deps = [
+        ":column_stringifier",
+        ":query",
+        ":rotation_stringifier",
     ],
 )
 

--- a/tachyon/zk/plonk/circuit/BUILD.bazel
+++ b/tachyon/zk/plonk/circuit/BUILD.bazel
@@ -58,6 +58,15 @@ tachyon_cc_library(
 )
 
 tachyon_cc_library(
+    name = "challenge_stringifier",
+    hdrs = ["challenge_stringifier.h"],
+    deps = [
+        ":challenge",
+        ":phase_stringifier",
+    ],
+)
+
+tachyon_cc_library(
     name = "circuit",
     hdrs = ["circuit.h"],
     deps = [":layouter"],
@@ -136,6 +145,15 @@ tachyon_cc_library(
 )
 
 tachyon_cc_library(
+    name = "phase_stringifier",
+    hdrs = ["phase_stringifier.h"],
+    deps = [
+        ":phase",
+        "//tachyon/base/strings:rust_stringifier",
+    ],
+)
+
+tachyon_cc_library(
     name = "query",
     hdrs = ["query.h"],
     deps = [
@@ -183,6 +201,15 @@ tachyon_cc_library(
         "//tachyon/base:logging",
         "//tachyon/base/strings:string_number_conversions",
         "//tachyon/math/polynomials/univariate:univariate_evaluation_domain",
+    ],
+)
+
+tachyon_cc_library(
+    name = "rotation_stringifier",
+    hdrs = ["rotation_stringifier.h"],
+    deps = [
+        ":rotation",
+        "//tachyon/base/strings:rust_stringifier",
     ],
 )
 

--- a/tachyon/zk/plonk/circuit/challenge_stringifier.h
+++ b/tachyon/zk/plonk/circuit/challenge_stringifier.h
@@ -1,0 +1,31 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
+#ifndef TACHYON_ZK_PLONK_CIRCUIT_CHALLENGE_STRINGIFIER_H_
+#define TACHYON_ZK_PLONK_CIRCUIT_CHALLENGE_STRINGIFIER_H_
+
+#include <ostream>
+
+#include "tachyon/base/strings/rust_stringifier.h"
+#include "tachyon/zk/plonk/circuit/challenge.h"
+
+namespace tachyon::base::internal {
+
+template <>
+class RustDebugStringifier<zk::Challenge> {
+ public:
+  static std::ostream& AppendToStream(std::ostream& os, RustFormatter& fmt,
+                                      const zk::Challenge& challenge) {
+    return os << fmt.DebugStruct("Challenge")
+                     .Field("index", challenge.index())
+                     .Field("phase", challenge.phase())
+                     .Finish();
+  }
+};
+
+}  // namespace tachyon::base::internal
+
+#endif  // TACHYON_ZK_PLONK_CIRCUIT_CHALLENGE_STRINGIFIER_H_

--- a/tachyon/zk/plonk/circuit/column_stringifier.h
+++ b/tachyon/zk/plonk/circuit/column_stringifier.h
@@ -1,0 +1,34 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
+#ifndef TACHYON_ZK_PLONK_CIRCUIT_COLUMN_STRINGIFIER_H_
+#define TACHYON_ZK_PLONK_CIRCUIT_COLUMN_STRINGIFIER_H_
+
+#include <ostream>
+
+#include "tachyon/base/strings/rust_stringifier.h"
+#include "tachyon/zk/plonk/circuit/column.h"
+#include "tachyon/zk/plonk/circuit/column_type_stringifier.h"
+
+namespace tachyon::base::internal {
+
+template <zk::ColumnType C>
+class RustDebugStringifier<zk::Column<C>> {
+ public:
+  static std::ostream& AppendToStream(std::ostream& os, RustFormatter& fmt,
+                                      const zk::Column<C>& column) {
+    // NOTE(chokobole): See
+    // https://github.com/kroma-network/halo2/blob/7d0a36990452c8e7ebd600de258420781a9b7917/halo2_proofs/src/plonk/circuit.rs#L26-L31.
+    return os << fmt.DebugStruct("Column")
+                     .Field("index", column.index())
+                     .Field("column_type", column.type())
+                     .Finish();
+  }
+};
+
+}  // namespace tachyon::base::internal
+
+#endif  // TACHYON_ZK_PLONK_CIRCUIT_COLUMN_STRINGIFIER_H_

--- a/tachyon/zk/plonk/circuit/column_type_stringifier.h
+++ b/tachyon/zk/plonk/circuit/column_type_stringifier.h
@@ -1,0 +1,28 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
+#ifndef TACHYON_ZK_PLONK_CIRCUIT_COLUMN_TYPE_STRINGIFIER_H_
+#define TACHYON_ZK_PLONK_CIRCUIT_COLUMN_TYPE_STRINGIFIER_H_
+
+#include <ostream>
+
+#include "tachyon/base/strings/rust_stringifier.h"
+#include "tachyon/zk/plonk/circuit/column_type.h"
+
+namespace tachyon::base::internal {
+
+template <>
+class RustDebugStringifier<zk::ColumnType> {
+ public:
+  static std::ostream& AppendToStream(std::ostream& os, RustFormatter& fmt,
+                                      zk::ColumnType type) {
+    return os << zk::ColumnTypeToString(type);
+  }
+};
+
+}  // namespace tachyon::base::internal
+
+#endif  // TACHYON_ZK_PLONK_CIRCUIT_COLUMN_TYPE_STRINGIFIER_H_

--- a/tachyon/zk/plonk/circuit/expressions/BUILD.bazel
+++ b/tachyon/zk/plonk/circuit/expressions/BUILD.bazel
@@ -69,6 +69,27 @@ tachyon_cc_library(
 )
 
 tachyon_cc_library(
+    name = "expression_stringifier",
+    hdrs = ["expression_stringifier.h"],
+    deps = [
+        ":advice_expression",
+        ":challenge_expression",
+        ":constant_expression",
+        ":fixed_expression",
+        ":instance_expression",
+        ":negated_expression",
+        ":product_expression",
+        ":scaled_expression",
+        ":selector_expression",
+        ":sum_expression",
+        "//tachyon/zk/base:field_stringifier",
+        "//tachyon/zk/plonk/circuit:challenge_stringifier",
+        "//tachyon/zk/plonk/circuit:phase_stringifier",
+        "//tachyon/zk/plonk/circuit:rotation_stringifier",
+    ],
+)
+
+tachyon_cc_library(
     name = "expression_type",
     srcs = ["expression_type.cc"],
     hdrs = ["expression_type.h"],

--- a/tachyon/zk/plonk/circuit/expressions/expression_stringifier.h
+++ b/tachyon/zk/plonk/circuit/expressions/expression_stringifier.h
@@ -1,0 +1,122 @@
+#ifndef TACHYON_ZK_PLONK_CIRCUIT_EXPRESSIONS_EXPRESSION_STRINGIFIER_H_
+#define TACHYON_ZK_PLONK_CIRCUIT_EXPRESSIONS_EXPRESSION_STRINGIFIER_H_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "tachyon/base/logging.h"
+#include "tachyon/base/strings/rust_stringifier.h"
+#include "tachyon/zk/base/field_stringifier.h"
+#include "tachyon/zk/plonk/circuit/challenge_stringifier.h"
+#include "tachyon/zk/plonk/circuit/expressions/advice_expression.h"
+#include "tachyon/zk/plonk/circuit/expressions/challenge_expression.h"
+#include "tachyon/zk/plonk/circuit/expressions/constant_expression.h"
+#include "tachyon/zk/plonk/circuit/expressions/fixed_expression.h"
+#include "tachyon/zk/plonk/circuit/expressions/instance_expression.h"
+#include "tachyon/zk/plonk/circuit/expressions/negated_expression.h"
+#include "tachyon/zk/plonk/circuit/expressions/product_expression.h"
+#include "tachyon/zk/plonk/circuit/expressions/scaled_expression.h"
+#include "tachyon/zk/plonk/circuit/expressions/selector_expression.h"
+#include "tachyon/zk/plonk/circuit/expressions/sum_expression.h"
+#include "tachyon/zk/plonk/circuit/phase_stringifier.h"
+#include "tachyon/zk/plonk/circuit/rotation_stringifier.h"
+
+namespace tachyon::base::internal {
+
+template <typename F>
+class RustDebugStringifier<zk::Expression<F>> {
+ public:
+  static std::ostream& AppendToStream(std::ostream& os, RustFormatter& fmt,
+                                      const zk::Expression<F>& expression) {
+    switch (expression.type()) {
+      case zk::ExpressionType::kConstant: {
+        return os << fmt.DebugTuple("Constant")
+                         .Field(expression.ToConstant()->value())
+                         .Finish();
+      }
+      case zk::ExpressionType::kSelector: {
+        const zk::Selector& selector = expression.ToSelector()->selector();
+        return os
+               << fmt.DebugTuple("Selector").Field(selector.index()).Finish();
+      }
+      case zk::ExpressionType::kFixed: {
+        const zk::FixedQuery& query = expression.ToFixed()->query();
+        return os << fmt.DebugStruct("Fixed")
+                         .Field("query_index", query.index())
+                         .Field("column_index", query.column().index())
+                         .Field("rotation", query.rotation())
+                         .Finish();
+      }
+      case zk::ExpressionType::kAdvice: {
+        const zk::AdviceQuery& query = expression.ToAdvice()->query();
+        base::internal::DebugStruct debug_struct = fmt.DebugStruct("Advice");
+        debug_struct.Field("query_index", query.index())
+            .Field("column_index", query.column().index())
+            .Field("rotation", query.rotation());
+        if (query.column().phase() != zk::kFirstPhase) {
+          debug_struct.Field("phase", query.column().phase());
+        }
+        return os << debug_struct.Finish();
+      }
+      case zk::ExpressionType::kInstance: {
+        const zk::InstanceQuery& query = expression.ToInstance()->query();
+        return os << fmt.DebugStruct("Instance")
+                         .Field("query_index", query.index())
+                         .Field("column_index", query.column().index())
+                         .Field("rotation", query.rotation())
+                         .Finish();
+      }
+      case zk::ExpressionType::kChallenge: {
+        const zk::Challenge& challenge = expression.ToChallenge()->challenge();
+        return os << fmt.DebugTuple("Challenge").Field(challenge).Finish();
+      }
+      case zk::ExpressionType::kNegated: {
+        return os << fmt.DebugTuple("Negated")
+                         .Field(*expression.ToNegated()->expr())
+                         .Finish();
+      }
+      case zk::ExpressionType::kSum: {
+        const zk::SumExpression<F>* sum = expression.ToSum();
+        return os << fmt.DebugTuple("Sum")
+                         .Field(*sum->left())
+                         .Field(*sum->right())
+                         .Finish();
+      }
+      case zk::ExpressionType::kProduct: {
+        const zk::ProductExpression<F>* product = expression.ToProduct();
+        return os << fmt.DebugTuple("Product")
+                         .Field(*product->left())
+                         .Field(*product->right())
+                         .Finish();
+      }
+      case zk::ExpressionType::kScaled: {
+        const zk::ScaledExpression<F>* scaled = expression.ToScaled();
+        return os << fmt.DebugTuple("Scaled")
+                         .Field(*scaled->expr())
+                         .Field(scaled->scale())
+                         .Finish();
+      }
+    }
+    NOTREACHED();
+    return os;
+  }
+};
+
+template <typename F>
+class RustDebugStringifier<std::vector<std::unique_ptr<zk::Expression<F>>>> {
+ public:
+  static std::ostream& AppendToStream(
+      std::ostream& os, RustFormatter& fmt,
+      const std::vector<std::unique_ptr<zk::Expression<F>>>& expressions) {
+    base::internal::DebugList list = fmt.DebugList();
+    for (const std::unique_ptr<zk::Expression<F>>& expression : expressions) {
+      list.Entry(*expression);
+    }
+    return os << list.Finish();
+  }
+};
+
+}  // namespace tachyon::base::internal
+
+#endif  // TACHYON_ZK_PLONK_CIRCUIT_EXPRESSIONS_EXPRESSION_STRINGIFIER_H_

--- a/tachyon/zk/plonk/circuit/phase_stringifier.h
+++ b/tachyon/zk/plonk/circuit/phase_stringifier.h
@@ -1,0 +1,28 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
+#ifndef TACHYON_ZK_PLONK_CIRCUIT_PHASE_STRINGIFIER_H_
+#define TACHYON_ZK_PLONK_CIRCUIT_PHASE_STRINGIFIER_H_
+
+#include <ostream>
+
+#include "tachyon/base/strings/rust_stringifier.h"
+#include "tachyon/zk/plonk/circuit/phase.h"
+
+namespace tachyon::base::internal {
+
+template <>
+class RustDebugStringifier<zk::Phase> {
+ public:
+  static std::ostream& AppendToStream(std::ostream& os, RustFormatter& fmt,
+                                      zk::Phase phase) {
+    return os << fmt.DebugTuple("Phase").Field(int{phase.value()}).Finish();
+  }
+};
+
+}  // namespace tachyon::base::internal
+
+#endif  // TACHYON_ZK_PLONK_CIRCUIT_PHASE_STRINGIFIER_H_

--- a/tachyon/zk/plonk/circuit/query_stringifier.h
+++ b/tachyon/zk/plonk/circuit/query_stringifier.h
@@ -1,0 +1,35 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
+#ifndef TACHYON_ZK_PLONK_CIRCUIT_QUERY_STRINGIFIER_H_
+#define TACHYON_ZK_PLONK_CIRCUIT_QUERY_STRINGIFIER_H_
+
+#include <ostream>
+
+#include "tachyon/base/strings/rust_stringifier.h"
+#include "tachyon/zk/plonk/circuit/column_stringifier.h"
+#include "tachyon/zk/plonk/circuit/query.h"
+#include "tachyon/zk/plonk/circuit/rotation_stringifier.h"
+
+namespace tachyon::base::internal {
+
+template <zk::ColumnType C>
+class RustDebugStringifier<zk::QueryData<C>> {
+ public:
+  static std::ostream& AppendToStream(std::ostream& os, RustFormatter& fmt,
+                                      const zk::QueryData<C>& query) {
+    // NOTE(chokobole): See
+    // https://github.com/kroma-network/halo2/blob/7d0a36990452c8e7ebd600de258420781a9b7917/halo2_proofs/src/plonk/circuit.rs#L1382.
+    return os << fmt.DebugTuple("")
+                     .Field(query.column())
+                     .Field(query.rotation())
+                     .Finish();
+  }
+};
+
+}  // namespace tachyon::base::internal
+
+#endif  // TACHYON_ZK_PLONK_CIRCUIT_QUERY_STRINGIFIER_H_

--- a/tachyon/zk/plonk/circuit/rotation_stringifier.h
+++ b/tachyon/zk/plonk/circuit/rotation_stringifier.h
@@ -1,0 +1,28 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
+#ifndef TACHYON_ZK_PLONK_CIRCUIT_ROTATION_STRINGIFIER_H_
+#define TACHYON_ZK_PLONK_CIRCUIT_ROTATION_STRINGIFIER_H_
+
+#include <ostream>
+
+#include "tachyon/base/strings/rust_stringifier.h"
+#include "tachyon/zk/plonk/circuit/rotation.h"
+
+namespace tachyon::base::internal {
+
+template <>
+class RustDebugStringifier<zk::Rotation> {
+ public:
+  static std::ostream& AppendToStream(std::ostream& os, RustFormatter& fmt,
+                                      zk::Rotation rotation) {
+    return os << fmt.DebugTuple("Rotation").Field(rotation.value()).Finish();
+  }
+};
+
+}  // namespace tachyon::base::internal
+
+#endif  // TACHYON_ZK_PLONK_CIRCUIT_ROTATION_STRINGIFIER_H_

--- a/tachyon/zk/plonk/keys/BUILD.bazel
+++ b/tachyon/zk/plonk/keys/BUILD.bazel
@@ -31,8 +31,6 @@ tachyon_cc_unittest(
     ],
     deps = [
         ":proving_key",
-        "//tachyon/crypto/commitments/kzg:kzg_commitment_scheme",
-        "//tachyon/math/elliptic_curves/bn/bn254:g1",
-        "//tachyon/math/elliptic_curves/bn/bn254:g2",
+        "//tachyon/zk/base:halo2_prover_test",
     ],
 )

--- a/tachyon/zk/plonk/keys/BUILD.bazel
+++ b/tachyon/zk/plonk/keys/BUILD.bazel
@@ -16,10 +16,12 @@ tachyon_cc_library(
     name = "verifying_key",
     hdrs = ["verifying_key.h"],
     deps = [
+        "//tachyon/base/strings:rust_stringifier",
         "//tachyon/math/polynomials/univariate:univariate_evaluation_domain_factory",
         "//tachyon/zk/plonk:constraint_system",
         "//tachyon/zk/plonk/circuit:assembly",
         "//tachyon/zk/plonk/permutation:permutation_verifying_key",
+        "@com_google_boringssl//:crypto",
     ],
 )
 
@@ -32,5 +34,6 @@ tachyon_cc_unittest(
     deps = [
         ":proving_key",
         "//tachyon/zk/base:halo2_prover_test",
+        "//tachyon/zk/plonk/keys/halo2:pinned_verifying_key",
     ],
 )

--- a/tachyon/zk/plonk/keys/halo2/BUILD.bazel
+++ b/tachyon/zk/plonk/keys/halo2/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//bazel:tachyon_cc.bzl", "tachyon_cc_library")
+load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_unittest")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -28,4 +28,24 @@ tachyon_cc_library(
     name = "pinned_gates",
     hdrs = ["pinned_gates.h"],
     deps = ["//tachyon/base/strings:rust_stringifier"],
+)
+
+tachyon_cc_library(
+    name = "pinned_verifying_key",
+    hdrs = ["pinned_verifying_key.h"],
+    deps = [
+        ":pinned_constraint_system",
+        ":pinned_evaluation_domain",
+        "//tachyon/zk/plonk/keys:verifying_key",
+        "//tachyon/zk/plonk/permutation:permutation_verifying_key_stringifier",
+    ],
+)
+
+tachyon_cc_unittest(
+    name = "halo2_unittests",
+    srcs = ["pinned_verifying_key_unittest.cc"],
+    deps = [
+        ":pinned_verifying_key",
+        "//tachyon/zk/base:halo2_prover_test",
+    ],
 )

--- a/tachyon/zk/plonk/keys/halo2/BUILD.bazel
+++ b/tachyon/zk/plonk/keys/halo2/BUILD.bazel
@@ -3,6 +3,19 @@ load("//bazel:tachyon_cc.bzl", "tachyon_cc_library")
 package(default_visibility = ["//visibility:public"])
 
 tachyon_cc_library(
+    name = "pinned_constraint_system",
+    hdrs = ["pinned_constraint_system.h"],
+    deps = [
+        ":pinned_gates",
+        "//tachyon/zk/plonk:constraint_system",
+        "//tachyon/zk/plonk/circuit:phase_stringifier",
+        "//tachyon/zk/plonk/circuit:query_stringifier",
+        "//tachyon/zk/plonk/lookup:lookup_argument_stringifier",
+        "//tachyon/zk/plonk/permutation:permutation_argument_stringifier",
+    ],
+)
+
+tachyon_cc_library(
     name = "pinned_evaluation_domain",
     hdrs = ["pinned_evaluation_domain.h"],
     deps = [

--- a/tachyon/zk/plonk/keys/halo2/BUILD.bazel
+++ b/tachyon/zk/plonk/keys/halo2/BUILD.bazel
@@ -1,0 +1,12 @@
+load("//bazel:tachyon_cc.bzl", "tachyon_cc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+tachyon_cc_library(
+    name = "pinned_evaluation_domain",
+    hdrs = ["pinned_evaluation_domain.h"],
+    deps = [
+        "//tachyon/base/strings:rust_stringifier",
+        "//tachyon/zk/base:field_stringifier",
+    ],
+)

--- a/tachyon/zk/plonk/keys/halo2/BUILD.bazel
+++ b/tachyon/zk/plonk/keys/halo2/BUILD.bazel
@@ -10,3 +10,9 @@ tachyon_cc_library(
         "//tachyon/zk/base:field_stringifier",
     ],
 )
+
+tachyon_cc_library(
+    name = "pinned_gates",
+    hdrs = ["pinned_gates.h"],
+    deps = ["//tachyon/base/strings:rust_stringifier"],
+)

--- a/tachyon/zk/plonk/keys/halo2/pinned_constraint_system.h
+++ b/tachyon/zk/plonk/keys/halo2/pinned_constraint_system.h
@@ -1,0 +1,127 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
+#ifndef TACHYON_ZK_PLONK_KEYS_HALO2_PINNED_CONSTRAINT_SYSTEM_H_
+#define TACHYON_ZK_PLONK_KEYS_HALO2_PINNED_CONSTRAINT_SYSTEM_H_
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "tachyon/zk/plonk/circuit/phase_stringifier.h"
+#include "tachyon/zk/plonk/circuit/query_stringifier.h"
+#include "tachyon/zk/plonk/constraint_system.h"
+#include "tachyon/zk/plonk/keys/halo2/pinned_gates.h"
+#include "tachyon/zk/plonk/lookup/lookup_argument_stringifier.h"
+#include "tachyon/zk/plonk/permutation/permutation_argument_stringifier.h"
+
+namespace tachyon {
+namespace zk::halo2 {
+
+template <typename F>
+class PinnedConstraintSystem {
+ public:
+  explicit PinnedConstraintSystem(const ConstraintSystem<F>& constraint_system)
+      : num_fixed_columns_(constraint_system.num_fixed_columns()),
+        num_advice_columns_(constraint_system.num_advice_columns()),
+        num_instance_columns_(constraint_system.num_instance_columns()),
+        num_selectors_(constraint_system.num_selectors()),
+        num_challenges_(constraint_system.num_challenges()),
+        advice_column_phases_(constraint_system.advice_column_phases()),
+        challenge_phases_(constraint_system.challenge_phases()),
+        gates_(constraint_system.gates()),
+        advice_queries_(constraint_system.advice_queries()),
+        instance_queries_(constraint_system.instance_queries()),
+        fixed_queries_(constraint_system.fixed_queries()),
+        permutation_(constraint_system.permutation()),
+        lookups_(constraint_system.lookups()),
+        constants_(constraint_system.constants()),
+        minimum_degree_(constraint_system.minimum_degree()) {}
+
+  size_t num_fixed_columns() const { return num_fixed_columns_; }
+  size_t num_advice_columns() const { return num_advice_columns_; }
+  size_t num_instance_columns() const { return num_instance_columns_; }
+  size_t num_selectors() const { return num_selectors_; }
+  size_t num_challenges() const { return num_challenges_; }
+  const std::vector<Phase>& advice_column_phases() const {
+    return advice_column_phases_;
+  }
+  const std::vector<Phase>& challenge_phases() const {
+    return challenge_phases_;
+  }
+  const PinnedGates<F>& gates() const { return gates_; }
+  const std::vector<AdviceQueryData>& advice_queries() const {
+    return advice_queries_;
+  }
+  const std::vector<InstanceQueryData>& instance_queries() const {
+    return instance_queries_;
+  }
+  const std::vector<FixedQueryData>& fixed_queries() const {
+    return fixed_queries_;
+  }
+  const PermutationArgument& permutation() const { return permutation_; }
+  const std::vector<LookupArgument<F>>& lookups() const { return lookups_; }
+  const std::vector<FixedColumn>& constants() const { return constants_; }
+  const std::optional<size_t>& minimum_degree() const {
+    return minimum_degree_;
+  }
+
+ private:
+  size_t num_fixed_columns_;
+  size_t num_advice_columns_;
+  size_t num_instance_columns_;
+  size_t num_selectors_;
+  size_t num_challenges_;
+  const std::vector<Phase>& advice_column_phases_;
+  const std::vector<Phase>& challenge_phases_;
+  PinnedGates<F> gates_;
+  const std::vector<AdviceQueryData>& advice_queries_;
+  const std::vector<InstanceQueryData>& instance_queries_;
+  const std::vector<FixedQueryData>& fixed_queries_;
+  PermutationArgument permutation_;
+  const std::vector<LookupArgument<F>>& lookups_;
+  const std::vector<FixedColumn>& constants_;
+  const std::optional<size_t>& minimum_degree_;
+};
+
+}  // namespace zk::halo2
+
+namespace base::internal {
+
+template <typename F>
+class RustDebugStringifier<zk::halo2::PinnedConstraintSystem<F>> {
+ public:
+  static std::ostream& AppendToStream(
+      std::ostream& os, RustFormatter& fmt,
+      const zk::halo2::PinnedConstraintSystem<F>& constraint_system) {
+    DebugStruct debug_struct = fmt.DebugStruct("PinnedConstraintSystem");
+    debug_struct
+        .Field("num_fixed_columns", constraint_system.num_fixed_columns())
+        .Field("num_advice_columns", constraint_system.num_advice_columns())
+        .Field("num_instance_columns", constraint_system.num_instance_columns())
+        .Field("num_selectors", constraint_system.num_selectors());
+    if (constraint_system.num_challenges() > 0) {
+      debug_struct.Field("num_challenges", constraint_system.num_challenges())
+          .Field("advice_column_phases",
+                 constraint_system.advice_column_phases())
+          .Field("challenge_phases", constraint_system.challenge_phases());
+    }
+    debug_struct.Field("gates", constraint_system.gates())
+        .Field("advice_queries", constraint_system.advice_queries())
+        .Field("instance_queries", constraint_system.instance_queries())
+        .Field("fixed_queries", constraint_system.fixed_queries())
+        .Field("permutation", constraint_system.permutation())
+        .Field("lookups", constraint_system.lookups())
+        .Field("constants", constraint_system.constants())
+        .Field("minimum_degree", constraint_system.minimum_degree());
+    return os << debug_struct.Finish();
+  }
+};
+
+}  // namespace base::internal
+}  // namespace tachyon
+
+#endif  // TACHYON_ZK_PLONK_KEYS_HALO2_PINNED_CONSTRAINT_SYSTEM_H_

--- a/tachyon/zk/plonk/keys/halo2/pinned_evaluation_domain.h
+++ b/tachyon/zk/plonk/keys/halo2/pinned_evaluation_domain.h
@@ -1,0 +1,61 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
+#ifndef TACHYON_ZK_PLONK_KEYS_HALO2_PINNED_EVALUATION_DOMAIN_H_
+#define TACHYON_ZK_PLONK_KEYS_HALO2_PINNED_EVALUATION_DOMAIN_H_
+
+#include <stdint.h>
+
+#include <string>
+#include <utility>
+
+#include "tachyon/base/strings/rust_stringifier.h"
+#include "tachyon/zk/base/field_stringifier.h"
+
+namespace tachyon {
+namespace zk::halo2 {
+
+template <typename F>
+class PinnedEvaluationDomain {
+ public:
+  PinnedEvaluationDomain() = default;
+  PinnedEvaluationDomain(uint32_t k, uint32_t extended_k, const F& omega)
+      : k_(k), extended_k_(extended_k), omega_(omega) {}
+  PinnedEvaluationDomain(uint32_t k, uint32_t extended_k, F&& omega)
+      : k_(k), extended_k_(extended_k), omega_(std::move(omega)) {}
+
+  uint32_t k() const { return k_; }
+  uint32_t extended_k() const { return extended_k_; }
+  const F& omega() const { return omega_; }
+
+ private:
+  uint32_t k_ = 0;
+  uint32_t extended_k_ = 0;
+  F omega_;
+};
+
+}  // namespace zk::halo2
+
+namespace base::internal {
+
+template <typename F>
+class RustDebugStringifier<zk::halo2::PinnedEvaluationDomain<F>> {
+ public:
+  static std::ostream& AppendToStream(
+      std::ostream& os, RustFormatter& fmt,
+      const zk::halo2::PinnedEvaluationDomain<F>& value) {
+    return os << fmt.DebugStruct("PinnedEvaluationDomain")
+                     .Field("k", value.k())
+                     .Field("extended_k", value.extended_k())
+                     .Field("omega", value.omega())
+                     .Finish();
+  }
+};
+
+}  // namespace base::internal
+}  // namespace tachyon
+
+#endif  // TACHYON_ZK_PLONK_KEYS_HALO2_PINNED_EVALUATION_DOMAIN_H_

--- a/tachyon/zk/plonk/keys/halo2/pinned_gates.h
+++ b/tachyon/zk/plonk/keys/halo2/pinned_gates.h
@@ -1,0 +1,56 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
+#ifndef TACHYON_ZK_PLONK_KEYS_HALO2_PINNED_GATES_H_
+#define TACHYON_ZK_PLONK_KEYS_HALO2_PINNED_GATES_H_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "tachyon/zk/plonk/circuit/expressions/expression_stringifier.h"
+#include "tachyon/zk/plonk/circuit/gate.h"
+
+namespace tachyon {
+namespace zk::halo2 {
+
+template <typename F>
+class PinnedGates {
+ public:
+  explicit PinnedGates(const std::vector<Gate<F>>& gates) : gates_(gates) {}
+
+  const std::vector<Gate<F>>& gates() const { return gates_; }
+
+ private:
+  const std::vector<Gate<F>>& gates_;
+};
+
+}  // namespace zk::halo2
+
+namespace base::internal {
+
+template <typename F>
+class RustDebugStringifier<zk::halo2::PinnedGates<F>> {
+ public:
+  static std::ostream& AppendToStream(
+      std::ostream& os, RustFormatter& fmt,
+      const zk::halo2::PinnedGates<F>& pinned_gates) {
+    DebugList list = fmt.DebugList();
+    for (const zk::Gate<F>& gate : pinned_gates.gates()) {
+      const std::vector<std::unique_ptr<zk::Expression<F>>>& polys =
+          gate.polys();
+      for (const std::unique_ptr<zk::Expression<F>>& poly : polys) {
+        list.Entry(*poly);
+      }
+    }
+    return os << list.Finish();
+  }
+};
+
+}  // namespace base::internal
+}  // namespace tachyon
+
+#endif  // TACHYON_ZK_PLONK_KEYS_HALO2_PINNED_GATES_H_

--- a/tachyon/zk/plonk/keys/halo2/pinned_verifying_key.h
+++ b/tachyon/zk/plonk/keys/halo2/pinned_verifying_key.h
@@ -1,0 +1,89 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
+#ifndef TACHYON_ZK_PLONK_KEYS_HALO2_PINNED_VERIFYING_KEY_H_
+#define TACHYON_ZK_PLONK_KEYS_HALO2_PINNED_VERIFYING_KEY_H_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "tachyon/base/strings/rust_stringifier.h"
+#include "tachyon/zk/plonk/keys/halo2/pinned_constraint_system.h"
+#include "tachyon/zk/plonk/keys/halo2/pinned_evaluation_domain.h"
+#include "tachyon/zk/plonk/keys/verifying_key.h"
+#include "tachyon/zk/plonk/permutation/permutation_verifying_key_stringifier.h"
+
+namespace tachyon {
+namespace zk::halo2 {
+
+template <typename PCSTy>
+class PinnedVerifyingKey {
+ public:
+  using F = typename PCSTy::Field;
+  using Commitment = typename PCSTy::Commitment;
+  using BaseField = typename Commitment::BaseField;
+  using ScalarField = typename Commitment::ScalarField;
+
+  explicit PinnedVerifyingKey(const VerifyingKey<PCSTy>& vk)
+      : base_modulus_(BaseField::Config::kModulus.ToHexString()),
+        scalar_modulus_(ScalarField::Config::kModulus.ToHexString()),
+        // TODO(chokobole): initialize |domain_|.
+        constraint_system_(vk.constraint_system()),
+        fixed_commitments_(vk.fixed_commitments()),
+        permutation_verifying_key_(vk.permutation_verifying_key()) {}
+
+  const std::string& base_modulus() const { return base_modulus_; }
+  const std::string& scalar_modulus() const { return scalar_modulus_; }
+  const PinnedEvaluationDomain<F>& domain() const { return domain_; }
+  const PinnedConstraintSystem<F>& constraint_system() const {
+    return constraint_system_;
+  }
+  const std::vector<Commitment>& fixed_commitments() const {
+    return fixed_commitments_;
+  }
+  const PermutationVerifyingKey<PCSTy>& permutation_verifying_key() const {
+    return permutation_verifying_key_;
+  }
+
+ private:
+  std::string base_modulus_;
+  std::string scalar_modulus_;
+  PinnedEvaluationDomain<F> domain_;
+  PinnedConstraintSystem<F> constraint_system_;
+  const std::vector<Commitment>& fixed_commitments_;
+  const PermutationVerifyingKey<PCSTy>& permutation_verifying_key_;
+};
+
+}  // namespace zk::halo2
+
+namespace base::internal {
+
+template <typename PCSTy>
+class RustDebugStringifier<zk::halo2::PinnedVerifyingKey<PCSTy>> {
+ public:
+  static std::ostream& AppendToStream(
+      std::ostream& os, RustFormatter& fmt,
+      const zk::halo2::PinnedVerifyingKey<PCSTy>& pinned_vk) {
+    // NOTE(chokobole): Original name is PinnedVerificationKey not
+    // PinnedVerifyingKey. See
+    // https://github.com/kroma-network/halo2/blob/7d0a36990452c8e7ebd600de258420781a9b7917/halo2_proofs/src/plonk.rs#L252-L263.
+    return os << fmt.DebugStruct("PinnedVerificationKey")
+                     .Field("base_modulus", pinned_vk.base_modulus())
+                     .Field("scalar_modulus", pinned_vk.scalar_modulus())
+                     .Field("domain", pinned_vk.domain())
+                     .Field("cs", pinned_vk.constraint_system())
+                     .Field("fixed_commitments", pinned_vk.fixed_commitments())
+                     .Field("permutation",
+                            pinned_vk.permutation_verifying_key())
+                     .Finish();
+  }
+};
+
+}  // namespace base::internal
+}  // namespace tachyon
+
+#endif  // TACHYON_ZK_PLONK_KEYS_HALO2_PINNED_VERIFYING_KEY_H_

--- a/tachyon/zk/plonk/keys/halo2/pinned_verifying_key_unittest.cc
+++ b/tachyon/zk/plonk/keys/halo2/pinned_verifying_key_unittest.cc
@@ -1,0 +1,23 @@
+#include "tachyon/zk/plonk/keys/halo2/pinned_verifying_key.h"
+
+#include "gtest/gtest.h"
+
+#include "tachyon/zk/base/halo2_prover_test.h"
+
+namespace tachyon::zk::halo2 {
+
+namespace {
+
+class PinnedVerifyingKeyTest : public Halo2ProverTest {};
+
+}  // namespace
+
+TEST_F(PinnedVerifyingKeyTest, ToRustDebugString) {
+  // TODO(chokobole): Enable this test once every feature is implemented.
+  // This just tests whether compilation is working or not.
+  VerifyingKey<PCS> verifying_key;
+  PinnedVerifyingKey<PCS> pinned_verifying_key(verifying_key);
+  base::ToRustDebugString(pinned_verifying_key);
+}
+
+}  // namespace tachyon::zk::halo2

--- a/tachyon/zk/plonk/keys/proving_key.h
+++ b/tachyon/zk/plonk/keys/proving_key.h
@@ -1,3 +1,9 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
 #ifndef TACHYON_ZK_PLONK_KEYS_PROVING_KEY_H_
 #define TACHYON_ZK_PLONK_KEYS_PROVING_KEY_H_
 

--- a/tachyon/zk/plonk/keys/proving_key_unittest.cc
+++ b/tachyon/zk/plonk/keys/proving_key_unittest.cc
@@ -1,3 +1,9 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
 #include "tachyon/zk/plonk/keys/proving_key.h"
 
 #include "gtest/gtest.h"

--- a/tachyon/zk/plonk/keys/verifying_key.h
+++ b/tachyon/zk/plonk/keys/verifying_key.h
@@ -25,22 +25,19 @@ class VerifyingKey {
   using Commitments = std::vector<Commitment>;
 
   VerifyingKey() = default;
-  VerifyingKey(
-      std::unique_ptr<math::UnivariateEvaluationDomain<F, kMaxDegree>> domain,
-      Commitments fixed_commitments,
-      PermutationVerifyingKey<PCSTy> permutation_verifying_key,
-      ConstraintSystem<F> constraint_system)
-      : domain_(std::move(domain)),
+  VerifyingKey(const Domain* domain, Commitments fixed_commitments,
+               PermutationVerifyingKey<PCSTy> permutation_verifying_key,
+               ConstraintSystem<F> constraint_system)
+      : domain_(domain),
         fixed_commitments_(std::move(fixed_commitments)),
         permutation_verifying_Key_(std::move(permutation_verifying_key)),
         constraint_system_(std::move(constraint_system)) {}
 
   static VerifyingKey FromParts(
-      std::unique_ptr<math::UnivariateEvaluationDomain<F, kMaxDegree>> domain,
-      Commitments fixed_commitments,
+      const Domain* domain, Commitments fixed_commitments,
       PermutationVerifyingKey<PCSTy> permutation_verifying_key,
       ConstraintSystem<F> constraint_system) {
-    VerifyingKey ret(std::move(domain), std::move(fixed_commitments),
+    VerifyingKey ret(domain, std::move(fixed_commitments),
                      std::move(permutation_verifying_key),
                      std::move(constraint_system));
     // TODO(chokobole): Implement blake transcript.
@@ -53,9 +50,7 @@ class VerifyingKey {
   static Error Generate(const PCSTy& pcs, const CircuitTy& circuit,
                         VerifyingKey* verifying_key);
 
-  const math::UnivariateEvaluationDomain<F, kMaxDegree>* domain() const {
-    return domain_.get();
-  }
+  const Domain* domain() const { return domain_; }
 
   const Commitments& fixed_commitments() const { return fixed_commitments_; }
 
@@ -70,7 +65,8 @@ class VerifyingKey {
   const F& transcript_repr() const { return transcript_repr_; }
 
  private:
-  std::unique_ptr<Domain> domain_;
+  // not owned
+  const Domain* domain_ = nullptr;
   Commitments fixed_commitments_;
   PermutationVerifyingKey<PCSTy> permutation_verifying_Key_;
   ConstraintSystem<F> constraint_system_;

--- a/tachyon/zk/plonk/keys/verifying_key.h
+++ b/tachyon/zk/plonk/keys/verifying_key.h
@@ -1,3 +1,9 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
 #ifndef TACHYON_ZK_PLONK_KEYS_VERIFYING_KEY_H_
 #define TACHYON_ZK_PLONK_KEYS_VERIFYING_KEY_H_
 

--- a/tachyon/zk/plonk/keys/verifying_key_unittest.cc
+++ b/tachyon/zk/plonk/keys/verifying_key_unittest.cc
@@ -1,3 +1,9 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
 #include "tachyon/zk/plonk/keys/verifying_key.h"
 
 #include "gtest/gtest.h"

--- a/tachyon/zk/plonk/keys/verifying_key_unittest.cc
+++ b/tachyon/zk/plonk/keys/verifying_key_unittest.cc
@@ -3,6 +3,7 @@
 #include "gtest/gtest.h"
 
 #include "tachyon/zk/base/halo2_prover_test.h"
+#include "tachyon/zk/plonk/keys/halo2/pinned_verifying_key.h"
 
 namespace tachyon::zk {
 
@@ -11,6 +12,15 @@ namespace {
 class VerifyingKeyTest : public Halo2ProverTest {};
 
 }  // namespace
+
+// TODO(chokobole): Check verifying key hash against halo2 one.
+TEST_F(VerifyingKeyTest, SetTranscriptRepresentative) {
+  VerifyingKey<PCS> verifying_key;
+  EXPECT_EQ(verifying_key.transcript_repr(), F::Zero());
+
+  verifying_key.SetTranscriptRepresentative();
+  EXPECT_NE(verifying_key.transcript_repr(), F::Zero());
+}
 
 // TODO(chokobole): Implement test codes.
 TEST_F(VerifyingKeyTest, Generate) { VerifyingKey<PCS> verifying_key; }

--- a/tachyon/zk/plonk/keys/verifying_key_unittest.cc
+++ b/tachyon/zk/plonk/keys/verifying_key_unittest.cc
@@ -2,25 +2,13 @@
 
 #include "gtest/gtest.h"
 
-#include "tachyon/crypto/commitments/kzg/kzg_commitment_scheme.h"
-#include "tachyon/math/elliptic_curves/bn/bn254/g1.h"
-#include "tachyon/math/elliptic_curves/bn/bn254/g2.h"
+#include "tachyon/zk/base/halo2_prover_test.h"
 
 namespace tachyon::zk {
 
 namespace {
 
-class VerifyingKeyTest : public testing::Test {
- public:
-  constexpr static size_t kMaxDegree = 7;
-
-  using PCS =
-      crypto::KZGCommitmentScheme<math::bn254::G1AffinePoint,
-                                  math::bn254::G2AffinePoint, kMaxDegree,
-                                  math::bn254::G1AffinePoint>;
-
-  static void SetUpTestSuite() { math::bn254::G1Curve::Init(); }
-};
+class VerifyingKeyTest : public Halo2ProverTest {};
 
 }  // namespace
 

--- a/tachyon/zk/plonk/lookup/BUILD.bazel
+++ b/tachyon/zk/plonk/lookup/BUILD.bazel
@@ -18,6 +18,16 @@ tachyon_cc_library(
 )
 
 tachyon_cc_library(
+    name = "lookup_argument_stringifier",
+    hdrs = ["lookup_argument_stringifier.h"],
+    deps = [
+        ":lookup_argument",
+        "//tachyon/base/strings:rust_stringifier",
+        "//tachyon/zk/plonk/circuit/expressions:expression_stringifier",
+    ],
+)
+
+tachyon_cc_library(
     name = "lookup_committed",
     hdrs = ["lookup_committed.h"],
     deps = [

--- a/tachyon/zk/plonk/lookup/lookup_argument_stringifier.h
+++ b/tachyon/zk/plonk/lookup/lookup_argument_stringifier.h
@@ -1,0 +1,32 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
+#ifndef TACHYON_ZK_PLONK_LOOKUP_LOOKUP_ARGUMENT_STRINGIFIER_H_
+#define TACHYON_ZK_PLONK_LOOKUP_LOOKUP_ARGUMENT_STRINGIFIER_H_
+
+#include <ostream>
+
+#include "tachyon/base/strings/rust_stringifier.h"
+#include "tachyon/zk/plonk/circuit/expressions/expression_stringifier.h"
+#include "tachyon/zk/plonk/lookup/lookup_argument.h"
+
+namespace tachyon::base::internal {
+
+template <typename F>
+class RustDebugStringifier<zk::LookupArgument<F>> {
+ public:
+  static std::ostream& AppendToStream(std::ostream& os, RustFormatter& fmt,
+                                      const zk::LookupArgument<F>& argument) {
+    return os << fmt.DebugStruct("Argument")
+                     .Field("input_expressions", argument.input_expressions())
+                     .Field("table_expressions", argument.table_expressions())
+                     .Finish();
+  }
+};
+
+}  // namespace tachyon::base::internal
+
+#endif  // TACHYON_ZK_PLONK_LOOKUP_LOOKUP_ARGUMENT_STRINGIFIER_H_

--- a/tachyon/zk/plonk/permutation/BUILD.bazel
+++ b/tachyon/zk/plonk/permutation/BUILD.bazel
@@ -62,6 +62,16 @@ tachyon_cc_library(
 )
 
 tachyon_cc_library(
+    name = "permutation_verifying_key_stringifier",
+    hdrs = ["permutation_verifying_key_stringifier.h"],
+    deps = [
+        ":permutation_verifying_key",
+        "//tachyon/base/strings:rust_stringifier",
+        "//tachyon/zk/base:point_stringifier",
+    ],
+)
+
+tachyon_cc_library(
     name = "permutation_assembly",
     hdrs = ["permutation_assembly.h"],
     deps = [

--- a/tachyon/zk/plonk/permutation/BUILD.bazel
+++ b/tachyon/zk/plonk/permutation/BUILD.bazel
@@ -38,6 +38,16 @@ tachyon_cc_library(
 )
 
 tachyon_cc_library(
+    name = "permutation_argument_stringifier",
+    hdrs = ["permutation_argument_stringifier.h"],
+    deps = [
+        ":permutation_argument",
+        "//tachyon/base/strings:rust_stringifier",
+        "//tachyon/zk/plonk/circuit:column_stringifier",
+    ],
+)
+
+tachyon_cc_library(
     name = "permutation_proving_key",
     hdrs = ["permutation_proving_key.h"],
     deps = ["//tachyon/base/buffer:copyable"],

--- a/tachyon/zk/plonk/permutation/permutation_argument_stringifier.h
+++ b/tachyon/zk/plonk/permutation/permutation_argument_stringifier.h
@@ -1,0 +1,31 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
+#ifndef TACHYON_ZK_PLONK_PERMUTATION_PERMUTATION_ARGUMENT_STRINGIFIER_H_
+#define TACHYON_ZK_PLONK_PERMUTATION_PERMUTATION_ARGUMENT_STRINGIFIER_H_
+
+#include <ostream>
+
+#include "tachyon/base/strings/rust_stringifier.h"
+#include "tachyon/zk/plonk/circuit/column_stringifier.h"
+#include "tachyon/zk/plonk/permutation/permutation_argument.h"
+
+namespace tachyon::base::internal {
+
+template <>
+class RustDebugStringifier<zk::PermutationArgument> {
+ public:
+  static std::ostream& AppendToStream(std::ostream& os, RustFormatter& fmt,
+                                      const zk::PermutationArgument& argument) {
+    return os << fmt.DebugStruct("Argument")
+                     .Field("columns", argument.columns())
+                     .Finish();
+  }
+};
+
+}  // namespace tachyon::base::internal
+
+#endif  // TACHYON_ZK_PLONK_PERMUTATION_PERMUTATION_ARGUMENT_STRINGIFIER_H_

--- a/tachyon/zk/plonk/permutation/permutation_verifying_key_stringifier.h
+++ b/tachyon/zk/plonk/permutation/permutation_verifying_key_stringifier.h
@@ -1,0 +1,34 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
+#ifndef TACHYON_ZK_PLONK_PERMUTATION_PERMUTATION_VERIFYING_KEY_STRINGIFIER_H_
+#define TACHYON_ZK_PLONK_PERMUTATION_PERMUTATION_VERIFYING_KEY_STRINGIFIER_H_
+
+#include <ostream>
+
+#include "tachyon/base/strings/rust_stringifier.h"
+#include "tachyon/zk/base/point_stringifier.h"
+#include "tachyon/zk/plonk/permutation/permutation_verifying_key.h"
+
+namespace tachyon::base::internal {
+
+template <typename PCSTy>
+class RustDebugStringifier<zk::PermutationVerifyingKey<PCSTy>> {
+ public:
+  static std::ostream& AppendToStream(
+      std::ostream& os, RustFormatter& fmt,
+      const zk::PermutationVerifyingKey<PCSTy>& vk) {
+    // NOTE(chokobole): See
+    // https://github.com/kroma-network/halo2/blob/7d0a36990452c8e7ebd600de258420781a9b7917/halo2_proofs/src/plonk/permutation.rs#L80-L84
+    return os << fmt.DebugStruct("VerifyingKey")
+                     .Field("commitments", vk.commitments())
+                     .Finish();
+  }
+};
+
+}  // namespace tachyon::base::internal
+
+#endif  // TACHYON_ZK_PLONK_PERMUTATION_PERMUTATION_VERIFYING_KEY_STRINGIFIER_H_


### PR DESCRIPTION
This PR implements [PinnedVerifyingKey](https://github.com/kroma-network/halo2/blob/7d0a36990452c8e7ebd600de258420781a9b7917/halo2_proofs/src/plonk.rs#L256-L263). 
`PinnedVerifyingKey` can generate a string of `VerifyingKey` with only selective members.

And `transcript_repr` of the `VerifyingKey` is assigned a field element generated with a hash value of string of `PinnedVerifyingKey`.