### PR TITLE
feat: implement proof verification

### DIFF
--- a/tachyon/math/base/BUILD.bazel
+++ b/tachyon/math/base/BUILD.bazel
@@ -89,7 +89,7 @@ tachyon_cc_library(
     hdrs = ["rings.h"],
     deps = [
         ":groups",
-        "//tachyon/base:template_util",
+        "//tachyon/base:parallelize",
     ],
 )
 

--- a/tachyon/math/base/field.h
+++ b/tachyon/math/base/field.h
@@ -19,20 +19,16 @@ template <typename F>
 class Field : public AdditiveGroup<F>, public MultiplicativeGroup<F> {
  public:
   // Sum of products: a₁ * b₁ + a₂ * b₂ + ... + aₙ * bₙ
-  template <
-      typename InputIterator,
-      std::enable_if_t<std::is_same_v<F, base::iter_value_t<InputIterator>>>* =
-          nullptr>
-  constexpr static F SumOfProducts(InputIterator a_first, InputIterator a_last,
-                                   InputIterator b_first,
-                                   InputIterator b_last) {
-    return Ring<F>::SumOfProducts(std::move(a_first), std::move(a_last),
-                                  std::move(b_first), std::move(b_last));
-  }
-
   template <typename Container>
   constexpr static F SumOfProducts(const Container& a, const Container& b) {
     return Ring<F>::SumOfProducts(a, b);
+  }
+
+  // Sum of products: a₁ * b₁ + a₂ * b₂ + ... + aₙ * bₙ
+  template <typename Container>
+  constexpr static F SumOfProductsSerial(const Container& a,
+                                         const Container& b) {
+    return Ring<F>::SumOfProductsSerial(a, b);
   }
 };
 

