### PR TITLE
build(math): include prime_field.h if TACHYON_POLYGON_ZKEVM_BACKEND is not defined

### DIFF
--- a/tachyon/math/finite_fields/goldilocks_prime/BUILD.bazel
+++ b/tachyon/math/finite_fields/goldilocks_prime/BUILD.bazel
@@ -11,10 +11,11 @@ GOLDILOCKS_MODULUS = "18446744069414584321"
 generate_prime_fields(
     name = "goldilocks",
     class_name = "Goldilocks",
-    hdr_include_override = """#include "tachyon/export.h"
-#if defined(TACHYON_POLYGON_ZKEVM_BACKEND)
+    hdr_include_override = """#if defined(TACHYON_POLYGON_ZKEVM_BACKEND)
 #include "tachyon/math/finite_fields/goldilocks_prime/prime_field_goldilocks.h"
 #include "tachyon/build/build_config.h"
+#else
+#include "tachyon/math/finite_fields/prime_field.h"
 #endif  // defined(TACHYON_POLYGON_ZKEVM_BACKEND)""",
     modulus = GOLDILOCKS_MODULUS,
     namespace = "tachyon::math",


### PR DESCRIPTION
# Description

This fixes build bug when building goldilocks without polygon zkevm backend.