### PR TITLE
feat: implement fri commitment

### DIFF
--- a/tachyon/crypto/commitments/fri/BUILD.bazel
+++ b/tachyon/crypto/commitments/fri/BUILD.bazel
@@ -1,0 +1,41 @@
+load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_unittest")
+
+package(default_visibility = ["//visibility:public"])
+
+tachyon_cc_library(
+    name = "fri_proof",
+    hdrs = ["fri_proof.h"],
+    deps = ["//tachyon/crypto/commitments/merkle_tree/binary_merkle_tree:binary_merkle_proof"],
+)
+
+tachyon_cc_library(
+    name = "fri_storage",
+    hdrs = ["fri_storage.h"],
+    deps = ["//tachyon/crypto/commitments/merkle_tree/binary_merkle_tree:binary_merkle_tree_storage"],
+)
+
+tachyon_cc_library(
+    name = "fri",
+    hdrs = ["fri.h"],
+    deps = [
+        ":fri_proof",
+        ":fri_storage",
+        "//tachyon/base:logging",
+        "//tachyon/base/containers:container_util",
+        "//tachyon/crypto/commitments:univariate_polynomial_commitment_scheme",
+        "//tachyon/crypto/commitments/merkle_tree/binary_merkle_tree",
+        "//tachyon/crypto/transcripts:transcript",
+    ],
+)
+
+tachyon_cc_unittest(
+    name = "fri_unittests",
+    srcs = ["fri_unittest.cc"],
+    deps = [
+        ":fri",
+        "//tachyon/crypto/commitments/merkle_tree/binary_merkle_tree:simple_binary_merkle_tree_storage",
+        "//tachyon/crypto/transcripts:simple_transcript",
+        "//tachyon/math/finite_fields/goldilocks_prime:goldilocks",
+        "//tachyon/math/polynomials/univariate:univariate_evaluation_domain_factory",
+    ],
+)

