### PR TITLE
refac(zk): add permutation argument runner

### DIFF
--- a/tachyon/zk/plonk/keys/proving_key.h
+++ b/tachyon/zk/plonk/keys/proving_key.h
@@ -28,7 +28,7 @@ class ProvingKey {
   ProvingKey() = default;
   ProvingKey(VerifyingKey<PCSTy> verifying_key, Poly l0, Poly l_last,
              Poly l_active_row, Evals fixed_values, Evals fixed_polys,
-             PermutationProvingKey<PCSTy> permutation_proving_key)
+             PermutationProvingKey<Poly, Evals> permutation_proving_key)
       : verifying_key_(std::move(verifying_key)),
         l0_(std::move(l0)),
         l_last_(std::move(l_last)),
@@ -43,7 +43,7 @@ class ProvingKey {
   const Poly& l_active_row() const { return l_active_row_; }
   const std::vector<Evals>& fixed_values() const { return fixed_values_; }
   const std::vector<Evals>& fixed_polys() const { return fixed_polys_; }
-  const PermutationProvingKey<PCSTy>& permutation_proving_key() const {
+  const PermutationProvingKey<Poly, Evals>& permutation_proving_key() const {
     return permutation_proving_key_;
   }
 
@@ -54,7 +54,7 @@ class ProvingKey {
   Poly l_active_row_;
   std::vector<Evals> fixed_values_;
   std::vector<Evals> fixed_polys_;
-  PermutationProvingKey<PCSTy> permutation_proving_key_;
+  PermutationProvingKey<Poly, Evals> permutation_proving_key_;
   VanishingArgument<PCSTy> vanishing_argument_;
 };
 

--- a/tachyon/zk/plonk/permutation/BUILD.bazel
+++ b/tachyon/zk/plonk/permutation/BUILD.bazel
@@ -51,8 +51,8 @@ tachyon_cc_library(
         ":permutation_evaluated",
         ":permutation_proving_key",
         ":permutation_table_store",
-        "//tachyon/zk/base:blinded_polynomial",
-        "//tachyon/zk/base:prover",
+        "//tachyon/zk/base:prover_query",
+        "//tachyon/zk/plonk/circuit:rotation",
     ],
 )
 
@@ -75,12 +75,7 @@ tachyon_cc_library(
 tachyon_cc_library(
     name = "permutation_evaluated",
     hdrs = ["permutation_evaluated.h"],
-    deps = [
-        "//tachyon/zk/base:blinded_polynomial",
-        "//tachyon/zk/base:prover",
-        "//tachyon/zk/base:prover_query",
-        "//tachyon/zk/plonk/circuit:rotation",
-    ],
+    deps = ["//tachyon/zk/base:blinded_polynomial"],
 )
 
 tachyon_cc_library(

--- a/tachyon/zk/plonk/permutation/BUILD.bazel
+++ b/tachyon/zk/plonk/permutation/BUILD.bazel
@@ -48,6 +48,7 @@ tachyon_cc_library(
         ":grand_product_argument",
         ":permutation_argument",
         ":permutation_committed",
+        ":permutation_evaluated",
         ":permutation_proving_key",
         ":permutation_table_store",
         "//tachyon/zk/base:blinded_polynomial",
@@ -68,7 +69,7 @@ tachyon_cc_library(
 tachyon_cc_library(
     name = "permutation_committed",
     hdrs = ["permutation_committed.h"],
-    deps = [":permutation_evaluated"],
+    deps = ["//tachyon/zk/base:blinded_polynomial"],
 )
 
 tachyon_cc_library(

--- a/tachyon/zk/plonk/permutation/BUILD.bazel
+++ b/tachyon/zk/plonk/permutation/BUILD.bazel
@@ -33,14 +33,25 @@ tachyon_cc_library(
     name = "permutation_argument",
     hdrs = ["permutation_argument.h"],
     deps = [
+        "//tachyon/base/containers:contains",
+        "//tachyon/zk/plonk/circuit:column_key",
+    ],
+)
+
+tachyon_cc_library(
+    name = "permutation_argument_runner",
+    hdrs = [
+        "permutation_argument_runner.h",
+        "permutation_argument_runner_impl.h",
+    ],
+    deps = [
         ":grand_product_argument",
+        ":permutation_argument",
         ":permutation_committed",
         ":permutation_proving_key",
         ":permutation_table_store",
-        "//tachyon/base/containers:contains",
         "//tachyon/zk/base:blinded_polynomial",
         "//tachyon/zk/base:prover",
-        "//tachyon/zk/plonk/circuit:column_key",
     ],
 )
 
@@ -158,6 +169,7 @@ tachyon_cc_unittest(
         "unpermuted_table_unittest.cc",
     ],
     deps = [
+        ":permutation_argument_runner",
         ":permutation_assembly",
         ":permutation_table_store",
         "//tachyon/base/buffer:vector_buffer",

--- a/tachyon/zk/plonk/permutation/permutation_argument_runner.h
+++ b/tachyon/zk/plonk/permutation/permutation_argument_runner.h
@@ -12,6 +12,7 @@
 
 #include "tachyon/base/parallelize.h"
 #include "tachyon/zk/base/prover.h"
+#include "tachyon/zk/base/prover_query.h"
 #include "tachyon/zk/plonk/circuit/table.h"
 #include "tachyon/zk/plonk/permutation/permutation_argument.h"
 #include "tachyon/zk/plonk/permutation/permutation_committed.h"
@@ -39,6 +40,11 @@ class PermutationArgumentRunner {
   template <typename PCSTy, typename F>
   static PermutationEvaluated<Poly> EvaluateCommitted(
       Prover<PCSTy>* prover, PermutationCommitted<Poly>&& committed,
+      const F& x);
+
+  template <typename PCSTy, typename F>
+  static std::vector<ProverQuery<PCSTy>> OpenEvaluated(
+      const Prover<PCSTy>* prover, const PermutationEvaluated<Poly>& evaluated,
       const F& x);
 
  private:

--- a/tachyon/zk/plonk/permutation/permutation_argument_runner.h
+++ b/tachyon/zk/plonk/permutation/permutation_argument_runner.h
@@ -47,6 +47,22 @@ class PermutationArgumentRunner {
       const Prover<PCSTy>* prover, const PermutationEvaluated<Poly>& evaluated,
       const F& x);
 
+  template <typename PCSTy, typename F>
+  static std::vector<BlindedPolynomial<Poly>> BlindProvingKey(
+      Prover<PCSTy>* prover,
+      const PermutationProvingKey<Poly, Evals>& proving_key);
+
+  template <typename PCSTy, typename F>
+  static std::vector<ProverQuery<PCSTy>> OpenBlindedPolynomials(
+      const std::vector<BlindedPolynomial<Poly>>& blinded_polys, const F& x);
+
+  // TODO(dongchangYoo): Check if this func can be merged with the
+  // |OpenBlindedPolynomials| when refactoring |CreateProof()|
+  template <typename PCSTy, typename F>
+  static void EvaluateProvingKey(
+      Prover<PCSTy>* prover,
+      const PermutationProvingKey<Poly, Evals>& proving_key, const F& x);
+
  private:
   template <typename F>
   static std::function<base::ParallelizeCallback3<F>(size_t)>

--- a/tachyon/zk/plonk/permutation/permutation_argument_runner.h
+++ b/tachyon/zk/plonk/permutation/permutation_argument_runner.h
@@ -34,7 +34,7 @@ class PermutationArgumentRunner {
   static PermutationCommitted<Poly> CommitArgument(
       Prover<PCSTy>* prover, const PermutationArgument& argument,
       Table<Evals>& table, size_t constraint_system_degree,
-      const PermutationProvingKey<PCSTy>& permutation_proving_key,
+      const PermutationProvingKey<Poly, Evals>& permutation_proving_key,
       const F& beta, const F& gamma);
 
   template <typename PCSTy, typename F>

--- a/tachyon/zk/plonk/permutation/permutation_argument_runner.h
+++ b/tachyon/zk/plonk/permutation/permutation_argument_runner.h
@@ -1,0 +1,58 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
+#ifndef TACHYON_ZK_PLONK_PERMUTATION_PERMUTATION_ARGUMENT_RUNNER_H_
+#define TACHYON_ZK_PLONK_PERMUTATION_PERMUTATION_ARGUMENT_RUNNER_H_
+
+#include <functional>
+#include <vector>
+
+#include "tachyon/base/parallelize.h"
+#include "tachyon/zk/base/prover.h"
+#include "tachyon/zk/plonk/circuit/table.h"
+#include "tachyon/zk/plonk/permutation/permutation_argument.h"
+#include "tachyon/zk/plonk/permutation/permutation_committed.h"
+#include "tachyon/zk/plonk/permutation/permutation_proving_key.h"
+
+namespace tachyon::zk {
+
+template <typename Poly, typename Evals>
+class PermutationArgumentRunner {
+ public:
+  PermutationArgumentRunner() = delete;
+
+  // Returns commitments of Zₚ,ᵢ for chunk index i.
+  //
+  // See Halo2 book to figure out logic in detail.
+  // https://zcash.github.io/halo2/design/proving-system/permutation.html
+  template <typename PCSTy, typename F>
+  static PermutationCommitted<Poly> CommitArgument(
+      Prover<PCSTy>* prover, const PermutationArgument& argument,
+      Table<Evals>& table, size_t constraint_system_degree,
+      const PermutationProvingKey<PCSTy>& permutation_proving_key,
+      const F& beta, const F& gamma);
+
+ private:
+  template <typename F>
+  static std::function<base::ParallelizeCallback3<F>(size_t)>
+  CreateNumeratorCallback(
+      const std::vector<Ref<const Evals>>& unpermuted_columns,
+      const std::vector<Ref<const Evals>>& value_columns, const F& beta,
+      const F& gamma);
+
+  template <typename F>
+  static std::function<base::ParallelizeCallback3<F>(size_t)>
+  CreateDenominatorCallback(
+      const std::vector<Ref<const Evals>>& permuted_columns,
+      const std::vector<Ref<const Evals>>& value_columns, const F& beta,
+      const F& gamma);
+};
+
+}  // namespace tachyon::zk
+
+#include "tachyon/zk/plonk/permutation/permutation_argument_runner_impl.h"
+
+#endif  // TACHYON_ZK_PLONK_PERMUTATION_PERMUTATION_ARGUMENT_RUNNER_H_

--- a/tachyon/zk/plonk/permutation/permutation_argument_runner.h
+++ b/tachyon/zk/plonk/permutation/permutation_argument_runner.h
@@ -15,6 +15,7 @@
 #include "tachyon/zk/plonk/circuit/table.h"
 #include "tachyon/zk/plonk/permutation/permutation_argument.h"
 #include "tachyon/zk/plonk/permutation/permutation_committed.h"
+#include "tachyon/zk/plonk/permutation/permutation_evaluated.h"
 #include "tachyon/zk/plonk/permutation/permutation_proving_key.h"
 
 namespace tachyon::zk {
@@ -34,6 +35,11 @@ class PermutationArgumentRunner {
       Table<Evals>& table, size_t constraint_system_degree,
       const PermutationProvingKey<PCSTy>& permutation_proving_key,
       const F& beta, const F& gamma);
+
+  template <typename PCSTy, typename F>
+  static PermutationEvaluated<Poly> EvaluateCommitted(
+      Prover<PCSTy>* prover, PermutationCommitted<Poly>&& committed,
+      const F& x);
 
  private:
   template <typename F>

--- a/tachyon/zk/plonk/permutation/permutation_argument_runner_impl.h
+++ b/tachyon/zk/plonk/permutation/permutation_argument_runner_impl.h
@@ -28,8 +28,8 @@ PermutationCommitted<Poly>
 PermutationArgumentRunner<Poly, Evals>::CommitArgument(
     Prover<PCSTy>* prover, const PermutationArgument& argument,
     Table<Evals>& table, size_t constraint_system_degree,
-    const PermutationProvingKey<PCSTy>& permutation_proving_key, const F& beta,
-    const F& gamma) {
+    const PermutationProvingKey<Poly, Evals>& permutation_proving_key,
+    const F& beta, const F& gamma) {
   // How many columns can be included in a single permutation polynomial?
   // We need to multiply by z(X) and (1 - (l_last(X) + l_blind(X))). This
   // will never underflow because of the requirement of at least a degree

--- a/tachyon/zk/plonk/permutation/permutation_argument_runner_impl.h
+++ b/tachyon/zk/plonk/permutation/permutation_argument_runner_impl.h
@@ -135,6 +135,44 @@ PermutationArgumentRunner<Poly, Evals>::OpenEvaluated(
 }
 
 template <typename Poly, typename Evals>
+template <typename PCSTy, typename F>
+std::vector<BlindedPolynomial<Poly>>
+PermutationArgumentRunner<Poly, Evals>::BlindProvingKey(
+    Prover<PCSTy>* prover,
+    const PermutationProvingKey<Poly, Evals>& proving_key) {
+  std::vector<BlindedPolynomial<Poly>> ret;
+  ret.reserve(proving_key.polys().size());
+  for (Poly& poly : proving_key.polys()) {
+    F blind = prover->blinder().Generate();
+    ret.emplace_back(std::move(poly), std::move(blind));
+  }
+  return ret;
+}
+
+template <typename Poly, typename Evals>
+template <typename PCSTy, typename F>
+std::vector<ProverQuery<PCSTy>>
+PermutationArgumentRunner<Poly, Evals>::OpenBlindedPolynomials(
+    const std::vector<BlindedPolynomial<Poly>>& blinded_polys, const F& x) {
+  std::vector<ProverQuery<PCSTy>> ret;
+  ret.reserve(blinded_polys.size());
+  for (const BlindedPolynomial<Poly>& blind_poly : blinded_polys) {
+    ret.emplace_back(x, blind_poly.ToRef());
+  }
+  return ret;
+}
+
+template <typename Poly, typename Evals>
+template <typename PCSTy, typename F>
+void PermutationArgumentRunner<Poly, Evals>::EvaluateProvingKey(
+    Prover<PCSTy>* prover,
+    const PermutationProvingKey<Poly, Evals>& proving_key, const F& x) {
+  for (const Poly& poly : proving_key.polys()) {
+    prover->Evaluate(poly, x);
+  }
+}
+
+template <typename Poly, typename Evals>
 template <typename F>
 std::function<base::ParallelizeCallback3<F>(size_t)>
 PermutationArgumentRunner<Poly, Evals>::CreateNumeratorCallback(

--- a/tachyon/zk/plonk/permutation/permutation_argument_runner_impl.h
+++ b/tachyon/zk/plonk/permutation/permutation_argument_runner_impl.h
@@ -1,0 +1,125 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
+#ifndef TACHYON_ZK_PLONK_PERMUTATION_PERMUTATION_ARGUMENT_RUNNER_IMPL_H_
+#define TACHYON_ZK_PLONK_PERMUTATION_PERMUTATION_ARGUMENT_RUNNER_IMPL_H_
+
+#include <functional>
+#include <utility>
+#include <vector>
+
+#include "tachyon/base/logging.h"
+#include "tachyon/zk/base/blinded_polynomial.h"
+#include "tachyon/zk/plonk/permutation/grand_product_argument.h"
+#include "tachyon/zk/plonk/permutation/permutation_argument_runner.h"
+#include "tachyon/zk/plonk/permutation/permutation_table_store.h"
+#include "tachyon/zk/plonk/permutation/permuted_table.h"
+#include "tachyon/zk/plonk/permutation/unpermuted_table.h"
+
+namespace tachyon::zk {
+
+template <typename Poly, typename Evals>
+template <typename PCSTy, typename F>
+PermutationCommitted<Poly>
+PermutationArgumentRunner<Poly, Evals>::CommitArgument(
+    Prover<PCSTy>* prover, const PermutationArgument& argument,
+    Table<Evals>& table, size_t constraint_system_degree,
+    const PermutationProvingKey<PCSTy>& permutation_proving_key, const F& beta,
+    const F& gamma) {
+  // How many columns can be included in a single permutation polynomial?
+  // We need to multiply by z(X) and (1 - (l_last(X) + l_blind(X))). This
+  // will never underflow because of the requirement of at least a degree
+  // 3 circuit for the permutation argument.
+  CHECK_GE(constraint_system_degree, argument.RequiredDegree());
+
+  size_t chunk_size = constraint_system_degree - 2;
+  size_t chunk_num = (argument.columns().size() + chunk_size - 1) / chunk_size;
+
+  UnpermutedTable<Evals> unpermuted_table = UnpermutedTable<Evals>::Construct(
+      argument.columns().size(), prover->domain());
+  PermutedTable<Evals> permuted_table(&permutation_proving_key.permutations());
+  PermutationTableStore<Evals> table_store(
+      argument.columns(), table, permuted_table, unpermuted_table, chunk_size);
+
+  std::vector<BlindedPolynomial<Poly>> grand_product_polys;
+  grand_product_polys.reserve(chunk_num);
+
+  // Track the "last" value from the previous column set.
+  F last_z = F::One();
+
+  for (size_t i = 0; i < chunk_num; ++i) {
+    std::vector<Ref<const Evals>> permuted_columns =
+        table_store.GetPermutedColumns(i);
+    std::vector<Ref<const Evals>> unpermuted_columns =
+        table_store.GetUnpermutedColumns(i);
+    std::vector<Ref<const Evals>> value_columns =
+        table_store.GetValueColumns(i);
+
+    size_t chunk_size = table_store.GetChunkSize(i);
+    BlindedPolynomial<Poly> grand_product_poly =
+        GrandProductArgument::CommitExcessive(
+            prover,
+            CreateNumeratorCallback<F>(unpermuted_columns, value_columns, beta,
+                                       gamma),
+            CreateDenominatorCallback<F>(permuted_columns, value_columns, beta,
+                                         gamma),
+            chunk_size, last_z);
+
+    grand_product_polys.push_back(std::move(grand_product_poly));
+  }
+
+  return PermutationCommitted<Poly>(std::move(grand_product_polys));
+}
+
+template <typename Poly, typename Evals>
+template <typename F>
+std::function<base::ParallelizeCallback3<F>(size_t)>
+PermutationArgumentRunner<Poly, Evals>::CreateNumeratorCallback(
+    const std::vector<Ref<const Evals>>& unpermuted_columns,
+    const std::vector<Ref<const Evals>>& value_columns, const F& beta,
+    const F& gamma) {
+  // vᵢ(ωʲ) + β * δⁱ * ωʲ + γ
+  return [&unpermuted_columns, &value_columns, &beta,
+          &gamma](size_t column_index) {
+    const Evals& unpermuted_values = *unpermuted_columns[column_index];
+    const Evals& values = *value_columns[column_index];
+    return [&unpermuted_values, &values, &beta, &gamma](
+               absl::Span<F> chunk, size_t chunk_index, size_t chunk_size_in) {
+      size_t i = chunk_index * chunk_size_in;
+      for (F& result : chunk) {
+        result *= *values[i] + beta * *unpermuted_values[i] + gamma;
+        ++i;
+      }
+    };
+  };
+}
+
+template <typename Poly, typename Evals>
+template <typename F>
+std::function<base::ParallelizeCallback3<F>(size_t)>
+PermutationArgumentRunner<Poly, Evals>::CreateDenominatorCallback(
+    const std::vector<Ref<const Evals>>& permuted_columns,
+    const std::vector<Ref<const Evals>>& value_columns, const F& beta,
+    const F& gamma) {
+  // vᵢ(ωʲ) + β * sᵢ(ωʲ) + γ
+  return [&permuted_columns, &value_columns, &beta,
+          &gamma](size_t column_index) {
+    const Evals& permuted_values = *permuted_columns[column_index];
+    const Evals& values = *value_columns[column_index];
+    return [&permuted_values, &values, &beta, &gamma](
+               absl::Span<F> chunk, size_t chunk_index, size_t chunk_size_in) {
+      size_t i = chunk_index * chunk_size_in;
+      for (F& result : chunk) {
+        result *= *values[i] + beta * *permuted_values[i] + gamma;
+        ++i;
+      }
+    };
+  };
+}
+
+}  // namespace tachyon::zk
+
+#endif  // TACHYON_ZK_PLONK_PERMUTATION_PERMUTATION_ARGUMENT_RUNNER_IMPL_H_

--- a/tachyon/zk/plonk/permutation/permutation_argument_unittest.cc
+++ b/tachyon/zk/plonk/permutation/permutation_argument_unittest.cc
@@ -10,6 +10,8 @@
 
 #include "tachyon/base/random.h"
 #include "tachyon/zk/base/halo2_prover_test.h"
+#include "tachyon/zk/plonk/circuit/table.h"
+#include "tachyon/zk/plonk/permutation/permutation_argument_runner.h"
 #include "tachyon/zk/plonk/permutation/permutation_assembly.h"
 
 namespace tachyon::zk {
@@ -83,7 +85,8 @@ TEST_F(PermutationArgumentTest, Commit) {
   F beta = F::Random();
   F gamma = F::Random();
 
-  argument_.Commit(prover_.get(), table_, prover_->pcs().N(), pk, beta, gamma);
+  PermutationArgumentRunner<Poly, Evals>::CommitArgument(
+      prover_.get(), argument_, table_, prover_->pcs().N(), pk, beta, gamma);
 }
 
 }  // namespace tachyon::zk

--- a/tachyon/zk/plonk/permutation/permutation_argument_unittest.cc
+++ b/tachyon/zk/plonk/permutation/permutation_argument_unittest.cc
@@ -79,7 +79,7 @@ TEST_F(PermutationArgumentTest, Commit) {
 
   std::vector<Evals> permutations =
       assembly.GeneratePermutations(prover_->domain());
-  PermutationProvingKey<PCS> pk =
+  PermutationProvingKey<Poly, Evals> pk =
       assembly.BuildProvingKey(prover_.get(), permutations);
 
   F beta = F::Random();

--- a/tachyon/zk/plonk/permutation/permutation_assembly.h
+++ b/tachyon/zk/plonk/permutation/permutation_assembly.h
@@ -96,7 +96,7 @@ class PermutationAssembly {
 
   // Returns the |PermutationProvingKey| that has the coefficient form and
   // evaluation form of the permutation.
-  constexpr PermutationProvingKey<PCSTy> BuildProvingKey(
+  constexpr PermutationProvingKey<Poly, Evals> BuildProvingKey(
       const Prover<PCSTy>* prover,
       const std::vector<Evals>& permutations) const {
     const Domain* domain = prover->domain();
@@ -109,8 +109,8 @@ class PermutationAssembly {
       polys.push_back(std::move(poly));
     }
 
-    return PermutationProvingKey<PCSTy>(std::move(permutations),
-                                        std::move(polys));
+    return PermutationProvingKey<Poly, Evals>(std::move(permutations),
+                                              std::move(polys));
   }
 
   // Generate the permutation polynomials based on the accumulated copy

--- a/tachyon/zk/plonk/permutation/permutation_assembly_unittest.cc
+++ b/tachyon/zk/plonk/permutation/permutation_assembly_unittest.cc
@@ -49,7 +49,7 @@ TEST_F(PermutationAssemblyTest, BuildKeys) {
 
   std::vector<Evals> permutations =
       assembly_.GeneratePermutations(prover_->domain());
-  PermutationProvingKey<PCS> pk =
+  PermutationProvingKey<Poly, Evals> pk =
       assembly_.BuildProvingKey(prover_.get(), permutations);
   EXPECT_EQ(pk.permutations().size(), pk.polys().size());
 

--- a/tachyon/zk/plonk/permutation/permutation_evaluated.h
+++ b/tachyon/zk/plonk/permutation/permutation_evaluated.h
@@ -11,9 +11,6 @@
 #include <vector>
 
 #include "tachyon/zk/base/blinded_polynomial.h"
-#include "tachyon/zk/base/prover.h"
-#include "tachyon/zk/base/prover_query.h"
-#include "tachyon/zk/plonk/circuit/rotation.h"
 
 namespace tachyon::zk {
 
@@ -27,29 +24,6 @@ class PermutationEvaluated {
 
   const std::vector<BlindedPolynomial<Poly>>& product_polys() const {
     return product_polys_;
-  }
-
-  template <typename PCSTy, typename F>
-  std::vector<ProverQuery<PCSTy>> Open(const Prover<PCSTy>* prover,
-                                       const F& x) const {
-    std::vector<ProverQuery<PCSTy>> ret;
-    ret.reserve(product_polys_.size() * 3 - 1);
-
-    F x_next = Rotation::Next().RotateOmega(prover->domain(), x);
-    for (const BlindedPolynomial<Poly>& blinded_poly : product_polys_) {
-      ret.emplace_back(x, blinded_poly.ToRef());
-      ret.emplace_back(x_next, blinded_poly.ToRef());
-    }
-
-    int32_t blinding_factors =
-        static_cast<int32_t>(prover->blinder().blinding_factors());
-    F x_last =
-        Rotation(-(blinding_factors + 1)).RotateOmega(prover->domain(), x);
-    for (auto it = product_polys_.rbegin() + 1; it != product_polys_.rend();
-         ++it) {
-      ret.emplace_back(x_last, it->ToRef());
-    }
-    return ret;
   }
 
  private:

--- a/tachyon/zk/plonk/permutation/permutation_proving_key.h
+++ b/tachyon/zk/plonk/permutation/permutation_proving_key.h
@@ -28,6 +28,7 @@ class PermutationProvingKey {
 
   const std::vector<Evals>& permutations() const { return permutations_; }
   const std::vector<Poly>& polys() const { return polys_; }
+  std::vector<Poly>& polys() { return polys_; }
 
   size_t BytesLength() const { return base::EstimateSize(this); }
 

--- a/tachyon/zk/plonk/permutation/permutation_proving_key.h
+++ b/tachyon/zk/plonk/permutation/permutation_proving_key.h
@@ -15,15 +15,9 @@
 namespace tachyon {
 namespace zk {
 
-template <typename PCSTy>
+template <typename Poly, typename Evals>
 class PermutationProvingKey {
  public:
-  constexpr static size_t kMaxDegree = PCSTy::kMaxDegree;
-
-  using F = typename PCSTy::Field;
-  using Poly = typename PCSTy::Poly;
-  using Evals = typename PCSTy::Evals;
-
   PermutationProvingKey() = default;
   PermutationProvingKey(const std::vector<Evals>& permutations,
                         const std::vector<Poly>& polys)
@@ -53,28 +47,26 @@ class PermutationProvingKey {
 
 namespace base {
 
-template <typename PCSTy>
-class Copyable<zk::PermutationProvingKey<PCSTy>> {
+template <typename Poly, typename Evals>
+class Copyable<zk::PermutationProvingKey<Poly, Evals>> {
  public:
-  using Poly = typename PCSTy::Poly;
-  using Evals = typename PCSTy::Evals;
-
-  static bool WriteTo(const zk::PermutationProvingKey<PCSTy>& pk,
+  static bool WriteTo(const zk::PermutationProvingKey<Poly, Evals>& pk,
                       Buffer* buffer) {
     return buffer->WriteMany(pk.permutations(), pk.polys());
   }
 
   static bool ReadFrom(const Buffer& buffer,
-                       zk::PermutationProvingKey<PCSTy>* pk) {
+                       zk::PermutationProvingKey<Poly, Evals>* pk) {
     std::vector<Evals> perms;
     std::vector<Poly> poly;
     if (!buffer.ReadMany(&perms, &poly)) return false;
 
-    *pk = zk::PermutationProvingKey<PCSTy>(std::move(perms), std::move(poly));
+    *pk = zk::PermutationProvingKey<Poly, Evals>(std::move(perms),
+                                                 std::move(poly));
     return true;
   }
 
-  static size_t EstimateSize(const zk::PermutationProvingKey<PCSTy>& pk) {
+  static size_t EstimateSize(const zk::PermutationProvingKey<Poly, Evals>& pk) {
     return base::EstimateSize(pk.permutations()) +
            base::EstimateSize(pk.polys());
   }

--- a/tachyon/zk/plonk/permutation/permutation_proving_key_unittest.cc
+++ b/tachyon/zk/plonk/permutation/permutation_proving_key_unittest.cc
@@ -17,7 +17,7 @@ namespace {
 
 class PermutationProvingKeyTest : public Halo2ProverTest {
  public:
-  using ProvingKey = PermutationProvingKey<PCS>;
+  using ProvingKey = PermutationProvingKey<Poly, Evals>;
 };
 
 }  // namespace


### PR DESCRIPTION
In this PR, the permutation state transition methods were integrated into the `PermutationArgumentRunner`, allowing state transitions to be monitored from a single implementation. And this will enhance the readability of the plonk's “create_proof()” function.

[FYI] Permutation arguments proof has intermediate 4 states in proving process.
- `PermutationArgument`
- `PermutationCommitted`
- `PermutationEvaluated`
- finally, `ProverQuery` for permutation