### PR TITLE
feat: add more utilities to `Range`

### DIFF
--- a/tachyon/base/BUILD.bazel
+++ b/tachyon/base/BUILD.bazel
@@ -152,6 +152,7 @@ tachyon_cc_unittest(
         ":random",
         ":range",
         ":scoped_generic",
+        "//tachyon/base/containers:container_util",
         "//tachyon/base/containers:contains",
         "//tachyon/base/containers:cxx20_erase",
     ],

--- a/tachyon/base/random.h
+++ b/tachyon/base/random.h
@@ -16,16 +16,16 @@ template <typename T, bool IsStartInclusive, bool IsEndInclusive>
 T Uniform(const Range<T, IsStartInclusive, IsEndInclusive>& range) {
   if constexpr (IsStartInclusive && IsEndInclusive) {
     return absl::Uniform(absl::IntervalClosedClosed, GetAbslBitGen(),
-                         range.start, range.end);
+                         range.from, range.to);
   } else if constexpr (IsStartInclusive && !IsEndInclusive) {
-    return absl::Uniform(absl::IntervalClosedOpen, GetAbslBitGen(), range.start,
-                         range.end);
+    return absl::Uniform(absl::IntervalClosedOpen, GetAbslBitGen(), range.from,
+                         range.to);
   } else if constexpr (!IsStartInclusive && IsEndInclusive) {
-    return absl::Uniform(absl::IntervalOpenClosed, GetAbslBitGen(), range.start,
-                         range.end);
+    return absl::Uniform(absl::IntervalOpenClosed, GetAbslBitGen(), range.from,
+                         range.to);
   } else {
-    return absl::Uniform(absl::IntervalOpenOpen, GetAbslBitGen(), range.start,
-                         range.end);
+    return absl::Uniform(absl::IntervalOpenOpen, GetAbslBitGen(), range.from,
+                         range.to);
   }
 }
 

--- a/tachyon/base/range.h
+++ b/tachyon/base/range.h
@@ -1,6 +1,7 @@
 #ifndef TACHYON_BASE_RANGE_H_
 #define TACHYON_BASE_RANGE_H_
 
+#include <algorithm>
 #include <limits>
 #include <string>
 #include <type_traits>
@@ -19,64 +20,189 @@ struct Range<T, IsStartInclusive, IsEndInclusive,
   constexpr static bool kIsStartInclusive = IsStartInclusive;
   constexpr static bool kIsEndInclusive = IsEndInclusive;
 
+  class Iterator {
+   public:
+    static_assert(std::is_integral_v<T>);
+
+    using difference_type = std::ptrdiff_t;
+    using value_type = T;
+    using pointer = value_type*;
+    using reference = value_type&;
+    using iterator_category = std::random_access_iterator_tag;
+
+    constexpr Iterator() = default;
+    constexpr explicit Iterator(T cur) : cur_(cur) {}
+
+    constexpr bool operator==(Iterator other) const {
+      return cur_ == other.cur_;
+    }
+
+    constexpr bool operator!=(Iterator other) const {
+      return cur_ != other.cur_;
+    }
+
+    constexpr bool operator<(Iterator other) const { return cur_ < other.cur_; }
+
+    constexpr bool operator<=(Iterator other) const {
+      return cur_ <= other.cur_;
+    }
+
+    constexpr bool operator>(Iterator other) const { return cur_ > other.cur_; }
+
+    constexpr bool operator>=(Iterator other) const {
+      return cur_ >= other.cur_;
+    }
+
+    constexpr Iterator& operator++() {
+      ++cur_;
+      return *this;
+    }
+
+    constexpr Iterator operator++(int) const {
+      Iterator it(*this);
+      ++(*this);
+      return it;
+    }
+
+    constexpr Iterator& operator--() {
+      --cur_;
+      return *this;
+    }
+
+    constexpr Iterator operator--(int) const {
+      Iterator it(*this);
+      --(*this);
+      return it;
+    }
+
+    constexpr Iterator operator+(difference_type n) const {
+      return Iterator(cur_ + n);
+    }
+
+    constexpr Iterator& operator+=(difference_type n) {
+      cur_ += n;
+      return *this;
+    }
+
+    constexpr Iterator operator-(difference_type n) const {
+      return Iterator(cur_ - n);
+    }
+
+    constexpr Iterator& operator-=(difference_type n) {
+      cur_ -= n;
+      return *this;
+    }
+
+    constexpr difference_type operator-(Iterator other) const {
+      return cur_ - other.cur_;
+    }
+
+    constexpr reference operator*() { return cur_; }
+
+    constexpr pointer operator->() { return &cur_; }
+
+   private:
+    T cur_ = 0;
+  };
+
   // Returns the lowest finite value representable by the numeric type T, that
   // is, a finite value x such that there is no other finite value y where
   // y < x. This is different from std::numeric_limits<T>::min() for
   // floating-point types. Only meaningful for bounded types.
   // See https://en.cppreference.com/w/cpp/types/numeric_limits/lowest
   // NOTE(chokobole): I used |lowest()| over |min()| for the reason above.
