### PR TITLE
refac(zk): integrate lookup transition methods

### DIFF
--- a/tachyon/zk/plonk/lookup/BUILD.bazel
+++ b/tachyon/zk/plonk/lookup/BUILD.bazel
@@ -27,10 +27,7 @@ tachyon_cc_library(
 tachyon_cc_library(
     name = "lookup_committed",
     hdrs = ["lookup_committed.h"],
-    deps = [
-        ":lookup_evaluated",
-        "//tachyon/zk/plonk/circuit:rotation",
-    ],
+    deps = ["//tachyon/zk/base:blinded_polynomial"],
 )
 
 tachyon_cc_library(
@@ -62,8 +59,10 @@ tachyon_cc_library(
         ":compress_expression",
         ":lookup_argument",
         ":lookup_committed",
+        ":lookup_evaluated",
         ":lookup_permuted",
         "//tachyon/zk/base:prover",
+        "//tachyon/zk/plonk/circuit:rotation",
         "//tachyon/zk/plonk/circuit/expressions/evaluator:simple_evaluator",
         "//tachyon/zk/plonk/permutation:grand_product_argument",
     ],

--- a/tachyon/zk/plonk/lookup/BUILD.bazel
+++ b/tachyon/zk/plonk/lookup/BUILD.bazel
@@ -11,10 +11,7 @@ tachyon_cc_library(
 tachyon_cc_library(
     name = "lookup_argument",
     hdrs = ["lookup_argument.h"],
-    deps = [
-        ":compress_expression",
-        ":lookup_permuted",
-    ],
+    deps = ["//tachyon/zk/plonk/circuit/expressions:expression"],
 )
 
 tachyon_cc_library(
@@ -54,6 +51,21 @@ tachyon_cc_library(
         ":permute_expression_pair",
         "//tachyon/zk/base:evals_pair",
         "//tachyon/zk/plonk/permutation:grand_product_argument",
+    ],
+)
+
+tachyon_cc_library(
+    name = "lookup_argument_runner",
+    hdrs = [
+        "lookup_argument_runner.h",
+        "lookup_argument_runner_impl.h",
+    ],
+    deps = [
+        ":compress_expression",
+        ":lookup_argument",
+        ":lookup_permuted",
+        "//tachyon/zk/base:prover",
+        "//tachyon/zk/plonk/circuit/expressions/evaluator:simple_evaluator",
     ],
 )
 

--- a/tachyon/zk/plonk/lookup/BUILD.bazel
+++ b/tachyon/zk/plonk/lookup/BUILD.bazel
@@ -33,11 +33,7 @@ tachyon_cc_library(
 tachyon_cc_library(
     name = "lookup_evaluated",
     hdrs = ["lookup_evaluated.h"],
-    deps = [
-        "//tachyon/zk/base:blinded_polynomial",
-        "//tachyon/zk/base:prover",
-        "//tachyon/zk/base:prover_query",
-    ],
+    deps = ["//tachyon/zk/base:blinded_polynomial"],
 )
 
 tachyon_cc_library(
@@ -62,6 +58,7 @@ tachyon_cc_library(
         ":lookup_evaluated",
         ":lookup_permuted",
         "//tachyon/zk/base:prover",
+        "//tachyon/zk/base:prover_query",
         "//tachyon/zk/plonk/circuit:rotation",
         "//tachyon/zk/plonk/circuit/expressions/evaluator:simple_evaluator",
         "//tachyon/zk/plonk/permutation:grand_product_argument",

--- a/tachyon/zk/plonk/lookup/BUILD.bazel
+++ b/tachyon/zk/plonk/lookup/BUILD.bazel
@@ -47,10 +47,8 @@ tachyon_cc_library(
     name = "lookup_permuted",
     hdrs = ["lookup_permuted.h"],
     deps = [
-        ":lookup_committed",
-        ":permute_expression_pair",
+        "//tachyon/zk/base:blinded_polynomial",
         "//tachyon/zk/base:evals_pair",
-        "//tachyon/zk/plonk/permutation:grand_product_argument",
     ],
 )
 
@@ -63,9 +61,11 @@ tachyon_cc_library(
     deps = [
         ":compress_expression",
         ":lookup_argument",
+        ":lookup_committed",
         ":lookup_permuted",
         "//tachyon/zk/base:prover",
         "//tachyon/zk/plonk/circuit/expressions/evaluator:simple_evaluator",
+        "//tachyon/zk/plonk/permutation:grand_product_argument",
     ],
 )
 
@@ -85,12 +85,12 @@ tachyon_cc_unittest(
     name = "lookup_argument_unittests",
     srcs = [
         "compress_expression_unittest.cc",
-        "lookup_permuted_unittest.cc",
+        "lookup_argument_runner_unittest.cc",
         "permute_expression_pair_unittest.cc",
     ],
     deps = [
         ":compress_expression",
-        ":lookup_permuted",
+        ":lookup_argument_runner",
         ":permute_expression_pair",
         "//tachyon/base:random",
         "//tachyon/zk/plonk/circuit/expressions:expression_factory",

--- a/tachyon/zk/plonk/lookup/lookup_argument_runner.h
+++ b/tachyon/zk/plonk/lookup/lookup_argument_runner.h
@@ -13,6 +13,7 @@
 #include "tachyon/zk/plonk/circuit/expressions/evaluator/simple_evaluator.h"
 #include "tachyon/zk/plonk/lookup/lookup_argument.h"
 #include "tachyon/zk/plonk/lookup/lookup_committed.h"
+#include "tachyon/zk/plonk/lookup/lookup_evaluated.h"
 #include "tachyon/zk/plonk/lookup/lookup_permuted.h"
 
 namespace tachyon::zk {
@@ -31,6 +32,11 @@ class LookupArgumentRunner {
   static LookupCommitted<Poly> CommitPermuted(
       Prover<PCSTy, ExtendedDomain>* prover,
       LookupPermuted<Poly, Evals>&& permuted, const F& beta, const F& gamma);
+
+  template <typename PCSTy, typename ExtendedDomain, typename F>
+  static LookupEvaluated<Poly> EvaluateCommitted(
+      Prover<PCSTy, ExtendedDomain>* prover, LookupCommitted<Poly>&& committed,
+      const F& x);
 
  private:
   FRIEND_TEST(LookupArgumentRunnerTest, ComputePermutationProduct);

--- a/tachyon/zk/plonk/lookup/lookup_argument_runner.h
+++ b/tachyon/zk/plonk/lookup/lookup_argument_runner.h
@@ -1,0 +1,32 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
+#ifndef TACHYON_ZK_PLONK_LOOKUP_LOOKUP_ARGUMENT_RUNNER_H_
+#define TACHYON_ZK_PLONK_LOOKUP_LOOKUP_ARGUMENT_RUNNER_H_
+
+#include "tachyon/zk/base/prover.h"
+#include "tachyon/zk/plonk/circuit/expressions/evaluator/simple_evaluator.h"
+#include "tachyon/zk/plonk/lookup/lookup_argument.h"
+#include "tachyon/zk/plonk/lookup/lookup_permuted.h"
+
+namespace tachyon::zk {
+
+template <typename Poly, typename Evals>
+class LookupArgumentRunner {
+ public:
+  LookupArgumentRunner() = delete;
+
+  template <typename PCSTy, typename ExtendedDomain, typename F>
+  static LookupPermuted<Poly, Evals> PermuteArgument(
+      Prover<PCSTy, ExtendedDomain>* prover, const LookupArgument<F>& argument,
+      const F& theta, const SimpleEvaluator<Evals>& evaluator_tpl);
+};
+
+}  // namespace tachyon::zk
+
+#include "tachyon/zk/plonk/lookup/lookup_argument_runner_impl.h"
+
+#endif  // TACHYON_ZK_PLONK_LOOKUP_LOOKUP_ARGUMENT_RUNNER_H_

--- a/tachyon/zk/plonk/lookup/lookup_argument_runner.h
+++ b/tachyon/zk/plonk/lookup/lookup_argument_runner.h
@@ -7,9 +7,12 @@
 #ifndef TACHYON_ZK_PLONK_LOOKUP_LOOKUP_ARGUMENT_RUNNER_H_
 #define TACHYON_ZK_PLONK_LOOKUP_LOOKUP_ARGUMENT_RUNNER_H_
 
+#include <vector>
+
 #include "gtest/gtest_prod.h"
 
 #include "tachyon/zk/base/prover.h"
+#include "tachyon/zk/base/prover_query.h"
 #include "tachyon/zk/plonk/circuit/expressions/evaluator/simple_evaluator.h"
 #include "tachyon/zk/plonk/lookup/lookup_argument.h"
 #include "tachyon/zk/plonk/lookup/lookup_committed.h"
@@ -37,6 +40,11 @@ class LookupArgumentRunner {
   static LookupEvaluated<Poly> EvaluateCommitted(
       Prover<PCSTy, ExtendedDomain>* prover, LookupCommitted<Poly>&& committed,
       const F& x);
+
+  template <typename PCSTy, typename ExtendedDomain, typename F>
+  static std::vector<ProverQuery<PCSTy>> OpenEvaluated(
+      const Prover<PCSTy, ExtendedDomain>* prover,
+      const LookupEvaluated<Poly>& evaluated, const F& x);
 
  private:
   FRIEND_TEST(LookupArgumentRunnerTest, ComputePermutationProduct);

--- a/tachyon/zk/plonk/lookup/lookup_argument_runner.h
+++ b/tachyon/zk/plonk/lookup/lookup_argument_runner.h
@@ -7,9 +7,12 @@
 #ifndef TACHYON_ZK_PLONK_LOOKUP_LOOKUP_ARGUMENT_RUNNER_H_
 #define TACHYON_ZK_PLONK_LOOKUP_LOOKUP_ARGUMENT_RUNNER_H_
 
+#include "gtest/gtest_prod.h"
+
 #include "tachyon/zk/base/prover.h"
 #include "tachyon/zk/plonk/circuit/expressions/evaluator/simple_evaluator.h"
 #include "tachyon/zk/plonk/lookup/lookup_argument.h"
+#include "tachyon/zk/plonk/lookup/lookup_committed.h"
 #include "tachyon/zk/plonk/lookup/lookup_permuted.h"
 
 namespace tachyon::zk {
@@ -23,6 +26,24 @@ class LookupArgumentRunner {
   static LookupPermuted<Poly, Evals> PermuteArgument(
       Prover<PCSTy, ExtendedDomain>* prover, const LookupArgument<F>& argument,
       const F& theta, const SimpleEvaluator<Evals>& evaluator_tpl);
+
+  template <typename PCSTy, typename ExtendedDomain, typename F>
+  static LookupCommitted<Poly> CommitPermuted(
+      Prover<PCSTy, ExtendedDomain>* prover,
+      LookupPermuted<Poly, Evals>&& permuted, const F& beta, const F& gamma);
+
+ private:
+  FRIEND_TEST(LookupArgumentRunnerTest, ComputePermutationProduct);
+
+  template <typename F>
+  static base::ParallelizeCallback3<F> CreateNumeratorCallback(
+      const LookupPermuted<Poly, Evals>& permuted, const F& beta,
+      const F& gamma);
+
+  template <typename F>
+  static base::ParallelizeCallback3<F> CreateDenominatorCallback(
+      const LookupPermuted<Poly, Evals>& permuted, const F& beta,
+      const F& gamma);
 };
 
 }  // namespace tachyon::zk

--- a/tachyon/zk/plonk/lookup/lookup_argument_runner_impl.h
+++ b/tachyon/zk/plonk/lookup/lookup_argument_runner_impl.h
@@ -1,0 +1,61 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
+#ifndef TACHYON_ZK_PLONK_LOOKUP_LOOKUP_ARGUMENT_RUNNER_IMPL_H_
+#define TACHYON_ZK_PLONK_LOOKUP_LOOKUP_ARGUMENT_RUNNER_IMPL_H_
+
+#include <utility>
+
+#include "tachyon/zk/plonk/lookup/compress_expression.h"
+#include "tachyon/zk/plonk/lookup/lookup_argument_runner.h"
+
+namespace tachyon::zk {
+
+template <typename Poly, typename Evals>
+template <typename PCSTy, typename ExtendedDomain, typename F>
+LookupPermuted<Poly, Evals> LookupArgumentRunner<Poly, Evals>::PermuteArgument(
+    Prover<PCSTy, ExtendedDomain>* prover, const LookupArgument<F>& argument,
+    const F& theta, const SimpleEvaluator<Evals>& evaluator_tpl) {
+  // A_compressed(X) = θᵐ⁻¹A₀(X) + θᵐ⁻²A₁(X) + ... + θAₘ₋₂(X) + Aₘ₋₁(X)
+  Evals compressed_input_expression;
+  CHECK(CompressExpressions(argument.input_expressions(),
+                            prover->domain()->size(), theta, evaluator_tpl,
+                            &compressed_input_expression));
+
+  // S_compressed(X) = θᵐ⁻¹S₀(X) + θᵐ⁻²S₁(X) + ... + θSₘ₋₂(X) + Sₘ₋₁(X)
+  Evals compressed_table_expression;
+  CHECK(CompressExpressions(argument.table_expressions(),
+                            prover->domain()->size(), theta, evaluator_tpl,
+                            &compressed_table_expression));
+
+  // Permute compressed (InputExpression, TableExpression) pair.
+  EvalsPair<Evals> compressed_evals_pair(
+      std::move(compressed_input_expression),
+      std::move(compressed_table_expression));
+
+  // A'(X), S'(X)
+  EvalsPair<Evals> permuted_evals_pair;
+  Error err = PermuteExpressionPair(prover, compressed_evals_pair,
+                                    &permuted_evals_pair);
+  CHECK_EQ(err, Error::kNone);
+
+  // Commit(A'(X))
+  BlindedPolynomial<Poly> permuted_input_poly;
+  CHECK(prover->CommitEvalsWithBlind(permuted_evals_pair.input(),
+                                     &permuted_input_poly));
+
+  // Commit(S'(X))
+  BlindedPolynomial<Poly> permuted_table_poly;
+  CHECK(prover->CommitEvalsWithBlind(permuted_evals_pair.table(),
+                                     &permuted_table_poly));
+
+  return {std::move(compressed_evals_pair), std::move(permuted_evals_pair),
+          std::move(permuted_input_poly), std::move(permuted_table_poly)};
+}
+
+}  // namespace tachyon::zk
+
+#endif  // TACHYON_ZK_PLONK_LOOKUP_LOOKUP_ARGUMENT_RUNNER_IMPL_H_

--- a/tachyon/zk/plonk/lookup/lookup_argument_runner_unittest.cc
+++ b/tachyon/zk/plonk/lookup/lookup_argument_runner_unittest.cc
@@ -4,7 +4,7 @@
 // can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
 // file.
 
-#include "tachyon/zk/plonk/lookup/lookup_permuted.h"
+#include "tachyon/zk/plonk/lookup/lookup_argument_runner.h"
 
 #include <memory>
 #include <vector>
@@ -18,9 +18,9 @@
 
 namespace tachyon::zk {
 
-class LookupPermutedTest : public CompressExpressionTestSetting {};
+class LookupArgumentRunnerTest : public CompressExpressionTestSetting {};
 
-TEST_F(LookupPermutedTest, ComputePermutationProduct) {
+TEST_F(LookupArgumentRunnerTest, ComputePermutationProduct) {
   constexpr size_t kBlindingFactors = 5;
 
   const F beta = F::Random();
@@ -58,8 +58,10 @@ TEST_F(LookupPermutedTest, ComputePermutationProduct) {
 
   Evals z_evals = GrandProductArgument::CreatePolynomial<Evals>(
       kDomainSize, kBlindingFactors,
-      lookup_permuted.CreateNumeratorCallback<F>(beta, gamma),
-      lookup_permuted.CreateDenominatorCallback<F>(beta, gamma));
+      LookupArgumentRunner<Poly, Evals>::CreateNumeratorCallback<F>(
+          lookup_permuted, beta, gamma),
+      LookupArgumentRunner<Poly, Evals>::CreateDenominatorCallback<F>(
+          lookup_permuted, beta, gamma));
   const std::vector<F>& z = z_evals.evaluations();
 
   // sanity check brought from halo2

--- a/tachyon/zk/plonk/lookup/lookup_committed.h
+++ b/tachyon/zk/plonk/lookup/lookup_committed.h
@@ -9,9 +9,7 @@
 
 #include <utility>
 
-#include "tachyon/zk/base/prover.h"
-#include "tachyon/zk/plonk/circuit/rotation.h"
-#include "tachyon/zk/plonk/lookup/lookup_evaluated.h"
+#include "tachyon/zk/base/blinded_polynomial.h"
 
 namespace tachyon::zk {
 
@@ -28,31 +26,14 @@ class LookupCommitted {
         permuted_table_poly_(std::move(permuted_table_poly)),
         product_poly_(std::move(product_poly)) {}
 
-  const BlindedPolynomial<Poly>& permuted_input_poly() const {
-    return permuted_input_poly_;
+  BlindedPolynomial<Poly>&& permuted_input_poly() && {
+    return std::move(permuted_input_poly_);
   }
-  const BlindedPolynomial<Poly>& permuted_table_poly() const {
-    return permuted_table_poly_;
+  BlindedPolynomial<Poly>&& permuted_table_poly() && {
+    return std::move(permuted_table_poly_);
   }
-  const BlindedPolynomial<Poly>& product_poly() const { return product_poly_; }
-
-  template <typename PCSTy, typename ExtendedDomain>
-  LookupEvaluated<Poly> Evaluate(const Prover<PCSTy, ExtendedDomain>* prover,
-                                 const F& x) && {
-    F x_inv = Rotation::Prev().RotateOmega(prover->domain(), x);
-    F x_next = Rotation::Next().RotateOmega(prover->domain(), x);
-
-    prover->Evaluate(product_poly_.poly(), x);
-    prover->Evaluate(product_poly_.poly(), x_next);
-    prover->Evaluate(permuted_input_poly_.poly(), x);
-    prover->Evaluate(permuted_input_poly_.poly(), x_inv);
-    prover->Evaluate(permuted_table_poly_.poly(), x);
-
-    return {
-        std::move(permuted_input_poly_),
-        std::move(permuted_table_poly_),
-        std::move(product_poly_),
-    };
+  BlindedPolynomial<Poly>&& product_poly() && {
+    return std::move(product_poly_);
   }
 
  private:

--- a/tachyon/zk/plonk/lookup/lookup_evaluated.h
+++ b/tachyon/zk/plonk/lookup/lookup_evaluated.h
@@ -8,11 +8,8 @@
 #define TACHYON_ZK_PLONK_LOOKUP_LOOKUP_EVALUATED_H_
 
 #include <utility>
-#include <vector>
 
 #include "tachyon/zk/base/blinded_polynomial.h"
-#include "tachyon/zk/base/prover.h"
-#include "tachyon/zk/base/prover_query.h"
 
 namespace tachyon::zk {
 
@@ -36,19 +33,6 @@ class LookupEvaluated {
     return permuted_table_poly_;
   }
   const BlindedPolynomial<Poly>& product_poly() const { return product_poly_; }
-
-  template <typename PCSTy, typename ExtendedDomain>
-  std::vector<ProverQuery<PCSTy>> Open(
-      const Prover<PCSTy, ExtendedDomain>* prover, const F& x) const {
-    F x_inv = Rotation::Prev().RotateOmega(prover->domain(), x);
-    F x_next = Rotation::Next().RotateOmega(prover->domain(), x);
-
-    return {ProverQuery<PCSTy>(x, product_poly_.ToRef()),
-            ProverQuery<PCSTy>(x, permuted_input_poly_.ToRef()),
-            ProverQuery<PCSTy>(std::move(x), permuted_table_poly_.ToRef()),
-            ProverQuery<PCSTy>(std::move(x_inv), permuted_input_poly_.ToRef()),
-            ProverQuery<PCSTy>(std::move(x_next), product_poly_.ToRef())};
-  }
 
  private:
   BlindedPolynomial<Poly> permuted_input_poly_;

--- a/tachyon/zk/plonk/permutation/grand_product_argument.h
+++ b/tachyon/zk/plonk/permutation/grand_product_argument.h
@@ -61,7 +61,7 @@ class GrandProductArgument {
   }
 
  private:
-  FRIEND_TEST(LookupPermutedTest, ComputePermutationProduct);
+  FRIEND_TEST(LookupArgumentRunnerTest, ComputePermutationProduct);
 
   template <typename Evals, typename Callable>
   static Evals CreatePolynomial(size_t size, size_t blinding_factors,


### PR DESCRIPTION
In this PR, the lookup state transition methods were integrated into the `LookupRunner`, allowing state transitions to be monitored from a single implementation. And this will enhance the readability of the plonk's “create_proof()” function.

[FYI] `Lookup arguments proof` has intermediate 4 states in proving process.
- `LookupArgument`
- `LookupPermuted`
- `LookupCommitted`
- `LookupEvaluated`
- finally, `ProverQuery` for lookup.