### PR TITLE
refac(zk): use minimum template type for LookupArgument classes

### DIFF
--- a/tachyon/zk/plonk/lookup/lookup_argument.h
+++ b/tachyon/zk/plonk/lookup/lookup_argument.h
@@ -76,6 +76,7 @@ class LookupArgument {
   }
 
   template <typename ProverTy, typename Evals,
+            typename Poly = typename ProverTy::Poly,
             typename PCSTy = typename ProverTy::PCSTy>
   LookupPermuted<PCSTy> CommitPermuted(
       ProverTy& prover, const F& theta,
@@ -104,12 +105,12 @@ class LookupArgument {
     CHECK_EQ(err, Error::kNone);
 
     // Commit(A'(X))
-    BlindedPolynomial<PCSTy> permuted_input_poly;
+    BlindedPolynomial<Poly> permuted_input_poly;
     CHECK(prover.CommitEvalsWithBlind(permuted_evals_pair.input(),
                                       &permuted_input_poly));
 
     // Commit(S'(X))
-    BlindedPolynomial<PCSTy> permuted_table_poly;
+    BlindedPolynomial<Poly> permuted_table_poly;
     CHECK(prover.CommitEvalsWithBlind(permuted_evals_pair.table(),
                                       &permuted_table_poly));
 

--- a/tachyon/zk/plonk/lookup/lookup_argument.h
+++ b/tachyon/zk/plonk/lookup/lookup_argument.h
@@ -76,9 +76,8 @@ class LookupArgument {
   }
 
   template <typename ProverTy, typename Evals,
-            typename Poly = typename ProverTy::Poly,
-            typename PCSTy = typename ProverTy::PCSTy>
-  LookupPermuted<PCSTy> CommitPermuted(
+            typename Poly = typename ProverTy::Poly>
+  LookupPermuted<Poly, Evals> CommitPermuted(
       ProverTy& prover, const F& theta,
       const SimpleEvaluator<Evals>& evaluator_tpl) {
     // A_compressed(X) = θᵐ⁻¹A₀(X) + θᵐ⁻²A₁(X) + ... + θAₘ₋₂(X) + Aₘ₋₁(X)

--- a/tachyon/zk/plonk/lookup/lookup_committed.h
+++ b/tachyon/zk/plonk/lookup/lookup_committed.h
@@ -15,14 +15,10 @@
 
 namespace tachyon::zk {
 
-template <typename PCSTy>
+template <typename Poly>
 class LookupCommitted {
  public:
-  using F = typename PCSTy::Field;
-  using Poly = typename PCSTy::Poly;
-  using MaxDegree = typename PCSTy::kMaxDegree;
-  using Commitment = typename PCSTy::Commitment;
-  using Domain = typename PCSTy::Domain;
+  using F = typename Poly::Field;
 
   LookupCommitted() = default;
   LookupCommitted(BlindedPolynomial<Poly> permuted_input_poly,
@@ -41,7 +37,7 @@ class LookupCommitted {
   const BlindedPolynomial<Poly>& product_poly() const { return product_poly_; }
 
   template <typename ProverTy>
-  LookupEvaluated<PCSTy> Evaluate(ProverTy& prover, const F& x) && {
+  LookupEvaluated<Poly> Evaluate(ProverTy& prover, const F& x) && {
     F x_inv = Rotation::Prev().RotateOmega(prover.domain(), x);
     F x_next = Rotation::Next().RotateOmega(prover.domain(), x);
 

--- a/tachyon/zk/plonk/lookup/lookup_evaluated.h
+++ b/tachyon/zk/plonk/lookup/lookup_evaluated.h
@@ -15,11 +15,10 @@
 
 namespace tachyon::zk {
 
-template <typename PCSTy>
+template <typename Poly>
 class LookupEvaluated {
  public:
-  using F = typename PCSTy::Field;
-  using Poly = typename PCSTy::Poly;
+  using F = typename Poly::Field;
 
   LookupEvaluated() = default;
   LookupEvaluated(BlindedPolynomial<Poly> permuted_input_poly,
@@ -37,7 +36,7 @@ class LookupEvaluated {
   }
   const BlindedPolynomial<Poly>& product_poly() const { return product_poly_; }
 
-  template <typename ProverTy>
+  template <typename ProverTy, typename PCSTy = typename ProverTy::PCSTy>
   std::vector<ProverQuery<PCSTy>> Open(const ProverTy& prover,
                                        const F& x) const {
     F x_inv = Rotation::Prev().RotateOmega(prover.domain(), x);

--- a/tachyon/zk/plonk/lookup/lookup_permuted.h
+++ b/tachyon/zk/plonk/lookup/lookup_permuted.h
@@ -57,7 +57,7 @@ class LookupPermuted {
                                         prover.pcs().N());
     prover.blinder().Blind(z);
 
-    BlindedPolynomial<PCSTy> product_poly;
+    BlindedPolynomial<Poly> product_poly;
     CHECK(prover.CommitEvalsWithBlind(z, &product_poly));
 
     return LookupCommitted<PCSTy>(std::move(permuted_input_poly_),

--- a/tachyon/zk/plonk/lookup/lookup_permuted.h
+++ b/tachyon/zk/plonk/lookup/lookup_permuted.h
@@ -19,14 +19,10 @@
 
 namespace tachyon::zk {
 
-template <typename PCSTy>
+template <typename Poly, typename Evals>
 class LookupPermuted {
  public:
-  using F = typename PCSTy::Field;
-  using Evals = typename PCSTy::Evals;
-  using Poly = typename PCSTy::Poly;
-  using Commitment = typename PCSTy::Commitment;
-  using Domain = typename PCSTy::Domain;
+  using F = typename Poly::Field;
 
   LookupPermuted() = default;
   LookupPermuted(EvalsPair<Evals> compressed_evals_pair,
@@ -50,8 +46,8 @@ class LookupPermuted {
   }
 
   template <typename ProverTy>
-  LookupCommitted<PCSTy> CommitProduct(ProverTy& prover, const F& beta,
-                                       const F& gamma) && {
+  LookupCommitted<Poly> CommitProduct(ProverTy& prover, const F& beta,
+                                      const F& gamma) && {
     size_t blinding_factors = prover.blinder().blinded_factors();
     Evals z = ComputePermutationProduct(blinding_factors, beta, gamma,
                                         prover.pcs().N());
@@ -60,9 +56,9 @@ class LookupPermuted {
     BlindedPolynomial<Poly> product_poly;
     CHECK(prover.CommitEvalsWithBlind(z, &product_poly));
 
-    return LookupCommitted<PCSTy>(std::move(permuted_input_poly_),
-                                  std::move(permuted_table_poly_),
-                                  std::move(product_poly));
+    return LookupCommitted<Poly>(std::move(permuted_input_poly_),
+                                 std::move(permuted_table_poly_),
+                                 std::move(product_poly));
   }
 
  private:

--- a/tachyon/zk/plonk/lookup/lookup_permuted_unittest.cc
+++ b/tachyon/zk/plonk/lookup/lookup_permuted_unittest.cc
@@ -52,7 +52,7 @@ TEST_F(LookupPermutedTest, ComputePermutationProduct) {
                                     &permuted_evals_pair);
   ASSERT_EQ(err, Error::kNone);
 
-  LookupPermuted<PCS> lookup_permuted(
+  LookupPermuted<Poly, Evals> lookup_permuted(
       std::move(compressed_evals_pair), std::move(permuted_evals_pair),
       BlindedPolynomial<Poly>(), BlindedPolynomial<Poly>());
 


### PR DESCRIPTION
# Description

This PR contains 2 changes.

- Fix incorrect template type for `BlindedPolynomial<Poly>`
- Maintain minimum template type for classes in lookup argument.
   - LookupCommitted<PCSTy> -> LookupCommitted<Poly>
   - LookupEvaluatd<PCSTy> -> LookupEvaluated<Poly>
   - LookupPermuted<PCSTy> -> LookupPermuted<Poly, Evals>

The rule of this is if your class is a template class, then my suggestion is your template type should be a minimum set of type of the member variables of class. So I want the class is instantiated differently depending on member variable, not the method.