-  T start = std::numeric_limits<T>::lowest();
-  T end = std::numeric_limits<T>::max();
+  T from = std::numeric_limits<T>::lowest();
+  T to = std::numeric_limits<T>::max();
 
   constexpr Range() = default;
-  constexpr Range(T start, T end) : start(start), end(end) {}
+  constexpr Range(T from, T to) : from(from), to(to) {}
 
   constexpr static Range All() { return Range(); }
 
-  constexpr static Range From(T start) {
+  constexpr static Range From(T from) {
     Range range;
-    range.start = start;
+    range.from = from;
     return range;
   }
 
-  constexpr static Range Until(T end) {
+  constexpr static Range Until(T to) {
     Range range;
-    range.end = end;
+    range.to = to;
     return range;
+  }
+
+  Iterator begin() const {
+    if constexpr (IsStartInclusive) {
+      return Iterator(from);
+    } else {
+      return Iterator(from + 1);
+    }
+  }
+
+  Iterator end() const {
+    if constexpr (IsEndInclusive) {
+      return Iterator(to + 1);
+    } else {
+      return Iterator(to);
+    }
+  }
+
+  constexpr Range Intersect(Range other) const {
+    return Range(std::max(from, other.from), std::min(to, other.to));
+  }
+
+  // Returns the number of integral elements within the range.
+  template <typename U = T, std::enable_if_t<std::is_integral_v<U>>* = nullptr>
+  constexpr size_t GetSize() const {
+    if (IsEmpty()) return 0;
+    if constexpr (IsStartInclusive && IsEndInclusive) {
+      return to - from + 1;
+    } else if constexpr (IsStartInclusive && !IsEndInclusive) {
+      return to - from;
+    } else if constexpr (!IsStartInclusive && IsEndInclusive) {
+      return to - from;
+    } else {
+      return to - from - 1;
+    }
   }
 
   // Returns true if the range doesn't contain any value. |Contains()| always
   // gives you false in this case.
   constexpr bool IsEmpty() const {
     if constexpr (IsStartInclusive && IsEndInclusive) {
-      return start > end;
+      return from > to;
     } else {
-      return start >= end;
+      return from >= to;
     }
   }
 
   // Returns true if the range contains |value|.
   constexpr bool Contains(T value) const {
     if constexpr (IsStartInclusive && IsEndInclusive) {
-      return start <= value && value <= end;
+      return from <= value && value <= to;
     } else if constexpr (IsStartInclusive && !IsEndInclusive) {
-      return start <= value && value < end;
+      return from <= value && value < to;
     } else if constexpr (!IsStartInclusive && IsEndInclusive) {
-      return start < value && value <= end;
+      return from < value && value <= to;
     } else {
-      return start < value && value < end;
+      return from < value && value < to;
     }
   }
 
+  constexpr bool operator==(Range other) const {
+    return from == other.from && to == other.to;
+  }
+  constexpr bool operator!=(Range other) const { return !operator==(other); }
+
   std::string ToString() const {
     if constexpr (IsStartInclusive && IsEndInclusive) {
-      return absl::Substitute("$0 ≤ x ≤ $1", start, end);
+      return absl::Substitute("$0 ≤ x ≤ $1", from, to);
     } else if constexpr (IsStartInclusive && !IsEndInclusive) {
-      return absl::Substitute("$0 ≤ x < $1", start, end);
+      return absl::Substitute("$0 ≤ x < $1", from, to);
     } else if constexpr (!IsStartInclusive && IsEndInclusive) {
-      return absl::Substitute("$0 < x ≤ $1", start, end);
+      return absl::Substitute("$0 < x ≤ $1", from, to);
     } else {
-      return absl::Substitute("$0 < x < $1", start, end);
+      return absl::Substitute("$0 < x < $1", from, to);
     }
   }
 };

--- a/tachyon/base/range_unittest.cc
+++ b/tachyon/base/range_unittest.cc
@@ -1,6 +1,10 @@
 #include "tachyon/base/range.h"
 
+#include <vector>
+
 #include "gtest/gtest.h"
+
+#include "tachyon/base/containers/container_util.h"
 
 namespace tachyon::base {
 
@@ -11,6 +15,25 @@ using RangeTypes =
     testing::Types<Range<int, false, false>, Range<int, false, true>,
                    Range<int, true, false>, Range<int, true, true>>;
 TYPED_TEST_SUITE(RangeTest, RangeTypes);
+
+TYPED_TEST(RangeTest, Iterator) {
+  using RangeType = TypeParam;
+
+  RangeType range(1, 5);
+  std::vector<int> elements =
+      base::Map(range.begin(), range.end(), [](int v) { return v; });
+  std::vector<int> expected;
+  if constexpr (RangeType::kIsStartInclusive) {
+    expected.push_back(1);
+  }
+  for (int i = 2; i < 5; ++i) {
+    expected.push_back(i);
+  }
+  if constexpr (RangeType::kIsEndInclusive) {
+    expected.push_back(5);
+  }
+  EXPECT_EQ(elements, expected);
+}
 
 TYPED_TEST(RangeTest, IsEmpty) {
   using RangeType = TypeParam;
@@ -42,6 +65,35 @@ TYPED_TEST(RangeTest, Contains) {
     EXPECT_FALSE(range.Contains(4));
   }
   EXPECT_FALSE(range.Contains(5));
+}
+
+TYPED_TEST(RangeTest, Intersect) {
+  using RangeType = TypeParam;
+
+  RangeType range(1, 7);
+  RangeType range2(5, 10);
+  RangeType expected(5, 7);
+  EXPECT_EQ(range.Intersect(range2), expected);
+  EXPECT_EQ(range2.Intersect(range), expected);
+}
+
+TYPED_TEST(RangeTest, GetSize) {
+  using RangeType = TypeParam;
+
+  RangeType range(3, 4);
+  if constexpr (RangeType::kIsStartInclusive) {
+    if constexpr (RangeType::kIsEndInclusive) {
+      EXPECT_EQ(range.GetSize(), 2);
+    } else {
+      EXPECT_EQ(range.GetSize(), 1);
+    }
+  } else {
+    if constexpr (RangeType::kIsEndInclusive) {
+      EXPECT_EQ(range.GetSize(), 1);
+    } else {
+      EXPECT_EQ(range.GetSize(), 0);
+    }
+  }
 }
 
 }  // namespace tachyon::base

--- a/tachyon/zk/plonk/circuit/assembly.h
+++ b/tachyon/zk/plonk/circuit/assembly.h
@@ -7,6 +7,7 @@
 #ifndef TACHYON_ZK_PLONK_CIRCUIT_ASSEMBLY_H_
 #define TACHYON_ZK_PLONK_CIRCUIT_ASSEMBLY_H_
 
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -86,7 +87,9 @@ class Assembly : public Assignment<typename PCSTy::Field> {
       return Error::kNotEnoughRowsAvailable;
     }
     math::RationalField<F> value = std::move(assign).Run();
-    for (size_t i = usable_rows_.start + from_row; i < usable_rows_.end; ++i) {
+    base::Range<size_t> range(usable_rows_.from + from_row, usable_rows_.to);
+    for (size_t i : range) {
+      std::ignore = i;
       fixeds_[column.index()] = value;
     }
     return Error::kNone;


### PR DESCRIPTION
# Description

- add `begin()` and `end()` to `Range`, this leads to renaming member variables.
- add `Intersect()` and `GetSize()` to `Range`.
