### PR TITLE
feat: support halo2 proof encoding

### DIFF
--- a/tachyon/base/buffer/BUILD.bazel
+++ b/tachyon/base/buffer/BUILD.bazel
@@ -38,6 +38,7 @@ tachyon_cc_library(
 
 tachyon_cc_library(
     name = "vector_buffer",
+    srcs = ["vector_buffer.cc"],
     hdrs = ["vector_buffer.h"],
     deps = [":buffer"],
 )

--- a/tachyon/base/buffer/buffer_unittest.cc
+++ b/tachyon/base/buffer/buffer_unittest.cc
@@ -54,7 +54,7 @@ TEST(BufferTest, Write) {
   std::array<int, 4> kIntArray = {8, 9, 10, 11};
 
   for (Endian endian : {Endian::kNative, Endian::kBig, Endian::kLittle}) {
-    VectorBuffer write_buf;
+    Uint8VectorBuffer write_buf;
     write_buf.set_endian(endian);
     ASSERT_TRUE(write_buf.Write(kCharValue));
     ASSERT_TRUE(write_buf.Write(kIntValue));
@@ -106,7 +106,7 @@ TEST(BufferTest, WriteMany) {
   std::array<int, 4> kIntArray = {8, 9, 10, 11};
 
   for (Endian endian : {Endian::kNative, Endian::kBig, Endian::kLittle}) {
-    VectorBuffer write_buf;
+    Uint8VectorBuffer write_buf;
     write_buf.set_endian(endian);
     ASSERT_TRUE(write_buf.WriteMany(kCharValue, kIntValue, kBooleanValue,
                                     kCharPtrValue, kStringValue,

--- a/tachyon/base/buffer/string_buffer.h
+++ b/tachyon/base/buffer/string_buffer.h
@@ -23,6 +23,10 @@ class TACHYON_EXPORT StringBuffer : public Buffer {
   }
   ~StringBuffer() override = default;
 
+  const std::string& owned_buffer() const { return owned_buffer_; }
+
+  std::string&& TakeOwnedBuffer() && { return std::move(owned_buffer_); }
+
   [[nodiscard]] bool Grow(size_t size) override {
     owned_buffer_.resize(size);
     buffer_ = owned_buffer_.data();

--- a/tachyon/base/buffer/vector_buffer.cc
+++ b/tachyon/base/buffer/vector_buffer.cc
@@ -1,0 +1,8 @@
+#include "tachyon/base/buffer/vector_buffer.h"
+
+namespace tachyon::base {
+
+template class VectorBuffer<char>;
+template class VectorBuffer<uint8_t>;
+
+}  // namespace tachyon::base

--- a/tachyon/base/buffer/vector_buffer.h
+++ b/tachyon/base/buffer/vector_buffer.h
@@ -23,6 +23,10 @@ class TACHYON_EXPORT VectorBuffer : public Buffer {
   }
   ~VectorBuffer() override = default;
 
+  const std::vector<char>& owned_buffer() const { return owned_buffer_; }
+
+  std::vector<char>&& TakeOwnedBuffer() && { return std::move(owned_buffer_); }
+
   [[nodiscard]] bool Grow(size_t size) override {
     owned_buffer_.resize(size);
     buffer_ = owned_buffer_.data();

--- a/tachyon/base/buffer/vector_buffer.h
+++ b/tachyon/base/buffer/vector_buffer.h
@@ -8,8 +8,11 @@
 
 namespace tachyon::base {
 
-class TACHYON_EXPORT VectorBuffer : public Buffer {
+template <typename T>
+class VectorBuffer : public Buffer {
  public:
+  static_assert(sizeof(T) == 1);
+
   VectorBuffer() = default;
   VectorBuffer(const VectorBuffer& other) = delete;
   VectorBuffer& operator=(const VectorBuffer& other) = delete;
@@ -23,9 +26,9 @@ class TACHYON_EXPORT VectorBuffer : public Buffer {
   }
   ~VectorBuffer() override = default;
 
-  const std::vector<char>& owned_buffer() const { return owned_buffer_; }
+  const std::vector<T>& owned_buffer() const { return owned_buffer_; }
 
-  std::vector<char>&& TakeOwnedBuffer() && { return std::move(owned_buffer_); }
+  std::vector<T>&& TakeOwnedBuffer() && { return std::move(owned_buffer_); }
 
   [[nodiscard]] bool Grow(size_t size) override {
     owned_buffer_.resize(size);
@@ -35,8 +38,14 @@ class TACHYON_EXPORT VectorBuffer : public Buffer {
   }
 
  protected:
-  std::vector<char> owned_buffer_;
+  std::vector<T> owned_buffer_;
 };
+
+using CharVectorBuffer = VectorBuffer<char>;
+using Uint8VectorBuffer = VectorBuffer<uint8_t>;
+
+extern template class TACHYON_EXPORT VectorBuffer<char>;
+extern template class TACHYON_EXPORT VectorBuffer<uint8_t>;
 
 }  // namespace tachyon::base
 

--- a/tachyon/crypto/commitments/kzg/BUILD.bazel
+++ b/tachyon/crypto/commitments/kzg/BUILD.bazel
@@ -43,9 +43,9 @@ tachyon_cc_unittest(
     deps = [
         ":shplonk",
         "//tachyon/base/buffer:vector_buffer",
+        "//tachyon/crypto/transcripts:simple_transcript",
         "//tachyon/math/elliptic_curves/bn/bn254:g1",
         "//tachyon/math/elliptic_curves/bn/bn254:g2",
         "//tachyon/math/polynomials/univariate:univariate_evaluation_domain_factory",
-        "//tachyon/zk/plonk/halo2:poseidon_transcript",
     ],
 )

--- a/tachyon/crypto/commitments/kzg/kzg_unittest.cc
+++ b/tachyon/crypto/commitments/kzg/kzg_unittest.cc
@@ -67,7 +67,7 @@ TEST_F(KZGTest, Copyable) {
   PCS expected;
   ASSERT_TRUE(expected.UnsafeSetup(N));
 
-  base::VectorBuffer write_buf;
+  base::Uint8VectorBuffer write_buf;
   ASSERT_TRUE(write_buf.Write(expected));
 
   write_buf.set_buffer_offset(0);

--- a/tachyon/crypto/commitments/kzg/shplonk_unittest.cc
+++ b/tachyon/crypto/commitments/kzg/shplonk_unittest.cc
@@ -30,10 +30,10 @@ class SHPlonkTest : public testing::Test {
 
   static void SetUpTestSuite() { math::bn254::G1Curve::Init(); }
 
+  SHPlonkTest() : writer_(base::Uint8VectorBuffer()) {}
+
   void SetUp() override {
     KZG<math::bn254::G1AffinePoint, kMaxDegree, math::bn254::G1AffinePoint> kzg;
-    base::Uint8VectorBuffer write_buf;
-    writer_ = zk::halo2::PoseidonWriter<Commitment>(std::move(write_buf));
     pcs_ = PCS(std::move(kzg), &writer_);
     ASSERT_TRUE(pcs_.UnsafeSetup(N));
 

--- a/tachyon/crypto/commitments/kzg/shplonk_unittest.cc
+++ b/tachyon/crypto/commitments/kzg/shplonk_unittest.cc
@@ -4,10 +4,10 @@
 
 #include "gtest/gtest.h"
 
+#include "tachyon/crypto/transcripts/simple_transcript.h"
 #include "tachyon/math/elliptic_curves/bn/bn254/g1.h"
 #include "tachyon/math/elliptic_curves/bn/bn254/g2.h"
 #include "tachyon/math/polynomials/univariate/univariate_evaluation_domain_factory.h"
-#include "tachyon/zk/plonk/halo2/poseidon_transcript.h"
 
 namespace tachyon::crypto {
 
@@ -79,7 +79,7 @@ class SHPlonkTest : public testing::Test {
   std::vector<Poly> polys_;
   std::vector<F> points_;
   std::vector<PolynomialOpening<Poly>> poly_openings_;
-  zk::halo2::PoseidonWriter<Commitment> writer_;
+  SimpleTranscriptWriter<Commitment> writer_;
 };
 
 }  // namespace

--- a/tachyon/crypto/commitments/kzg/shplonk_unittest.cc
+++ b/tachyon/crypto/commitments/kzg/shplonk_unittest.cc
@@ -32,7 +32,7 @@ class SHPlonkTest : public testing::Test {
 
   void SetUp() override {
     KZG<math::bn254::G1AffinePoint, kMaxDegree, math::bn254::G1AffinePoint> kzg;
-    base::VectorBuffer write_buf;
+    base::Uint8VectorBuffer write_buf;
     writer_ = zk::halo2::PoseidonWriter<Commitment>(std::move(write_buf));
     pcs_ = PCS(std::move(kzg), &writer_);
     ASSERT_TRUE(pcs_.UnsafeSetup(N));

--- a/tachyon/crypto/commitments/pedersen/pedersen_unittest.cc
+++ b/tachyon/crypto/commitments/pedersen/pedersen_unittest.cc
@@ -42,7 +42,7 @@ TEST_F(PedersenTest, Copyable) {
   VCS expected;
   ASSERT_TRUE(expected.Setup());
 
-  base::VectorBuffer write_buf;
+  base::Uint8VectorBuffer write_buf;
   ASSERT_TRUE(write_buf.Write(expected));
 
   write_buf.set_buffer_offset(0);

--- a/tachyon/crypto/hashes/sponge/poseidon/poseidon.h
+++ b/tachyon/crypto/hashes/sponge/poseidon/poseidon.h
@@ -197,7 +197,7 @@ struct PoseidonSponge
     std::vector<F> bytes;
     bytes.reserve(usable_bytes * num_elements);
     for (const F& elem : src_elements) {
-      std::vector<uint8_t> elem_bytes = elem.ToBigInt().ToBytesLE();
+      auto elem_bytes = elem.ToBigInt().ToBytesLE();
       bytes.insert(bytes.end(), elem_bytes.begin(), elem_bytes.end());
     }
 

--- a/tachyon/crypto/transcripts/BUILD.bazel
+++ b/tachyon/crypto/transcripts/BUILD.bazel
@@ -3,6 +3,13 @@ load("//bazel:tachyon_cc.bzl", "tachyon_cc_library")
 package(default_visibility = ["//visibility:public"])
 
 tachyon_cc_library(
+    name = "simple_transcript",
+    testonly = True,
+    hdrs = ["simple_transcript.h"],
+    deps = [":transcript"],
+)
+
+tachyon_cc_library(
     name = "transcript",
     hdrs = ["transcript.h"],
     deps = [

--- a/tachyon/crypto/transcripts/simple_transcript.h
+++ b/tachyon/crypto/transcripts/simple_transcript.h
@@ -1,0 +1,166 @@
+#ifndef TACHYON_CRYPTO_TRANSCRIPTS_SIMPLE_TRANSCRIPT_H_
+#define TACHYON_CRYPTO_TRANSCRIPTS_SIMPLE_TRANSCRIPT_H_
+
+#include <utility>
+
+#include "tachyon/crypto/transcripts/transcript.h"
+
+namespace tachyon::crypto {
+namespace internal {
+
+template <typename F, typename SFINAE = void>
+class SimpleTranscript;
+
+template <typename F>
+class SimpleTranscript<
+    F, std::enable_if_t<std::is_base_of_v<math::PrimeFieldBase<F>, F>>> {
+ protected:
+  F DoSqueezeChallenge() { return state_.DoubleInPlace(); }
+
+  bool DoWriteToTranscript(const F& value) {
+    state_ += value;
+    return true;
+  }
+
+ private:
+  F state_ = F::Zero();
+};
+
+template <typename Curve>
+class SimpleTranscript<math::AffinePoint<Curve>> {
+ protected:
+  using F = typename TranscriptTraits<math::AffinePoint<Curve>>::Field;
+  using CurveConfig = typename Curve::Config;
+
+  F DoSqueezeChallenge() { return state_.DoubleInPlace(); }
+
+  bool DoWriteToTranscript(const math::AffinePoint<Curve>& point) {
+    state_ += CurveConfig::BaseToScalar(point.x());
+    state_ += CurveConfig::BaseToScalar(point.y());
+    return true;
+  }
+
+  bool DoWriteToTranscript(const F& scalar) {
+    state_ += scalar;
+    return true;
+  }
+
+ private:
+  F state_ = F::Zero();
+};
+
+}  // namespace internal
+
+template <typename F, typename SFINAE = void>
+class SimpleTranscriptReader;
+
+template <typename F>
+class SimpleTranscriptReader<
+    F, std::enable_if_t<std::is_base_of_v<math::PrimeFieldBase<F>, F>>>
+    : public TranscriptReader<F>, protected internal::SimpleTranscript<F> {
+ public:
+  explicit SimpleTranscriptReader(base::Buffer read_buf)
+      : TranscriptReader<F>(std::move(read_buf)) {}
+
+  // TranscriptReader methods
+  F SqueezeChallenge() override { return this->DoSqueezeChallenge(); }
+
+  bool WriteToTranscript(const F& value) override {
+    return this->DoWriteToTranscript(value);
+  }
+
+ private:
+  bool DoReadFromProof(F* value) const override {
+    return this->buffer_.Read(value);
+  }
+};
+
+template <typename Curve>
+class SimpleTranscriptReader<math::AffinePoint<Curve>>
+    : public TranscriptReader<math::AffinePoint<Curve>>,
+      protected internal::SimpleTranscript<math::AffinePoint<Curve>> {
+ public:
+  using F = typename TranscriptTraits<math::AffinePoint<Curve>>::Field;
+
+  explicit SimpleTranscriptReader(base::Buffer read_buf)
+      : TranscriptReader<math::AffinePoint<Curve>>(std::move(read_buf)) {}
+
+  // TranscriptReader methods
+  F SqueezeChallenge() override { return this->DoSqueezeChallenge(); }
+
+  bool WriteToTranscript(const math::AffinePoint<Curve>& point) override {
+    return this->DoWriteToTranscript(point);
+  }
+
+  bool WriteToTranscript(const F& scalar) override {
+    return this->DoWriteToTranscript(scalar);
+  }
+
+ private:
+  bool DoReadFromProof(math::AffinePoint<Curve>* point) const override {
+    return this->buffer_.Read(point);
+  }
+
+  bool DoReadFromProof(F* scalar) const override {
+    return this->buffer_.Read(scalar);
+  }
+};
+
+template <typename F, typename SFINAE = void>
+class SimpleTranscriptWriter;
+
+template <typename F>
+class SimpleTranscriptWriter<
+    F, std::enable_if_t<std::is_base_of_v<math::PrimeFieldBase<F>, F>>>
+    : public TranscriptWriter<F>, protected internal::SimpleTranscript<F> {
+ public:
+  explicit SimpleTranscriptWriter(base::Uint8VectorBuffer write_buf)
+      : TranscriptWriter<F>(std::move(write_buf)) {}
+
+  // TranscriptWriter methods
+  F SqueezeChallenge() override { return this->DoSqueezeChallenge(); }
+
+  bool WriteToTranscript(const F& value) override {
+    return this->DoWriteToTranscript(value);
+  }
+
+ private:
+  bool DoWriteToProof(const F& value) override {
+    return this->buffer_.Write(value);
+  }
+};
+
+template <typename Curve>
+class SimpleTranscriptWriter<math::AffinePoint<Curve>>
+    : public TranscriptWriter<math::AffinePoint<Curve>>,
+      protected internal::SimpleTranscript<math::AffinePoint<Curve>> {
+ public:
+  using F = typename TranscriptTraits<math::AffinePoint<Curve>>::Field;
+
+  explicit SimpleTranscriptWriter(base::Uint8VectorBuffer write_buf)
+      : TranscriptWriter<math::AffinePoint<Curve>>(std::move(write_buf)) {}
+
+  // TranscriptWriter methods
+  F SqueezeChallenge() override { return this->DoSqueezeChallenge(); }
+
+  bool WriteToTranscript(const math::AffinePoint<Curve>& point) override {
+    return this->DoWriteToTranscript(point);
+  }
+
+  bool WriteToTranscript(const F& scalar) override {
+    return this->DoWriteToTranscript(scalar);
+  }
+
+ private:
+  bool DoWriteToProof(const math::AffinePoint<Curve>& point) override {
+    return this->buffer_.Write(point);
+  }
+
+  bool DoWriteToProof(const F& scalar) override {
+    return this->buffer_.Write(scalar);
+  }
+};
+
+}  // namespace tachyon::crypto
+
+#endif  // TACHYON_CRYPTO_TRANSCRIPTS_SIMPLE_TRANSCRIPT_H_

--- a/tachyon/crypto/transcripts/transcript.h
+++ b/tachyon/crypto/transcripts/transcript.h
@@ -98,16 +98,22 @@ class TranscriptReaderImpl<Commitment, false> : public Transcript<Commitment> {
   // Read a |commitment| from the proof. Note that it also writes the
   // |commitment| to the transcript by calling |WriteToTranscript()| internally.
   [[nodiscard]] bool ReadFromProof(Commitment* commitment) {
-    return buffer_.Read(commitment) && this->WriteToTranscript(*commitment);
+    return DoReadFromProof(commitment) && this->WriteToTranscript(*commitment);
   }
 
   // Read a |value| from the proof. Note that it also writes the
   // |value| to the transcript by calling |WriteToTranscript()| internally.
   [[nodiscard]] bool ReadFromProof(Field* value) {
-    return buffer_.Read(value) && this->WriteToTranscript(*value);
+    return DoReadFromProof(value) && this->WriteToTranscript(*value);
   }
 
- private:
+ protected:
+  //  Read a |commitment| from the proof.
+  [[nodiscard]] virtual bool DoReadFromProof(Commitment* commitment) const = 0;
+
+  //  Read a |value| from the proof.
+  [[nodiscard]] virtual bool DoReadFromProof(Field* value) const = 0;
+
   base::Buffer buffer_;
 };
 
@@ -125,10 +131,13 @@ class TranscriptReaderImpl<Field, true> : public Transcript<Field> {
   // Read a |value| from the proof. Note that it also writes the
   // |value| to the transcript by calling |WriteToTranscript()| internally.
   [[nodiscard]] bool ReadFromProof(Field* value) {
-    return buffer_.Read(value) && this->WriteToTranscript(*value);
+    return DoReadFromProof(value) && this->WriteToTranscript(*value);
   }
 
- private:
+ protected:
+  //  Read a |value| from the proof.
+  [[nodiscard]] virtual bool DoReadFromProof(Field* value) const = 0;
+
   base::Buffer buffer_;
 };
 
@@ -155,16 +164,22 @@ class TranscriptWriterImpl<Commitment, false> : public Transcript<Commitment> {
   // Write a |commitment| to the proof. Note that it also writes the
   // |commitment| to the transcript by calling |WriteToTranscript()| internally.
   [[nodiscard]] bool WriteToProof(const Commitment& commitment) {
-    return this->WriteToTranscript(commitment) && buffer_.Write(commitment);
+    return this->WriteToTranscript(commitment) && DoWriteToProof(commitment);
   }
 
   // Write a |value| to the proof. Note that it also writes the
   // |value| to the transcript by calling |WriteToTranscript()| internally.
   [[nodiscard]] bool WriteToProof(const Field& value) {
-    return this->WriteToTranscript(value) && buffer_.Write(value);
+    return this->WriteToTranscript(value) && DoWriteToProof(value);
   }
 
- private:
+ protected:
+  //  Write a |commitment| to the proof.
+  [[nodiscard]] virtual bool DoWriteToProof(const Commitment& commitment) = 0;
+
+  //  Write a |value| to the proof.
+  [[nodiscard]] virtual bool DoWriteToProof(const Field& value) = 0;
+
   base::Uint8VectorBuffer buffer_;
 };
 
@@ -184,10 +199,13 @@ class TranscriptWriterImpl<Field, true> : public Transcript<Field> {
   // Write a |value| to the proof. Note that it also writes the
   // |value| to the transcript by calling |WriteToTranscript()| internally.
   [[nodiscard]] bool WriteToProof(const Field& value) {
-    return this->WriteToTranscript(value) && buffer_.Write(value);
+    return this->WriteToTranscript(value) && DoWriteToProof(value);
   }
 
- private:
+ protected:
+  //  Write a |value| to the proof.
+  [[nodiscard]] virtual bool DoWriteToProof(const Field& value) = 0;
+
   base::Uint8VectorBuffer buffer_;
 };
 

--- a/tachyon/crypto/transcripts/transcript.h
+++ b/tachyon/crypto/transcripts/transcript.h
@@ -146,11 +146,11 @@ class TranscriptWriterImpl<Commitment, false> : public Transcript<Commitment> {
 
   TranscriptWriterImpl() = default;
   // Initialize a transcript given an output buffer.
-  explicit TranscriptWriterImpl(base::VectorBuffer buf)
+  explicit TranscriptWriterImpl(base::Uint8VectorBuffer buf)
       : buffer_(std::move(buf)) {}
 
-  base::VectorBuffer& buffer() { return buffer_; }
-  const base::VectorBuffer& buffer() const { return buffer_; }
+  base::Uint8VectorBuffer& buffer() { return buffer_; }
+  const base::Uint8VectorBuffer& buffer() const { return buffer_; }
 
   // Write a |commitment| to the proof. Note that it also writes the
   // |commitment| to the transcript by calling |WriteToTranscript()| internally.
@@ -165,7 +165,7 @@ class TranscriptWriterImpl<Commitment, false> : public Transcript<Commitment> {
   }
 
  private:
-  base::VectorBuffer buffer_;
+  base::Uint8VectorBuffer buffer_;
 };
 
 // Transcript view from the perspective of a prover that has access to an output
@@ -175,11 +175,11 @@ class TranscriptWriterImpl<Field, true> : public Transcript<Field> {
  public:
   TranscriptWriterImpl() = default;
   // Initialize a transcript given an output buffer.
-  explicit TranscriptWriterImpl(base::VectorBuffer buf)
+  explicit TranscriptWriterImpl(base::Uint8VectorBuffer buf)
       : buffer_(std::move(buf)) {}
 
-  base::VectorBuffer& buffer() { return buffer_; }
-  const base::VectorBuffer& buffer() const { return buffer_; }
+  base::Uint8VectorBuffer& buffer() { return buffer_; }
+  const base::Uint8VectorBuffer& buffer() const { return buffer_; }
 
   // Write a |value| to the proof. Note that it also writes the
   // |value| to the transcript by calling |WriteToTranscript()| internally.
@@ -188,7 +188,7 @@ class TranscriptWriterImpl<Field, true> : public Transcript<Field> {
   }
 
  private:
-  base::VectorBuffer buffer_;
+  base::Uint8VectorBuffer buffer_;
 };
 
 template <typename T>

--- a/tachyon/math/base/BUILD.bazel
+++ b/tachyon/math/base/BUILD.bazel
@@ -40,8 +40,6 @@ tachyon_cc_library(
         "//tachyon/base/strings:string_util",
         "//tachyon/build:build_config",
         "//tachyon/math/base/gmp:gmp_util",
-        "@com_google_absl//absl/container:inlined_vector",
-        "@com_google_absl//absl/types:span",
     ],
 )
 
@@ -143,6 +141,8 @@ tachyon_cc_unittest(
         "//tachyon/math/elliptic_curves/msm/test:msm_test_set",
         "//tachyon/math/elliptic_curves/short_weierstrass/test:sw_curve_config",
         "//tachyon/math/finite_fields/test:gf7",
+        "@com_google_absl//absl/container:inlined_vector",
+        "@com_google_absl//absl/types:span",
     ],
 )
 

--- a/tachyon/math/base/big_int.h
+++ b/tachyon/math/base/big_int.h
@@ -704,14 +704,14 @@ struct ALIGNAS(internal::LimbsAlignment(N)) BigInt {
   // Converts the BigInt to a byte array in little-endian order. This method
   // processes the limbs of the BigInt, extracts individual bytes, and sets them
   // in the resulting array.
-  std::vector<uint8_t> ToBytesLE() const {
-    std::vector<uint8_t> ret;
-    ret.reserve(kByteNums);
+  std::array<uint8_t, kByteNums> ToBytesLE() const {
+    std::array<uint8_t, kByteNums> ret;
+    auto it = ret.begin();
     FOR_FROM_SMALLEST(i, 0, kByteNums) {
       size_t limb_idx = i / kLimbByteNums;
       uint64_t limb = limbs[limb_idx];
       size_t byte_r_idx = i % kLimbByteNums;
-      ret.push_back(reinterpret_cast<uint8_t*>(&limb)[byte_r_idx]);
+      *(it++) = reinterpret_cast<uint8_t*>(&limb)[byte_r_idx];
     }
     return ret;
   }
@@ -719,14 +719,14 @@ struct ALIGNAS(internal::LimbsAlignment(N)) BigInt {
   // Converts the BigInt to a byte array in big-endian order. This method
   // processes the limbs of the BigInt, extracts individual bytes, and sets them
   // in the resulting array.
-  std::vector<uint8_t> ToBytesBE() const {
-    std::vector<uint8_t> ret;
-    ret.reserve(kByteNums);
+  std::array<uint8_t, kByteNums> ToBytesBE() const {
+    std::array<uint8_t, kByteNums> ret;
+    auto it = ret.begin();
     FOR_FROM_BIGGEST(i, 0, kByteNums) {
       size_t limb_idx = i / kLimbByteNums;
       uint64_t limb = limbs[limb_idx];
       size_t byte_r_idx = i % kLimbByteNums;
-      ret.push_back(reinterpret_cast<uint8_t*>(&limb)[byte_r_idx]);
+      *(it++) = reinterpret_cast<uint8_t*>(&limb)[byte_r_idx];
     }
     return ret;
   }

--- a/tachyon/math/base/big_int.h
+++ b/tachyon/math/base/big_int.h
@@ -16,9 +16,6 @@
 #include <utility>
 #include <vector>
 
-#include "absl/container/inlined_vector.h"
-#include "absl/types/span.h"
-
 #include "tachyon/base/bit_cast.h"
 #include "tachyon/base/buffer/copyable.h"
 #include "tachyon/base/compiler_specific.h"

--- a/tachyon/math/base/big_int_unittest.cc
+++ b/tachyon/math/base/big_int_unittest.cc
@@ -271,7 +271,7 @@ TEST(BigIntTest, Copyable) {
   BigInt<2> expected = BigInt<2>::Random();
   BigInt<2> value;
 
-  base::VectorBuffer write_buf;
+  base::Uint8VectorBuffer write_buf;
   ASSERT_TRUE(write_buf.Write(expected));
 
   write_buf.set_buffer_offset(0);

--- a/tachyon/math/base/big_int_unittest.cc
+++ b/tachyon/math/base/big_int_unittest.cc
@@ -3,6 +3,8 @@
 #include <algorithm>
 #include <vector>
 
+#include "absl/container/inlined_vector.h"
+#include "absl/types/span.h"
 #include "gtest/gtest.h"
 
 #include "tachyon/base/buffer/vector_buffer.h"

--- a/tachyon/math/base/big_int_unittest.cc
+++ b/tachyon/math/base/big_int_unittest.cc
@@ -128,7 +128,7 @@ TYPED_TEST(BigIntConversionTest, BytesLEConversion) {
   BigInt<4> actual = BigInt<4>::FromBytesLE(expected_input);
   ASSERT_EQ(actual, this->expected_);
 
-  std::vector<uint8_t> actual_input = actual.ToBytesLE();
+  std::array<uint8_t, 32> actual_input = actual.ToBytesLE();
   EXPECT_TRUE(std::equal(actual_input.begin(), actual_input.end(),
                          expected_input.begin()));
 }
@@ -152,7 +152,7 @@ TYPED_TEST(BigIntConversionTest, BytesBEConversion) {
   BigInt<4> actual = BigInt<4>::FromBytesBE(expected_input);
   ASSERT_EQ(actual, this->expected_);
 
-  std::vector<uint8_t> actual_input = actual.ToBytesBE();
+  std::array<uint8_t, 32> actual_input = actual.ToBytesBE();
   EXPECT_TRUE(std::equal(actual_input.begin(), actual_input.end(),
                          expected_input.begin()));
 }

--- a/tachyon/math/elliptic_curves/affine_point_unittest.cc
+++ b/tachyon/math/elliptic_curves/affine_point_unittest.cc
@@ -20,7 +20,7 @@ TEST_F(AffinePointTest, Copyable) {
   test::AffinePoint expected = test::AffinePoint::Random();
   test::AffinePoint value;
 
-  base::VectorBuffer write_buf;
+  base::Uint8VectorBuffer write_buf;
   ASSERT_TRUE(write_buf.Write(expected));
 
   write_buf.set_buffer_offset(0);

--- a/tachyon/math/elliptic_curves/jacobian_point_unittest.cc
+++ b/tachyon/math/elliptic_curves/jacobian_point_unittest.cc
@@ -20,7 +20,7 @@ TEST_F(JacobianPointTest, Copyable) {
   test::JacobianPoint expected = test::JacobianPoint::Random();
   test::JacobianPoint value;
 
-  base::VectorBuffer write_buf;
+  base::Uint8VectorBuffer write_buf;
   ASSERT_TRUE(write_buf.Write(expected));
 
   write_buf.set_buffer_offset(0);

--- a/tachyon/math/elliptic_curves/point_xyzz_unittest.cc
+++ b/tachyon/math/elliptic_curves/point_xyzz_unittest.cc
@@ -20,7 +20,7 @@ TEST_F(PointXYZZTest, Copyable) {
   test::PointXYZZ expected = test::PointXYZZ::Random();
   test::PointXYZZ value;
 
-  base::VectorBuffer write_buf;
+  base::Uint8VectorBuffer write_buf;
   ASSERT_TRUE(write_buf.Write(expected));
 
   write_buf.set_buffer_offset(0);

--- a/tachyon/math/elliptic_curves/projective_point_unittest.cc
+++ b/tachyon/math/elliptic_curves/projective_point_unittest.cc
@@ -20,7 +20,7 @@ TEST_F(ProjectivePointTest, Copyable) {
   test::ProjectivePoint expected = test::ProjectivePoint::Random();
   test::ProjectivePoint value;
 
-  base::VectorBuffer write_buf;
+  base::Uint8VectorBuffer write_buf;
   ASSERT_TRUE(write_buf.Write(expected));
 
   write_buf.set_buffer_offset(0);

--- a/tachyon/math/finite_fields/fp12_unittest.cc
+++ b/tachyon/math/finite_fields/fp12_unittest.cc
@@ -25,7 +25,7 @@ TEST_F(Fp12Test, Copyable) {
   const F expected = F::Random();
   F value;
 
-  base::VectorBuffer write_buf;
+  base::Uint8VectorBuffer write_buf;
   ASSERT_TRUE(write_buf.Write(expected));
 
   write_buf.set_buffer_offset(0);

--- a/tachyon/math/finite_fields/fp2_unittest.cc
+++ b/tachyon/math/finite_fields/fp2_unittest.cc
@@ -25,7 +25,7 @@ TEST_F(Fp2Test, Copyable) {
   const F expected = F::Random();
   F value;
 
-  base::VectorBuffer write_buf;
+  base::Uint8VectorBuffer write_buf;
   ASSERT_TRUE(write_buf.Write(expected));
 
   write_buf.set_buffer_offset(0);

--- a/tachyon/math/finite_fields/fp6_unittest.cc
+++ b/tachyon/math/finite_fields/fp6_unittest.cc
@@ -25,7 +25,7 @@ TEST_F(Fp6Test, Copyable) {
   const F expected = F::Random();
   F value;
 
-  base::VectorBuffer write_buf;
+  base::Uint8VectorBuffer write_buf;
   ASSERT_TRUE(write_buf.Write(expected));
 
   write_buf.set_buffer_offset(0);

--- a/tachyon/math/finite_fields/prime_field_unittest.cc
+++ b/tachyon/math/finite_fields/prime_field_unittest.cc
@@ -189,7 +189,7 @@ TEST_F(PrimeFieldTest, Copyable) {
   const GF7 expected = GF7::Random();
   GF7 value;
 
-  base::VectorBuffer write_buf;
+  base::Uint8VectorBuffer write_buf;
   ASSERT_TRUE(write_buf.Write(expected));
 
   write_buf.set_buffer_offset(0);

--- a/tachyon/math/geometry/point2_unittest.cc
+++ b/tachyon/math/geometry/point2_unittest.cc
@@ -42,7 +42,7 @@ TEST(Point2Test, Copyable) {
   Point2GF7 expected(GF7(1), GF7(2));
   Point2GF7 value;
 
-  base::VectorBuffer write_buf;
+  base::Uint8VectorBuffer write_buf;
   ASSERT_TRUE(write_buf.Write(expected));
 
   write_buf.set_buffer_offset(0);

--- a/tachyon/math/geometry/point3_unittest.cc
+++ b/tachyon/math/geometry/point3_unittest.cc
@@ -44,7 +44,7 @@ TEST(Point3Test, Copyable) {
   Point3GF7 expected(GF7(1), GF7(2), GF7(3));
   Point3GF7 value;
 
-  base::VectorBuffer write_buf;
+  base::Uint8VectorBuffer write_buf;
   ASSERT_TRUE(write_buf.Write(expected));
 
   write_buf.set_buffer_offset(0);

--- a/tachyon/math/geometry/point4_unittest.cc
+++ b/tachyon/math/geometry/point4_unittest.cc
@@ -48,7 +48,7 @@ TEST(Point4Test, Copyable) {
   Point4GF7 expected(GF7(1), GF7(2), GF7(3), GF7(4));
   Point4GF7 value;
 
-  base::VectorBuffer write_buf;
+  base::Uint8VectorBuffer write_buf;
   ASSERT_TRUE(write_buf.Write(expected));
 
   write_buf.set_buffer_offset(0);

--- a/tachyon/math/polynomials/univariate/univariate_dense_polynomial_unittest.cc
+++ b/tachyon/math/polynomials/univariate/univariate_dense_polynomial_unittest.cc
@@ -355,7 +355,7 @@ TEST_F(UnivariateDensePolynomialTest, Copyable) {
   Poly expected(Coeffs({GF7(1), GF7(4), GF7(3), GF7(5)}));
   Poly value;
 
-  base::VectorBuffer buf;
+  base::Uint8VectorBuffer buf;
   ASSERT_TRUE(buf.Write(expected));
 
   buf.set_buffer_offset(0);

--- a/tachyon/math/polynomials/univariate/univariate_evaluations_unittest.cc
+++ b/tachyon/math/polynomials/univariate/univariate_evaluations_unittest.cc
@@ -257,7 +257,7 @@ TEST_F(UnivariateEvaluationsTest, DivScalar) {
 }
 
 TEST_F(UnivariateEvaluationsTest, Copyable) {
-  base::VectorBuffer buf;
+  base::Uint8VectorBuffer buf;
   ASSERT_TRUE(buf.Write(polys_[0]));
 
   buf.set_buffer_offset(0);

--- a/tachyon/math/polynomials/univariate/univariate_sparse_polynomial_unittest.cc
+++ b/tachyon/math/polynomials/univariate/univariate_sparse_polynomial_unittest.cc
@@ -378,7 +378,7 @@ TEST_F(UnivariateSparsePolynomialTest, Copyable) {
   Poly expected(Coeffs({{0, GF7(3)}, {1, GF7(1)}}));
   Poly value;
 
-  base::VectorBuffer buf;
+  base::Uint8VectorBuffer buf;
   ASSERT_TRUE(buf.Write(expected));
 
   buf.set_buffer_offset(0);

--- a/tachyon/zk/plonk/halo2/BUILD.bazel
+++ b/tachyon/zk/plonk/halo2/BUILD.bazel
@@ -7,6 +7,7 @@ tachyon_cc_library(
     hdrs = ["blake2b_transcript.h"],
     deps = [
         ":constants",
+        ":proof_serializer",
         "//tachyon/crypto/transcripts:transcript",
         "//tachyon/math/base:big_int",
         "@com_google_boringssl//:crypto",
@@ -72,7 +73,18 @@ tachyon_cc_library(
     hdrs = ["poseidon_transcript.h"],
     deps = [
         ":poseidon_sponge",
+        ":proof_serializer",
         "//tachyon/crypto/transcripts:transcript",
+    ],
+)
+
+tachyon_cc_library(
+    name = "proof_serializer",
+    hdrs = ["proof_serializer.h"],
+    deps = [
+        "//tachyon/base/buffer",
+        "//tachyon/math/elliptic_curves:points",
+        "//tachyon/math/finite_fields:prime_field_base",
     ],
 )
 
@@ -116,6 +128,7 @@ tachyon_cc_library(
     hdrs = ["sha256_transcript.h"],
     deps = [
         ":constants",
+        ":proof_serializer",
         "//tachyon/base/types:always_false",
         "//tachyon/crypto/transcripts:transcript",
         "//tachyon/math/base:big_int",
@@ -129,6 +142,7 @@ tachyon_cc_unittest(
         "blake2b_transcript_unittest.cc",
         "pinned_verifying_key_unittest.cc",
         "poseidon_transcript_unittest.cc",
+        "proof_serializer_unittest.cc",
         "random_field_generator_unittest.cc",
         "sha256_transcript_unittest.cc",
     ],

--- a/tachyon/zk/plonk/halo2/blake2b_transcript.h
+++ b/tachyon/zk/plonk/halo2/blake2b_transcript.h
@@ -14,6 +14,7 @@
 #include "tachyon/crypto/transcripts/transcript.h"
 #include "tachyon/math/base/big_int.h"
 #include "tachyon/zk/plonk/halo2/constants.h"
+#include "tachyon/zk/plonk/halo2/proof_serializer.h"
 
 namespace tachyon::zk::halo2 {
 
@@ -68,6 +69,14 @@ class Blake2bReader : public crypto::TranscriptReader<AffinePointTy> {
   }
 
  private:
+  bool DoReadFromProof(AffinePointTy* point) const override {
+    return ProofSerializer<AffinePointTy>::ReadFromProof(this->buffer_, point);
+  }
+
+  bool DoReadFromProof(ScalarField* scalar) const override {
+    return ProofSerializer<ScalarField>::ReadFromProof(this->buffer_, scalar);
+  }
+
   BLAKE2B_CTX state_;
 };
 
@@ -119,6 +128,14 @@ class Blake2bWriter : public crypto::TranscriptWriter<AffinePointTy> {
   }
 
  private:
+  bool DoWriteToProof(const AffinePointTy& point) override {
+    return ProofSerializer<AffinePointTy>::WriteToProof(point, this->buffer_);
+  }
+
+  bool DoWriteToProof(const ScalarField& scalar) override {
+    return ProofSerializer<ScalarField>::WriteToProof(scalar, this->buffer_);
+  }
+
   BLAKE2B_CTX state_;
 };
 

--- a/tachyon/zk/plonk/halo2/blake2b_transcript.h
+++ b/tachyon/zk/plonk/halo2/blake2b_transcript.h
@@ -79,7 +79,7 @@ class Blake2bWriter : public crypto::TranscriptWriter<AffinePointTy> {
 
   Blake2bWriter() = default;
   // Initialize a transcript given an output buffer.
-  explicit Blake2bWriter(base::VectorBuffer write_buf)
+  explicit Blake2bWriter(base::Uint8VectorBuffer write_buf)
       : crypto::TranscriptWriter<AffinePointTy>(std::move(write_buf)) {
     BLAKE2B512_InitWithPersonal(&state_, kTranscriptStr);
   }

--- a/tachyon/zk/plonk/halo2/blake2b_transcript_unittest.cc
+++ b/tachyon/zk/plonk/halo2/blake2b_transcript_unittest.cc
@@ -27,7 +27,7 @@ class Blake2bTranscriptTest : public testing::Test {
 }  // namespace
 
 TEST_F(Blake2bTranscriptTest, WritePoint) {
-  base::VectorBuffer write_buf;
+  base::Uint8VectorBuffer write_buf;
   Blake2bWriter<G1AffinePoint> writer(std::move(write_buf));
   G1AffinePoint expected = G1AffinePoint::Random();
   ASSERT_TRUE(writer.WriteToProof(expected));
@@ -41,7 +41,7 @@ TEST_F(Blake2bTranscriptTest, WritePoint) {
 }
 
 TEST_F(Blake2bTranscriptTest, WriteScalar) {
-  base::VectorBuffer write_buf;
+  base::Uint8VectorBuffer write_buf;
   Blake2bWriter<G1AffinePoint> writer(std::move(write_buf));
   Fr expected = Fr::Random();
   ASSERT_TRUE(writer.WriteToProof(expected));
@@ -55,7 +55,7 @@ TEST_F(Blake2bTranscriptTest, WriteScalar) {
 }
 
 TEST_F(Blake2bTranscriptTest, SqueezeChallenge) {
-  base::VectorBuffer write_buf;
+  base::Uint8VectorBuffer write_buf;
   Blake2bWriter<G1AffinePoint> writer(std::move(write_buf));
   G1AffinePoint generator = G1AffinePoint::Generator();
   ASSERT_TRUE(writer.WriteToProof(generator));

--- a/tachyon/zk/plonk/halo2/poseidon_transcript.h
+++ b/tachyon/zk/plonk/halo2/poseidon_transcript.h
@@ -12,6 +12,7 @@
 
 #include "tachyon/crypto/transcripts/transcript.h"
 #include "tachyon/zk/plonk/halo2/poseidon_sponge.h"
+#include "tachyon/zk/plonk/halo2/proof_serializer.h"
 
 namespace tachyon::zk::halo2 {
 
@@ -45,6 +46,14 @@ class PoseidonReader : public crypto::TranscriptReader<AffinePointTy> {
   }
 
  private:
+  bool DoReadFromProof(AffinePointTy* point) const override {
+    return ProofSerializer<AffinePointTy>::ReadFromProof(this->buffer_, point);
+  }
+
+  bool DoReadFromProof(ScalarField* scalar) const override {
+    return ProofSerializer<ScalarField>::ReadFromProof(this->buffer_, scalar);
+  }
+
   PoseidonSponge<ScalarField> state_;
 };
 
@@ -78,6 +87,14 @@ class PoseidonWriter : public crypto::TranscriptWriter<AffinePointTy> {
   }
 
  private:
+  bool DoWriteToProof(const AffinePointTy& point) override {
+    return ProofSerializer<AffinePointTy>::WriteToProof(point, this->buffer_);
+  }
+
+  bool DoWriteToProof(const ScalarField& scalar) override {
+    return ProofSerializer<ScalarField>::WriteToProof(scalar, this->buffer_);
+  }
+
   PoseidonSponge<ScalarField> state_;
 };
 

--- a/tachyon/zk/plonk/halo2/poseidon_transcript.h
+++ b/tachyon/zk/plonk/halo2/poseidon_transcript.h
@@ -15,34 +15,57 @@
 #include "tachyon/zk/plonk/halo2/proof_serializer.h"
 
 namespace tachyon::zk::halo2 {
+namespace internal {
 
 template <typename AffinePointTy>
-class PoseidonReader : public crypto::TranscriptReader<AffinePointTy> {
- public:
+class PoseidonBase {
+ protected:
   using ScalarField = typename AffinePointTy::ScalarField;
   using Curve = typename AffinePointTy::Curve;
   using CurveConfig = typename Curve::Config;
 
-  PoseidonReader() = default;
-  // Initialize a transcript given an input buffer.
-  explicit PoseidonReader(base::Buffer buffer)
-      : crypto::TranscriptReader<AffinePointTy>(std::move(buffer)),
-        state_(crypto::PoseidonConfig<ScalarField>::CreateCustom(8, 5, 8, 63,
+  PoseidonBase()
+      : state_(crypto::PoseidonConfig<ScalarField>::CreateCustom(8, 5, 8, 63,
                                                                  0)) {}
 
-  // crypto::TranscriptReader methods
-  ScalarField SqueezeChallenge() override {
+  ScalarField DoSqueezeChallenge() {
     return state_.SqueezeNativeFieldElements(1)[0];
   }
 
-  bool WriteToTranscript(const AffinePointTy& point) override {
+  bool DoWriteToTranscript(const AffinePointTy& point) {
     std::array<ScalarField, 2> coords = {CurveConfig::BaseToScalar(point.x()),
                                          CurveConfig::BaseToScalar(point.y())};
     return state_.Absorb(coords);
   }
 
-  bool WriteToTranscript(const ScalarField& value) override {
-    return state_.Absorb(value);
+  bool DoWriteToTranscript(const ScalarField& scalar) {
+    return state_.Absorb(scalar);
+  }
+
+  PoseidonSponge<ScalarField> state_;
+};
+
+}  // namespace internal
+
+template <typename AffinePointTy>
+class PoseidonReader : public crypto::TranscriptReader<AffinePointTy>,
+                       protected internal::PoseidonBase<AffinePointTy> {
+ public:
+  using ScalarField = typename AffinePointTy::ScalarField;
+
+  // Initialize a transcript given an input buffer.
+  explicit PoseidonReader(base::Buffer buffer)
+      : crypto::TranscriptReader<AffinePointTy>(std::move(buffer)) {}
+
+  // crypto::TranscriptReader methods
+  ScalarField SqueezeChallenge() override { return this->DoSqueezeChallenge(); }
+
+  bool WriteToTranscript(const AffinePointTy& point) override {
+    return this->DoWriteToTranscript(point);
+  }
+
+  bool WriteToTranscript(const ScalarField& scalar) override {
+    return this->DoWriteToTranscript(scalar);
   }
 
  private:
@@ -53,37 +76,27 @@ class PoseidonReader : public crypto::TranscriptReader<AffinePointTy> {
   bool DoReadFromProof(ScalarField* scalar) const override {
     return ProofSerializer<ScalarField>::ReadFromProof(this->buffer_, scalar);
   }
-
-  PoseidonSponge<ScalarField> state_;
 };
 
 template <typename AffinePointTy>
-class PoseidonWriter : public crypto::TranscriptWriter<AffinePointTy> {
+class PoseidonWriter : public crypto::TranscriptWriter<AffinePointTy>,
+                       protected internal::PoseidonBase<AffinePointTy> {
  public:
   using ScalarField = typename AffinePointTy::ScalarField;
-  using Curve = typename AffinePointTy::Curve;
-  using CurveConfig = typename Curve::Config;
 
-  PoseidonWriter() = default;
   // Initialize a transcript given an output buffer.
   explicit PoseidonWriter(base::Uint8VectorBuffer buffer)
-      : crypto::TranscriptWriter<AffinePointTy>(std::move(buffer)),
-        state_(crypto::PoseidonConfig<ScalarField>::CreateCustom(8, 5, 8, 63,
-                                                                 0)) {}
+      : crypto::TranscriptWriter<AffinePointTy>(std::move(buffer)) {}
 
   // crypto::TranscriptWriter methods
-  ScalarField SqueezeChallenge() override {
-    return state_.SqueezeNativeFieldElements(1)[0];
-  }
+  ScalarField SqueezeChallenge() override { return this->DoSqueezeChallenge(); }
 
   bool WriteToTranscript(const AffinePointTy& point) override {
-    std::array<ScalarField, 2> coords = {CurveConfig::BaseToScalar(point.x()),
-                                         CurveConfig::BaseToScalar(point.y())};
-    return state_.Absorb(coords);
+    return this->DoWriteToTranscript(point);
   }
 
-  bool WriteToTranscript(const ScalarField& value) override {
-    return state_.Absorb(value);
+  bool WriteToTranscript(const ScalarField& scalar) override {
+    return this->DoWriteToTranscript(scalar);
   }
 
  private:
@@ -94,8 +107,6 @@ class PoseidonWriter : public crypto::TranscriptWriter<AffinePointTy> {
   bool DoWriteToProof(const ScalarField& scalar) override {
     return ProofSerializer<ScalarField>::WriteToProof(scalar, this->buffer_);
   }
-
-  PoseidonSponge<ScalarField> state_;
 };
 
 }  // namespace tachyon::zk::halo2

--- a/tachyon/zk/plonk/halo2/poseidon_transcript.h
+++ b/tachyon/zk/plonk/halo2/poseidon_transcript.h
@@ -57,7 +57,7 @@ class PoseidonWriter : public crypto::TranscriptWriter<AffinePointTy> {
 
   PoseidonWriter() = default;
   // Initialize a transcript given an output buffer.
-  explicit PoseidonWriter(base::VectorBuffer buffer)
+  explicit PoseidonWriter(base::Uint8VectorBuffer buffer)
       : crypto::TranscriptWriter<AffinePointTy>(std::move(buffer)),
         state_(crypto::PoseidonConfig<ScalarField>::CreateCustom(8, 5, 8, 63,
                                                                  0)) {}

--- a/tachyon/zk/plonk/halo2/poseidon_transcript_unittest.cc
+++ b/tachyon/zk/plonk/halo2/poseidon_transcript_unittest.cc
@@ -27,7 +27,7 @@ class PoseidonTranscriptTest : public testing::Test {
 }  // namespace
 
 TEST_F(PoseidonTranscriptTest, WritePoint) {
-  base::VectorBuffer write_buf;
+  base::Uint8VectorBuffer write_buf;
   PoseidonWriter<G1AffinePoint> writer(std::move(write_buf));
   G1AffinePoint expected = G1AffinePoint::Random();
   ASSERT_TRUE(writer.WriteToProof(expected));
@@ -41,7 +41,7 @@ TEST_F(PoseidonTranscriptTest, WritePoint) {
 }
 
 TEST_F(PoseidonTranscriptTest, WriteScalar) {
-  base::VectorBuffer write_buf;
+  base::Uint8VectorBuffer write_buf;
   PoseidonWriter<G1AffinePoint> writer(std::move(write_buf));
   Fr expected = Fr::Random();
   ASSERT_TRUE(writer.WriteToProof(expected));
@@ -55,7 +55,7 @@ TEST_F(PoseidonTranscriptTest, WriteScalar) {
 }
 
 TEST_F(PoseidonTranscriptTest, SqueezeChallenge) {
-  base::VectorBuffer write_buf;
+  base::Uint8VectorBuffer write_buf;
   PoseidonWriter<G1AffinePoint> writer(std::move(write_buf));
   G1AffinePoint generator = G1AffinePoint::Generator();
   ASSERT_TRUE(writer.WriteToProof(generator));

--- a/tachyon/zk/plonk/halo2/proof_serializer.h
+++ b/tachyon/zk/plonk/halo2/proof_serializer.h
@@ -1,0 +1,86 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
+#ifndef TACHYON_ZK_PLONK_HALO2_PROOF_SERIALIZER_H_
+#define TACHYON_ZK_PLONK_HALO2_PROOF_SERIALIZER_H_
+
+#include <type_traits>
+#include <utility>
+
+#include "tachyon/base/buffer/buffer.h"
+#include "tachyon/math/elliptic_curves/affine_point.h"
+#include "tachyon/math/finite_fields/prime_field_base.h"
+
+namespace tachyon::zk::halo2 {
+
+template <typename F, typename SFINAE = void>
+class ProofSerializer;
+
+template <typename F>
+class ProofSerializer<
+    F, std::enable_if_t<std::is_base_of_v<math::PrimeFieldBase<F>, F>>> {
+ public:
+  [[nodiscard]] static bool ReadFromProof(const base::Buffer& buffer,
+                                          F* scalar) {
+    return buffer.Read(scalar);
+  }
+
+  [[nodiscard]] static bool WriteToProof(const F& scalar,
+                                         base::Buffer& buffer) {
+    return buffer.Write(scalar);
+  }
+};
+
+template <typename Curve>
+class ProofSerializer<math::AffinePoint<Curve>> {
+ public:
+  using BaseField = typename math::AffinePoint<Curve>::BaseField;
+  using BigIntTy = typename BaseField::BigIntTy;
+
+  static_assert(BaseField::kModulusBits % 8 != 0,
+                "Halo2 needs 1 spare bit to put sign bit");
+
+  constexpr static size_t kByteSize = BaseField::kLimbNums * sizeof(uint64_t);
+
+  [[nodiscard]] static bool ReadFromProof(const base::Buffer& buffer,
+                                          math::AffinePoint<Curve>* point_out) {
+    uint8_t bytes[kByteSize];
+    if (!buffer.Read(bytes)) return false;
+    uint8_t is_odd = bytes[kByteSize - 1] >> 7;
+    bytes[kByteSize - 1] &= 0b01111111;
+    BaseField x = BaseField::FromBigInt(BigIntTy::FromBytesLE(bytes));
+    if (x.IsZero()) {
+      *point_out = math::AffinePoint<Curve>::Zero();
+      return true;
+    } else {
+      std::optional<math::AffinePoint<Curve>> point =
+          math::AffinePoint<Curve>::CreateFromX(x, is_odd);
+      if (!point.has_value()) return false;
+      *point_out = std::move(point).value();
+      return true;
+    }
+  }
+
+  [[nodiscard]] static bool WriteToProof(const math::AffinePoint<Curve>& point,
+                                         base::Buffer& buffer) {
+    if (point.infinity()) {
+      constexpr uint8_t kZeroBytes[kByteSize] = {
+          0,
+      };
+      return buffer.Write(kZeroBytes);
+    } else {
+      uint8_t is_odd = uint8_t{point.y().ToBigInt().IsOdd()} << 7;
+      std::array<uint8_t, kByteSize> x = point.x().ToBigInt().ToBytesLE();
+      if (!buffer.Write(x)) return false;
+      return buffer.WriteAt(buffer.buffer_offset() - 1,
+                            static_cast<uint8_t>(x[kByteSize - 1] | is_odd));
+    }
+  }
+};
+
+}  // namespace tachyon::zk::halo2
+
+#endif  // TACHYON_ZK_PLONK_HALO2_PROOF_SERIALIZER_H_

--- a/tachyon/zk/plonk/halo2/proof_serializer_unittest.cc
+++ b/tachyon/zk/plonk/halo2/proof_serializer_unittest.cc
@@ -1,0 +1,98 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
+#include "tachyon/zk/plonk/halo2/proof_serializer.h"
+
+#include <vector>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include "tachyon/base/buffer/vector_buffer.h"
+#include "tachyon/math/elliptic_curves/bn/bn254/g1.h"
+
+namespace tachyon::zk::halo2 {
+
+namespace {
+
+using namespace math::bn254;
+
+class ProofSerializerTest : public testing::Test {
+ public:
+  static void SetUpTestSuite() { G1Curve::Init(); }
+};
+
+}  // namespace
+
+TEST_F(ProofSerializerTest, SerializeScalar) {
+  struct {
+    std::string_view hex;
+    std::vector<uint8_t> proof;
+  } tests[] = {
+      {"0x2482c9ce1f365ed93c2afe1df9c673b0ba65278badd4d150f3b848cdd3d0cec8",
+       {200, 206, 208, 211, 205, 72,  184, 243, 80,  209, 212,
+        173, 139, 39,  101, 186, 176, 115, 198, 249, 29,  254,
+        42,  60,  217, 94,  54,  31,  206, 201, 130, 36}},
+  };
+
+  for (const auto& test : tests) {
+    std::vector<uint8_t> buffer;
+    buffer.resize(test.proof.size());
+    base::Buffer write_buf(buffer.data(), buffer.size());
+    Fr expected = Fr::FromHexString(test.hex);
+    ASSERT_TRUE(ProofSerializer<Fr>::WriteToProof(expected, write_buf));
+    EXPECT_THAT(buffer, testing::ElementsAreArray(test.proof));
+
+    write_buf.set_buffer_offset(0);
+    Fr actual;
+    ASSERT_TRUE(ProofSerializer<Fr>::ReadFromProof(write_buf, &actual));
+    EXPECT_EQ(actual, expected);
+  }
+}
+
+TEST_F(ProofSerializerTest, SerializeProof) {
+  struct {
+    std::array<std::string_view, 2> hex;
+    std::vector<uint8_t> proof;
+  } tests[] = {
+      // even point
+      {{
+           "0x233bd4dc42ffd123f6d041dca2117acea5f6a201b4612a81e7081cad001df470",
+           "0x14ecc49a7d74ee9059862ca5237c72f22dc6c39b64ec3e7c4ec314187577ee56",
+       },
+       {112, 244, 29,  0,   173, 28,  8,   231, 129, 42,  97,
+        180, 1,   162, 246, 165, 206, 122, 17,  162, 220, 65,
+        208, 246, 35,  209, 255, 66,  220, 212, 59,  35}},
+      // odd point
+      {{
+           "0x1ec72fa9df2846c267ad6bc77e438c0d8c0c9bba978be3095cc48b0334299dbb",
+           "0x2c1b5dfdca4dfc40a864355fead42fb3656a8a3304ad11b1dee1a4b924ac5a03",
+       },
+       {187, 157, 41,  52, 3,   139, 196, 92, 9,   227, 139,
+        151, 186, 155, 12, 140, 13,  140, 67, 126, 199, 107,
+        173, 103, 194, 70, 40,  223, 169, 47, 199, 158}},
+  };
+
+  for (const auto& test : tests) {
+    std::vector<uint8_t> buffer;
+    buffer.resize(test.proof.size());
+    base::Buffer write_buf(buffer.data(), buffer.size());
+    Fq x = Fq::FromHexString(test.hex[0]);
+    Fq y = Fq::FromHexString(test.hex[1]);
+    G1AffinePoint expected(x, y);
+    ASSERT_TRUE(
+        ProofSerializer<G1AffinePoint>::WriteToProof(expected, write_buf));
+    EXPECT_THAT(buffer, testing::ElementsAreArray(test.proof));
+
+    write_buf.set_buffer_offset(0);
+    G1AffinePoint actual;
+    ASSERT_TRUE(
+        ProofSerializer<G1AffinePoint>::ReadFromProof(write_buf, &actual));
+    EXPECT_EQ(actual, expected);
+  }
+}
+
+}  // namespace tachyon::zk::halo2

--- a/tachyon/zk/plonk/halo2/prover_test.h
+++ b/tachyon/zk/plonk/halo2/prover_test.h
@@ -40,7 +40,7 @@ class ProverTest : public testing::Test {
     PCS pcs;
     ASSERT_TRUE(pcs.UnsafeSetup(kMaxDomainSize));
 
-    base::VectorBuffer write_buf;
+    base::Uint8VectorBuffer write_buf;
     std::unique_ptr<crypto::TranscriptWriter<Commitment>> writer =
         std::make_unique<Blake2bWriter<Commitment>>(std::move(write_buf));
 

--- a/tachyon/zk/plonk/halo2/sha256_transcript.h
+++ b/tachyon/zk/plonk/halo2/sha256_transcript.h
@@ -18,22 +18,17 @@
 #include "tachyon/zk/plonk/halo2/proof_serializer.h"
 
 namespace tachyon::zk::halo2 {
+namespace internal {
 
 template <typename AffinePointTy>
-class Sha256Reader : public crypto::TranscriptReader<AffinePointTy> {
- public:
+class Sha256Base {
+ protected:
   using BaseField = typename AffinePointTy::BaseField;
   using ScalarField = typename AffinePointTy::ScalarField;
 
-  Sha256Reader() = default;
-  // Initialize a transcript given an input buffer.
-  explicit Sha256Reader(base::Buffer read_buf)
-      : crypto::TranscriptReader<AffinePointTy>(std::move(read_buf)) {
-    SHA256_Init(&state_);
-  }
+  Sha256Base() { SHA256_Init(&state_); }
 
-  // crypto::TranscriptReader methods
-  ScalarField SqueezeChallenge() override {
+  ScalarField DoSqueezeChallenge() {
     SHA256_Update(&state_, kShaPrefixChallenge, 1);
     SHA256_CTX hasher = state_;
     uint8_t result[32] = {0};
@@ -50,7 +45,7 @@ class Sha256Reader : public crypto::TranscriptReader<AffinePointTy> {
     }
   }
 
-  bool WriteToTranscript(const AffinePointTy& point) override {
+  bool DoWriteToTranscript(const AffinePointTy& point) {
     SHA256_Update(&state_, kShaPrefixZeros, 31);
     SHA256_Update(&state_, kShaPrefixPoint, 1);
     SHA256_Update(&state_, point.x().ToBigInt().ToBytesBE().data(),
@@ -60,12 +55,38 @@ class Sha256Reader : public crypto::TranscriptReader<AffinePointTy> {
     return true;
   }
 
-  bool WriteToTranscript(const ScalarField& scalar) override {
+  bool DoWriteToTranscript(const ScalarField& scalar) {
     SHA256_Update(&state_, kShaPrefixZeros, 31);
     SHA256_Update(&state_, kShaPrefixScalar, 1);
     SHA256_Update(&state_, scalar.ToBigInt().ToBytesBE().data(),
                   ScalarField::BigIntTy::kByteNums);
     return true;
+  }
+
+  SHA256_CTX state_;
+};
+
+}  // namespace internal
+
+template <typename AffinePointTy>
+class Sha256Reader : public crypto::TranscriptReader<AffinePointTy>,
+                     protected internal::Sha256Base<AffinePointTy> {
+ public:
+  using ScalarField = typename AffinePointTy::ScalarField;
+
+  // Initialize a transcript given an input buffer.
+  explicit Sha256Reader(base::Buffer read_buf)
+      : crypto::TranscriptReader<AffinePointTy>(std::move(read_buf)) {}
+
+  // crypto::TranscriptReader methods
+  ScalarField SqueezeChallenge() override { return this->DoSqueezeChallenge(); }
+
+  bool WriteToTranscript(const AffinePointTy& point) override {
+    return this->DoWriteToTranscript(point);
+  }
+
+  bool WriteToTranscript(const ScalarField& scalar) override {
+    return this->DoWriteToTranscript(scalar);
   }
 
  private:
@@ -76,17 +97,14 @@ class Sha256Reader : public crypto::TranscriptReader<AffinePointTy> {
   bool DoReadFromProof(ScalarField* scalar) const override {
     return ProofSerializer<ScalarField>::ReadFromProof(this->buffer_, scalar);
   }
-
-  SHA256_CTX state_;
 };
 
 template <typename AffinePointTy>
-class Sha256Writer : public crypto::TranscriptWriter<AffinePointTy> {
+class Sha256Writer : public crypto::TranscriptWriter<AffinePointTy>,
+                     protected internal::Sha256Base<AffinePointTy> {
  public:
-  using BaseField = typename AffinePointTy::BaseField;
   using ScalarField = typename AffinePointTy::ScalarField;
 
-  Sha256Writer() = default;
   // Initialize a transcript given an output buffer.
   explicit Sha256Writer(base::Uint8VectorBuffer write_buf)
       : crypto::TranscriptWriter<AffinePointTy>(std::move(write_buf)) {
@@ -94,39 +112,14 @@ class Sha256Writer : public crypto::TranscriptWriter<AffinePointTy> {
   }
 
   // crypto::TranscriptWriter methods
-  ScalarField SqueezeChallenge() override {
-    SHA256_Update(&state_, kShaPrefixChallenge, 1);
-    SHA256_CTX hasher = state_;
-    uint8_t result[32] = {0};
-    SHA256_Final(result, &hasher);
-
-    SHA256_Init(&state_);
-    SHA256_Update(&state_, result, 32);
-
-    if constexpr (ScalarField::N <= 4) {
-      return ScalarField::FromAnySizedBigInt(
-          math::BigInt<4>::FromBytesLE(result));
-    } else {
-      base::AlwaysFalse<AffinePointTy>();
-    }
-  }
+  ScalarField SqueezeChallenge() override { return this->DoSqueezeChallenge(); }
 
   bool WriteToTranscript(const AffinePointTy& point) override {
-    SHA256_Update(&state_, kShaPrefixZeros, 31);
-    SHA256_Update(&state_, kShaPrefixPoint, 1);
-    SHA256_Update(&state_, point.x().ToBigInt().ToBytesBE().data(),
-                  BaseField::BigIntTy::kByteNums);
-    SHA256_Update(&state_, point.y().ToBigInt().ToBytesBE().data(),
-                  BaseField::BigIntTy::kByteNums);
-    return true;
+    return this->DoWriteToTranscript(point);
   }
 
   bool WriteToTranscript(const ScalarField& scalar) override {
-    SHA256_Update(&state_, kShaPrefixZeros, 31);
-    SHA256_Update(&state_, kShaPrefixScalar, 1);
-    SHA256_Update(&state_, scalar.ToBigInt().ToBytesBE().data(),
-                  ScalarField::BigIntTy::kByteNums);
-    return true;
+    return this->DoWriteToTranscript(scalar);
   }
 
  private:

--- a/tachyon/zk/plonk/halo2/sha256_transcript.h
+++ b/tachyon/zk/plonk/halo2/sha256_transcript.h
@@ -79,7 +79,7 @@ class Sha256Writer : public crypto::TranscriptWriter<AffinePointTy> {
 
   Sha256Writer() = default;
   // Initialize a transcript given an output buffer.
-  explicit Sha256Writer(base::VectorBuffer write_buf)
+  explicit Sha256Writer(base::Uint8VectorBuffer write_buf)
       : crypto::TranscriptWriter<AffinePointTy>(std::move(write_buf)) {
     SHA256_Init(&state_);
   }

--- a/tachyon/zk/plonk/halo2/sha256_transcript.h
+++ b/tachyon/zk/plonk/halo2/sha256_transcript.h
@@ -15,6 +15,7 @@
 #include "tachyon/crypto/transcripts/transcript.h"
 #include "tachyon/math/base/big_int.h"
 #include "tachyon/zk/plonk/halo2/constants.h"
+#include "tachyon/zk/plonk/halo2/proof_serializer.h"
 
 namespace tachyon::zk::halo2 {
 
@@ -68,6 +69,14 @@ class Sha256Reader : public crypto::TranscriptReader<AffinePointTy> {
   }
 
  private:
+  bool DoReadFromProof(AffinePointTy* point) const override {
+    return ProofSerializer<AffinePointTy>::ReadFromProof(this->buffer_, point);
+  }
+
+  bool DoReadFromProof(ScalarField* scalar) const override {
+    return ProofSerializer<ScalarField>::ReadFromProof(this->buffer_, scalar);
+  }
+
   SHA256_CTX state_;
 };
 
@@ -121,6 +130,14 @@ class Sha256Writer : public crypto::TranscriptWriter<AffinePointTy> {
   }
 
  private:
+  bool DoWriteToProof(const AffinePointTy& point) override {
+    return ProofSerializer<AffinePointTy>::WriteToProof(point, this->buffer_);
+  }
+
+  bool DoWriteToProof(const ScalarField& scalar) override {
+    return ProofSerializer<ScalarField>::WriteToProof(scalar, this->buffer_);
+  }
+
   SHA256_CTX state_;
 };
 

--- a/tachyon/zk/plonk/halo2/sha256_transcript_unittest.cc
+++ b/tachyon/zk/plonk/halo2/sha256_transcript_unittest.cc
@@ -27,7 +27,7 @@ class Sha256TranscriptTest : public testing::Test {
 }  // namespace
 
 TEST_F(Sha256TranscriptTest, WritePoint) {
-  base::VectorBuffer write_buf;
+  base::Uint8VectorBuffer write_buf;
   Sha256Writer<G1AffinePoint> writer(std::move(write_buf));
   G1AffinePoint expected = G1AffinePoint::Random();
   ASSERT_TRUE(writer.WriteToProof(expected));
@@ -41,7 +41,7 @@ TEST_F(Sha256TranscriptTest, WritePoint) {
 }
 
 TEST_F(Sha256TranscriptTest, WriteScalar) {
-  base::VectorBuffer write_buf;
+  base::Uint8VectorBuffer write_buf;
   Sha256Writer<G1AffinePoint> writer(std::move(write_buf));
   Fr expected = Fr::Random();
   ASSERT_TRUE(writer.WriteToProof(expected));
@@ -55,7 +55,7 @@ TEST_F(Sha256TranscriptTest, WriteScalar) {
 }
 
 TEST_F(Sha256TranscriptTest, SqueezeChallenge) {
-  base::VectorBuffer write_buf;
+  base::Uint8VectorBuffer write_buf;
   Sha256Writer<G1AffinePoint> writer(std::move(write_buf));
   G1AffinePoint generator = G1AffinePoint::Generator();
   ASSERT_TRUE(writer.WriteToProof(generator));

--- a/tachyon/zk/plonk/permutation/permutation_proving_key_unittest.cc
+++ b/tachyon/zk/plonk/permutation/permutation_proving_key_unittest.cc
@@ -27,7 +27,7 @@ TEST_F(PermutationProvingKeyTest, Copyable) {
   ProvingKey expected({domain->Random<Evals>()}, {domain->Random<Poly>()});
   ProvingKey value;
 
-  base::VectorBuffer write_buf;
+  base::Uint8VectorBuffer write_buf;
   ASSERT_TRUE(write_buf.Write(expected));
 
   write_buf.set_buffer_offset(0);

--- a/tachyon/zk/plonk/permutation/permutation_verifying_key_unittest.cc
+++ b/tachyon/zk/plonk/permutation/permutation_verifying_key_unittest.cc
@@ -26,7 +26,7 @@ TEST_F(PermutationVerifyingKeyTest, Copyable) {
   VerifyingKey expected({math::bn254::G1AffinePoint::Random()});
   VerifyingKey value;
 
-  base::VectorBuffer write_buf;
+  base::Uint8VectorBuffer write_buf;
   ASSERT_TRUE(write_buf.Write(expected));
 
   write_buf.set_buffer_offset(0);


### PR DESCRIPTION
# Description

Halo2 encodes point with a compression making use of a spare bit of base field. But our copyable was a just memory copy including y and infinity flag. To match with an outcome of Halo2 and furthermore support various encoding scheme, `Transcript` class delegates encoding to a child class