--- a/tachyon/crypto/commitments/fri/fri.h
+++ b/tachyon/crypto/commitments/fri/fri.h
@@ -1,0 +1,219 @@
+// Use of this source code is governed by a Apache-2.0 style license that
+// can be found in the LICENSE.lambdaworks.
+
+#ifndef TACHYON_CRYPTO_COMMITMENTS_FRI_FRI_H_
+#define TACHYON_CRYPTO_COMMITMENTS_FRI_FRI_H_
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "tachyon/base/containers/container_util.h"
+#include "tachyon/base/logging.h"
+#include "tachyon/crypto/commitments/fri/fri_proof.h"
+#include "tachyon/crypto/commitments/fri/fri_storage.h"
+#include "tachyon/crypto/commitments/merkle_tree/binary_merkle_tree/binary_merkle_tree.h"
+#include "tachyon/crypto/commitments/univariate_polynomial_commitment_scheme.h"
+#include "tachyon/crypto/transcripts/transcript.h"
+
+namespace tachyon::crypto {
+
+template <typename F, size_t MaxDegree>
+class FRI : public UnivariatePolynomialCommitmentScheme<FRI<F, MaxDegree>> {
+ public:
+  using Base = UnivariatePolynomialCommitmentScheme<FRI<F, MaxDegree>>;
+  using Poly = typename Base::Poly;
+  using Evals = typename Base::Evals;
+  using Domain = typename Base::Domain;
+
+  FRI() = default;
+  FRI(const Domain* domain, FRIStorage<F>* storage,
+      BinaryMerkleHasher<F, F>* hasher)
+      : domain_(domain), storage_(storage), hasher_(hasher) {
+    // This ensures last folding process.
+    CHECK_GE(domain->size(), size_t{2}) << "Domain size must be at least 2";
+    size_t k = domain->log_size_of_group();
+    if (k > 1) {
+      sub_domains_ = base::CreateVector(k - 1, [k](size_t i) {
+        return Domain::Create(size_t{1} << (k - i - 1));
+      });
+    }
+    storage_->Allocate(k);
+  }
+
+  // UnivariatePolynomialCommitmentScheme methods
+  size_t N() const { return domain_->size(); }
+
+  [[nodiscard]] bool Commit(const Poly& poly, Transcript<F>* transcript) const {
+    size_t num_layers = domain_->log_size_of_group();
+    TranscriptWriter<F>* writer = transcript->ToWriter();
+    BinaryMerkleTree<F, F, MaxDegree + 1> tree(storage_->GetLayer(0), hasher_);
+    Evals evals = domain_->FFT(poly);
+    F root;
+    if (!tree.Commit(evals.evaluations(), &root)) return false;
+    if (!writer->WriteToProof(root)) return false;
+    const Poly* cur_poly = &poly;
+
+    F beta;
+    Poly folded_poly;
+    if (num_layers > 1) {
+      for (size_t i = 1; i < num_layers; ++i) {
+        // Pᵢ(X)   = Pᵢ_even(X²) + X * Pᵢ_odd(X²)
+        // Pᵢ₊₁(X) = Pᵢ_even(X²) + β * Pᵢ_odd(X²)
+        beta = writer->SqueezeChallenge();
+        folded_poly = cur_poly->template Fold<false>(beta);
+        BinaryMerkleTree<F, F, MaxDegree + 1> tree(storage_->GetLayer(i),
+                                                   hasher_);
+        evals = sub_domains_[i - 1]->FFT(folded_poly);
+        if (!tree.Commit(evals.evaluations(), &root)) return false;
+        if (!writer->WriteToProof(root)) return false;
+        cur_poly = &folded_poly;
+      }
+    }
+
+    beta = writer->SqueezeChallenge();
+    folded_poly = cur_poly->template Fold<false>(beta);
+    const F* constant = folded_poly[0];
+    root = constant ? *constant : F::Zero();
+    return writer->WriteToProof(root);
+  }
+
+  [[nodiscard]] bool DoCreateOpeningProof(size_t index,
+                                          FRIProof<F>* fri_proof) const {
+    size_t domain_size = domain_->size();
+    size_t num_layers = domain_->log_size_of_group();
+    for (size_t i = 0; i < num_layers; ++i) {
+      size_t leaf_index = index % domain_size;
+      BinaryMerkleTreeStorage<F>* layer = storage_->GetLayer(i);
+      BinaryMerkleTree<F, F, MaxDegree + 1> tree(layer, hasher_);
+      BinaryMerkleProof<F> proof;
+      if (!tree.CreateOpeningProof(leaf_index, &proof)) return false;
+      // Merkle proof for Pᵢ(ωʲ) against Cᵢ
+      fri_proof->paths.push_back(std::move(proof));
+      // Pᵢ(ωʲ)
+      fri_proof->evaluations.push_back(
+          layer->GetHash(domain_size - 1 + leaf_index));
+
+      size_t half_domain_size = domain_size >> 1;
+      size_t leaf_index_sym = (index + half_domain_size) % domain_size;
+      BinaryMerkleProof<F> proof_sym;
+      if (!tree.CreateOpeningProof(leaf_index_sym, &proof_sym)) return false;
+      // Merkle proof for Pᵢ(-ωʲ) against Cᵢ
+      fri_proof->paths_sym.push_back(std::move(proof_sym));
+      // Pᵢ(-ωʲ)
+      fri_proof->evaluations_sym.push_back(
+          layer->GetHash(domain_size - 1 + leaf_index_sym));
+
+      domain_size = half_domain_size;
+    }
+    return true;
+  }
+
+  [[nodiscard]] bool DoVerifyOpeningProof(Transcript<F>& transcript,
+                                          size_t index,
+                                          const FRIProof<F>& proof) const {
+    TranscriptReader<F>* reader = transcript.ToReader();
+    size_t domain_size = domain_->size();
+    size_t num_layers = domain_->log_size_of_group();
+    F root;
+    F x;
+    F beta;
+    F evaluation;
+    F evaluation_sym;
+    F two_inv = F(2).Inverse();
+    for (size_t i = 0; i < num_layers; ++i) {
+      BinaryMerkleTreeStorage<F>* layer = storage_->GetLayer(i);
+      BinaryMerkleTree<F, F, MaxDegree + 1> tree(layer, hasher_);
+
+      if (!reader->ReadFromProof(&root)) return false;
+      if (!tree.VerifyOpeningProof(root, proof.evaluations[i], proof.paths[i]))
+        return false;
+
+      if (!tree.VerifyOpeningProof(root, proof.evaluations_sym[i],
+                                   proof.paths_sym[i]))
+        return false;
+
+      // Given equations:
+      // Pᵢ(X)  = Pᵢ_even(X²) + X * Pᵢ_odd(X²)
+      // Pᵢ(-X) = Pᵢ_even(X²) - X * Pᵢ_odd(X²)
+      //
+      // Using Gaussian elimination, we derive:
+      // Pᵢ_even(X²) = (Pᵢ(X) + Pᵢ(-X)) / 2
+      // Pᵢ_odd(X²)  = (Pᵢ(X) - Pᵢ(-X)) / (2 * X)
+      //
+      // Next layer equation:
+      // Pᵢ₊₁(X) = Pᵢ_even(X²) + β * Pᵢ_odd(X²)
+      //
+      // If the domain of Pᵢ(X) is Dᵢ = {ω⁰, ω¹, ..., ωⁿ⁻¹},
+      // then the domain of Pᵢ₊₁(X) is Dᵢ₊₁ = {ω⁰, ω¹, ..., ωᵏ⁻¹},
+      // where k = n / 2.
+      //
+      // As per the definition:
+      // Pᵢ₊₁(ωʲ) = Pᵢ_even((ωʲ)²) + β * Pᵢ_odd((ωʲ)²)
+      //
+      // Substituting Pᵢ_even and Pᵢ_odd:
+      // Pᵢ₊₁(ωʲ) = (Pᵢ(ωʲ) + Pᵢ(-ωʲ)) / 2 + β * (Pᵢ(ωʲ) - Pᵢ(-ωʲ)) / (2 * ωʲ)
+      //           = ((1 + β * ω⁻ʲ) * Pᵢ(ωʲ) + (1 - β * ω⁻ʲ) * Pᵢ(-ωʲ)) / 2
+      size_t leaf_index = index % domain_size;
+      if (i == 0) {
+        evaluation = proof.evaluations[i];
+        evaluation_sym = proof.evaluations_sym[i];
+        x = domain_->GetElement(leaf_index);
+      } else {
+        evaluation *= (F::One() + beta);
+        evaluation_sym *= (F::One() - beta);
+        evaluation += evaluation_sym;
+        evaluation *= two_inv;
+
+        if (evaluation != proof.evaluations[i]) {
+          LOG(ERROR)
+              << "Proof doesn't match with expected evaluation at layer [" << i
+              << "]";
+          return false;
+        }
+        evaluation_sym = proof.evaluations_sym[i];
+        x = sub_domains_[i - 1]->GetElement(leaf_index);
+      }
+      beta = reader->SqueezeChallenge();
+      beta *= x.Inverse();
+      domain_size = domain_size >> 1;
+    }
+
+    evaluation *= (F::One() + beta);
+    evaluation_sym *= (F::One() - beta);
+    evaluation += evaluation_sym;
+    evaluation *= two_inv;
+
+    if (!reader->ReadFromProof(&root)) return false;
+    if (root != evaluation) {
+      LOG(ERROR) << "Root doesn't match with expected evaluation";
+      return false;
+    }
+    return true;
+  }
+
+ private:
+  // not owned
+  const Domain* domain_ = nullptr;
+  // not owned
+  mutable FRIStorage<F>* storage_ = nullptr;
+  // not owned
+  BinaryMerkleHasher<F, F>* hasher_ = nullptr;
+  // not owned
+  Transcript<F>* transcript_ = nullptr;
+  std::vector<std::unique_ptr<Domain>> sub_domains_;
+};
+
+template <typename F, size_t MaxDegree>
+struct VectorCommitmentSchemeTraits<FRI<F, MaxDegree>> {
+ public:
+  constexpr static size_t kMaxSize = MaxDegree + 1;
+  constexpr static bool kIsTransparent = true;
+
+  using Field = F;
+  using Commitment = Transcript<F>;
+};
+
+}  // namespace tachyon::crypto
+
+#endif  // TACHYON_CRYPTO_COMMITMENTS_FRI_FRI_H_

--- a/tachyon/crypto/commitments/fri/fri_proof.h
+++ b/tachyon/crypto/commitments/fri/fri_proof.h
@@ -1,0 +1,23 @@
+// Use of this source code is governed by a Apache-2.0 style license that
+// can be found in the LICENSE.lambdaworks.
+
+#ifndef TACHYON_CRYPTO_COMMITMENTS_FRI_FRI_PROOF_H_
+#define TACHYON_CRYPTO_COMMITMENTS_FRI_FRI_PROOF_H_
+
+#include <vector>
+
+#include "tachyon/crypto/commitments/merkle_tree/binary_merkle_tree/binary_merkle_proof.h"
+
+namespace tachyon::crypto {
+
+template <typename F>
+struct FRIProof {
+  std::vector<BinaryMerkleProof<F>> paths;
+  std::vector<BinaryMerkleProof<F>> paths_sym;
+  std::vector<F> evaluations;
+  std::vector<F> evaluations_sym;
+};
+
+}  // namespace tachyon::crypto
+
+#endif  // TACHYON_CRYPTO_COMMITMENTS_FRI_FRI_PROOF_H_

