### PR TITLE
refac: change return type of `EvaluateAllLagrangeCoefficients`

### DIFF
--- a/tachyon/crypto/commitments/kzg/kzg.h
+++ b/tachyon/crypto/commitments/kzg/kzg.h
@@ -73,12 +73,12 @@ class KZG {
 
     // Get |g1_powers_of_tau_lagrange_| from 𝜏 and g₁.
     std::unique_ptr<DomainTy> domain = DomainTy::Create(size);
-    typename DomainTy::DenseCoeffs lagrange_coeffs =
+    std::vector<Field> lagrange_coeffs =
         domain->EvaluateAllLagrangeCoefficients(tau);
     std::vector<G1JacobianPointTy> g1_powers_of_tau_lagrange_jacobian;
 
     g1_powers_of_tau_lagrange_jacobian.resize(size);
-    if (!G1PointTy::MultiScalarMul(lagrange_coeffs.coefficients(), g1,
+    if (!G1PointTy::MultiScalarMul(lagrange_coeffs, g1,
                                    &g1_powers_of_tau_lagrange_jacobian)) {
       return false;
     }

--- a/tachyon/math/polynomials/univariate/univariate_evaluation_domain.h
+++ b/tachyon/math/polynomials/univariate/univariate_evaluation_domain.h
@@ -158,7 +158,7 @@ class UnivariateEvaluationDomain : public EvaluationDomain<F, MaxDegree> {
   // is computed in time O(m). Then given the evaluations of a degree d
   // polynomial P over H, where d < m, P(𝜏) can be computed as P(𝜏) =
   // Σ{i in m} Lᵢ_H(𝜏) * P(gⁱ).
-  constexpr DenseCoeffs EvaluateAllLagrangeCoefficients(const F& tau) const {
+  constexpr std::vector<F> EvaluateAllLagrangeCoefficients(const F& tau) const {
     // Evaluate all Lagrange polynomials at 𝜏 to get the lagrange
     // coefficients.
     //
@@ -183,7 +183,7 @@ class UnivariateEvaluationDomain : public EvaluationDomain<F, MaxDegree> {
         }
         omega_i *= group_gen_;
       }
-      return DenseCoeffs(std::move(u));
+      return u;
     } else {
       // In this case we have to compute Z_H(𝜏) * vᵢ / (𝜏 - h * gⁱ)
       // for i in 0..|size_|. We actually compute this by computing
@@ -219,7 +219,7 @@ class UnivariateEvaluationDomain : public EvaluationDomain<F, MaxDegree> {
       // and return these
       // Z_H(𝜏) * vᵢ / (𝜏 - h * gⁱ)
       F::BatchInverseInPlace(lagrange_coefficients_inverse);
-      return DenseCoeffs(std::move(lagrange_coefficients_inverse));
+      return lagrange_coefficients_inverse;
     }
   }
 

--- a/tachyon/math/polynomials/univariate/univariate_evaluation_domain_unittest.cc
+++ b/tachyon/math/polynomials/univariate/univariate_evaluation_domain_unittest.cc
@@ -182,7 +182,6 @@ TYPED_TEST(UnivariateEvaluationDomainTest, NonSystematicLagrangeCoefficients) {
   using F = typename UnivariateEvaluationDomainType::Field;
   using BaseUnivariateEvaluationDomainType =
       UnivariateEvaluationDomain<F, UnivariateEvaluationDomainType::kMaxDegree>;
-  using DenseCoeffs = typename UnivariateEvaluationDomainType::DenseCoeffs;
   using DensePoly = typename UnivariateEvaluationDomainType::DensePoly;
   using Evals = typename UnivariateEvaluationDomainType::Evals;
 
@@ -194,7 +193,7 @@ TYPED_TEST(UnivariateEvaluationDomainTest, NonSystematicLagrangeCoefficients) {
     this->TestDomains(
         domain_size, [domain_size, &rand_pt, &rand_poly, &actual_eval](
                          const BaseUnivariateEvaluationDomainType& d) {
-          DenseCoeffs lagrange_coeffs =
+          std::vector<F> lagrange_coeffs =
               d.EvaluateAllLagrangeCoefficients(rand_pt);
 
           Evals poly_evals = d.FFT(rand_poly);
@@ -203,7 +202,7 @@ TYPED_TEST(UnivariateEvaluationDomainTest, NonSystematicLagrangeCoefficients) {
           // evaluation
           F interpolated_eval = F::Zero();
           for (size_t i = 0; i < domain_size; ++i) {
-            interpolated_eval += (*lagrange_coeffs[i]) * (*poly_evals[i]);
+            interpolated_eval += lagrange_coeffs[i] * (*poly_evals[i]);
           }
           EXPECT_EQ(actual_eval, interpolated_eval);
         });
@@ -216,7 +215,6 @@ TYPED_TEST(UnivariateEvaluationDomainTest, SystematicLagrangeCoefficients) {
   // low. We generate lagrange coefficients for each element in the domain.
   using UnivariateEvaluationDomainType = TypeParam;
   using F = typename UnivariateEvaluationDomainType::Field;
-  using DenseCoeffs = typename UnivariateEvaluationDomainType::DenseCoeffs;
   using BaseUnivariateEvaluationDomainType =
       UnivariateEvaluationDomain<F, UnivariateEvaluationDomainType::kMaxDegree>;
 
@@ -227,15 +225,15 @@ TYPED_TEST(UnivariateEvaluationDomainTest, SystematicLagrangeCoefficients) {
         [domain_size](const BaseUnivariateEvaluationDomainType& d) {
           for (size_t i = 0; i < domain_size; ++i) {
             F x = d.GetElement(i);
-            DenseCoeffs lagrange_coeffs = d.EvaluateAllLagrangeCoefficients(x);
+            std::vector<F> lagrange_coeffs =
+                d.EvaluateAllLagrangeCoefficients(x);
             for (size_t j = 0; j < domain_size; ++j) {
               // Lagrange coefficient for the evaluation point,
               // which should be 1 if i == j
               if (i == j) {
-                EXPECT_TRUE(lagrange_coeffs[j]->IsOne());
+                EXPECT_TRUE(lagrange_coeffs[j].IsOne());
               } else {
-                EXPECT_TRUE(lagrange_coeffs[j] == nullptr ||
-                            lagrange_coeffs[j]->IsZero());
+                EXPECT_TRUE(lagrange_coeffs[j].IsZero());
               }
             }
           }


### PR DESCRIPTION
# Description

If we return it as a `DenseCoeffs`, we have to check whether leading coefficients are zero or not, even though we expect it to have zeros. Therefore, we change its return type to `std::vector<F>` to ensure this. FYI, Original arkworks codes use `Vec<F>` as a return type.

See
https://github.com/arkworks-rs/algebra/blob/d9527c832888ffbd9231999b30a700ce3e572c16/poly/src/domain/mod.rs#L156.