### PR TITLE
feat(zk): implement create proof part1

### DIFF
--- a/tachyon/base/containers/container_util_unittest.cc
+++ b/tachyon/base/containers/container_util_unittest.cc
@@ -1,5 +1,6 @@
 #include "tachyon/base/containers/container_util.h"
 
+#include <memory>
 #include <vector>
 
 #include "gmock/gmock.h"
@@ -85,6 +86,52 @@ TEST(ContainerUtilTest, FindIndexIf) {
   EXPECT_EQ(index.value(), 0);
   index = base::FindIndexIf(arr, [](size_t v) { return v == 3; });
   EXPECT_FALSE(index.has_value());
+}
+
+TEST(ContainerUtilTest, DoFindIndices) {
+  std::vector<int> arr({1, 2, 3, 1, 2, 3});
+  std::vector<std::unique_ptr<std::input_iterator_tag>> tags;
+  tags.push_back(std::make_unique<std::forward_iterator_tag>());
+  tags.push_back(std::make_unique<std::random_access_iterator_tag>());
+  for (const std::unique_ptr<std::input_iterator_tag>& tag : tags) {
+    std::vector<size_t> indices =
+        base::internal::DoFindIndices(arr.begin(), arr.end(), 1, *tag);
+    EXPECT_EQ(indices, std::vector<size_t>({0, 3}));
+    indices = base::internal::DoFindIndices(arr.begin(), arr.end(), 4, *tag);
+    EXPECT_TRUE(indices.empty());
+  }
+}
+
+TEST(ContainerUtilTest, FindIndices) {
+  std::vector<int> arr({1, 2, 3, 1, 2, 3});
+  std::vector<size_t> indices = base::FindIndices(arr, 1);
+  EXPECT_EQ(indices, std::vector<size_t>({0, 3}));
+  indices = base::FindIndices(arr, 4);
+  EXPECT_TRUE(indices.empty());
+}
+
+TEST(ContainerUtilTest, DoFindIndicesIf) {
+  std::vector<int> arr({1, 2, 3, 1, 2, 3});
+  std::vector<std::unique_ptr<std::input_iterator_tag>> tags;
+  tags.push_back(std::make_unique<std::forward_iterator_tag>());
+  tags.push_back(std::make_unique<std::random_access_iterator_tag>());
+  for (const std::unique_ptr<std::input_iterator_tag>& tag : tags) {
+    std::vector<size_t> indices = base::internal::DoFindIndicesIf(
+        arr.begin(), arr.end(), [](size_t v) { return v == 1; }, *tag);
+    EXPECT_EQ(indices, std::vector<size_t>({0, 3}));
+    indices = base::internal::DoFindIndicesIf(
+        arr.begin(), arr.end(), [](size_t v) { return v == 4; }, *tag);
+    EXPECT_TRUE(indices.empty());
+  }
+}
+
+TEST(ContainerUtilTest, FindIndicesIf) {
+  std::vector<int> arr({1, 2, 3, 1, 2, 3});
+  std::vector<size_t> indices =
+      base::FindIndicesIf(arr, [](size_t v) { return v == 1; });
+  EXPECT_EQ(indices, std::vector<size_t>({0, 3}));
+  indices = base::FindIndicesIf(arr, [](size_t v) { return v == 4; });
+  EXPECT_TRUE(indices.empty());
 }
 
 TEST(ContainerUtilTest, Shuffle) {

--- a/tachyon/zk/base/commitments/shplonk_extension.h
+++ b/tachyon/zk/base/commitments/shplonk_extension.h
@@ -21,6 +21,12 @@ class SHPlonkExtension
     : public UnivariatePolynomialCommitmentSchemeExtension<SHPlonkExtension<
           G1PointTy, G2PointTy, MaxDegree, MaxExtendedDegree, Commitment>> {
  public:
+  // NOTE(dongchangYoo): The following value are pre-determined according to
+  // the Commitment Opening Scheme.
+  // https://
+  // github.com/kroma-network/halo2/blob/7d0a36990452c8e7ebd600de258420781a9b7917/halo2_proofs/src/poly/kzg/multiopen/shplonk/prover.rs#L111
+  constexpr static bool kQueryInstance = false;
+
   using Field = typename G1PointTy::ScalarField;
 
   SHPlonkExtension() = default;

--- a/tachyon/zk/base/commitments/shplonk_extension.h
+++ b/tachyon/zk/base/commitments/shplonk_extension.h
@@ -52,10 +52,10 @@ class SHPlonkExtension
   }
 
   template <typename ContainerTy>
-  [[nodiscard]] bool DoCreateMultiOpeningProof(
+  [[nodiscard]] bool DoCreateOpeningProof(
       const ContainerTy& poly_openings,
       crypto::SHPlonkProof<Commitment>* proof) const {
-    return shplonk_.DoCreateMultiOpeningProof(poly_openings, proof);
+    return shplonk_.DoCreateOpeningProof(poly_openings, proof);
   }
 
  private:

--- a/tachyon/zk/base/entities/prover.h
+++ b/tachyon/zk/base/entities/prover.h
@@ -48,13 +48,17 @@ class Prover : public Entity<PCSTy> {
     return this->domain_->size() - (blinder_.blinding_factors() + 1);
   }
 
-  bool CommitEvalsWithBlind(const Evals& evals, BlindedPolynomial<Poly>* out) {
+  bool CommitEvals(const Evals& evals) {
     if (evals.NumElements() != this->domain_->size()) return false;
 
     Commitment commitment;
     if (!this->pcs_.CommitLagrange(evals, &commitment)) return false;
     GetWriter()->WriteToProof(commitment);
+    return true;
+  }
 
+  bool CommitEvalsWithBlind(const Evals& evals, BlindedPolynomial<Poly>* out) {
+    if (!CommitEvals(evals)) return false;
     *out = {this->domain_->IFFT(evals), blinder_.Generate()};
     return true;
   }

--- a/tachyon/zk/plonk/circuit/examples/simple_circuit.h
+++ b/tachyon/zk/plonk/circuit/examples/simple_circuit.h
@@ -34,6 +34,11 @@ class FieldConfig {
 
   FieldConfig() = default;
 
+  FieldConfig Clone() const {
+    std::array<AdviceColumnKey, 2> advice_clone = advice_;
+    return FieldConfig(std::move(advice_clone), instance_, s_mul_);
+  }
+
   const std::array<AdviceColumnKey, 2>& advice() const { return advice_; }
   const InstanceColumnKey& instance() const { return instance_; }
   const Selector& s_mul() const { return s_mul_; }

--- a/tachyon/zk/plonk/keys/proving_key.h
+++ b/tachyon/zk/plonk/keys/proving_key.h
@@ -42,7 +42,7 @@ class ProvingKey {
   const Poly& l_last() const { return l_last_; }
   const Poly& l_active_row() const { return l_active_row_; }
   const std::vector<Evals>& fixed_values() const { return fixed_values_; }
-  const std::vector<Evals>& fixed_polys() const { return fixed_polys_; }
+  const std::vector<Poly>& fixed_polys() const { return fixed_polys_; }
   const PermutationProvingKey<Poly, Evals>& permutation_proving_key() const {
     return permutation_proving_key_;
   }
@@ -53,7 +53,7 @@ class ProvingKey {
   Poly l_last_;
   Poly l_active_row_;
   std::vector<Evals> fixed_values_;
-  std::vector<Evals> fixed_polys_;
+  std::vector<Poly> fixed_polys_;
   PermutationProvingKey<Poly, Evals> permutation_proving_key_;
   VanishingArgument<PCSTy> vanishing_argument_;
 };

--- a/tachyon/zk/plonk/prover/BUILD.bazel
+++ b/tachyon/zk/plonk/prover/BUILD.bazel
@@ -3,6 +3,17 @@ load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_unittest")
 package(default_visibility = ["//visibility:public"])
 
 tachyon_cc_library(
+    name = "argument",
+    hdrs = ["argument.h"],
+    deps = [
+        "//tachyon/base:logging",
+        "//tachyon/base/containers:container_util",
+        "//tachyon/zk/base/entities:prover",
+        "//tachyon/zk/plonk/circuit:table",
+    ],
+)
+
+tachyon_cc_library(
     name = "synthesizer",
     hdrs = ["synthesizer.h"],
     deps = [
@@ -28,12 +39,14 @@ tachyon_cc_library(
 tachyon_cc_unittest(
     name = "prover_unittests",
     srcs = [
+        "argument_unittest.cc",
         "synthesizer_unittest.cc",
         "witness_collection_unittest.cc",
     ],
     deps = [
+        ":argument",
         ":synthesizer",
-        ":witness_collection",
+        "//tachyon/base/containers:container_util",
         "//tachyon/zk/base/halo2:halo2_prover_test",
         "//tachyon/zk/plonk/circuit/examples:simple_circuit",
         "//tachyon/zk/plonk/keys/halo2:pinned_verifying_key",

--- a/tachyon/zk/plonk/prover/BUILD.bazel
+++ b/tachyon/zk/plonk/prover/BUILD.bazel
@@ -1,0 +1,27 @@
+load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_unittest")
+
+package(default_visibility = ["//visibility:public"])
+
+tachyon_cc_library(
+    name = "witness_collection",
+    hdrs = ["witness_collection.h"],
+    deps = [
+        "//tachyon/base:range",
+        "//tachyon/base/containers:container_util",
+        "//tachyon/zk/plonk/circuit:assignment",
+        "//tachyon/zk/plonk/circuit:phase",
+        "@com_google_absl//absl/container:btree",
+    ],
+)
+
+tachyon_cc_unittest(
+    name = "prover_unittests",
+    srcs = [
+        "witness_collection_unittest.cc",
+    ],
+    deps = [
+        ":witness_collection",
+        "//tachyon/zk/base/halo2:halo2_prover_test",
+        "//tachyon/zk/plonk/circuit/examples:simple_circuit",
+    ],
+)

--- a/tachyon/zk/plonk/prover/BUILD.bazel
+++ b/tachyon/zk/plonk/prover/BUILD.bazel
@@ -3,6 +3,17 @@ load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_unittest")
 package(default_visibility = ["//visibility:public"])
 
 tachyon_cc_library(
+    name = "synthesizer",
+    hdrs = ["synthesizer.h"],
+    deps = [
+        ":witness_collection",
+        "//tachyon/base/containers:container_util",
+        "//tachyon/zk/base/entities:prover",
+        "//tachyon/zk/plonk:constraint_system",
+    ],
+)
+
+tachyon_cc_library(
     name = "witness_collection",
     hdrs = ["witness_collection.h"],
     deps = [
@@ -17,11 +28,14 @@ tachyon_cc_library(
 tachyon_cc_unittest(
     name = "prover_unittests",
     srcs = [
+        "synthesizer_unittest.cc",
         "witness_collection_unittest.cc",
     ],
     deps = [
+        ":synthesizer",
         ":witness_collection",
         "//tachyon/zk/base/halo2:halo2_prover_test",
         "//tachyon/zk/plonk/circuit/examples:simple_circuit",
+        "//tachyon/zk/plonk/keys/halo2:pinned_verifying_key",
     ],
 )

--- a/tachyon/zk/plonk/prover/argument.h
+++ b/tachyon/zk/plonk/prover/argument.h
@@ -1,0 +1,176 @@
+#ifndef TACHYON_ZK_PLONK_PROVER_ARGUMENT_H_
+#define TACHYON_ZK_PLONK_PROVER_ARGUMENT_H_
+
+#include <utility>
+#include <vector>
+
+#include "tachyon/base/containers/container_util.h"
+#include "tachyon/base/logging.h"
+#include "tachyon/zk/base/entities/prover.h"
+#include "tachyon/zk/plonk/circuit/table.h"
+
+namespace tachyon::zk {
+
+// Data class including all arguments for creating proof.
+template <typename PCSTy>
+class Argument {
+ public:
+  constexpr static size_t kMaxDegree = PCSTy::kMaxDegree;
+
+  using F = typename PCSTy::Field;
+  using Poly = typename PCSTy::Poly;
+  using Evals = typename PCSTy::Evals;
+  using Domain = typename PCSTy::Domain;
+
+  Argument() = default;
+  static Argument Create(Prover<PCSTy>* prover, size_t num_circuits,
+                         const std::vector<Evals>* fixed_columns,
+                         const std::vector<Poly>* fixed_polys,
+                         std::vector<std::vector<Evals>>&& advice_columns_vec,
+                         std::vector<std::vector<F>>&& advice_blinds_vec,
+                         std::vector<std::vector<Evals>>&& instance_columns_vec,
+                         std::vector<F>&& challenges) {
+    std::vector<std::vector<Poly>> instance_polys_vec =
+        GenerateInstancePolys(prover, instance_columns_vec);
+
+    return Argument(num_circuits, fixed_columns, fixed_polys,
+                    std::move(advice_columns_vec), std::move(advice_blinds_vec),
+                    std::move(instance_columns_vec),
+                    std::move(instance_polys_vec), std::move(challenges));
+  }
+
+  bool advice_transformed() const { return advice_transformed_; }
+
+  // Generate a vector of advice coefficient-formed polynomials with a vector
+  // of advice evaluation-formed columns. (a.k.a. Batch IFFT)
+  // And for memory optimization, every evaluations of advice will be released
+  // as soon as transforming it to coefficient form.
+  void TransformAdvice(const Domain* domain) {
+    CHECK(!advice_transformed_);
+    advice_polys_vec_ = base::Map(
+        advice_columns_vec_, [domain](std::vector<Evals>& advice_columns) {
+          return base::Map(advice_columns, [domain](Evals& advice_column) {
+            Poly poly = domain->IFFT(advice_column);
+            // Release advice evals for memory optimization.
+            advice_column = Evals::Zero();
+            return poly;
+          });
+        });
+    // Deallocate evaluations for memory optimization.
+    advice_columns_vec_.clear();
+    advice_transformed_ = true;
+  }
+
+  // Return tables including every type of polynomials in evaluation form.
+  std::vector<Table<Evals>> ExportColumnTables() const {
+    CHECK(!advice_transformed_);
+    absl::Span<const Evals> fixed_columns =
+        absl::MakeConstSpan(*fixed_columns_);
+
+    base::Range<size_t> circuit_range =
+        base::Range<size_t>::Until(num_circuits_);
+    return base::Map(circuit_range.begin(), circuit_range.end(),
+                     [fixed_columns, this](size_t i) {
+                       absl::Span<const Evals> advice_columns =
+                           absl::MakeConstSpan(advice_columns_vec_[i]);
+                       absl::Span<const Evals> instance_columns =
+                           absl::MakeConstSpan(instance_columns_vec_[i]);
+                       return Table<Evals>(fixed_columns, advice_columns,
+                                           instance_columns);
+                     });
+  }
+
+  // Return a table including every type of polynomials in coefficient form.
+  std::vector<Table<Poly>> ExportPolyTables() const {
+    CHECK(advice_transformed_);
+    absl::Span<const Poly> fixed_polys = absl::MakeConstSpan(*fixed_polys_);
+
+    base::Range<size_t> circuit_range =
+        base::Range<size_t>::Until(num_circuits_);
+    return base::Map(circuit_range.begin(), circuit_range.end(),
+                     [fixed_polys, this](size_t i) {
+                       absl::Span<const Poly> advice_polys =
+                           absl::MakeConstSpan(advice_polys_vec_[i]);
+                       absl::Span<const Poly> instance_polys =
+                           absl::MakeConstSpan(instance_polys_vec_[i]);
+                       return Table<Poly>(fixed_polys, advice_polys,
+                                          instance_polys);
+                     });
+  }
+
+  const std::vector<F>& GetAdviceBlinds(size_t circuit_idx) const {
+    CHECK_LT(circuit_idx, num_circuits_);
+    return advice_blinds_vec_[circuit_idx];
+  }
+
+  const std::vector<F>& challenges() const { return challenges_; }
+
+ private:
+  Argument(size_t num_circuits, const std::vector<Evals>* fixed_columns,
+           const std::vector<Poly>* fixed_polys,
+           std::vector<std::vector<Evals>>&& advice_columns_vec,
+           std::vector<std::vector<F>>&& advice_blinds_vec,
+           std::vector<std::vector<Evals>>&& instance_columns_vec,
+           std::vector<std::vector<Poly>>&& instance_polys_vec,
+           std::vector<F>&& challenges)
+      : num_circuits_(num_circuits),
+        fixed_columns_(fixed_columns),
+        fixed_polys_(fixed_polys),
+        advice_columns_vec_(std::move(advice_columns_vec)),
+        advice_blinds_vec_(std::move(advice_blinds_vec)),
+        instance_columns_vec_(std::move(instance_columns_vec)),
+        instance_polys_vec_(std::move(instance_polys_vec)),
+        challenges_(std::move(challenges)) {
+    CHECK_EQ(num_circuits_, advice_columns_vec_.size());
+    CHECK_EQ(num_circuits_, advice_blinds_vec_.size());
+    CHECK_EQ(num_circuits_, instance_columns_vec_.size());
+    CHECK_EQ(num_circuits_, instance_polys_vec_.size());
+  }
+
+  // Generate a vector of instance coefficient-formed polynomials with a vector
+  // of instance evaluation-formed columns. (a.k.a. Batch IFFT)
+  static std::vector<std::vector<Poly>> GenerateInstancePolys(
+      Prover<PCSTy>* prover,
+      std::vector<std::vector<Evals>> instance_columns_vec) {
+    return base::Map(instance_columns_vec,
+                     [prover](const std::vector<Evals>& instance_columns) {
+                       return base::Map(
+                           instance_columns,
+                           [prover](const Evals& instance_column) {
+                             if constexpr (PCSTy::kQueryInstance) {
+                               CHECK(prover->CommitEvals(instance_column));
+                             } else {
+                               for (size_t i = 0; i <= kMaxDegree; ++i) {
+                                 CHECK(prover->GetWriter()->WriteToTranscript(
+                                     *instance_column[i]));
+                               }
+                             }
+                             return prover->domain()->IFFT(instance_column);
+                           });
+                     });
+  }
+
+  size_t num_circuits_ = 0;
+  // not owned
+  const std::vector<Evals>* fixed_columns_ = nullptr;
+  // not owned
+  const std::vector<Poly>* fixed_polys_ = nullptr;
+
+  std::vector<std::vector<Evals>> advice_columns_vec_;
+  std::vector<std::vector<F>> advice_blinds_vec_;
+  // Note(dongchangYoo): to optimize memory usage, release every advice
+  // evaluations after generating an advice polynomial. That is, when
+  // |advice_transformed_| is set to true, |advice_values_by_circuits| is
+  // released, and only |advice_polys_by_circuits| becomes available for use.
+  std::vector<std::vector<Poly>> advice_polys_vec_;
+  bool advice_transformed_ = false;
+
+  std::vector<std::vector<Evals>> instance_columns_vec_;
+  std::vector<std::vector<Poly>> instance_polys_vec_;
+
+  std::vector<F> challenges_;
+};
+
+}  // namespace tachyon::zk
+
+#endif  // TACHYON_ZK_PLONK_PROVER_ARGUMENT_H_

--- a/tachyon/zk/plonk/prover/argument_unittest.cc
+++ b/tachyon/zk/plonk/prover/argument_unittest.cc
@@ -1,0 +1,122 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
+#include "tachyon/zk/plonk/prover/argument.h"
+
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "tachyon/base/containers/container_util.h"
+#include "tachyon/zk/base/halo2/halo2_prover_test.h"
+
+namespace tachyon::zk {
+namespace {
+
+class ArgumentTest : public Halo2ProverTest {
+ public:
+  static constexpr size_t kMaxDegree = PCS::kMaxDegree;
+
+  using F = typename PCS::Field;
+  using Poly = typename PCS::Poly;
+  using Evals = typename PCS::Evals;
+
+  void InitColumns() {
+    num_circuits_ = 2;
+    expected_fixed_columns_ =
+        base::CreateVector(1, []() { return Evals::Random(); });
+    expected_fixed_polys_ =
+        base::CreateVector(1, []() { return Poly::Random(kMaxDegree); });
+    expected_advice_columns_vec_ = base::CreateVector(num_circuits_, []() {
+      return base::CreateVector(2, []() { return Evals::Random(); });
+    });
+    expected_advice_blinds_vec_ = base::CreateVector(num_circuits_, []() {
+      return base::CreateVector(2, []() { return F::Random(); });
+    });
+    expected_instance_columns_vec_ = base::CreateVector(num_circuits_, []() {
+      return base::CreateVector(1, []() { return Evals::Random(); });
+    });
+    expected_challenges_ = {F::Random()};
+  }
+
+  void SetUp() override {
+    Halo2ProverTest::SetUp();
+    InitColumns();
+
+    // Copy data to be moved.
+    std::vector<std::vector<Evals>> advice_columns_vec =
+        expected_advice_columns_vec_;
+    std::vector<std::vector<F>> advice_blinds_vec = expected_advice_blinds_vec_;
+    std::vector<std::vector<Evals>> instance_columns_vec =
+        expected_instance_columns_vec_;
+    std::vector<F> challenges = expected_challenges_;
+
+    argument_ = Argument<PCS>::Create(
+        prover_.get(), num_circuits_, &expected_fixed_columns_,
+        &expected_fixed_polys_, std::move(advice_columns_vec),
+        std::move(advice_blinds_vec), std::move(instance_columns_vec),
+        std::move(challenges));
+  }
+
+ protected:
+  size_t num_circuits_ = 2;
+  std::vector<Evals> expected_fixed_columns_;
+  std::vector<Poly> expected_fixed_polys_;
+  std::vector<std::vector<Evals>> expected_advice_columns_vec_;
+  std::vector<std::vector<F>> expected_advice_blinds_vec_;
+  std::vector<std::vector<Evals>> expected_instance_columns_vec_;
+  std::vector<F> expected_challenges_;
+
+  Argument<PCS> argument_;
+};
+
+}  // namespace
+
+TEST_F(ArgumentTest, ExportEvalsTables) {
+  EXPECT_FALSE(argument_.advice_transformed());
+  std::vector<Table<Evals>> column_tables = argument_.ExportColumnTables();
+
+  for (size_t i = 0; i < num_circuits_; ++i) {
+    absl::Span<const Evals> fixed_columns = column_tables[i].fixed_columns();
+    absl::Span<const Evals> advice_columns = column_tables[i].advice_columns();
+    absl::Span<const Evals> instance_columns =
+        column_tables[i].instance_columns();
+
+    CHECK_EQ(expected_fixed_columns_[0], fixed_columns[0]);
+    CHECK_EQ(expected_advice_columns_vec_[i][0], advice_columns[0]);
+    CHECK_EQ(expected_advice_columns_vec_[i][1], advice_columns[1]);
+    CHECK_EQ(expected_instance_columns_vec_[i][0], instance_columns[0]);
+  }
+}
+
+TEST_F(ArgumentTest, ExportPolyTables) {
+  argument_.TransformAdvice(prover_->domain());
+  EXPECT_TRUE(argument_.advice_transformed());
+  std::vector<Table<Poly>> poly_tables = argument_.ExportPolyTables();
+
+  for (size_t i = 0; i < num_circuits_; ++i) {
+    absl::Span<const Poly> fixed_polys = poly_tables[i].fixed_columns();
+    absl::Span<const Poly> advice_polys = poly_tables[i].advice_columns();
+    absl::Span<const Poly> instance_polys = poly_tables[i].instance_columns();
+
+    CHECK_EQ(expected_fixed_polys_[0], fixed_polys[0]);
+    CHECK_EQ(expected_advice_columns_vec_[i][0],
+             prover_->domain()->FFT(advice_polys[0]));
+    CHECK_EQ(expected_advice_columns_vec_[i][1],
+             prover_->domain()->FFT(advice_polys[1]));
+    CHECK_EQ(expected_instance_columns_vec_[i][0],
+             prover_->domain()->FFT(instance_polys[0]));
+  }
+}
+
+TEST_F(ArgumentTest, GetAdviceBlinds) {
+  for (size_t i = 0; i < num_circuits_; ++i) {
+    std::vector<F> blinds = argument_.GetAdviceBlinds(i);
+    EXPECT_EQ(blinds, expected_advice_blinds_vec_[i]);
+  }
+}
+
+}  // namespace tachyon::zk

--- a/tachyon/zk/plonk/prover/synthesizer.h
+++ b/tachyon/zk/plonk/prover/synthesizer.h
@@ -1,0 +1,145 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
+#ifndef TACHYON_ZK_PLONK_PROVER_SYNTHESIZER_H_
+#define TACHYON_ZK_PLONK_PROVER_SYNTHESIZER_H_
+
+#include <utility>
+#include <vector>
+
+#include "tachyon/base/containers/container_util.h"
+#include "tachyon/zk/base/entities/prover.h"
+#include "tachyon/zk/plonk/constraint_system.h"
+#include "tachyon/zk/plonk/prover/witness_collection.h"
+
+namespace tachyon::zk {
+
+template <typename PCSTy>
+class Synthesizer {
+ public:
+  constexpr static size_t kMaxDegree = PCSTy::kMaxDegree;
+  constexpr static size_t kDomainSize = kMaxDegree + 1;
+
+  using F = typename PCSTy::Field;
+  using Poly = typename PCSTy::Poly;
+  using Evals = typename PCSTy::Evals;
+  using RationalEvals = typename PCSTy::RationalEvals;
+
+  Synthesizer() = default;
+  Synthesizer(size_t num_circuits, const ConstraintSystem<F>* constraint_system)
+      : num_circuits_(num_circuits), constraint_system_(constraint_system) {
+    advice_columns_vec_.resize(num_circuits_);
+    advice_blinds_vec_.resize(num_circuits_);
+    for (size_t i = 0; i < num_circuits_; ++i) {
+      // And these may be assigned with random order.
+      advice_columns_vec_[i] = base::CreateVector(
+          constraint_system->num_advice_columns(), Evals::Zero());
+      advice_blinds_vec_[i] = base::CreateVector(
+          constraint_system->num_advice_columns(), F::Zero());
+    }
+  }
+
+  // Synthesize circuit and store advice columns.
+  template <typename CircuitTy>
+  void GenerateAdviceColumns(
+      Prover<PCSTy>* prover, const std::vector<CircuitTy>& circuits,
+      const std::vector<std::vector<Evals>>& instance_columns_vec) {
+    CHECK_EQ(num_circuits_, circuits.size());
+
+    ConstraintSystem<F> empty_constraint_system;
+    typename CircuitTy::Config config =
+        CircuitTy::Configure(empty_constraint_system);
+
+    for (Phase current_phase : constraint_system_->GetPhases()) {
+      for (size_t i = 0; i < num_circuits_; ++i) {
+        std::vector<RationalEvals> rational_advice_columns =
+            GenerateRationalAdvices(prover, current_phase,
+                                    instance_columns_vec[i], circuits[i],
+                                    config);
+
+        // Parse only indices related to the |current_phase|.
+        const std::vector<Phase>& phases =
+            constraint_system_->challenge_phases();
+        for (size_t j = 0; j < phases.size(); ++i) {
+          if (current_phase != phases[j]) continue;
+          const RationalEvals& column = rational_advice_columns[j];
+          std::vector<F> evaluated;
+          CHECK(math::RationalField<F>::BatchEvaluate(column.evaluations(),
+                                                      &evaluated));
+          // Add blinding factors to advice columns
+          evaluated[kMaxDegree] = F::One();
+
+          Evals evaluated_evals(evaluated);
+          CHECK(prover->CommitEvals(evaluated_evals));
+          SetAdviceColumn(i, j, std::move(evaluated_evals),
+                          prover->blinder().Generate());
+        }
+      }
+      UpdateChallenges(prover, current_phase);
+    }
+  }
+
+  // Return |challenge_| as a vector.
+  std::vector<F> ExportChallenges() {
+    return base::Map(
+        std::make_move_iterator(challenges_.begin()),
+        std::make_move_iterator(challenges_.end()),
+        [](std::pair<size_t, F>&& item) { return std::move(item.second); });
+  }
+
+ private:
+  void SetAdviceColumn(size_t circuit_idx, size_t column_idx, Evals&& column,
+                       F&& blind) {
+    CHECK_LT(circuit_idx, num_circuits_);
+    CHECK_LT(column_idx, constraint_system_->num_advice_columns());
+    advice_columns_vec_[circuit_idx][column_idx] = std::move(column);
+    advice_blinds_vec_[circuit_idx][column_idx] = std::move(blind);
+  }
+
+  // Performs synthesis for a specific |circuit| and a specific |phase|, and
+  // returns a vector of |RationalEvals|.
+  template <typename CircuitTy>
+  std::vector<RationalEvals> GenerateRationalAdvices(
+      Prover<PCSTy>* prover, const Phase phase,
+      const std::vector<Evals>& instance_columns, const CircuitTy& circuit,
+      const typename CircuitTy::Config& config) {
+    // The prover will not be allowed to assign values to advice
+    // cells that exist within inactive rows, which include some
+    // number of blinding factors and an extra row for use in the
+    // permutation argument.
+    WitnessCollection<PCSTy> witness(
+        prover->pcs().K(), constraint_system_->num_advice_columns(),
+        prover->GetUsableRows(), phase, challenges_, instance_columns);
+
+    CircuitTy::FloorPlanner::Synthesize(&witness, circuit, config.Clone(),
+                                        constraint_system_->constants());
+
+    return std::move(witness).advices();
+  }
+
+  void UpdateChallenges(Prover<PCSTy>* prover, const Phase phase) {
+    const std::vector<Phase>& phases = constraint_system_->challenge_phases();
+    for (size_t i = 0; i < phases.size(); ++i) {
+      if (phase == phases[i]) {
+        auto it = challenges_.try_emplace(
+            i, prover->GetWriter()->SqueezeChallengeAsScalar());
+        CHECK(it.second);
+      }
+    }
+  }
+
+  size_t num_circuits_ = 0;
+  // not owned
+  const ConstraintSystem<F>* constraint_system_ = nullptr;
+
+  absl::btree_map<size_t, F> challenges_;
+  std::vector<std::vector<Evals>> advice_columns_vec_;
+  std::vector<std::vector<F>> advice_blinds_vec_;
+};
+
+}  // namespace tachyon::zk
+
+#endif  // TACHYON_ZK_PLONK_PROVER_SYNTHESIZER_H_

--- a/tachyon/zk/plonk/prover/synthesizer_unittest.cc
+++ b/tachyon/zk/plonk/prover/synthesizer_unittest.cc
@@ -1,0 +1,55 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
+#include "tachyon/zk/plonk/prover/synthesizer.h"
+
+#include <memory>
+
+#include "gtest/gtest.h"
+
+#include "tachyon/zk/base/halo2/halo2_prover_test.h"
+#include "tachyon/zk/plonk/circuit/examples/simple_circuit.h"
+#include "tachyon/zk/plonk/keys/halo2/pinned_verifying_key.h"
+
+namespace tachyon::zk {
+namespace {
+
+class SynthesizerTest : public Halo2ProverTest {
+ public:
+  using F = typename PCS::Field;
+
+  void SetUp() override {
+    Halo2ProverTest::SetUp();
+
+    circuits_ = {SimpleCircuit<F>(), SimpleCircuit<F>()};
+
+    CHECK(VerifyingKey<PCS>::Generate<SimpleCircuit<F>>(
+        prover_.get(), circuits_[0], &verifying_key_));
+
+    synthesizer_ =
+        Synthesizer<PCS>(circuits_.size(), &verifying_key_.constraint_system());
+  }
+
+ protected:
+  std::vector<SimpleCircuit<F>> circuits_;
+  VerifyingKey<PCS> verifying_key_;
+  Synthesizer<PCS> synthesizer_;
+};
+
+}  // namespace
+
+// TODO(dongchangYoo): it should be verified if it produces the expected values.
+TEST_F(SynthesizerTest, GenerateAdviceColumns) {
+  std::vector<std::vector<Evals>> instance_columns_vec = base::CreateVector(
+      circuits_.size(),
+      []() { return base::CreateVector(1, Evals::Random()); });
+  synthesizer_.GenerateAdviceColumns(prover_.get(), circuits_,
+                                     instance_columns_vec);
+
+  std::vector<F> challenges = synthesizer_.ExportChallenges();
+}
+
+}  // namespace tachyon::zk

--- a/tachyon/zk/plonk/prover/witness_collection.h
+++ b/tachyon/zk/plonk/prover/witness_collection.h
@@ -1,0 +1,91 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
+#ifndef TACHYON_ZK_PLONK_PROVER_WITNESS_COLLECTION_H_
+#define TACHYON_ZK_PLONK_PROVER_WITNESS_COLLECTION_H_
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/container/btree_map.h"
+
+#include "tachyon/base/containers/container_util.h"
+#include "tachyon/base/range.h"
+#include "tachyon/zk/plonk/circuit/assignment.h"
+#include "tachyon/zk/plonk/circuit/phase.h"
+
+namespace tachyon::zk {
+
+template <typename PCSTy>
+class WitnessCollection : public Assignment<typename PCSTy::Field> {
+ public:
+  constexpr static size_t kMaxDegree = PCSTy::kMaxDegree;
+
+  using F = typename PCSTy::Field;
+  using Evals = typename PCSTy::Evals;
+  using RationalEvals = typename PCSTy::RationalEvals;
+  using AssignCallback = typename Assignment<F>::AssignCallback;
+
+  WitnessCollection() = default;
+  WitnessCollection(size_t k, size_t num_advice_columns, size_t usable_rows,
+                    const Phase current_phase,
+                    const absl::btree_map<size_t, F>& challenges,
+                    const std::vector<Evals>& instance_columns)
+      : k_(k),
+        advices_(base::CreateVector(num_advice_columns,
+                                    RationalEvals::UnsafeZero(kMaxDegree))),
+        usable_rows_(base::Range<size_t>::Until(usable_rows)),
+        current_phase_(current_phase),
+        challenges_(challenges),
+        instance_columns_(instance_columns) {}
+
+  size_t k() const { return k_; }
+  // NOTE(dongchangYoo): This getter of |advices| transfers ownership as well.
+  // That's why, |WitnessCollection| will be released as soon as emitting it.
+  std::vector<RationalEvals>&& advices() && { return std::move(advices_); }
+  const Phase current_phase() const { return current_phase_; }
+  const base::Range<size_t>& usable_rows() const { return usable_rows_; }
+  const absl::btree_map<size_t, F>& challenges() const { return challenges_; }
+  const std::vector<Evals>& instance_columns() const {
+    return instance_columns;
+  }
+
+  Value<F> QueryInstance(const InstanceColumnKey& column, size_t row) override {
+    CHECK(usable_rows_.Contains(row));
+    CHECK_LT(column.index(), instance_columns_.size());
+
+    return Value<F>::Known(*instance_columns_[column.index()][row]);
+  }
+
+  void AssignAdvice(std::string_view, const AdviceColumnKey& column, size_t row,
+                    AssignCallback assign) override {
+    // Ignore assignment of advice column in different phase than current one.
+    if (current_phase_ < column.phase()) return;
+
+    CHECK(usable_rows_.Contains(row));
+    CHECK_LT(column.index(), advices_.size());
+
+    *advices_[column.index()][row] = std::move(assign).Run().value();
+  }
+
+  Value<F> GetChallenge(const Challenge& challenge) override {
+    CHECK_LT(challenge.index(), challenges_.size());
+    return Value<F>::Known(challenges_[challenge.index()]);
+  }
+
+ private:
+  size_t k_ = 0;
+  std::vector<RationalEvals> advices_;
+  base::Range<size_t> usable_rows_;
+  Phase current_phase_;
+  absl::btree_map<size_t, F> challenges_;
+  std::vector<Evals> instance_columns_;
+};
+
+}  // namespace tachyon::zk
+
+#endif  // TACHYON_ZK_PLONK_PROVER_WITNESS_COLLECTION_H_

--- a/tachyon/zk/plonk/prover/witness_collection_unittest.cc
+++ b/tachyon/zk/plonk/prover/witness_collection_unittest.cc
@@ -1,0 +1,80 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
+#include "tachyon/zk/plonk/prover/witness_collection.h"
+
+#include "gtest/gtest.h"
+
+#include "tachyon/zk/base/halo2/halo2_prover_test.h"
+#include "tachyon/zk/base/value.h"
+#include "tachyon/zk/plonk/circuit/examples/simple_circuit.h"
+
+namespace tachyon::zk {
+namespace {
+
+class WitnessCollectionTest : public Halo2ProverTest {
+ public:
+  using F = typename PCS::Field;
+  using RationalEvals = typename PCS::RationalEvals;
+
+  void SetUp() override {
+    Halo2ProverTest::SetUp();
+
+    // There is a single challenge in |challenges_|.
+    expected_challenges_[0] = F::Random();
+    expected_instance_columns_ = {Evals::Random()};
+
+    Phase current_phase(0);
+    witness_collection_ = WitnessCollection<PCS>(
+        5, 3, kUsableRows, current_phase, expected_challenges_,
+        expected_instance_columns_);
+  }
+
+ protected:
+  absl::btree_map<size_t, F> expected_challenges_;
+  std::vector<Evals> expected_instance_columns_;
+  WitnessCollection<PCS> witness_collection_;
+};
+
+}  // namespace
+
+TEST_F(WitnessCollectionTest, QueryInstance) {
+  size_t col = 0;
+  size_t row = 10;
+
+  // Query a value in specific instance column.
+  Value<F> queried_value =
+      witness_collection_.QueryInstance(InstanceColumnKey(col), row);
+  EXPECT_EQ(queried_value,
+            Value<F>::Known(*expected_instance_columns_[col][row]));
+}
+
+TEST_F(WitnessCollectionTest, AssignAdvice) {
+  math::RationalField<F> value_to_be_assign(F::Random());
+  size_t col = 0;
+  size_t row = 10;
+
+  // Assign a random value to specific cell.
+  witness_collection_.AssignAdvice(
+      "", AdviceColumnKey(col), row, [value_to_be_assign]() {
+        return Value<math::RationalField<F>>::Known(value_to_be_assign);
+      });
+
+  std::vector<RationalEvals> rational_advice_columns =
+      std::move(witness_collection_).advices();
+  const RationalEvals& rational_column = rational_advice_columns[col];
+  EXPECT_EQ(value_to_be_assign, *rational_column[row]);
+}
+
+TEST_F(WitnessCollectionTest, GetChallenge) {
+  // Get challenge value.
+  size_t target_idx = 0;
+  Value<F> challenge =
+      witness_collection_.GetChallenge(Challenge(target_idx, kFirstPhase));
+  EXPECT_EQ(Value<F>::Known(expected_challenges_[target_idx]), challenge);
+}
+
+}  // namespace tachyon::zk


### PR DESCRIPTION
This PR contains implementations of `Synthesizer` and `Argument`.

The `Synthesizer` covers the code generating advice columns in the `CreateProof()`. 
See [AdviceSingle](https://github.com/kroma-network/halo2/blob/7d0a36990452c8e7ebd600de258420781a9b7917/halo2_proofs/src/plonk/prover.rs#L135-L138), [Assigning AdviceSingles](https://github.com/kroma-network/halo2/blob/7d0a36990452c8e7ebd600de258420781a9b7917/halo2_proofs/src/plonk/prover.rs#L284-L430).

The `Argument` provides all the data required to generate a proof. In detail, it has fixed/advice/instance columns in evaluation form and coefficient form. `Argument` makes it easier to analyze data and to understand the data flow during the proof generation process. 
See [InstanceSingle](https://github.com/kroma-network/halo2/blob/7d0a36990452c8e7ebd600de258420781a9b7917/halo2_proofs/src/plonk/prover.rs#L74-L77), [Assigning InstanceSingle](https://github.com/kroma-network/halo2/blob/7d0a36990452c8e7ebd600de258420781a9b7917/halo2_proofs/src/plonk/prover.rs#L74-L132).

And this PR includes minor fix bugs.