--- a/tachyon/crypto/commitments/fri/fri_storage.h
+++ b/tachyon/crypto/commitments/fri/fri_storage.h
@@ -1,0 +1,22 @@
+// Use of this source code is governed by a Apache-2.0 style license that
+// can be found in the LICENSE.lambdaworks.
+
+#ifndef TACHYON_CRYPTO_COMMITMENTS_FRI_FRI_STORAGE_H_
+#define TACHYON_CRYPTO_COMMITMENTS_FRI_FRI_STORAGE_H_
+
+#include "tachyon/crypto/commitments/merkle_tree/binary_merkle_tree/binary_merkle_tree_storage.h"
+
+namespace tachyon::crypto {
+
+template <typename HashTy>
+class FRIStorage {
+ public:
+  virtual ~FRIStorage() = default;
+
+  virtual void Allocate(size_t size) = 0;
+  virtual BinaryMerkleTreeStorage<HashTy>* GetLayer(size_t index) = 0;
+};
+
+}  // namespace tachyon::crypto
+
+#endif  // TACHYON_CRYPTO_COMMITMENTS_FRI_FRI_STORAGE_H_

--- a/tachyon/crypto/commitments/fri/fri_unittest.cc
+++ b/tachyon/crypto/commitments/fri/fri_unittest.cc
@@ -1,0 +1,94 @@
+// Use of this source code is governed by a Apache-2.0 style license that
+// can be found in the LICENSE.lambdaworks.
+
+#include "tachyon/crypto/commitments/fri/fri.h"
+
+#include "gtest/gtest.h"
+
+#include "tachyon/base/containers/container_util.h"
+#include "tachyon/crypto/commitments/merkle_tree/binary_merkle_tree/simple_binary_merkle_tree_storage.h"
+#include "tachyon/crypto/transcripts/simple_transcript.h"
+#include "tachyon/math/finite_fields/goldilocks_prime/goldilocks.h"
+#include "tachyon/math/polynomials/univariate/univariate_evaluation_domain_factory.h"
+#include "tachyon/math/polynomials/univariate/univariate_polynomial.h"
+
+namespace tachyon::crypto {
+
+namespace {
+
+class SimpleHasher
+    : public BinaryMerkleHasher<math::Goldilocks, math::Goldilocks> {
+ public:
+  // BinaryMerkleHasher<math::Goldilocks, math::Goldilocks> methods
+  math::Goldilocks ComputeLeafHash(
+      const math::Goldilocks& leaf) const override {
+    return leaf;
+  }
+  math::Goldilocks ComputeParentHash(
+      const math::Goldilocks& left,
+      const math::Goldilocks& right) const override {
+    return left + right.Double();
+  }
+};
+
+class SimpleFRIStorage : public FRIStorage<math::Goldilocks> {
+ public:
+  const std::vector<SimpleBinaryMerkleTreeStorage<math::Goldilocks>>& layers()
+      const {
+    return layers_;
+  }
+
+  // FRIStorage<math::Goldilocks> methods
+  void Allocate(size_t size) override { layers_.resize(size); }
+  BinaryMerkleTreeStorage<math::Goldilocks>* GetLayer(size_t index) override {
+    return &layers_[index];
+  }
+
+ private:
+  std::vector<SimpleBinaryMerkleTreeStorage<math::Goldilocks>> layers_;
+};
+
+class FRITest : public testing::Test {
+ public:
+  constexpr static size_t K = 3;
+  constexpr static size_t N = size_t{1} << K;
+  constexpr static size_t kMaxDegree = N - 1;
+
+  using PCS = FRI<math::Goldilocks, kMaxDegree>;
+  using F = PCS::Field;
+  using Poly = PCS::Poly;
+  using Commitment = PCS::Commitment;
+  using Domain = PCS::Domain;
+
+  static void SetUpTestSuite() { math::Goldilocks::Init(); }
+
+  void SetUp() override {
+    domain_ = Domain::Create(N);
+    pcs_ = PCS(domain_.get(), &storage_, &hasher_);
+  }
+
+ protected:
+  std::unique_ptr<Domain> domain_;
+  SimpleFRIStorage storage_;
+  SimpleHasher hasher_;
+  PCS pcs_;
+};
+
+}  // namespace
+
+TEST_F(FRITest, CommitAndVerify) {
+  Poly poly = Poly::Random(kMaxDegree);
+  base::Uint8VectorBuffer write_buffer;
+  SimpleTranscriptWriter<F> writer(std::move(write_buffer));
+  ASSERT_TRUE(pcs_.Commit(poly, &writer));
+
+  size_t index = base::Uniform(base::Range<size_t>::Until(kMaxDegree + 1));
+  FRIProof<math::Goldilocks> proof;
+  ASSERT_TRUE(pcs_.CreateOpeningProof(index, &proof));
+
+  SimpleTranscriptReader<F> reader(std::move(writer).TakeBuffer());
+  reader.buffer().set_buffer_offset(0);
+  ASSERT_TRUE(pcs_.VerifyOpeningProof(reader, index, proof));
+}
+
+}  // namespace tachyon::crypto

--- a/tachyon/crypto/commitments/kzg/kzg_family.h
+++ b/tachyon/crypto/commitments/kzg/kzg_family.h
@@ -10,6 +10,8 @@
 #include <utility>
 
 #include "tachyon/crypto/commitments/kzg/kzg.h"
