### PR TITLE
refac(base): separate iterator from adapters

### DIFF
--- a/tachyon/base/containers/BUILD.bazel
+++ b/tachyon/base/containers/BUILD.bazel
@@ -6,6 +6,15 @@ tachyon_cc_library(
     name = "adapters",
     hdrs = ["adapters.h"],
     deps = [
+        ":chunked_iterator",
+        ":zipped_iterator",
+    ],
+)
+
+tachyon_cc_library(
+    name = "chunked_iterator",
+    hdrs = ["chunked_iterator.h"],
+    deps = [
         "//tachyon/base:template_util",
         "//tachyon/base/numerics:checked_math",
         "@com_google_absl//absl/types:span",
@@ -78,6 +87,12 @@ tachyon_cc_library(
         "//tachyon/base:logging",
         "//tachyon/base/numerics:checked_math",
     ],
+)
+
+tachyon_cc_library(
+    name = "zipped_iterator",
+    hdrs = ["zipped_iterator.h"],
+    deps = ["//tachyon/base:template_util"],
 )
 
 tachyon_cc_unittest(

--- a/tachyon/base/containers/adapters_unittest.cc
+++ b/tachyon/base/containers/adapters_unittest.cc
@@ -4,6 +4,8 @@
 
 #include "tachyon/base/containers/adapters.h"
 
+#include <tuple>
+#include <utility>
 #include <vector>
 
 #include "gmock/gmock.h"

--- a/tachyon/base/containers/adapters_unittest.cc
+++ b/tachyon/base/containers/adapters_unittest.cc
@@ -6,23 +6,19 @@
 
 #include <vector>
 
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace tachyon::base {
 
 TEST(AdaptersTest, Reversed) {
-  std::vector<int> v;
-  v.push_back(3);
-  v.push_back(2);
-  v.push_back(1);
+  std::vector<int> v{3, 2, 1};
   int j = 0;
   for (int& i : Reversed(v)) {
     EXPECT_EQ(++j, i);
     i += 100;
   }
-  EXPECT_EQ(103, v[0]);
-  EXPECT_EQ(102, v[1]);
-  EXPECT_EQ(101, v[2]);
+  EXPECT_THAT(v, testing::ContainerEq(std::vector<int>{103, 102, 101}));
 }
 
 TEST(AdaptersTest, ReversedArray) {
@@ -32,16 +28,11 @@ TEST(AdaptersTest, ReversedArray) {
     EXPECT_EQ(++j, i);
     i += 100;
   }
-  EXPECT_EQ(103, v[0]);
-  EXPECT_EQ(102, v[1]);
-  EXPECT_EQ(101, v[2]);
+  EXPECT_THAT(v, testing::ElementsAreArray({103, 102, 101}));
 }
 
 TEST(AdaptersTest, ReversedConst) {
-  std::vector<int> v;
-  v.push_back(3);
-  v.push_back(2);
-  v.push_back(1);
+  std::vector<int> v{3, 2, 1};
   const std::vector<int>& cv = v;
   int j = 0;
   for (int i : Reversed(cv)) {
@@ -69,10 +60,7 @@ void TestChunked(T&& v) {
 }
 
 TEST(AdaptersTest, Chunked) {
-  std::vector<int> v;
-  v.push_back(1);
-  v.push_back(2);
-  v.push_back(3);
+  std::vector<int> v{1, 2, 3};
   TestChunked<int>(v);
 }
 
@@ -82,23 +70,14 @@ TEST(AdaptersTest, ChunkedArray) {
 }
 
 TEST(AdaptersTest, ChunkedConst) {
-  std::vector<int> v;
-  v.push_back(1);
-  v.push_back(2);
-  v.push_back(3);
+  std::vector<int> v{1, 2, 3};
   const std::vector<int>& cv = v;
   TestChunked<const int>(cv);
 }
 
 TEST(AdaptersTest, Zipped) {
-  std::vector<int> v;
-  v.push_back(1);
-  v.push_back(2);
-  v.push_back(3);
-  std::vector<int> w;
-  w.push_back(4);
-  w.push_back(5);
-  w.push_back(6);
+  std::vector<int> v{1, 2, 3};
+  std::vector<int> w{4, 5, 6};
   size_t offset = 0;
   for (const std::tuple<int, int>& j : Zipped(v, w)) {
     EXPECT_EQ(std::get<0>(j), v[offset]);
@@ -121,14 +100,8 @@ TEST(AdaptersTest, ZippedArray) {
 }
 
 TEST(AdaptersTest, ZippedConst) {
-  std::vector<int> v;
-  v.push_back(1);
-  v.push_back(2);
-  v.push_back(3);
-  std::vector<int> w;
-  w.push_back(4);
-  w.push_back(5);
-  w.push_back(6);
+  std::vector<int> v{1, 2, 3};
+  std::vector<int> w{4, 5, 6};
   const std::vector<int>& cv = v;
   const std::vector<int>& cw = w;
   size_t offset = 0;

--- a/tachyon/base/containers/chunked_iterator.h
+++ b/tachyon/base/containers/chunked_iterator.h
@@ -1,0 +1,124 @@
+#ifndef TACHYON_BASE_CONTAINERS_CHUNKED_ITERATOR_H_
+#define TACHYON_BASE_CONTAINERS_CHUNKED_ITERATOR_H_
+
+#include <algorithm>
+#include <type_traits>
+#include <utility>
+
+#include "absl/types/span.h"
+
+#include "tachyon/base/numerics/checked_math.h"
+#include "tachyon/base/template_util.h"
+
+namespace tachyon::base {
+
+template <typename Iter, bool IsConst>
+class ChunkedIterator {
+ public:
+  using underlying_value_type =
+      std::conditional_t<IsConst, const iter_value_t<Iter>, iter_value_t<Iter>>;
+
+  using difference_type = iter_difference_t<Iter>;
+  using value_type = absl::Span<underlying_value_type>;
+  using pointer = value_type*;
+  using reference = value_type&;
+  using iterator_category =
+      typename std::iterator_traits<Iter>::iterator_category;
+
+  ChunkedIterator(Iter current, size_t chunk_size)
+      : current_(std::move(current)),
+        chunk_size_(chunk_size),
+        size_(0),
+        len_(0) {}
+  ChunkedIterator(Iter current, size_t chunk_size, size_t size)
+      : current_(std::move(current)),
+        chunk_size_(chunk_size),
+        size_(size),
+        len_(std::min(chunk_size, size)),
+        value_(value_type(&*current, len_)) {}
+
+  ChunkedIterator(const ChunkedIterator& other) = default;
+  ChunkedIterator& operator=(const ChunkedIterator& other) = default;
+
+  bool operator==(const ChunkedIterator& other) const {
+    return current_ == other.current_;
+  }
+  bool operator!=(const ChunkedIterator& other) const {
+    return !(*this == other);
+  }
+
+  // TODO(chokobole): Add more operators to support iterator category other than
+  // forward_iterator.
+  ChunkedIterator& operator++() {
+    current_ += len_;
+    offset_ += len_;
+    base::CheckedNumeric<size_t> len = offset_;
+    len += chunk_size_;
+    size_t new_len = len.ValueOrDie();
+    if (new_len > size_) {
+      len_ = size_ - offset_;
+    } else {
+      len_ = chunk_size_;
+    }
+    value_ = value_type(&*current_, len_);
+    return *this;
+  }
+
+  ChunkedIterator operator++(int) {
+    ChunkedIterator iterator(*this);
+    ++(*this);
+    return iterator;
+  }
+
+  difference_type operator-(const ChunkedIterator& other) const {
+    return (current_ - other.current_ + chunk_size_ - 1) / chunk_size_;
+  }
+
+  // NOTE(chokobole): To suppress -Werror,-Wignored-reference-qualifiers on
+  // mac
+  const std::remove_const_t<pointer> operator->() const { return &value_; }
+  pointer operator->() { return &value_; }
+
+  // NOTE(chokobole): To suppress -Werror,-Wignored-reference-qualifiers on
+  // mac
+  const std::remove_const_t<reference> operator*() const { return value_; }
+  reference operator*() { return value_; }
+
+ private:
+  Iter current_;
+  size_t offset_ = 0;
+  size_t chunk_size_;
+  size_t size_;
+  size_t len_;
+  value_type value_;
+};
+
+template <typename T>
+auto ChunkedBegin(T& t, size_t chunk_size) {
+  using Iter = decltype(std::begin(std::declval<T&>()));
+  return ChunkedIterator<Iter, false>(
+      std::begin(t), chunk_size, std::distance(std::begin(t), std::end(t)));
+}
+
+template <typename T>
+auto ChunkedEnd(T& t, size_t chunk_size) {
+  using Iter = decltype(std::end(std::declval<T&>()));
+  return ChunkedIterator<Iter, false>(std::end(t), chunk_size);
+}
+
+template <typename T>
+auto ChunkedConstBegin(T& t, size_t chunk_size) {
+  using Iter = decltype(std::cbegin(std::declval<T&>()));
+  return ChunkedIterator<Iter, true>(
+      std::cbegin(t), chunk_size, std::distance(std::cbegin(t), std::cend(t)));
+}
+
+template <typename T>
+auto ChunkedConstEnd(T& t, size_t chunk_size) {
+  using Iter = decltype(std::cend(std::declval<T&>()));
+  return ChunkedIterator<Iter, true>(std::cend(t), chunk_size);
+}
+
+}  // namespace tachyon::base
+
+#endif  // TACHYON_BASE_CONTAINERS_CHUNKED_ITERATOR_H_

--- a/tachyon/base/containers/zipped_iterator.h
+++ b/tachyon/base/containers/zipped_iterator.h
@@ -1,0 +1,91 @@
+#ifndef TACHYON_BASE_CONTAINERS_ZIPPED_ITERATOR_H_
+#define TACHYON_BASE_CONTAINERS_ZIPPED_ITERATOR_H_
+
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+#include "tachyon/base/template_util.h"
+
+namespace tachyon::base {
+
+template <typename Iter, typename Iter2>
+class ZippedIterator {
+ public:
+  using underlying_value_type = iter_value_t<Iter>;
+  using underlying_value_type2 = iter_value_t<Iter2>;
+
+  using difference_type = iter_difference_t<Iter>;
+  using value_type = std::tuple<underlying_value_type, underlying_value_type2>;
+  using pointer = value_type*;
+  using reference = value_type&;
+  using iterator_category =
+      typename std::iterator_traits<Iter>::iterator_category;
+
+  ZippedIterator(Iter current, Iter2 current2)
+      : current_(std::move(current)),
+        current2_(std::move(current2)),
+        value_(value_type(*current, *current2)) {}
+
+  ZippedIterator(const ZippedIterator& other) = default;
+  ZippedIterator& operator=(const ZippedIterator& other) = default;
+
+  bool operator==(const ZippedIterator& other) const {
+    return current_ == other.current_ && current2_ == other.current2_;
+  }
+  bool operator!=(const ZippedIterator& other) const {
+    return !(*this == other);
+  }
+
+  // TODO(chokobole): Add more operators to support iterator category other than
+  // forward_iterator.
+  ZippedIterator& operator++() {
+    ++current_;
+    ++current2_;
+    value_ = value_type(*current_, *current2_);
+    return *this;
+  }
+
+  ZippedIterator operator++(int) {
+    ZippedIterator iterator(*this);
+    ++(*this);
+    return iterator;
+  }
+
+  difference_type operator-(const ZippedIterator& other) const {
+    return current_ - other.current_;
+  }
+
+  // NOTE(chokobole): To suppress -Werror,-Wignored-reference-qualifiers on
+  // mac
+  const std::remove_const_t<pointer> operator->() const { return &value_; }
+  pointer operator->() { return &value_; }
+
+  // NOTE(chokobole): To suppress -Werror,-Wignored-reference-qualifiers on
+  // mac
+  const std::remove_const_t<reference> operator*() const { return value_; }
+  reference operator*() { return value_; }
+
+ private:
+  Iter current_;
+  Iter2 current2_;
+  value_type value_;
+};
+
+template <typename T, typename U>
+auto ZippedBegin(T& t, U& u) {
+  using Iter = decltype(std::begin(std::declval<T&>()));
+  using Iter2 = decltype(std::begin(std::declval<U&>()));
+  return ZippedIterator<Iter, Iter2>(std::begin(t), std::begin(u));
+}
+
+template <typename T, typename U>
+auto ZippedEnd(T& t, U& u) {
+  using Iter = decltype(std::end(std::declval<T&>()));
+  using Iter2 = decltype(std::end(std::declval<U&>()));
+  return ZippedIterator<Iter, Iter2>(std::end(t), std::end(u));
+}
+
+}  // namespace tachyon::base
+
+#endif  // TACHYON_BASE_CONTAINERS_ZIPPED_ITERATOR_H_

--- a/tachyon/base/template_util.h
+++ b/tachyon/base/template_util.h
@@ -66,6 +66,16 @@ template <typename Iter>
 using iter_value_t =
     typename std::iterator_traits<remove_cvref_t<Iter>>::value_type;
 
+// Simplified implementation of C++20's std::iter_difference_t.
+// As opposed to std::iter_difference_t, this implementation does not restrict
+// the type of `Iter` and does not consider specializations of
+// `indirectly_readable_traits`.
+//
+// Reference: https://wg21.link/readable.traits#2
+template <typename Iter>
+using iter_difference_t =
+    typename std::iterator_traits<remove_cvref_t<Iter>>::difference_type;
+
 // Simplified implementation of C++20's std::iter_reference_t.
 // As opposed to std::iter_reference_t, this implementation does not restrict
 // the type of `Iter`.


### PR DESCRIPTION
# Description

I wrote this codes in Devconnect to create `Iterator` class to help us to take rust codes in c++ easily. But i couldn't finish it completely so this is a code change that is part of that purpose. You can think of it as a preparation for that.