--- a/tachyon/math/base/field.h
+++ b/tachyon/math/base/field.h
@@ -19,15 +19,15 @@ template <typename F>
 class Field : public AdditiveGroup<F>, public MultiplicativeGroup<F> {
  public:
   // Sum of products: a₁ * b₁ + a₂ * b₂ + ... + aₙ * bₙ
-  template <typename Container>
-  constexpr static F SumOfProducts(const Container& a, const Container& b) {
+  template <typename ContainerA, typename ContainerB>
+  constexpr static F SumOfProducts(const ContainerA& a, const ContainerB& b) {
     return Ring<F>::SumOfProducts(a, b);
   }
 
   // Sum of products: a₁ * b₁ + a₂ * b₂ + ... + aₙ * bₙ
-  template <typename Container>
-  constexpr static F SumOfProductsSerial(const Container& a,
-                                         const Container& b) {
+  template <typename ContainerA, typename ContainerB>
+  constexpr static F SumOfProductsSerial(const ContainerA& a,
+                                         const ContainerB& b) {
     return Ring<F>::SumOfProductsSerial(a, b);
   }
 };

--- a/tachyon/math/base/field_unittest.cc
+++ b/tachyon/math/base/field_unittest.cc
@@ -13,12 +13,28 @@ class FieldTest : public testing::Test {
 
 }  // namespace
 
-TEST(FieldTest, SumOfProducts) {
+TEST(FieldTest, SumOfProductsSerial) {
   std::vector<GF7> a = {GF7(2), GF7(3), GF7(4)};
   std::vector<GF7> b = {GF7(1), GF7(2), GF7(3)};
 
-  GF7 result = Field<GF7>::SumOfProducts(a, b);
+  GF7 result = Field<GF7>::SumOfProductsSerial(a, b);
   EXPECT_EQ(result, GF7(6));
+}
+
+TEST(FieldTest, SumOfProductsParallel) {
+#if defined(TACHYON_HAS_OPENMP)
+  size_t thread_nums = static_cast<size_t>(omp_get_max_threads());
+#else
+  size_t thread_nums = 1;
+#endif
+
+  std::vector<GF7> a =
+      base::CreateVector(thread_nums * 10, []() { return GF7::Random(); });
+  std::vector<GF7> b =
+      base::CreateVector(thread_nums * 10, []() { return GF7::Random(); });
+
+  EXPECT_EQ(Field<GF7>::SumOfProducts(a, b),
+            Field<GF7>::SumOfProductsSerial(a, b));
 }
 
 }  // namespace tachyon::math

--- a/tachyon/math/base/rings.h
+++ b/tachyon/math/base/rings.h
@@ -30,8 +30,8 @@ class Ring : public AdditiveGroup<F>, public MultiplicativeSemigroup<F> {
   // |SumOfProductsSerial| for all call sites, it gets stuck when doing
   // unittests. I think we need a some general threshold to check whether it is
   // good to doing parallelization.
-  template <typename Container>
-  constexpr static F SumOfProducts(const Container& a, const Container& b) {
+  template <typename ContainerA, typename ContainerB>
+  constexpr static F SumOfProducts(const ContainerA& a, const ContainerB& b) {
     size_t size = std::size(a);
     CHECK_EQ(size, std::size(b));
     CHECK_NE(size, size_t{0});
@@ -52,9 +52,9 @@ class Ring : public AdditiveGroup<F>, public MultiplicativeSemigroup<F> {
                            });
   }
 
-  template <typename Container>
-  constexpr static F SumOfProductsSerial(const Container& a,
-                                         const Container& b) {
+  template <typename ContainerA, typename ContainerB>
+  constexpr static F SumOfProductsSerial(const ContainerA& a,
+                                         const ContainerB& b) {
     size_t size = std::size(a);
     CHECK_EQ(size, std::size(b));
     CHECK_NE(size, size_t{0});
@@ -62,9 +62,9 @@ class Ring : public AdditiveGroup<F>, public MultiplicativeSemigroup<F> {
   }
 
  private:
-  template <typename Container>
-  constexpr static F DoSumOfProductsSerial(const Container& a,
-                                           const Container& b) {
+  template <typename ContainerA, typename ContainerB>
+  constexpr static F DoSumOfProductsSerial(const ContainerA& a,
+                                           const ContainerB& b) {
     size_t n = std::size(a);
     F sum = F::Zero();
     for (size_t i = 0; i < n; ++i) {

--- a/tachyon/math/base/rings.h
+++ b/tachyon/math/base/rings.h
@@ -2,8 +2,9 @@
 #define TACHYON_MATH_BASE_RINGS_H_
 
 #include <type_traits>
+#include <vector>
 
-#include "tachyon/base/template_util.h"
+#include "tachyon/base/parallelize.h"
 #include "tachyon/math/base/groups.h"
 
 namespace tachyon::math {
@@ -25,26 +26,51 @@ class Ring : public AdditiveGroup<F>, public MultiplicativeSemigroup<F> {
   // This is taken and modified from
   // https://github.com/arkworks-rs/algebra/blob/5dfeedf560da6937a5de0a2163b7958bd32cd551/ff/src/fields/mod.rs#L298C1-L305
   // Sum of products: a₁ * b₁ + a₂ * b₂ + ... + aₙ * bₙ
-  template <
-      typename InputIterator,
-      std::enable_if_t<std::is_same_v<F, base::iter_value_t<InputIterator>>>* =
-          nullptr>
-  constexpr static F SumOfProducts(InputIterator a_first, InputIterator a_last,
-                                   InputIterator b_first,
-                                   InputIterator b_last) {
-    F sum = F::Zero();
-    while (a_first != a_last) {
-      sum += (*a_first * *b_first);
-      ++a_first;
-      ++b_first;
-    }
-    return sum;
+  // TODO(chokobole): If I call |SumOfProducts()| instead of
+  // |SumOfProductsSerial| for all call sites, it gets stuck when doing
+  // unittests. I think we need a some general threshold to check whether it is
+  // good to doing parallelization.
+  template <typename Container>
+  constexpr static F SumOfProducts(const Container& a, const Container& b) {
+    size_t size = std::size(a);
+    CHECK_EQ(size, std::size(b));
+    CHECK_NE(size, size_t{0});
+    std::vector<F> partial_sum_of_products = base::ParallelizeMap(
+        a,
+        [&b](absl::Span<const F> chunk, size_t chunk_idx, size_t chunk_size) {
+          F sum = F::Zero();
+          size_t i = chunk_idx * chunk_size;
+          for (size_t j = 0; j < chunk.size(); ++j) {
+            sum += (chunk[j] * b[i + j]);
+          }
+          return sum;
+        });
+    return std::accumulate(partial_sum_of_products.begin(),
+                           partial_sum_of_products.end(), F::Zero(),
+                           [](F& acc, const F& partial_sum_of_product) {
+                             return acc += partial_sum_of_product;
+                           });
   }
 
   template <typename Container>
-  constexpr static F SumOfProducts(const Container& a, const Container& b) {
-    return SumOfProducts(std::begin(a), std::end(a), std::begin(b),
-                         std::end(b));
+  constexpr static F SumOfProductsSerial(const Container& a,
+                                         const Container& b) {
+    size_t size = std::size(a);
+    CHECK_EQ(size, std::size(b));
+    CHECK_NE(size, size_t{0});
+    return DoSumOfProductsSerial(a, b);
+  }
+
+ private:
+  template <typename Container>
+  constexpr static F DoSumOfProductsSerial(const Container& a,
+                                           const Container& b) {
+    size_t n = std::size(a);
+    F sum = F::Zero();
+    for (size_t i = 0; i < n; ++i) {
+      sum += (a[i] * b[i]);
+    }
+    return sum;
   }
 };
 

--- a/tachyon/math/elliptic_curves/short_weierstrass/affine_point_impl.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/affine_point_impl.h
@@ -118,7 +118,7 @@ constexpr PointXYZZ<Curve> CLASS::DoubleXYZZ() const {
   // Y3 = M * (S - X3) - W * Y1
   BaseField lefts[] = {std::move(m), -w};
   BaseField rights[] = {s - x, y_};
-  BaseField y = BaseField::SumOfProducts(lefts, rights);
+  BaseField y = BaseField::SumOfProductsSerial(lefts, rights);
 
   // ZZ3 = V
   BaseField zz = std::move(v);

--- a/tachyon/math/elliptic_curves/short_weierstrass/jacobian_point_impl.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/jacobian_point_impl.h
@@ -86,7 +86,7 @@ constexpr CLASS& CLASS::AddInPlace(const JacobianPoint& other) {
     y_.DoubleInPlace();
     BaseField lefts[] = {std::move(r), y_};
     BaseField rights[] = {std::move(v), std::move(j)};
-    y_ = BaseField::SumOfProducts(lefts, rights);
+    y_ = BaseField::SumOfProductsSerial(lefts, rights);
 
     // Z3 = ((Z1 + Z2)² - Z1Z1 - Z2Z2) * H
     // This is equal to Z3 = 2 * Z1 * Z2 * H, and computing it this way is
@@ -159,7 +159,7 @@ constexpr CLASS& CLASS::AddInPlace(const AffinePoint<Curve>& other) {
     // Y3 = r * (V - X3) + 2 * Y1 * J
     BaseField lefts[] = {std::move(r), y_.Double()};
     BaseField rights[] = {v - x_, std::move(j)};
-    y_ = BaseField::SumOfProducts(lefts, rights);
+    y_ = BaseField::SumOfProductsSerial(lefts, rights);
 
     // Z3 = 2 * Z1 * H;
     // Can alternatively be computed as (Z1 + H)² - Z1Z1 - HH, but the latter is

--- a/tachyon/math/elliptic_curves/short_weierstrass/point_xyzz_impl.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/point_xyzz_impl.h
@@ -71,7 +71,7 @@ constexpr CLASS& CLASS::AddInPlace(const PointXYZZ& other) {
   // Y3 = R * (Q - X3) - S1 * PPP
   BaseField lefts[] = {std::move(r), -s1};
   BaseField rights[] = {q - x_, ppp};
-  y_ = BaseField::SumOfProducts(lefts, rights);
+  y_ = BaseField::SumOfProductsSerial(lefts, rights);
 
   // ZZ3 = ZZ1 * ZZ2 * PP
   zz_ *= other.zz_;
@@ -136,7 +136,7 @@ constexpr CLASS& CLASS::AddInPlace(const AffinePoint<Curve>& other) {
   // Y3 = R * (Q - X3) - Y1 * PPP
   BaseField lefts[] = {std::move(r), -y_};
   BaseField rights[] = {q - x_, ppp};
-  y_ = BaseField::SumOfProducts(lefts, rights);
+  y_ = BaseField::SumOfProductsSerial(lefts, rights);
 
   // ZZ3 = ZZ1 * PP
   zz_ *= pp;
@@ -186,7 +186,7 @@ constexpr CLASS& CLASS::DoubleInPlace() {
   // Y3 = M * (S - X3) - W * Y1
   BaseField lefts[] = {std::move(m), -w};
   BaseField rights[] = {s - x_, y_};
-  y_ = BaseField::SumOfProducts(lefts, rights);
+  y_ = BaseField::SumOfProductsSerial(lefts, rights);
 
   // ZZ3 = V * ZZ1
   zz_ *= v;

--- a/tachyon/math/elliptic_curves/short_weierstrass/projective_point_impl.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/projective_point_impl.h
@@ -76,7 +76,7 @@ constexpr CLASS& CLASS::AddInPlace(const ProjectivePoint& other) {
   // Y3 = u * (R - A) - vvv * Y1Z2
   BaseField lefts[] = {std::move(u), -vvv};
   BaseField rights[] = {r - a, std::move(y1z2)};
-  y_ = BaseField::SumOfProducts(lefts, rights);
+  y_ = BaseField::SumOfProductsSerial(lefts, rights);
 
   // Z3 = vvv * Z1Z2
   z_ = std::move(vvv);
@@ -139,7 +139,7 @@ constexpr CLASS& CLASS::AddInPlace(const AffinePoint<Curve>& other) {
   // Y3 = u * (R - A) - vvv * Y1
   BaseField lefts[] = {std::move(u), -vvv};
   BaseField rights[] = {r - a, std::move(y_)};
-  y_ = BaseField::SumOfProducts(lefts, rights);
+  y_ = BaseField::SumOfProductsSerial(lefts, rights);
 
   // Z3 = vvv * Z1
   z_ *= vvv;

--- a/tachyon/math/finite_fields/prime_field_unittest.cc
+++ b/tachyon/math/finite_fields/prime_field_unittest.cc
@@ -150,10 +150,10 @@ TEST_F(PrimeFieldTest, MultiplicativeGroupOperators) {
   EXPECT_EQ(f.Pow(5), GF7(5));
 }
 
-TEST_F(PrimeFieldTest, SumOfProducts) {
+TEST_F(PrimeFieldTest, SumOfProductsSerial) {
   const GF7 a[] = {GF7(3), GF7(2)};
   const GF7 b[] = {GF7(2), GF7(5)};
-  EXPECT_EQ(GF7::SumOfProducts(a, b), GF7(2));
+  EXPECT_EQ(GF7::SumOfProductsSerial(a, b), GF7(2));
 }
 
 TEST_F(PrimeFieldTest, Random) {

--- a/tachyon/math/finite_fields/quadratic_extension_field.h
+++ b/tachyon/math/finite_fields/quadratic_extension_field.h
@@ -157,13 +157,13 @@ class QuadraticExtensionField
       {
         BaseField lefts[] = {c0_, Config::MulByNonResidue(c1_)};
         BaseField rights[] = {other.c0_, other.c1_};
-        c0 = BaseField::SumOfProducts(lefts, rights);
+        c0 = BaseField::SumOfProductsSerial(lefts, rights);
       }
       BaseField c1;
       {
         BaseField lefts[] = {c0_, c1_};
         BaseField rights[] = {other.c1_, other.c0_};
-        c1 = BaseField::SumOfProducts(lefts, rights);
+        c1 = BaseField::SumOfProductsSerial(lefts, rights);
       }
       c0_ = std::move(c0);
       c1_ = std::move(c1);

--- a/tachyon/math/polynomials/univariate/BUILD.bazel
+++ b/tachyon/math/polynomials/univariate/BUILD.bazel
@@ -47,6 +47,7 @@ tachyon_cc_library(
         ":univariate_polynomial",
         "//tachyon/base:bits",
         "//tachyon/base:openmp_util",
+        "//tachyon/base:range",
         "//tachyon/math/polynomials:evaluation_domain",
     ],
 )

--- a/tachyon/math/polynomials/univariate/univariate_evaluation_domain.h
+++ b/tachyon/math/polynomials/univariate/univariate_evaluation_domain.h
@@ -309,11 +309,12 @@ class UnivariateEvaluationDomain : public EvaluationDomain<F, MaxDegree> {
   // Returns all the elements of the domain.
   constexpr std::vector<F> GetElements() const {
     if (offset_.IsOne()) {
-      return base::CreateVector(size_,
-                                [this](size_t i) { return group_gen_.Pow(i); });
+      return F::GetSuccessivePowers(size_, group_gen_);
     } else {
-      return base::CreateVector(
-          size_, [this](size_t i) { return group_gen_.Pow(i) * offset_; });
+      F value = offset_;
+      return base::CreateVector(size_, [this, &value]() {
+        return std::exchange(value, value * group_gen_);
+      });
     }
   }
 

--- a/tachyon/math/polynomials/univariate/univariate_evaluation_domain_unittest.cc
+++ b/tachyon/math/polynomials/univariate/univariate_evaluation_domain_unittest.cc
@@ -196,6 +196,17 @@ TYPED_TEST(UnivariateEvaluationDomainTest, NonSystematicLagrangeCoefficients) {
           std::vector<F> lagrange_coeffs =
               d.EvaluateAllLagrangeCoefficients(rand_pt);
 
+          std::vector<F> sub_lagrange_coeffs =
+              d.EvaluatePartialLagrangeCoefficients(
+                  rand_pt, base::Range<size_t>(1, domain_size - 1));
+
+          if (domain_size > 2) {
+            sub_lagrange_coeffs.push_back(lagrange_coeffs.back());
+            sub_lagrange_coeffs.insert(sub_lagrange_coeffs.begin(),
+                                       lagrange_coeffs.front());
+            EXPECT_EQ(lagrange_coeffs, sub_lagrange_coeffs);
+          }
+
           Evals poly_evals = d.FFT(rand_poly);
 
           // Do lagrange interpolation, and compare against the actual
@@ -227,6 +238,18 @@ TYPED_TEST(UnivariateEvaluationDomainTest, SystematicLagrangeCoefficients) {
             F x = d.GetElement(i);
             std::vector<F> lagrange_coeffs =
                 d.EvaluateAllLagrangeCoefficients(x);
+
+            std::vector<F> sub_lagrange_coeffs =
+                d.EvaluatePartialLagrangeCoefficients(
+                    x, base::Range<size_t>(1, domain_size - 1));
+
+            if (domain_size > 2) {
+              sub_lagrange_coeffs.push_back(lagrange_coeffs.back());
+              sub_lagrange_coeffs.insert(sub_lagrange_coeffs.begin(),
+                                         lagrange_coeffs.front());
+              EXPECT_EQ(lagrange_coeffs, sub_lagrange_coeffs);
+            }
+
             for (size_t j = 0; j < domain_size; ++j) {
               // Lagrange coefficient for the evaluation point,
               // which should be 1 if i == j

--- a/tachyon/math/polynomials/univariate/univariate_evaluation_domain_unittest.cc
+++ b/tachyon/math/polynomials/univariate/univariate_evaluation_domain_unittest.cc
@@ -185,7 +185,7 @@ TYPED_TEST(UnivariateEvaluationDomainTest, NonSystematicLagrangeCoefficients) {
   using DensePoly = typename UnivariateEvaluationDomainType::DensePoly;
   using Evals = typename UnivariateEvaluationDomainType::Evals;
 
-  for (size_t domain_dim = 1; domain_dim < kNumCoeffs; ++domain_dim) {
+  for (size_t domain_dim = 1; domain_dim < 5; ++domain_dim) {
     size_t domain_size = size_t{1} << domain_dim;
     F rand_pt = F::Random();
     DensePoly rand_poly = DensePoly::Random(domain_size - 1);

--- a/tachyon/zk/base/entities/entity.h
+++ b/tachyon/zk/base/entities/entity.h
@@ -49,12 +49,6 @@ class Entity {
   }
   crypto::Transcript<Commitment>* transcript() { return transcript_.get(); }
 
-  PCSTy&& TakePCS() { return std::move(pcs_); }
-  std::unique_ptr<Domain> TakeDomain() { return std::move(domain_); }
-  std::unique_ptr<ExtendedDomain> TakeExtendedDomain() {
-    return std::move(extended_domain_);
-  }
-
  protected:
   PCSTy pcs_;
   std::unique_ptr<Domain> domain_;

--- a/tachyon/zk/lookup/lookup_pair.h
+++ b/tachyon/zk/lookup/lookup_pair.h
@@ -25,6 +25,11 @@ class LookupPair {
   T&& TakeInput() && { return std::move(input_); }
   U&& TakeTable() && { return std::move(table_); }
 
+  bool operator==(const LookupPair& other) const {
+    return input_ == other.input_ && table_ == other.table_;
+  }
+  bool operator!=(const LookupPair& other) const { return !operator==(other); }
+
  private:
   T input_;
   U table_;

--- a/tachyon/zk/plonk/circuit/examples/circuit_test.h
+++ b/tachyon/zk/plonk/circuit/examples/circuit_test.h
@@ -1,14 +1,18 @@
 #ifndef TACHYON_ZK_PLONK_CIRCUIT_EXAMPLES_CIRCUIT_TEST_H_
 #define TACHYON_ZK_PLONK_CIRCUIT_EXAMPLES_CIRCUIT_TEST_H_
 
+#include <optional>
 #include <utility>
 #include <vector>
 
+#include "absl/types/span.h"
+
+#include "tachyon/zk/lookup/lookup_pair.h"
 #include "tachyon/zk/plonk/halo2/prover_test.h"
 
-namespace tachyon::zk {
+namespace tachyon::zk::halo2 {
 
-class CircuitTest : public halo2::ProverTest {
+class CircuitTest : public ProverTest {
  protected:
   struct Point {
     std::string_view x;
@@ -23,6 +27,17 @@ class CircuitTest : public halo2::ProverTest {
   static std::vector<Commitment> CreateCommitments(
       const std::vector<Point>& points) {
     return base::Map(points, &CreateCommitment);
+  }
+
+  static std::vector<LookupPair<Commitment>> CreateLookupPermutedCommitments(
+      const std::vector<Point>& input_points,
+      const std::vector<Point>& table_points) {
+    std::vector<LookupPair<Commitment>> lookup_pairs;
+    return base::Map(
+        input_points, [&table_points](size_t i, const Point& input_point) {
+          return LookupPair<Commitment>(CreateCommitment(input_point),
+                                        CreateCommitment(table_points[i]));
+        });
   }
 
   static Evals CreateColumn(const std::vector<std::string_view>& column) {
@@ -61,8 +76,26 @@ class CircuitTest : public halo2::ProverTest {
       const std::vector<std::vector<std::string_view>>& polys) {
     return base::Map(polys, &CreatePoly);
   }
+
+  static std::vector<F> CreateEvals(
+      const std::vector<std::string_view>& evals) {
+    return base::Map(
+        evals, [](std::string_view eval) { return F::FromHexString(eval); });
+  }
+
+  static std::vector<std::optional<F>> CreateOptionalEvals(
+      const std::vector<std::string_view>& evals) {
+    return base::Map(evals, [](std::string_view eval) {
+      if (eval.empty()) return std::optional<F>();
+      return std::optional<F>(F::FromHexString(eval));
+    });
+  }
+
+  static base::Buffer CreateBufferWithProof(absl::Span<uint8_t> proof) {
+    return {proof.data(), proof.size()};
+  }
 };
 
-}  // namespace tachyon::zk
+}  // namespace tachyon::zk::halo2
 
 #endif  // TACHYON_ZK_PLONK_CIRCUIT_EXAMPLES_CIRCUIT_TEST_H_

--- a/tachyon/zk/plonk/circuit/examples/simple_lookup_circuit_unittest.cc
+++ b/tachyon/zk/plonk/circuit/examples/simple_lookup_circuit_unittest.cc
@@ -8,11 +8,56 @@
 #include "tachyon/zk/plonk/halo2/pinned_verifying_key.h"
 #include "tachyon/zk/plonk/keys/proving_key.h"
 
-namespace tachyon::zk {
+namespace tachyon::zk::halo2 {
 
 namespace {
 
 constexpr size_t kBits = 3;
+
+constexpr uint8_t kExpectedProof[] = {
+    47,  182, 87,  188, 243, 30,  63,  165, 203, 25,  53,  75,  159, 66,  202,
+    142, 241, 131, 243, 14,  210, 25,  158, 80,  248, 54,  227, 231, 128, 14,
+    188, 33,  135, 89,  21,  76,  201, 3,   235, 80,  0,   226, 252, 125, 123,
+    57,  32,  116, 77,  132, 74,  28,  129, 87,  84,  88,  98,  197, 114, 110,
+    128, 182, 153, 19,  181, 198, 105, 109, 162, 166, 183, 84,  67,  244, 177,
+    201, 49,  196, 14,  0,   219, 248, 92,  5,   235, 57,  222, 34,  192, 113,
+    234, 166, 141, 6,   20,  44,  163, 197, 58,  201, 108, 119, 98,  206, 182,
+    224, 163, 217, 204, 19,  116, 126, 186, 254, 5,   145, 243, 143, 77,  148,
+    12,  156, 51,  163, 253, 50,  169, 174, 1,   0,   0,   0,   0,   0,   0,
+    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
+    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   252, 201, 198, 216, 151,
+    252, 234, 109, 125, 227, 44,  215, 90,  19,  227, 211, 16,  132, 218, 47,
+    20,  14,  103, 227, 190, 48,  56,  18,  141, 245, 147, 155, 111, 69,  183,
+    230, 171, 201, 152, 96,  96,  50,  231, 189, 239, 146, 228, 77,  195, 44,
+    115, 52,  100, 50,  26,  190, 251, 125, 237, 62,  51,  129, 206, 41,  213,
+    73,  24,  105, 24,  52,  90,  88,  74,  250, 189, 72,  232, 182, 82,  66,
+    236, 149, 14,  82,  230, 247, 77,  156, 203, 208, 59,  229, 232, 91,  174,
+    16,  185, 190, 49,  196, 79,  222, 232, 164, 156, 122, 177, 104, 52,  223,
+    34,  13,  85,  36,  146, 51,  96,  212, 188, 159, 26,  113, 139, 225, 166,
+    134, 23,  32,  124, 225, 54,  77,  154, 74,  58,  114, 7,   152, 224, 110,
+    164, 15,  197, 176, 210, 102, 181, 255, 137, 174, 192, 151, 54,  27,  201,
+    157, 161, 51,  146, 0,   206, 113, 69,  204, 199, 117, 182, 68,  68,  29,
+    252, 62,  114, 155, 151, 16,  34,  113, 23,  153, 119, 62,  100, 62,  166,
+    56,  197, 14,  18,  113, 57,  38,  12,  174, 198, 230, 163, 123, 21,  249,
+    53,  24,  174, 72,  9,   196, 231, 43,  117, 53,  121, 116, 113, 120, 244,
+    212, 71,  250, 245, 200, 183, 177, 200, 46,  1,   0,   0,   0,   0,   0,
+    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
+    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   74,  233, 48,  131,
+    22,  89,  250, 105, 203, 216, 104, 232, 153, 60,  228, 53,  103, 220, 115,
+    5,   204, 55,  219, 211, 190, 108, 68,  54,  163, 239, 67,  27,  110, 95,
+    81,  83,  107, 43,  251, 249, 233, 48,  243, 174, 235, 248, 127, 71,  163,
+    105, 128, 254, 55,  87,  239, 219, 221, 85,  82,  48,  34,  172, 26,  19,
+    44,  27,  229, 55,  53,  174, 87,  94,  5,   41,  104, 180, 183, 3,   108,
+    207, 242, 98,  41,  2,   174, 175, 254, 144, 50,  246, 136, 187, 62,  224,
+    212, 25,  16,  255, 92,  32,  104, 219, 15,  248, 16,  49,  250, 136, 75,
+    83,  112, 23,  116, 159, 191, 103, 244, 34,  61,  35,  192, 60,  93,  212,
+    133, 187, 243, 28,  111, 98,  50,  77,  146, 192, 142, 77,  44,  183, 174,
+    206, 135, 161, 1,   134, 241, 9,   121, 230, 187, 75,  196, 164, 56,  0,
+    174, 101, 190, 81,  190, 12,  74,  166, 34,  101, 37,  83,  187, 10,  167,
+    168, 129, 126, 12,  132, 0,   130, 183, 115, 192, 14,  219, 226, 9,   51,
+    208, 151, 250, 198, 0,   173, 91,  30,  189, 194, 22,  141, 13,  114, 113,
+    162, 210, 171, 230, 111, 50,  248, 118, 206, 52,  121, 43,  116, 34,  115,
+    77,  174, 137, 208, 21,  143, 232, 236, 188, 160};
 
 class SimpleLookupCircuitTest : public CircuitTest {};
 
@@ -471,4 +516,200 @@ TEST_F(SimpleLookupCircuitTest, LoadProvingKey) {
   }
 }
 
-}  // namespace tachyon::zk
+TEST_F(SimpleLookupCircuitTest, Verify) {
+  size_t n = 32;
+  CHECK(prover_->pcs().UnsafeSetup(n, F(2)));
+  prover_->set_domain(Domain::Create(n));
+
+  SimpleLookupCircuit<F, kBits> circuit(4);
+
+  VerifyingKey<PCS> vkey;
+  ASSERT_TRUE(vkey.Load(prover_.get(), circuit));
+
+  std::vector<uint8_t> owned_proof(std::begin(kExpectedProof),
+                                   std::end(kExpectedProof));
+  std::unique_ptr<Verifier<PCS>> verifier =
+      CreateVerifier(CreateBufferWithProof(absl::MakeSpan(owned_proof)));
+  std::vector<Evals> instance_columns;
+  std::vector<std::vector<Evals>> instance_columns_vec = {
+      std::move(instance_columns)};
+
+  Proof<F, Commitment> proof;
+  ASSERT_TRUE(
+      verifier->VerifyProofForTesting(vkey, instance_columns_vec, &proof));
+
+  std::vector<std::vector<Commitment>> expected_advice_commitments_vec;
+  {
+    std::vector<Point> points = {
+        {"0x21bc0e80e7e336f8509e19d20ef383f18eca429f4b3519cba53f1ef3bc57b62f",
+         "0x20f77de309a3f81a09883e451c96e1b091f7fc7799e27905444c4759806fc6d2"},
+    };
+    expected_advice_commitments_vec.push_back(CreateCommitments(points));
+  }
+  EXPECT_EQ(proof.advices_commitments_vec, expected_advice_commitments_vec);
+
+  EXPECT_TRUE(proof.challenges.empty());
+
+  F expected_theta = F::FromHexString(
+      "0x290f20708b8b7e7985088e9221743049fba8e682c6d7488e5213494da7649505");
+  EXPECT_EQ(proof.theta, expected_theta);
+
+  std::vector<std::vector<LookupPair<Commitment>>>
+      expected_lookup_permuted_commitments_vec;
+  {
+    std::vector<Point> input_points = {
+        {"0x1399b6806e72c562585457811c4a844d7420397b7dfce20050eb03c94c155987",
+         "0x0e2f049e4b617f6d07f7cfbd90d8cead3b4368a413f2c71cc4e73f1612c412f6"},
+    };
+    std::vector<Point> table_points = {
+        {"0x2c14068da6ea71c022de39eb055cf8db000ec431c9b1f44354b7a6a26d69c6b5",
+         "0x1bb517ae1ce20941980e210163591fc2b6c48892105d68b9ad8f1d48dd9aa59c"},
+    };
+    expected_lookup_permuted_commitments_vec.push_back(
+        CreateLookupPermutedCommitments(input_points, table_points));
+  }
+  EXPECT_EQ(proof.lookup_permuted_commitments_vec,
+            expected_lookup_permuted_commitments_vec);
+
+  F expected_beta = F::FromHexString(
+      "0x12183c0dc15c5e6071d6beecad709fa4fb11c14ad6089f1b39027775560e190c");
+  EXPECT_EQ(proof.beta, expected_beta);
+
+  F expected_gamma = F::FromHexString(
+      "0x1083f5b6c86390dfb35fbaeca4bf3fa53a05277508abc025bf7b05c4305b29a0");
+  EXPECT_EQ(proof.gamma, expected_gamma);
+
+  ASSERT_EQ(proof.permutation_product_commitments_vec.size(), 1);
+  EXPECT_TRUE(proof.permutation_product_commitments_vec[0].empty());
+
+  std::vector<std::vector<Commitment>> expected_lookup_product_commitments_vec;
+  {
+    std::vector<Point> points = {
+        {"0x2ea932fda3339c0c944d8ff39105feba7e7413ccd9a3e0b6ce62776cc93ac5a3",
+         "0x1b0446e5fd9752be88503dba0cfde03e808ce6114ed5d2766996b0a3e5717671"},
+    };
+    expected_lookup_product_commitments_vec.push_back(
+        CreateCommitments(points));
+  }
+  EXPECT_EQ(proof.lookup_product_commitments_vec,
+            expected_lookup_product_commitments_vec);
+
+  Commitment expected_vanishing_random_poly_commitment;
+  {
+    expected_vanishing_random_poly_commitment = CreateCommitment(
+        {"0x0000000000000000000000000000000000000000000000000000000000000001",
+         "0x0000000000000000000000000000000000000000000000000000000000000002"});
+  }
+  EXPECT_EQ(proof.vanishing_random_poly_commitment,
+            expected_vanishing_random_poly_commitment);
+
+  F expected_y = F::FromHexString(
+      "0x0ed52b381813f71a5b8c931fd9696534b96d49f2d21fa71a73c0ed19c5843953");
+  EXPECT_EQ(proof.y, expected_y);
+
+  std::vector<Commitment> expected_vanishing_h_poly_commitments;
+  {
+    std::vector<Point> points = {
+        {"0x1b93f58d123830bee3670e142fda8410d3e3135ad72ce37d6deafc97d8c6c9fc",
+         "0x2f5101e174e83a1e04f79bf48381b7369c256ae64bc5fefd0d499c6b81711abf"},
+        {"0x29ce81333eed7dfbbe1a326434732cc34de492efbde732606098c9abe6b7456f",
+         "0x2ad970331aee6de0a9464e6d4e2f928284c076c53b75f68280b9fe0c71590f9a"},
+        {"0x10ae5be8e53bd0cb9c4df7e6520e95ec4252b6e848bdfa4a585a3418691849d5",
+         "0x227b2836dd30acb1eb885302cd2ccb7092bccfe4fffe155eaa64da910044c8d6"},
+        {"0x201786a6e18b711a9fbcd460339224550d22df3468b17a9ca4e8de4fc431beb9",
+         "0x15aa249466f9008be03bbdaf7b79dc2dfcc3ba4aa6b7d3e6f7d8d172e4880e24"},
+    };
+    expected_vanishing_h_poly_commitments = CreateCommitments(points);
+  }
+  EXPECT_EQ(proof.vanishing_h_poly_commitments,
+            expected_vanishing_h_poly_commitments);
+
+  F expected_x = F::FromHexString(
+      "0x053a454eca02741827b727febbe275db5436ebd46105f169c4c82fdc6386f6c0");
+  EXPECT_EQ(proof.x, expected_x);
+
+  std::vector<std::vector<F>> expected_advice_evals_vec;
+  {
+    std::vector<std::string_view> evals = {
+        "0x009233a19dc91b3697c0ae89ffb566d2b0c50fa46ee09807723a4a9a4d36e17c",
+    };
+    expected_advice_evals_vec.push_back(CreateEvals(evals));
+  }
+  EXPECT_EQ(proof.advice_evals_vec, expected_advice_evals_vec);
+
+  std::vector<F> expected_fixed_evals;
+  {
+    std::vector<std::string_view> evals = {
+        "0x263971120ec538a63e643e779917712210979b723efc1d4444b675c7cc4571ce",
+        "0x2ec8b1b7c8f5fa47d4f47871747935752be7c40948ae1835f9157ba3e6c6ae0c",
+    };
+    expected_fixed_evals = CreateEvals(evals);
+  }
+  EXPECT_EQ(proof.fixed_evals, expected_fixed_evals);
+
+  F expected_vanishing_eval = F::FromHexString(
+      "0x0000000000000000000000000000000000000000000000000000000000000001");
+  EXPECT_EQ(proof.vanishing_eval, expected_vanishing_eval);
+
+  EXPECT_TRUE(proof.common_permutation_evals.empty());
+
+  ASSERT_EQ(proof.permutation_product_evals_vec.size(), 1);
+  EXPECT_TRUE(proof.permutation_product_evals_vec[0].empty());
+
+  ASSERT_EQ(proof.permutation_product_next_evals_vec.size(), 1);
+  EXPECT_TRUE(proof.permutation_product_next_evals_vec[0].empty());
+
+  ASSERT_EQ(proof.permutation_product_last_evals_vec.size(), 1);
+  EXPECT_TRUE(proof.permutation_product_last_evals_vec[0].empty());
+
+  std::vector<std::vector<F>> expected_lookup_product_evals_vec;
+  {
+    std::vector<std::string_view> evals = {
+        "0x1b43efa336446cbed3db37cc0573dc6735e43c99e868d8cb69fa59168330e94a",
+    };
+    expected_lookup_product_evals_vec.push_back(CreateEvals(evals));
+  }
+  EXPECT_EQ(proof.lookup_product_evals_vec, expected_lookup_product_evals_vec);
+
+  std::vector<std::vector<F>> expected_lookup_product_next_evals_vec;
+  {
+    std::vector<std::string_view> evals = {
+        "0x131aac22305255dddbef5737fe8069a3477ff8ebaef330e9f9fb2b6b53515f6e",
+    };
+    expected_lookup_product_next_evals_vec.push_back(CreateEvals(evals));
+  }
+  EXPECT_EQ(proof.lookup_product_next_evals_vec,
+            expected_lookup_product_next_evals_vec);
+
+  std::vector<std::vector<F>> expected_lookup_permuted_input_evals_vec;
+  {
+    std::vector<std::string_view> evals = {
+        "0x19d4e03ebb88f63290feafae022962f2cf6c03b7b46829055e57ae3537e51b2c",
+    };
+    expected_lookup_permuted_input_evals_vec.push_back(CreateEvals(evals));
+  }
+  EXPECT_EQ(proof.lookup_permuted_input_evals_vec,
+            expected_lookup_permuted_input_evals_vec);
+
+  std::vector<std::vector<F>> expected_lookup_permuted_input_inv_evals_vec;
+  {
+    std::vector<std::string_view> evals = {
+        "0x1cf3bb85d45d3cc0233d22f467bf9f741770534b88fa3110f80fdb68205cff10",
+    };
+    expected_lookup_permuted_input_inv_evals_vec.push_back(CreateEvals(evals));
+  }
+  EXPECT_EQ(proof.lookup_permuted_input_inv_evals_vec,
+            expected_lookup_permuted_input_inv_evals_vec);
+
+  std::vector<std::vector<F>> expected_lookup_permuted_table_evals_vec;
+  {
+    std::vector<std::string_view> evals = {
+        "0x0cbe51be65ae0038a4c44bbbe67909f18601a187ceaeb72c4d8ec0924d32626f",
+    };
+    expected_lookup_permuted_table_evals_vec.push_back(CreateEvals(evals));
+  }
+  EXPECT_EQ(proof.lookup_permuted_table_evals_vec,
+            expected_lookup_permuted_table_evals_vec);
+}
+
+}  // namespace tachyon::zk::halo2

--- a/tachyon/zk/plonk/halo2/BUILD.bazel
+++ b/tachyon/zk/plonk/halo2/BUILD.bazel
@@ -110,6 +110,7 @@ tachyon_cc_library(
     hdrs = ["prover.h"],
     deps = [
         ":random_field_generator",
+        ":verifier",
         "//tachyon/zk/base/entities:prover_base",
     ],
 )
@@ -150,6 +151,19 @@ tachyon_cc_library(
         "//tachyon/crypto/transcripts:transcript",
         "//tachyon/math/base:big_int",
         "@com_google_boringssl//:crypto",
+    ],
+)
+
+tachyon_cc_library(
+    name = "verifier",
+    hdrs = ["verifier.h"],
+    deps = [
+        ":proof_reader",
+        "//tachyon/base/containers:container_util",
+        "//tachyon/zk/base/entities:verifier_base",
+        "//tachyon/zk/plonk/keys:verifying_key",
+        "@com_google_absl//absl/functional:bind_front",
+        "@com_google_googletest//:gtest_prod",
     ],
 )
 

--- a/tachyon/zk/plonk/halo2/BUILD.bazel
+++ b/tachyon/zk/plonk/halo2/BUILD.bazel
@@ -79,6 +79,12 @@ tachyon_cc_library(
 )
 
 tachyon_cc_library(
+    name = "proof",
+    hdrs = ["proof.h"],
+    deps = ["//tachyon/zk/lookup:lookup_pair"],
+)
+
+tachyon_cc_library(
     name = "proof_serializer",
     hdrs = ["proof_serializer.h"],
     deps = [

--- a/tachyon/zk/plonk/halo2/BUILD.bazel
+++ b/tachyon/zk/plonk/halo2/BUILD.bazel
@@ -85,6 +85,17 @@ tachyon_cc_library(
 )
 
 tachyon_cc_library(
+    name = "proof_reader",
+    hdrs = ["proof_reader.h"],
+    deps = [
+        ":proof",
+        "//tachyon/base:logging",
+        "//tachyon/crypto/transcripts:transcript",
+        "//tachyon/zk/plonk/keys:verifying_key",
+    ],
+)
+
+tachyon_cc_library(
     name = "proof_serializer",
     hdrs = ["proof_serializer.h"],
     deps = [

--- a/tachyon/zk/plonk/halo2/proof.h
+++ b/tachyon/zk/plonk/halo2/proof.h
@@ -1,0 +1,42 @@
+#ifndef TACHYON_ZK_PLONK_HALO2_PROOF_H_
+#define TACHYON_ZK_PLONK_HALO2_PROOF_H_
+
+#include <optional>
+#include <vector>
+
+#include "tachyon/zk/lookup/lookup_pair.h"
+
+namespace tachyon::zk::halo2 {
+
+template <typename F, typename C>
+struct Proof {
+  std::vector<std::vector<C>> advices_commitments_vec;
+  std::vector<F> challenges;
+  F theta;
+  std::vector<std::vector<LookupPair<C>>> lookup_permuted_commitments_vec;
+  F beta;
+  F gamma;
+  std::vector<std::vector<C>> permutation_product_commitments_vec;
+  std::vector<std::vector<C>> lookup_product_commitments_vec;
+  C vanishing_random_poly_commitment;
+  F y;
+  std::vector<C> vanishing_h_poly_commitments;
+  F x;
+  std::vector<std::vector<F>> instance_evals_vec;
+  std::vector<std::vector<F>> advice_evals_vec;
+  std::vector<F> fixed_evals;
+  F vanishing_eval;
+  std::vector<F> common_permutation_evals;
+  std::vector<std::vector<F>> permutation_product_evals_vec;
+  std::vector<std::vector<F>> permutation_product_next_evals_vec;
+  std::vector<std::vector<std::optional<F>>> permutation_product_last_evals_vec;
+  std::vector<std::vector<F>> lookup_product_evals_vec;
+  std::vector<std::vector<F>> lookup_product_next_evals_vec;
+  std::vector<std::vector<F>> lookup_permuted_input_evals_vec;
+  std::vector<std::vector<F>> lookup_permuted_input_inv_evals_vec;
+  std::vector<std::vector<F>> lookup_permuted_table_evals_vec;
+};
+
+}  // namespace tachyon::zk::halo2
+
+#endif  // TACHYON_ZK_PLONK_HALO2_PROOF_H_

--- a/tachyon/zk/plonk/halo2/proof_reader.h
+++ b/tachyon/zk/plonk/halo2/proof_reader.h
@@ -1,0 +1,268 @@
+#ifndef TACHYON_ZK_PLONK_HALO2_PROOF_READER_H_
+#define TACHYON_ZK_PLONK_HALO2_PROOF_READER_H_
+
+#include <utility>
+#include <vector>
+
+#include "tachyon/base/logging.h"
+#include "tachyon/crypto/transcripts/transcript.h"
+#include "tachyon/zk/plonk/halo2/proof.h"
+#include "tachyon/zk/plonk/keys/verifying_key.h"
+
+namespace tachyon::zk::halo2 {
+
+enum class ProofCursor {
+  kAdviceCommitmentsVecAndChallenges,
+  kTheta,
+  kLookupPermutedCommitments,
+  kBetaAndGamma,
+  kPermutationProductCommitments,
+  kLookupProductCommitments,
+  kVanishingRandomPolyCommitment,
+  kY,
+  kVanishingHPolyCommitments,
+  kX,
+  kInstanceEvals,
+  kAdviceEvals,
+  kFixedEvals,
+  kVanishingEval,
+  kCommonPermutationEvals,
+  kPermutationEvals,
+  kLookupEvalsVec,
+  kDone,
+};
+
+template <typename PCSTy>
+class ProofReader {
+ public:
+  using F = typename PCSTy::Field;
+  using C = typename PCSTy::Commitment;
+
+  ProofReader(const VerifyingKey<PCSTy>& verifying_key,
+              crypto::TranscriptReader<C>* transcript, size_t num_circuits)
+      : verifying_key_(verifying_key),
+        transcript_(transcript),
+        num_circuits_(num_circuits) {}
+
+  const Proof<F, C>& proof() const { return proof_; }
+  Proof<F, C>& proof() { return proof_; }
+
+  void ReadAdviceCommitmentsVecAndChallenges() {
+    CHECK_EQ(cursor_, ProofCursor::kAdviceCommitmentsVecAndChallenges);
+    const ConstraintSystem<F>& constraint_system =
+        verifying_key_.constraint_system();
+    proof_.advices_commitments_vec.resize(num_circuits_);
+    for (size_t i = 0; i < num_circuits_; ++i) {
+      proof_.advices_commitments_vec[i].reserve(
+          constraint_system.num_advice_columns());
+    }
+    proof_.challenges.reserve(constraint_system.challenge_phases().size());
+    for (Phase current_phase : constraint_system.GetPhases()) {
+      for (size_t i = 0; i < num_circuits_; ++i) {
+        for (Phase phase : constraint_system.advice_column_phases()) {
+          if (current_phase == phase) {
+            proof_.advices_commitments_vec[i].push_back(Read<C>());
+          }
+        }
+      }
+      for (Phase phase : constraint_system.challenge_phases()) {
+        if (current_phase == phase) {
+          proof_.challenges.push_back(transcript_->SqueezeChallenge());
+        }
+      }
+    }
+    cursor_ = ProofCursor::kTheta;
+  }
+
+  void ReadTheta() {
+    CHECK_EQ(cursor_, ProofCursor::kTheta);
+    proof_.theta = transcript_->SqueezeChallenge();
+    cursor_ = ProofCursor::kLookupPermutedCommitments;
+  }
+
+  void ReadLookupPermutedCommitments() {
+    CHECK_EQ(cursor_, ProofCursor::kLookupPermutedCommitments);
+    size_t num_lookups = verifying_key_.constraint_system().lookups().size();
+    proof_.lookup_permuted_commitments_vec =
+        base::CreateVector(num_circuits_, [this, num_lookups]() {
+          return base::CreateVector(num_lookups, [this]() {
+            C input = Read<C>();
+            C table = Read<C>();
+            return LookupPair<C>(std::move(input), std::move(table));
+          });
+        });
+    cursor_ = ProofCursor::kBetaAndGamma;
+  }
+
+  void ReadBetaAndGamma() {
+    CHECK_EQ(cursor_, ProofCursor::kBetaAndGamma);
+    proof_.beta = transcript_->SqueezeChallenge();
+    proof_.gamma = transcript_->SqueezeChallenge();
+    cursor_ = ProofCursor::kPermutationProductCommitments;
+  }
+
+  void ReadPermutationProductCommitments() {
+    CHECK_EQ(cursor_, ProofCursor::kPermutationProductCommitments);
+    const ConstraintSystem<F>& constraint_system =
+        verifying_key_.constraint_system();
+    size_t chunk_len = constraint_system.ComputeDegree() - 2;
+    size_t num_products =
+        (constraint_system.permutation().columns().size() + chunk_len - 1) /
+        chunk_len;
+    proof_.permutation_product_commitments_vec = base::CreateVector(
+        num_circuits_,
+        [this, num_products]() { return ReadMany<C>(num_products); });
+    cursor_ = ProofCursor::kLookupProductCommitments;
+  }
+
+  void ReadLookupProductCommitments() {
+    CHECK_EQ(cursor_, ProofCursor::kLookupProductCommitments);
+    size_t num_lookups = verifying_key_.constraint_system().lookups().size();
+    proof_.lookup_product_commitments_vec = base::CreateVector(
+        num_circuits_,
+        [this, num_lookups]() { return ReadMany<C>(num_lookups); });
+    cursor_ = ProofCursor::kVanishingRandomPolyCommitment;
+  }
+
+  void ReadVanishingRandomPolyCommitment() {
+    CHECK_EQ(cursor_, ProofCursor::kVanishingRandomPolyCommitment);
+    proof_.vanishing_random_poly_commitment = Read<C>();
+    cursor_ = ProofCursor::kY;
+  }
+
+  void ReadY() {
+    CHECK_EQ(cursor_, ProofCursor::kY);
+    proof_.y = transcript_->SqueezeChallenge();
+    cursor_ = ProofCursor::kVanishingHPolyCommitments;
+  }
+
+  void ReadVanishingHPolyCommitments() {
+    CHECK_EQ(cursor_, ProofCursor::kVanishingHPolyCommitments);
+    size_t quotient_poly_degree =
+        verifying_key_.constraint_system().ComputeDegree() - 1;
+    proof_.vanishing_h_poly_commitments = ReadMany<C>(quotient_poly_degree);
+    cursor_ = ProofCursor::kX;
+  }
+
+  void ReadX() {
+    CHECK_EQ(cursor_, ProofCursor::kX);
+    proof_.x = transcript_->SqueezeChallenge();
+    cursor_ = ProofCursor::kInstanceEvals;
+  }
+
+  void ReadInstanceEvalsIfQueryInstance() {
+    CHECK_EQ(cursor_, ProofCursor::kInstanceEvals);
+    size_t num_instance_queries =
+        verifying_key_.constraint_system().instance_queries().size();
+    return base::CreateVector(num_circuits_, [this, num_instance_queries]() {
+      return ReadMany<F>(num_instance_queries);
+    });
+    cursor_ = ProofCursor::kAdviceEvals;
+  }
+
+  void ReadInstanceEvalsIfNoQueryInstance() {
+    CHECK_EQ(cursor_, ProofCursor::kInstanceEvals);
+    cursor_ = ProofCursor::kAdviceEvals;
+  }
+
+  void ReadAdviceEvals() {
+    CHECK_EQ(cursor_, ProofCursor::kAdviceEvals);
+    size_t num_advice_queries =
+        verifying_key_.constraint_system().advice_queries().size();
+    proof_.advice_evals_vec =
+        base::CreateVector(num_circuits_, [this, num_advice_queries]() {
+          return ReadMany<F>(num_advice_queries);
+        });
+    cursor_ = ProofCursor::kFixedEvals;
+  }
+
+  void ReadFixedEvals() {
+    CHECK_EQ(cursor_, ProofCursor::kFixedEvals);
+    size_t num_fixed_queries =
+        verifying_key_.constraint_system().fixed_queries().size();
+    proof_.fixed_evals = ReadMany<F>(num_fixed_queries);
+    cursor_ = ProofCursor::kVanishingEval;
+  }
+
+  void ReadVanishingEval() {
+    CHECK_EQ(cursor_, ProofCursor::kVanishingEval);
+    proof_.vanishing_eval = Read<F>();
+    cursor_ = ProofCursor::kCommonPermutationEvals;
+  }
+
+  void ReadCommonPermutationEvals() {
+    CHECK_EQ(cursor_, ProofCursor::kCommonPermutationEvals);
+    proof_.common_permutation_evals = ReadMany<F>(
+        verifying_key_.permutation_verifying_key().commitments().size());
+    cursor_ = ProofCursor::kPermutationEvals;
+  }
+
+  void ReadPermutationEvals() {
+    CHECK_EQ(cursor_, ProofCursor::kPermutationEvals);
+    proof_.permutation_product_evals_vec.resize(num_circuits_);
+    proof_.permutation_product_next_evals_vec.resize(num_circuits_);
+    proof_.permutation_product_last_evals_vec.resize(num_circuits_);
+    for (size_t i = 0; i < num_circuits_; ++i) {
+      size_t size = proof_.permutation_product_commitments_vec[i].size();
+      proof_.permutation_product_evals_vec[i].reserve(size);
+      proof_.permutation_product_next_evals_vec[i].reserve(size);
+      proof_.permutation_product_last_evals_vec[i].reserve(size);
+      for (size_t j = 0; j < size; ++j) {
+        proof_.permutation_product_evals_vec[i].push_back(Read<F>());
+        proof_.permutation_product_next_evals_vec[i].push_back(Read<F>());
+        proof_.permutation_product_last_evals_vec[i].push_back(
+            (j != size - 1) ? std::optional<F>(Read<F>()) : std::optional<F>());
+      }
+    }
+    cursor_ = ProofCursor::kLookupEvalsVec;
+  }
+
+  void ReadLookupEvals() {
+    CHECK_EQ(cursor_, ProofCursor::kLookupEvalsVec);
+    proof_.lookup_product_evals_vec.resize(num_circuits_);
+    proof_.lookup_product_next_evals_vec.resize(num_circuits_);
+    proof_.lookup_permuted_input_evals_vec.resize(num_circuits_);
+    proof_.lookup_permuted_input_inv_evals_vec.resize(num_circuits_);
+    proof_.lookup_permuted_table_evals_vec.resize(num_circuits_);
+    for (size_t i = 0; i < num_circuits_; ++i) {
+      size_t size = proof_.lookup_product_commitments_vec[i].size();
+      proof_.lookup_product_evals_vec[i].reserve(size);
+      proof_.lookup_product_next_evals_vec[i].reserve(size);
+      proof_.lookup_permuted_input_evals_vec[i].reserve(size);
+      proof_.lookup_permuted_input_inv_evals_vec[i].reserve(size);
+      proof_.lookup_permuted_table_evals_vec[i].reserve(size);
+      for (size_t j = 0; j < size; ++j) {
+        proof_.lookup_product_evals_vec[i].push_back(Read<F>());
+        proof_.lookup_product_next_evals_vec[i].push_back(Read<F>());
+        proof_.lookup_permuted_input_evals_vec[i].push_back(Read<F>());
+        proof_.lookup_permuted_input_inv_evals_vec[i].push_back(Read<F>());
+        proof_.lookup_permuted_table_evals_vec[i].push_back(Read<F>());
+      }
+    }
+    // TODO(chokobole): Implement reading data for the last pairing step.
+  }
+
+ private:
+  template <typename T>
+  T Read() {
+    T value;
+    CHECK(transcript_->ReadFromProof(&value));
+    return value;
+  }
+
+  template <typename T>
+  std::vector<T> ReadMany(size_t n) {
+    return base::CreateVector(n, [this]() { return Read<T>(); });
+  }
+
+  const VerifyingKey<PCSTy>& verifying_key_;
+  // not owned
+  crypto::TranscriptReader<C>* const transcript_ = nullptr;
+  size_t num_circuits_ = 0;
+  Proof<F, C> proof_;
+  ProofCursor cursor_ = ProofCursor::kAdviceCommitmentsVecAndChallenges;
+};
+
+}  // namespace tachyon::zk::halo2
+
+#endif  // TACHYON_ZK_PLONK_HALO2_PROOF_READER_H_

--- a/tachyon/zk/plonk/halo2/prover.h
+++ b/tachyon/zk/plonk/halo2/prover.h
@@ -12,6 +12,7 @@
 
 #include "tachyon/zk/base/entities/prover_base.h"
 #include "tachyon/zk/plonk/halo2/random_field_generator.h"
+#include "tachyon/zk/plonk/halo2/verifier.h"
 
 namespace tachyon::zk::halo2 {
 
@@ -51,6 +52,15 @@ class Prover : public ProverBase<PCSTy> {
 
   crypto::XORShiftRNG* rng() { return rng_.get(); }
   RandomFieldGenerator<F>* generator() { return generator_.get(); }
+
+  std::unique_ptr<Verifier<PCSTy>> ToVerifier(
+      std::unique_ptr<crypto::TranscriptReader<Commitment>> reader) {
+    std::unique_ptr<Verifier<PCSTy>> ret = std::make_unique<Verifier<PCSTy>>(
+        std::move(this->pcs_), std::move(reader));
+    ret->set_domain(std::move(this->domain_));
+    ret->set_extended_domain(std::move(this->extended_domain_));
+    return ret;
+  }
 
  private:
   Prover(PCSTy&& pcs,

--- a/tachyon/zk/plonk/halo2/prover_test.h
+++ b/tachyon/zk/plonk/halo2/prover_test.h
@@ -56,6 +56,12 @@ class ProverTest : public testing::Test {
   }
 
  protected:
+  std::unique_ptr<Verifier<PCS>> CreateVerifier(base::Buffer read_buf) {
+    std::unique_ptr<crypto::TranscriptReader<Commitment>> reader =
+        std::make_unique<Blake2bReader<Commitment>>(std::move(read_buf));
+    return prover_->ToVerifier(std::move(reader));
+  }
+
   std::unique_ptr<Prover<PCS>> prover_;
 };
 

--- a/tachyon/zk/plonk/halo2/verifier.h
+++ b/tachyon/zk/plonk/halo2/verifier.h
@@ -1,0 +1,253 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
+#ifndef TACHYON_ZK_PLONK_HALO2_VERIFIER_H_
+#define TACHYON_ZK_PLONK_HALO2_VERIFIER_H_
+
+#include <functional>
+#include <utility>
+#include <vector>
+
+#include "absl/functional/bind_front.h"
+#include "gtest/gtest_prod.h"
+
+#include "tachyon/base/containers/container_util.h"
+#include "tachyon/zk/base/entities/verifier_base.h"
+#include "tachyon/zk/plonk/halo2/proof_reader.h"
+#include "tachyon/zk/plonk/keys/verifying_key.h"
+
+namespace tachyon::zk::halo2 {
+
+template <typename PCSTy>
+class Verifier : public VerifierBase<PCSTy> {
+ public:
+  using F = typename PCSTy::Field;
+  using Commitment = typename PCSTy::Commitment;
+  using Evals = typename PCSTy::Evals;
+  using Poly = typename PCSTy::Poly;
+  using Coefficients = typename Poly::Coefficients;
+
+  using VerifierBase<PCSTy>::VerifierBase;
+
+  [[nodiscard]] bool VerifyProof(
+      const VerifyingKey<PCSTy>& vkey,
+      const std::vector<std::vector<Evals>>& instance_columns_vec) {
+    return VerifyProofForTesting(vkey, instance_columns_vec, nullptr);
+  }
+
+ private:
+  FRIEND_TEST(SimpleCircuitTest, Verify);
+  FRIEND_TEST(SimpleLookupCircuitTest, Verify);
+
+  bool VerifyProofForTesting(
+      const VerifyingKey<PCSTy>& vkey,
+      const std::vector<std::vector<Evals>>& instance_columns_vec,
+      Proof<F, Commitment>* proof_out) {
+    if (!ValidateInstanceColumnsVec(vkey, instance_columns_vec)) return false;
+
+    std::vector<std::vector<Commitment>> instance_commitments_vec;
+    if constexpr (PCSTy::kQueryInstance) {
+      instance_commitments_vec = CommitColumnsVec(vkey, instance_columns_vec);
+    } else {
+      instance_commitments_vec.resize(instance_columns_vec.size());
+    }
+
+    crypto::TranscriptReader<Commitment>* transcript = this->GetReader();
+    CHECK(transcript->WriteToTranscript(vkey.transcript_repr()));
+
+    if constexpr (PCSTy::kQueryInstance) {
+      WriteCommitmentsVecToTranscript(transcript, instance_commitments_vec);
+    } else {
+      WriteColumnsVecToTranscript(transcript, instance_columns_vec);
+    }
+
+    ProofReader<PCSTy> proof_reader(vkey, transcript,
+                                    instance_commitments_vec.size());
+    Proof<F, Commitment>& proof = proof_reader.proof();
+    proof_reader.ReadAdviceCommitmentsVecAndChallenges();
+    proof_reader.ReadTheta();
+    proof_reader.ReadLookupPermutedCommitments();
+    proof_reader.ReadBetaAndGamma();
+    proof_reader.ReadPermutationProductCommitments();
+    proof_reader.ReadLookupProductCommitments();
+    proof_reader.ReadVanishingRandomPolyCommitment();
+    proof_reader.ReadY();
+    proof_reader.ReadVanishingHPolyCommitments();
+    proof_reader.ReadX();
+    if constexpr (PCSTy::kQueryInstance) {
+      proof_reader.ReadInstanceEvalsIfQueryInstance();
+    } else {
+      proof_reader.ReadInstanceEvalsIfNoQueryInstance();
+      proof.instance_evals_vec =
+          ComputeInstanceEvalsVec(vkey, instance_columns_vec, proof.x);
+    }
+    proof_reader.ReadAdviceEvals();
+    proof_reader.ReadFixedEvals();
+    proof_reader.ReadVanishingEval();
+    proof_reader.ReadCommonPermutationEvals();
+    proof_reader.ReadPermutationEvals();
+    proof_reader.ReadLookupEvals();
+
+    if (proof_out) {
+      *proof_out = proof;
+    }
+    return true;
+  }
+
+  bool ValidateInstanceColumnsVec(
+      const VerifyingKey<PCSTy>& vkey,
+      const std::vector<std::vector<Evals>>& instance_columns_vec) {
+    size_t num_instance_columns =
+        vkey.constraint_system().num_instance_columns();
+    auto check_num_instance_columns =
+        [num_instance_columns](const std::vector<Evals>& instance_columns) {
+          if (instance_columns.size() != num_instance_columns) {
+            LOG(ERROR) << "The size of instance columns doesn't match with "
+                          "constraint system";
+            return false;
+          }
+          return true;
+        };
+
+    size_t max_rows = this->pcs_.N() -
+                      (vkey.constraint_system().ComputeBlindingFactors() + 1);
+    auto check_rows = [max_rows](const Evals& instance_columns) {
+      if (instance_columns.NumElements() > max_rows) {
+        LOG(ERROR) << "Too many number of elements in instance column";
+        return false;
+      }
+      return true;
+    };
+
+    return std::all_of(instance_columns_vec.begin(), instance_columns_vec.end(),
+                       [&check_num_instance_columns, &check_rows](
+                           const std::vector<Evals>& instance_columns) {
+                         if (!check_num_instance_columns(instance_columns))
+                           return false;
+                         return std::all_of(instance_columns.begin(),
+                                            instance_columns.end(), check_rows);
+                       });
+  }
+
+  std::vector<Commitment> CommitColumns(const std::vector<Evals>& columns) {
+    return base::Map(columns, [this](const Evals& column) {
+      std::vector<F> expanded_evals = column.evaluations();
+      expanded_evals.resize(this->pcs_.N());
+      Commitment c;
+      CHECK(this->pcs_.CommitLagrange(Evals(std::move(expanded_evals), &c)));
+      return c;
+    });
+  }
+
+  std::vector<std::vector<Commitment>> CommitColumnsVec(
+      const std::vector<std::vector<Evals>>& columns_vec) {
+    return base::Map(columns_vec, absl::bind_front(&CommitColumns, this));
+  }
+
+  static void WriteCommitmentsVecToTranscript(
+      crypto::TranscriptReader<Commitment>* transcript,
+      const std::vector<std::vector<Commitment>>& commitments_vec) {
+    for (const std::vector<Commitment>& commitments : commitments_vec) {
+      for (const Commitment& commitment : commitments) {
+        CHECK(transcript->WriteToTranscript(commitment));
+      }
+    }
+  }
+
+  static void WriteColumnsVecToTranscript(
+      crypto::TranscriptReader<Commitment>* transcript,
+      const std::vector<std::vector<Evals>>& columns_vec) {
+    for (const std::vector<Evals>& columns : columns_vec) {
+      for (const Evals& column : columns) {
+        for (const F& value : column.evaluations()) {
+          CHECK(transcript->WriteToTranscript(value));
+        }
+      }
+    }
+  }
+
+  static size_t ComputeMaxRow(const std::vector<Evals>& columns) {
+    if (columns.empty()) return 0;
+    std::vector<size_t> rows = base::Map(
+        columns, [](const Evals& evals) { return evals.NumElements(); });
+    return *std::max_element(rows.begin(), rows.end());
+  }
+
+  static F ComputeInstanceEval(const std::vector<Evals>& instance_columns,
+                               const InstanceQueryData& instance_query,
+                               const std::vector<F>& partial_lagrange_coeffs,
+                               size_t max_rotation) {
+    const std::vector<F>& instances =
+        instance_columns[instance_query.column().index()].evaluations();
+    size_t offset = max_rotation - instance_query.rotation().value();
+    absl::Span<const F> sub_partial_lagrange_coeffs =
+        absl::MakeConstSpan(partial_lagrange_coeffs);
+    sub_partial_lagrange_coeffs =
+        sub_partial_lagrange_coeffs.subspan(offset, instances.size());
+    return F::SumOfProductsSerial(instances, sub_partial_lagrange_coeffs);
+  }
+
+  static std::vector<F> ComputeInstanceEvals(
+      const std::vector<Evals>& instance_columns,
+      const std::vector<InstanceQueryData>& instance_queries,
+      const std::vector<F>& partial_lagrange_coeffs, size_t max_rotation) {
+    return base::Map(instance_queries,
+                     [&instance_columns, &partial_lagrange_coeffs,
+                      max_rotation](const InstanceQueryData& instance_query) {
+                       return ComputeInstanceEval(
+                           instance_columns, instance_query,
+                           partial_lagrange_coeffs, max_rotation);
+                     });
+  }
+
+  std::vector<std::vector<F>> ComputeInstanceEvalsVec(
+      const VerifyingKey<PCSTy>& vkey,
+      const std::vector<std::vector<Evals>>& instance_columns_vec, const F& x) {
+    struct RotationRange {
+      int32_t min = 0;
+      int32_t max = 0;
+    };
+
+    const std::vector<InstanceQueryData>& instance_queries =
+        vkey.constraint_system().instance_queries();
+    RotationRange range = std::accumulate(
+        instance_queries.begin(), instance_queries.end(), RotationRange(),
+        [](RotationRange& range, const InstanceQueryData& instance) {
+          int32_t rotation_value = instance.rotation().value();
+          if (rotation_value < range.min) {
+            range.min = rotation_value;
+          } else if (rotation_value > range.max) {
+            range.max = rotation_value;
+          }
+          return range;
+        });
+
+    std::vector<size_t> max_instances_rows =
+        base::Map(instance_columns_vec, &ComputeMaxRow);
+    auto max_instances_row_it =
+        std::max_element(max_instances_rows.begin(), max_instances_rows.end());
+    size_t max_instances_row = max_instances_row_it != max_instances_rows.end()
+                                   ? *max_instances_row_it
+                                   : 0;
+    std::vector<F> partial_lagrange_coeffs =
+        this->domain_->EvaluatePartialLagrangeCoefficients(
+            x, base::Range<int32_t>(-range.max,
+                                    static_cast<int32_t>(max_instances_row) +
+                                        std::abs(range.min)));
+
+    return base::Map(instance_columns_vec,
+                     [&instance_queries, &partial_lagrange_coeffs,
+                      &range](const std::vector<Evals>& instance_columns) {
+                       return ComputeInstanceEvals(
+                           instance_columns, instance_queries,
+                           partial_lagrange_coeffs, range.max);
+                     });
+  }
+};
+
+}  // namespace tachyon::zk::halo2
+
+#endif  // TACHYON_ZK_PLONK_HALO2_VERIFIER_H_

--- a/tachyon/zk/plonk/vanishing/vanishing_argument_unittest.cc
+++ b/tachyon/zk/plonk/vanishing/vanishing_argument_unittest.cc
@@ -43,17 +43,10 @@ TEST_F(VanishingArgumentTest, VanishingArgument) {
   std::vector<ProverQuery<PCS>> h_x =
       OpenVanishingArgument(std::move(evaluated), x);
 
-  base::Buffer read_buf(prover_->GetWriter()->buffer().buffer(),
-                        prover_->GetWriter()->buffer().buffer_len());
-  std::unique_ptr<crypto::TranscriptReader<Commitment>> reader =
-      absl::WrapUnique(
-          new halo2::Blake2bReader<Commitment>(std::move(read_buf)));
-
-  std::unique_ptr<VerifierBase<PCS>> verifier =
-      std::make_unique<VerifierBase<PCS>>(
-          VerifierBase<PCS>(prover_->TakePCS(), std::move(reader)));
-  verifier->set_domain(prover_->TakeDomain());
-  verifier->set_extended_domain(prover_->TakeExtendedDomain());
+  base::Uint8VectorBuffer& write_buf = prover_->GetWriter()->buffer();
+  write_buf.set_buffer_offset(0);
+  std::unique_ptr<halo2::Verifier<PCS>> verifier =
+      CreateVerifier(std::move(write_buf));
 
   VanishingCommitted<EntityTy::kVerifier, PCS> committed_v;
   ASSERT_TRUE(ReadCommitmentsBeforeY(verifier->GetReader(), &committed_v));


### PR DESCRIPTION
# Description

This PR implements proof verification [verify_proof()](https://github.com/kroma-network/halo2/blob/7d0a36990452c8e7ebd600de258420781a9b7917/halo2_proofs/src/plonk/verifier.rs#L41-L240) part. This doesn't include pairing part which involves evaluating expression.

Plus, it includes some optimizaitons.

- `ConstraintSystem::ComputeDegree()` and `ConstraintSystem::ComputeBlindingFactors()` by caching.
- `UnivariateEvaluationDomain::GetElements()`.
- Parallelize `Ring::SumOfProducts()`