+#include "tachyon/math/polynomials/univariate/univariate_evaluations.h"
+#include "tachyon/math/polynomials/univariate/univariate_polynomial.h"
 
 namespace tachyon::crypto {
 
@@ -42,6 +44,18 @@ class KZGFamily {
   [[nodiscard]] bool DoCommitLagrange(const ContainerTy& poly,
                                       Commitment* commitment) const {
     return kzg_.CommitLagrange(poly, commitment);
+  }
+
+  [[nodiscard]] bool DoCommit(
+      const math::UnivariateDensePolynomial<F, MaxDegree>& poly,
+      Commitment* commitment) const {
+    return kzg_.Commit(poly.coefficients().coefficients(), commitment);
+  }
+
+  [[nodiscard]] bool DoCommitLagrange(
+      const math::UnivariateEvaluations<F, MaxDegree>& evals,
+      Commitment* commitment) const {
+    return kzg_.CommitLagrange(evals.evaluations(), commitment);
   }
 
  protected:

--- a/tachyon/crypto/commitments/merkle_tree/binary_merkle_tree/BUILD.bazel
+++ b/tachyon/crypto/commitments/merkle_tree/binary_merkle_tree/BUILD.bazel
@@ -38,11 +38,19 @@ tachyon_cc_library(
     ],
 )
 
+tachyon_cc_library(
+    name = "simple_binary_merkle_tree_storage",
+    testonly = True,
+    hdrs = ["simple_binary_merkle_tree_storage.h"],
+    deps = [":binary_merkle_tree_storage"],
+)
+
 tachyon_cc_unittest(
     name = "binary_merkle_tree_unittests",
     srcs = ["binary_merkle_tree_unittest.cc"],
     deps = [
         ":binary_merkle_tree",
+        ":simple_binary_merkle_tree_storage",
         "//tachyon/base/containers:container_util",
     ],
 )

--- a/tachyon/crypto/commitments/merkle_tree/binary_merkle_tree/binary_merkle_tree.h
+++ b/tachyon/crypto/commitments/merkle_tree/binary_merkle_tree/binary_merkle_tree.h
@@ -66,17 +66,20 @@ class BinaryMerkleTree
     //
     // Finally, the remaining tree should be constructed from leaves 1 and 2.
     size_t leaves_size = std::size(leaves);
-    OPENMP_PARALLEL_FOR(size_t i = 0; i < leaves_size;
-                        i += leaves_size_for_parallelization_) {
-      size_t from = leaves_size - 1 + i;
-      size_t to = from + leaves_size_for_parallelization_;
-      BuildTreeFromLeaves(base::Range<size_t>(from, to));
-    }
     if (leaves_size > leaves_size_for_parallelization_) {
+      OPENMP_PARALLEL_FOR(size_t i = 0; i < leaves_size;
+                          i += leaves_size_for_parallelization_) {
+        size_t from = leaves_size - 1 + i;
+        size_t to = from + leaves_size_for_parallelization_;
+        BuildTreeFromLeaves(base::Range<size_t>(from, to));
+      }
       size_t i = base::bits::Log2Floor(leaves_size) -
                  base::bits::Log2Floor(leaves_size_for_parallelization_);
       BuildTreeFromLeaves(
           base::Range<size_t>((1 << i) - 1, (1 << (i + 1)) - 1));
+    } else {
+      BuildTreeFromLeaves(
+          base::Range<size_t>(leaves_size - 1, (leaves_size << 1) - 1));
     }
     *out = storage_->GetHash(0);
     return true;

--- a/tachyon/crypto/commitments/merkle_tree/binary_merkle_tree/binary_merkle_tree.h
+++ b/tachyon/crypto/commitments/merkle_tree/binary_merkle_tree/binary_merkle_tree.h
@@ -108,9 +108,9 @@ class BinaryMerkleTree
   }
 
   [[nodiscard]] bool DoVerifyOpeningProof(
-      const HashTy& root, const LeafTy& leaf,
+      const HashTy& root, const HashTy& leaf_hash,
       const BinaryMerkleProof<HashTy>& proof) const {
-    HashTy hash = hasher_->ComputeLeafHash(leaf);
+    HashTy hash = leaf_hash;
     for (const BinaryMerklePath<HashTy>& path : proof.paths) {
       if (path.left) {
         hash = hasher_->ComputeParentHash(path.hash, hash);

--- a/tachyon/crypto/commitments/merkle_tree/binary_merkle_tree/binary_merkle_tree_unittest.cc
+++ b/tachyon/crypto/commitments/merkle_tree/binary_merkle_tree/binary_merkle_tree_unittest.cc
@@ -31,7 +31,7 @@ class BinaryMerkleTreeTest : public testing::Test {
   void SetUp() override {
     vcs_ = VCS(&storage_, &hasher_);
     vcs_.set_leaves_size_for_parallelization(N >> 1);
-  };
+  }
 
   void CreateLeaves() { leaves_ = base::CreateRangedVector<int>(0, N); }
 

--- a/tachyon/crypto/commitments/merkle_tree/binary_merkle_tree/binary_merkle_tree_unittest.cc
+++ b/tachyon/crypto/commitments/merkle_tree/binary_merkle_tree/binary_merkle_tree_unittest.cc
@@ -107,7 +107,8 @@ TEST_F(BinaryMerkleTreeTest, CommitAndVerify) {
   };
   EXPECT_EQ(proof, expected_proof);
 
-  ASSERT_TRUE(vcs_.VerifyOpeningProof(commitment, 1, proof));
+  int leaf_hash = hasher_.ComputeLeafHash(1);
+  ASSERT_TRUE(vcs_.VerifyOpeningProof(commitment, leaf_hash, proof));
 }
 
 }  // namespace tachyon::crypto

--- a/tachyon/crypto/commitments/merkle_tree/binary_merkle_tree/binary_merkle_tree_unittest.cc
+++ b/tachyon/crypto/commitments/merkle_tree/binary_merkle_tree/binary_merkle_tree_unittest.cc
@@ -6,6 +6,7 @@
 #include "gtest/gtest.h"
 
 #include "tachyon/base/containers/container_util.h"
+#include "tachyon/crypto/commitments/merkle_tree/binary_merkle_tree/simple_binary_merkle_tree_storage.h"
 
 namespace tachyon::crypto {
 
@@ -18,20 +19,6 @@ class SimpleHasher : public BinaryMerkleHasher<int, int> {
   int ComputeParentHash(const int& left, const int& right) const override {
     return left + 2 * right;
   }
-};
-
-class SimpleMerkleTreeStorage : public BinaryMerkleTreeStorage<int> {
- public:
-  const std::vector<int>& hashes() const { return hashes_; }
-
-  // BinaryMerkleTreeStorage<int> methods
-  void Allocate(size_t size) override { hashes_.resize(size); }
-  size_t GetSize() const override { return hashes_.size(); }
-  const int& GetHash(size_t i) const override { return hashes_[i]; }
-  void SetHash(size_t i, const int& hash) override { hashes_[i] = hash; }
-
- private:
-  std::vector<int> hashes_;
 };
 
 class BinaryMerkleTreeTest : public testing::Test {
@@ -49,7 +36,7 @@ class BinaryMerkleTreeTest : public testing::Test {
   void CreateLeaves() { leaves_ = base::CreateRangedVector<int>(0, N); }
 
  protected:
-  SimpleMerkleTreeStorage storage_;
+  SimpleBinaryMerkleTreeStorage<int> storage_;
   SimpleHasher hasher_;
   VCS vcs_;
   std::vector<int> leaves_;

--- a/tachyon/crypto/commitments/merkle_tree/binary_merkle_tree/simple_binary_merkle_tree_storage.h
+++ b/tachyon/crypto/commitments/merkle_tree/binary_merkle_tree/simple_binary_merkle_tree_storage.h
@@ -1,0 +1,27 @@
+#ifndef TACHYON_CRYPTO_COMMITMENTS_MERKLE_TREE_BINARY_MERKLE_TREE_SIMPLE_BINARY_MERKLE_TREE_STORAGE_H_
+#define TACHYON_CRYPTO_COMMITMENTS_MERKLE_TREE_BINARY_MERKLE_TREE_SIMPLE_BINARY_MERKLE_TREE_STORAGE_H_
+
+#include <vector>
+
+#include "tachyon/crypto/commitments/merkle_tree/binary_merkle_tree/binary_merkle_tree_storage.h"
+
+namespace tachyon::crypto {
+
+template <typename T>
+class SimpleBinaryMerkleTreeStorage : public BinaryMerkleTreeStorage<T> {
+ public:
+  const std::vector<T>& hashes() const { return hashes_; }
+
+  // BinaryMerkleTreeStorage<T> methods
+  void Allocate(size_t size) override { hashes_.resize(size); }
+  size_t GetSize() const override { return hashes_.size(); }
+  const T& GetHash(size_t i) const override { return hashes_[i]; }
+  void SetHash(size_t i, const T& hash) override { hashes_[i] = hash; }
+
+ private:
+  std::vector<T> hashes_;
+};
+
+}  // namespace tachyon::crypto
+
+#endif  // TACHYON_CRYPTO_COMMITMENTS_MERKLE_TREE_BINARY_MERKLE_TREE_SIMPLE_BINARY_MERKLE_TREE_STORAGE_H_

--- a/tachyon/crypto/commitments/univariate_polynomial_commitment_scheme.h
+++ b/tachyon/crypto/commitments/univariate_polynomial_commitment_scheme.h
@@ -31,7 +31,7 @@ class UnivariatePolynomialCommitmentScheme
   // Return false if the degree of |poly| exceeds |kMaxDegree|.
   [[nodiscard]] bool Commit(const Poly& poly, Commitment* result) const {
     const Derived* derived = static_cast<const Derived*>(this);
-    return derived->DoCommit(poly.coefficients().coefficients(), result);
+    return derived->DoCommit(poly, result);
   }
 
   // Commit to |poly| and populates |result| with the commitment.
@@ -39,7 +39,7 @@ class UnivariatePolynomialCommitmentScheme
   [[nodiscard]] bool CommitLagrange(const Evals& evals,
                                     Commitment* result) const {
     const Derived* derived = static_cast<const Derived*>(this);
-    return derived->DoCommitLagrange(evals.evaluations(), result);
+    return derived->DoCommitLagrange(evals, result);
   }
 };
 

--- a/tachyon/crypto/commitments/vector_commitment_scheme.h
+++ b/tachyon/crypto/commitments/vector_commitment_scheme.h
@@ -94,8 +94,10 @@ class VectorCommitmentScheme {
 
   // Verify an opening |proof| that proves that |members| belong to a
   // |commitment|.
+  // NOTE(chokobole): const was removed from |Commitment| since it can be a
+  // |Transcript|. At this moment, |WriteToTranscript()| is not a const method.
   template <typename ContainerTy, typename Proof>
-  [[nodiscard]] bool VerifyOpeningProof(const Commitment& commitment,
+  [[nodiscard]] bool VerifyOpeningProof(Commitment& commitment,
                                         const ContainerTy& members,
                                         const Proof& proof) const {
     const Derived* derived = static_cast<const Derived*>(this);

--- a/tachyon/crypto/transcripts/transcript.h
+++ b/tachyon/crypto/transcripts/transcript.h
@@ -161,6 +161,8 @@ class TranscriptWriterImpl<Commitment, false> : public Transcript<Commitment> {
   base::Uint8VectorBuffer& buffer() { return buffer_; }
   const base::Uint8VectorBuffer& buffer() const { return buffer_; }
 
+  base::Uint8VectorBuffer&& TakeBuffer() && { return std::move(buffer_); }
+
   // Write a |commitment| to the proof. Note that it also writes the
   // |commitment| to the transcript by calling |WriteToTranscript()| internally.
   [[nodiscard]] bool WriteToProof(const Commitment& commitment) {
@@ -195,6 +197,8 @@ class TranscriptWriterImpl<Field, true> : public Transcript<Field> {
 
   base::Uint8VectorBuffer& buffer() { return buffer_; }
   const base::Uint8VectorBuffer& buffer() const { return buffer_; }
+
+  base::Uint8VectorBuffer&& TakeBuffer() && { return std::move(buffer_); }
 
   // Write a |value| to the proof. Note that it also writes the
   // |value| to the transcript by calling |WriteToTranscript()| internally.

--- a/tachyon/math/elliptic_curves/bls12/bls12_381/BUILD.bazel
+++ b/tachyon/math/elliptic_curves/bls12/bls12_381/BUILD.bazel
@@ -11,42 +11,26 @@ load(
 package(default_visibility = ["//visibility:public"])
 
 # Parameters are from https://zips.z.cash/protocol/protocol.pdf#page=98 and https://github.com/arkworks-rs/curves/tree/master/bls12_381/src/fields
-# Hex: 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab
-FQ_MODULUS = "4002409555221667393417789825735904156556882819939007885332058136124031650490837864442687629129015664037894272559787"
-
-FQ_SUBGROUP_GENERATOR = "2"
-
-FQ_SMALL_SUBGROUP_BASE = "3"
-
-FQ_SMALL_SUBGROUP_ADICITY = "2"
-
-# Hex: 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001
-FR_MODULUS = "52435875175126190479447740508185965837690552500527637822603658699938581184513"
-
-FR_SUBGROUP_GENERATOR = "7"
-
-FR_SMALL_SUBGROUP_BASE = "3"
-
-FR_SMALL_SUBGROUP_ADICITY = "1"
-
 generate_prime_fields(
     name = "fq",
     class_name = "Fq",
-    modulus = FQ_MODULUS,
+    # Hex: 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab
+    modulus = "4002409555221667393417789825735904156556882819939007885332058136124031650490837864442687629129015664037894272559787",
     namespace = "tachyon::math::bls12_381",
-    small_subgroup_adicity = FQ_SMALL_SUBGROUP_ADICITY,
-    small_subgroup_base = FQ_SMALL_SUBGROUP_BASE,
-    subgroup_generator = FQ_SUBGROUP_GENERATOR,
+    small_subgroup_adicity = "2",
+    small_subgroup_base = "3",
+    subgroup_generator = "2",
 )
 
 generate_prime_fields(
     name = "fr",
     class_name = "Fr",
-    modulus = FR_MODULUS,
+    # Hex: 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001
+    modulus = "52435875175126190479447740508185965837690552500527637822603658699938581184513",
     namespace = "tachyon::math::bls12_381",
-    small_subgroup_adicity = FR_SMALL_SUBGROUP_ADICITY,
-    small_subgroup_base = FR_SMALL_SUBGROUP_BASE,
-    subgroup_generator = FR_SUBGROUP_GENERATOR,
+    small_subgroup_adicity = "1",
+    small_subgroup_base = "3",
+    subgroup_generator = "7",
 )
 
 generate_fp2s(

--- a/tachyon/math/elliptic_curves/bn/bn254/BUILD.bazel
+++ b/tachyon/math/elliptic_curves/bn/bn254/BUILD.bazel
@@ -13,20 +13,6 @@ load(
 package(default_visibility = ["//visibility:public"])
 
 # Parameters are from https://zips.z.cash/protocol/protocol.pdf#page=97 and https://github.com/arkworks-rs/curves/tree/master/bn254/src/fields
-# Hex: 0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47
-FQ_MODULUS = "21888242871839275222246405745257275088696311157297823662689037894645226208583"
-
-FQ_SUBGROUP_GENERATOR = "3"
-
-# Hex: 0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001
-FR_MODULUS = "21888242871839275222246405745257275088548364400416034343698204186575808495617"
-
-FR_SUBGROUP_GENERATOR = "5"
-
-FR_SMALL_SUBGROUP_BASE = "3"
-
-FR_SMALL_SUBGROUP_ADICITY = "2"
-
 generate_prime_fields(
     name = "fq",
     class_name = "Fq",
@@ -36,7 +22,8 @@ generate_prime_fields(
 #else
 #include "tachyon/math/finite_fields/prime_field.h"
 #endif  // defined(TACHYON_POLYGON_ZKEVM_BACKEND)""",
-    modulus = FQ_MODULUS,
+    # Hex: 0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47
+    modulus = "21888242871839275222246405745257275088696311157297823662689037894645226208583",
     namespace = "tachyon::math::bn254",
     special_prime_override = """#if defined(TACHYON_POLYGON_ZKEVM_BACKEND)
 #if ARCH_CPU_X86_64
@@ -48,7 +35,7 @@ generate_prime_fields(
 #else
   constexpr static bool kIsSpecialPrime = false;
 #endif""",
-    subgroup_generator = FQ_SUBGROUP_GENERATOR,
+    subgroup_generator = "3",
     deps = if_polygon_zkevm_backend([
         ":prime_field_fq",
         "//tachyon/build:build_config",
@@ -64,10 +51,11 @@ generate_prime_fields(
 #else
 #include "tachyon/math/finite_fields/prime_field.h"
 #endif  // defined(TACHYON_POLYGON_ZKEVM_BACKEND)""",
-    modulus = FR_MODULUS,
+    # Hex: 0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001
+    modulus = "21888242871839275222246405745257275088548364400416034343698204186575808495617",
     namespace = "tachyon::math::bn254",
-    small_subgroup_adicity = FR_SMALL_SUBGROUP_ADICITY,
-    small_subgroup_base = FR_SMALL_SUBGROUP_BASE,
+    small_subgroup_adicity = "2",
+    small_subgroup_base = "3",
     special_prime_override = """#if defined(TACHYON_POLYGON_ZKEVM_BACKEND)
 #if ARCH_CPU_X86_64
   constexpr static bool kIsSpecialPrime = true;
@@ -78,7 +66,7 @@ generate_prime_fields(
 #else
   constexpr static bool kIsSpecialPrime = false;
 #endif""",
-    subgroup_generator = FR_SUBGROUP_GENERATOR,
+    subgroup_generator = "5",
     deps = if_polygon_zkevm_backend([
         ":prime_field_fr",
         "//tachyon/build:build_config",

--- a/tachyon/math/elliptic_curves/bn/bn384_small_two_adicity/BUILD.bazel
+++ b/tachyon/math/elliptic_curves/bn/bn384_small_two_adicity/BUILD.bazel
@@ -3,41 +3,25 @@ load("//tachyon/math/finite_fields/generator/prime_field_generator:build_defs.bz
 package(default_visibility = ["//visibility:public"])
 
 # Parameters are from https://github.com/arkworks-rs/algebra/blob/master/test-curves/src/bn384_small_two_adicity/fq.rs
-# Hex: 0x26a192ce09033aefd13bdbf17786104ad304fe31dc79b326e86a281d61074bec649bdd411682c645207c4e269a431001
-FQ_MODULUS = "5945877603251831796258517492029536515488649313567122628447476625319762940580461319088175968449723373773214087057409"
-
-FQ_SUBGROUP_GENERATOR = "7"
-
-FQ_SMALL_SUBGROUP_BASE = "3"
-
-FQ_SMALL_SUBGROUP_ADICITY = "2"
-
-# Parameters are from https://github.com/arkworks-rs/algebra/blob/master/test-curves/src/bn384_small_two_adicity/fr.rs
-# Hex: 0x26a192ce09033aefd13bdbf17786104ad304fe31dc79b32684f7e52225e599a5b91f07ba93282245f13a3723b4c31001
-FR_MODULUS = "5945877603251831796258517492029536515488649313567122628445038208291596545947608789992834434053176523624102324539393"
-
-FR_SUBGROUP_GENERATOR = "5"
-
-FR_SMALL_SUBGROUP_BASE = "3"
-
-FR_SMALL_SUBGROUP_ADICITY = "2"
-
 generate_prime_fields(
     name = "fq",
     class_name = "Fq",
-    modulus = FQ_MODULUS,
+    # Hex: 0x26a192ce09033aefd13bdbf17786104ad304fe31dc79b326e86a281d61074bec649bdd411682c645207c4e269a431001
+    modulus = "5945877603251831796258517492029536515488649313567122628447476625319762940580461319088175968449723373773214087057409",
     namespace = "tachyon::math::bn384_small_two_adicity",
-    small_subgroup_adicity = FQ_SMALL_SUBGROUP_ADICITY,
-    small_subgroup_base = FQ_SMALL_SUBGROUP_BASE,
-    subgroup_generator = FQ_SUBGROUP_GENERATOR,
+    small_subgroup_adicity = "2",
+    small_subgroup_base = "3",
+    subgroup_generator = "7",
 )
 
+# Parameters are from https://github.com/arkworks-rs/algebra/blob/master/test-curves/src/bn384_small_two_adicity/fr.rs
 generate_prime_fields(
     name = "fr",
     class_name = "Fr",
-    modulus = FR_MODULUS,
+    # Hex: 0x26a192ce09033aefd13bdbf17786104ad304fe31dc79b32684f7e52225e599a5b91f07ba93282245f13a3723b4c31001
+    modulus = "5945877603251831796258517492029536515488649313567122628445038208291596545947608789992834434053176523624102324539393",
     namespace = "tachyon::math::bn384_small_two_adicity",
-    small_subgroup_adicity = FR_SMALL_SUBGROUP_ADICITY,
-    small_subgroup_base = FR_SMALL_SUBGROUP_BASE,
-    subgroup_generator = FR_SUBGROUP_GENERATOR,
+    small_subgroup_adicity = "2",
+    small_subgroup_base = "3",
+    subgroup_generator = "5",
 )

--- a/tachyon/math/elliptic_curves/secp/secp256k1/BUILD.bazel
+++ b/tachyon/math/elliptic_curves/secp/secp256k1/BUILD.bazel
@@ -6,24 +6,6 @@ load("//tachyon/math/finite_fields/generator/prime_field_generator:build_defs.bz
 package(default_visibility = ["//visibility:public"])
 
 # Parameters are from https://www.secg.org/sec2-v2.pdf#page=13 and https://github.com/arkworks-rs/curves/tree/master/secp256k1/src/fields
-# Hex: 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f
-FQ_MODULUS = "115792089237316195423570985008687907853269984665640564039457584007908834671663"
-
-FQ_SUBGROUP_GENERATOR = "3"
-
-FQ_SMALL_SUBGROUP_BASE = "3"
-
-FQ_SMALL_SUBGROUP_ADICITY = "1"
-
-# Hex: 0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141
-FR_MODULUS = "115792089237316195423570985008687907852837564279074904382605163141518161494337"
-
-FR_SUBGROUP_GENERATOR = "7"
-
-FR_SMALL_SUBGROUP_BASE = "3"
-
-FR_SMALL_SUBGROUP_ADICITY = "1"
-
 generate_prime_fields(
     name = "fq",
     class_name = "Fq",
@@ -33,10 +15,11 @@ generate_prime_fields(
 #else
 #include "tachyon/math/finite_fields/prime_field.h"
 #endif  // defined(TACHYON_POLYGON_ZKEVM_BACKEND)""",
-    modulus = FQ_MODULUS,
+    # Hex: 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f
+    modulus = "115792089237316195423570985008687907853269984665640564039457584007908834671663",
     namespace = "tachyon::math::secp256k1",
-    small_subgroup_adicity = FQ_SMALL_SUBGROUP_ADICITY,
-    small_subgroup_base = FQ_SMALL_SUBGROUP_BASE,
+    small_subgroup_adicity = "1",
+    small_subgroup_base = "3",
     special_prime_override = """#if defined(TACHYON_POLYGON_ZKEVM_BACKEND)
 #if ARCH_CPU_X86_64
   constexpr static bool kIsSpecialPrime = true;
@@ -47,7 +30,7 @@ generate_prime_fields(
 #else
   constexpr static bool kIsSpecialPrime = false;
 #endif""",
-    subgroup_generator = FQ_SUBGROUP_GENERATOR,
+    subgroup_generator = "3",
     deps = if_polygon_zkevm_backend([
         ":prime_field_fq",
         "//tachyon/build:build_config",
@@ -63,10 +46,11 @@ generate_prime_fields(
 #else
 #include "tachyon/math/finite_fields/prime_field.h"
 #endif  // defined(TACHYON_POLYGON_ZKEVM_BACKEND)""",
-    modulus = FR_MODULUS,
+    # Hex: 0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141
+    modulus = "115792089237316195423570985008687907852837564279074904382605163141518161494337",
     namespace = "tachyon::math::secp256k1",
-    small_subgroup_adicity = FR_SMALL_SUBGROUP_ADICITY,
-    small_subgroup_base = FR_SMALL_SUBGROUP_BASE,
+    small_subgroup_adicity = "1",
+    small_subgroup_base = "3",
     special_prime_override = """#if defined(TACHYON_POLYGON_ZKEVM_BACKEND)
 #if ARCH_CPU_X86_64
   constexpr static bool kIsSpecialPrime = true;
@@ -77,7 +61,7 @@ generate_prime_fields(
 #else
   constexpr static bool kIsSpecialPrime = false;
 #endif""",
-    subgroup_generator = FR_SUBGROUP_GENERATOR,
+    subgroup_generator = "7",
     deps = if_polygon_zkevm_backend([
         ":prime_field_fr",
         "//tachyon/build:build_config",

--- a/tachyon/math/finite_fields/goldilocks_prime/BUILD.bazel
+++ b/tachyon/math/finite_fields/goldilocks_prime/BUILD.bazel
@@ -17,6 +17,8 @@ generate_prime_fields(
     # Hex: 0xffffffff00000001
     modulus = "18446744069414584321",
     namespace = "tachyon::math",
+    small_subgroup_adicity = "1",
+    small_subgroup_base = "3",
     special_prime_override = """#if defined(TACHYON_POLYGON_ZKEVM_BACKEND)
 #if ARCH_CPU_X86_64
   constexpr static bool kIsSpecialPrime = true;
@@ -27,6 +29,7 @@ generate_prime_fields(
 #else
   constexpr static bool kIsSpecialPrime = false;
 #endif""",
+    subgroup_generator = "7",
     deps = if_polygon_zkevm_backend([
         ":prime_field_goldilocks",
         "//tachyon/build:build_config",

--- a/tachyon/math/finite_fields/goldilocks_prime/BUILD.bazel
+++ b/tachyon/math/finite_fields/goldilocks_prime/BUILD.bazel
@@ -4,10 +4,6 @@ load("//tachyon/math/finite_fields/generator/prime_field_generator:build_defs.bz
 
 package(default_visibility = ["//visibility:public"])
 
-# 2^64 - 2^32 + 1
-# Hex: 0xffffffff00000001
-GOLDILOCKS_MODULUS = "18446744069414584321"
-
 generate_prime_fields(
     name = "goldilocks",
     class_name = "Goldilocks",
@@ -17,7 +13,9 @@ generate_prime_fields(
 #else
 #include "tachyon/math/finite_fields/prime_field.h"
 #endif  // defined(TACHYON_POLYGON_ZKEVM_BACKEND)""",
-    modulus = GOLDILOCKS_MODULUS,
+    # 2⁶⁴ - 2³² + 1
+    # Hex: 0xffffffff00000001
+    modulus = "18446744069414584321",
     namespace = "tachyon::math",
     special_prime_override = """#if defined(TACHYON_POLYGON_ZKEVM_BACKEND)
 #if ARCH_CPU_X86_64

--- a/tachyon/math/polynomials/univariate/BUILD.bazel
+++ b/tachyon/math/polynomials/univariate/BUILD.bazel
@@ -123,6 +123,7 @@ tachyon_cc_unittest(
         ":univariate_polynomial",
         "//tachyon/base/buffer:vector_buffer",
         "//tachyon/base/containers:contains",
+        "//tachyon/base/containers:cxx20_erase",
         "//tachyon/base/functional:function_ref",
         "//tachyon/math/elliptic_curves/bls12/bls12_381:fr",
         "//tachyon/math/elliptic_curves/bn/bn384_small_two_adicity:fq",

--- a/tachyon/math/polynomials/univariate/univariate_dense_polynomial_unittest.cc
+++ b/tachyon/math/polynomials/univariate/univariate_dense_polynomial_unittest.cc
@@ -351,6 +351,56 @@ TEST_F(UnivariateDensePolynomialTest, EvaluateVanishingPolyByRoots) {
             poly.Evaluate(point));
 }
 
+#define GET_COEFF(poly, degree)                \
+  ({                                           \
+    GF7* coeff = poly[degree];                 \
+    (coeff == nullptr) ? GF7::Zero() : *coeff; \
+  })
+
+TEST_F(UnivariateDensePolynomialTest, FoldEven) {
+  Poly poly = Poly::Random(kMaxDegree);
+  GF7 r = GF7::Random();
+  Poly folded = poly.Fold<true>(r);
+  EXPECT_EQ(folded,
+            Poly(Coeffs({r * GET_COEFF(poly, 0) + GET_COEFF(poly, 1),
+                         r * GET_COEFF(poly, 2) + GET_COEFF(poly, 3),
+                         r * GET_COEFF(poly, 4) + GET_COEFF(poly, 5)})));
+
+  GF7 r2 = GF7::Random();
+  Poly folded2 = folded.Fold<true>(r2);
+  EXPECT_EQ(folded2,
+            Poly(Coeffs({r2 * GET_COEFF(folded, 0) + GET_COEFF(folded, 1),
+                         r2 * GET_COEFF(folded, 2)})));
+
+  GF7 r3 = GF7::Random();
+  Poly folded3 = folded2.Fold<true>(r3);
+  EXPECT_EQ(folded3,
+            Poly(Coeffs({r3 * GET_COEFF(folded2, 0) + GET_COEFF(folded2, 1)})));
+}
+
+TEST_F(UnivariateDensePolynomialTest, FoldOdd) {
+  Poly poly = Poly::Random(kMaxDegree);
+  GF7 r = GF7::Random();
+  Poly folded = poly.Fold<false>(r);
+  EXPECT_EQ(folded,
+            Poly(Coeffs({GET_COEFF(poly, 0) + r * GET_COEFF(poly, 1),
+                         GET_COEFF(poly, 2) + r * GET_COEFF(poly, 3),
+                         GET_COEFF(poly, 4) + r * GET_COEFF(poly, 5)})));
+
+  GF7 r2 = GF7::Random();
+  Poly folded2 = folded.Fold<false>(r2);
+  EXPECT_EQ(folded2,
+            Poly(Coeffs({GET_COEFF(folded, 0) + r2 * GET_COEFF(folded, 1),
+                         GET_COEFF(folded, 2)})));
+
+  GF7 r3 = GF7::Random();
+  Poly folded3 = folded2.Fold<false>(r3);
+  EXPECT_EQ(folded3,
+            Poly(Coeffs({GET_COEFF(folded2, 0) + r3 * GET_COEFF(folded2, 1)})));
+}
+
+#undef GET_COEFF
+
 TEST_F(UnivariateDensePolynomialTest, Copyable) {
   Poly expected(Coeffs({GF7(1), GF7(4), GF7(3), GF7(5)}));
   Poly value;

--- a/tachyon/math/polynomials/univariate/univariate_polynomial.h
+++ b/tachyon/math/polynomials/univariate/univariate_polynomial.h
@@ -170,6 +170,15 @@ class UnivariatePolynomial final
                            });
   }
 
+  // Return a polynomial where the original polynomial reduces its degree
+  // by categorizing coefficients into even and odd degrees,
+  // multiplying either set of coefficients by a specified random field |r|,
+  // and summing them together.
+  template <bool MulRandomWithEvens>
+  constexpr UnivariatePolynomial Fold(const Field& r) const {
+    return UnivariatePolynomial(coefficients_.template Fold<MulRandomWithEvens>(r));
+  }
+
   auto ToSparse() const {
     return internal::UnivariatePolynomialOp<Coefficients>::ToSparse(*this);
   }

--- a/tachyon/zk/base/commitments/shplonk_extension.h
+++ b/tachyon/zk/base/commitments/shplonk_extension.h
@@ -27,8 +27,11 @@ class SHPlonkExtension
   // github.com/kroma-network/halo2/blob/7d0a36990452c8e7ebd600de258420781a9b7917/halo2_proofs/src/poly/kzg/multiopen/shplonk/prover.rs#L111
   constexpr static bool kQueryInstance = false;
 
-  using G1PointTy = typename CurveTy::G1Curve::AffinePointTy;
-  using Field = typename G1PointTy::ScalarField;
+  using Base = UnivariatePolynomialCommitmentSchemeExtension<
+      SHPlonkExtension<CurveTy, MaxDegree, MaxExtendedDegree, Commitment>>;
+  using Field = typename Base::Field;
+  using Poly = typename Base::Poly;
+  using Evals = typename Base::Evals;
 
   SHPlonkExtension() = default;
   explicit SHPlonkExtension(
@@ -50,6 +53,15 @@ class SHPlonkExtension
   template <typename BaseContainerTy>
   [[nodiscard]] bool DoCommit(const BaseContainerTy& v, Commitment* out) const {
     return shplonk_.DoCommit(v, out);
+  }
+
+  [[nodiscard]] bool DoCommit(const Poly& poly, Commitment* out) const {
+    return shplonk_.DoCommit(poly, out);
+  }
+
+  [[nodiscard]] bool DoCommitLagrange(const Evals& evals,
+                                      Commitment* out) const {
+    return shplonk_.DoCommitLagrange(evals, out);
   }
 
   template <typename BaseContainerTy>

--- a/tachyon/zk/plonk/circuit/rotation.h
+++ b/tachyon/zk/plonk/circuit/rotation.h
@@ -51,13 +51,9 @@ class TACHYON_EXPORT Rotation {
     return result;
   }
 
-  template <typename Domain, typename F = typename Domain::F>
+  template <typename Domain, typename F>
   F RotateOmega(const Domain* domain, const F& point) const {
-    if (value_ >= 0) {
-      return point * domain->group_gen().Pow(value_);
-    } else {
-      return point * domain->group_gen_inv().Pow(-1 * value_);
-    }
+    return point * domain->GetElement(value_);
   }
 
  private:


### PR DESCRIPTION
# Description

This PR implements FRI commitment. Therefore this introduces new class `FRI`, which is another child class of `UnivariatePolynomialCommitmentScheme`. In addition, this fixes a bug in `BinaryMerkleTree` and make `Goldilocks` FFT friendly field.

 See here for references!
- [fri_commit_phase()](https://github.com/lambdaclass/lambdaworks/blob/703db8a535793ecc820e044b06c1b735764f0881/exercises/message/src/starks/fri/mod.rs#L20-L72),
- [fri_decommit_phase()](https://github.com/lambdaclass/lambdaworks/blob/703db8a535793ecc820e044b06c1b735764f0881/exercises/message/src/starks/fri/mod.rs#L74-L127) 
- [Anatomy of a STARK, Part 3: FRI](https://aszepieniec.github.io/stark-anatomy/fri.html)
