### PR TITLE
refac: take `GrandProductArgument::Commit()` from `LookupPermuted`

### DIFF
--- a/tachyon/base/parallelize.h
+++ b/tachyon/base/parallelize.h
@@ -12,6 +12,13 @@
 
 namespace tachyon::base {
 
+template <typename T>
+using ParallelizeCallback1 = std::function<void(absl::Span<T>)>;
+template <typename T>
+using ParallelizeCallback2 = std::function<void(absl::Span<T>, size_t)>;
+template <typename T>
+using ParallelizeCallback3 = std::function<void(absl::Span<T>, size_t, size_t)>;
+
 // Splits the |container| by |chunk_size| and executes |callback| in parallel.
 // See parallelize_unittest.cc for more details.
 template <typename ContainerTy, typename Callable,

--- a/tachyon/zk/plonk/lookup/BUILD.bazel
+++ b/tachyon/zk/plonk/lookup/BUILD.bazel
@@ -52,8 +52,8 @@ tachyon_cc_library(
     deps = [
         ":lookup_committed",
         ":permute_expression_pair",
-        "//tachyon/base:parallelize",
         "//tachyon/zk/base:evals_pair",
+        "//tachyon/zk/plonk/permutation:grand_product_argument",
     ],
 )
 

--- a/tachyon/zk/plonk/lookup/lookup_permuted_unittest.cc
+++ b/tachyon/zk/plonk/lookup/lookup_permuted_unittest.cc
@@ -56,8 +56,10 @@ TEST_F(LookupPermutedTest, ComputePermutationProduct) {
       std::move(compressed_evals_pair), std::move(permuted_evals_pair),
       BlindedPolynomial<Poly>(), BlindedPolynomial<Poly>());
 
-  Evals z_evals = lookup_permuted.ComputePermutationProduct(
-      kBlindingFactors, beta, gamma, kDomainSize);
+  Evals z_evals = GrandProductArgument::CreatePolynomial<Evals>(
+      kDomainSize, kBlindingFactors,
+      lookup_permuted.CreateNumeratorCallback<F>(beta, gamma),
+      lookup_permuted.CreateDenominatorCallback<F>(beta, gamma));
   const std::vector<F>& z = z_evals.evaluations();
 
   // sanity check brought from halo2

--- a/tachyon/zk/plonk/permutation/BUILD.bazel
+++ b/tachyon/zk/plonk/permutation/BUILD.bazel
@@ -13,6 +13,17 @@ tachyon_cc_library(
 )
 
 tachyon_cc_library(
+    name = "grand_product_argument",
+    hdrs = ["grand_product_argument.h"],
+    deps = [
+        "//tachyon/base:parallelize",
+        "//tachyon/zk/base:blinded_polynomial",
+        "//tachyon/zk/base:prover",
+        "@com_google_googletest//:gtest_prod",
+    ],
+)
+
+tachyon_cc_library(
     name = "label",
     hdrs = ["label.h"],
     deps = ["//tachyon:export"],

--- a/tachyon/zk/plonk/permutation/grand_product_argument.h
+++ b/tachyon/zk/plonk/permutation/grand_product_argument.h
@@ -1,0 +1,65 @@
+#ifndef TACHYON_ZK_PLONK_PERMUTATION_GRAND_PRODUCT_ARGUMENT_H_
+#define TACHYON_ZK_PLONK_PERMUTATION_GRAND_PRODUCT_ARGUMENT_H_
+
+#include <utility>
+#include <vector>
+
+#include "gtest/gtest_prod.h"
+
+#include "tachyon/base/parallelize.h"
+#include "tachyon/zk/base/blinded_polynomial.h"
+#include "tachyon/zk/base/prover.h"
+
+namespace tachyon::zk {
+
+class GrandProductArgument {
+ public:
+  template <typename PCSTy, typename Callable,
+            typename Poly = typename PCSTy::Poly>
+  static BlindedPolynomial<Poly> Commit(Prover<PCSTy>* prover,
+                                        Callable numerator_callback,
+                                        Callable denominator_callback) {
+    using Evals = typename PCSTy::Evals;
+
+    size_t size = prover->pcs().N();
+    size_t blinding_factors = prover->blinder().blinded_factors();
+    Evals z = CreatePolynomial<Evals>(size, blinding_factors,
+                                      std::move(numerator_callback),
+                                      std::move(denominator_callback));
+    CHECK(prover->blinder().Blind(z));
+
+    BlindedPolynomial<Poly> ret;
+    CHECK(prover->CommitEvalsWithBlind(z, &ret));
+    return ret;
+  }
+
+ private:
+  FRIEND_TEST(LookupPermutedTest, ComputePermutationProduct);
+
+  template <typename Evals, typename Callable>
+  static Evals CreatePolynomial(size_t size, size_t blinding_factors,
+                                Callable numerator_callback,
+                                Callable denominator_callback) {
+    using F = typename Evals::Field;
+
+    std::vector<F> grand_product(size, F::Zero());
+
+    base::Parallelize(grand_product, std::move(denominator_callback));
+
+    F::BatchInverseInPlace(grand_product);
+
+    base::Parallelize(grand_product, std::move(numerator_callback));
+
+    std::vector<F> z;
+    z.resize(size);
+    z[0] = F::One();
+    for (size_t i = 0; i < size - blinding_factors - 1; ++i) {
+      z[i + 1] = z[i] * grand_product[i];
+    }
+    return Evals(std::move(z));
+  }
+};
+
+}  // namespace tachyon::zk
+
+#endif  // TACHYON_ZK_PLONK_PERMUTATION_GRAND_PRODUCT_ARGUMENT_H_


### PR DESCRIPTION
# Description

While reviewing #164, I found that grand product argument can be shared between `PermutationArgument` and `LookupArgument` and this PR creates a class `GrandProductArgument` for this purpose.

See https://research.metastate.dev/on-plonk-and-plookup/ for details.
