### PR TITLE
feat: implement SHPlonk VerifyOpeningProof

### DIFF
--- a/tachyon/crypto/commitments/kzg/BUILD.bazel
+++ b/tachyon/crypto/commitments/kzg/BUILD.bazel
@@ -31,6 +31,7 @@ tachyon_cc_library(
         "//tachyon/crypto/commitments:polynomial_openings",
         "//tachyon/crypto/commitments:univariate_polynomial_commitment_scheme",
         "//tachyon/crypto/transcripts:transcript",
+        "//tachyon/math/elliptic_curves/pairing",
     ],
 )
 
@@ -44,6 +45,7 @@ tachyon_cc_unittest(
         ":shplonk",
         "//tachyon/base/buffer:vector_buffer",
         "//tachyon/crypto/transcripts:simple_transcript",
+        "//tachyon/math/elliptic_curves/bn/bn254",
         "//tachyon/math/elliptic_curves/bn/bn254:g1",
         "//tachyon/math/elliptic_curves/bn/bn254:g2",
         "//tachyon/math/polynomials/univariate:univariate_evaluation_domain_factory",

--- a/tachyon/crypto/commitments/kzg/shplonk.h
+++ b/tachyon/crypto/commitments/kzg/shplonk.h
@@ -14,27 +14,34 @@
 #include "tachyon/crypto/commitments/polynomial_openings.h"
 #include "tachyon/crypto/commitments/univariate_polynomial_commitment_scheme.h"
 #include "tachyon/crypto/transcripts/transcript.h"
+#include "tachyon/math/elliptic_curves/pairing/pairing.h"
 
 namespace tachyon {
 namespace zk {
 
-template <typename G1PointTy, typename G2PointTy, size_t MaxDegree,
-          size_t MaxExtensionDegree,
-          typename _Commitment = typename math::Pippenger<G1PointTy>::Bucket>
+template <typename CurveTy, size_t MaxDegree, size_t MaxExtensionDegree,
+          typename _Commitment = typename math::Pippenger<
+              typename CurveTy::G1Curve::AffinePointTy>::Bucket>
 class SHPlonkExtension;
 
 }  // namespace zk
 
 namespace crypto {
 
-template <typename G1PointTy, typename G2PointTy, size_t MaxDegree,
-          typename Commitment = typename math::Pippenger<G1PointTy>::Bucket>
+template <typename CurveTy, size_t MaxDegree,
+          typename Commitment = typename math::Pippenger<
+              typename CurveTy::G1Curve::AffinePointTy>::Bucket>
 class SHPlonk : public UnivariatePolynomialCommitmentScheme<
-                    SHPlonk<G1PointTy, G2PointTy, MaxDegree, Commitment>>,
-                public KZGFamily<G1PointTy, MaxDegree, Commitment> {
+                    SHPlonk<CurveTy, MaxDegree, Commitment>>,
+                public KZGFamily<typename CurveTy::G1Curve::AffinePointTy,
+                                 MaxDegree, Commitment> {
  public:
   using Base = UnivariatePolynomialCommitmentScheme<
-      SHPlonk<G1PointTy, G2PointTy, MaxDegree, Commitment>>;
+      SHPlonk<CurveTy, MaxDegree, Commitment>>;
+  using G1PointTy = typename CurveTy::G1Curve::AffinePointTy;
+  using G2PointTy = typename CurveTy::G2Curve::AffinePointTy;
+  using G2Prepared = typename CurveTy::G2Prepared;
+  using Fp12Ty = typename CurveTy::Fp12Ty;
   using Field = typename Base::Field;
   using Poly = typename Base::Poly;
   using Point = typename Poly::Point;
@@ -45,12 +52,14 @@ class SHPlonk : public UnivariatePolynomialCommitmentScheme<
       : KZGFamily<G1PointTy, MaxDegree, Commitment>(std::move(kzg)) {}
 
  private:
-  friend class VectorCommitmentScheme<
-      SHPlonk<G1PointTy, G2PointTy, MaxDegree, Commitment>>;
+  friend class VectorCommitmentScheme<SHPlonk<CurveTy, MaxDegree, Commitment>>;
   friend class UnivariatePolynomialCommitmentScheme<
-      SHPlonk<G1PointTy, G2PointTy, MaxDegree, Commitment>>;
-  template <typename, typename, size_t, size_t, typename>
+      SHPlonk<CurveTy, MaxDegree, Commitment>>;
+  template <typename, size_t, size_t, typename>
   friend class zk::SHPlonkExtension;
+
+  // Set 𝜏G₂
+  void SetTauG2(const G2PointTy& tau_g2) { tau_g2_ = tau_g2; }
 
   // UnivariatePolynomialCommitmentScheme methods
   template <typename ContainerTy>
@@ -178,22 +187,172 @@ class SHPlonk : public UnivariatePolynomialCommitmentScheme<
     return writer->WriteToProof(q);
   }
 
+  template <typename ContainerTy>
+  [[nodiscard]] bool DoVerifyOpeningProof(
+      const ContainerTy& poly_openings,
+      TranscriptReader<Commitment>* reader) const {
+    using G1JacobianPointTy = typename G1PointTy::JacobianPointTy;
+
+    Field y = reader->SqueezeChallenge();
+    Field v = reader->SqueezeChallenge();
+
+    Commitment h;
+    if (!reader->ReadFromProof(&h)) return false;
+
+    Field u = reader->SqueezeChallenge();
+
+    Commitment q;
+    if (!reader->ReadFromProof(&q)) return false;
+
+    PolynomialOpeningGrouper<Poly, Commitment> grouper;
+    grouper.GroupByPolyAndPoints(poly_openings);
+
+    // Group |poly_openings| to |grouped_poly_openings_vec|.
+    // {[C₀, C₁, C₂], [x₀, x₁, x₂]}
+    // {[C₃], [x₂, x₃]}
+    // {[C₄], [x₄]}
+    const std::vector<GroupedPolynomialOpenings<Poly, Commitment>>&
+        grouped_poly_openings_vec = grouper.grouped_poly_openings_vec();
+    const absl::btree_set<PointDeepRef>& super_point_set =
+        grouper.super_point_set();
+
+    Field first_z_diff_inverse = Field::Zero();
+    Field first_z = Field::Zero();
+
+    std::vector<G1JacobianPointTy> l_commitments;
+    l_commitments.reserve(grouped_poly_openings_vec.size());
+    size_t i = 0;
+    for (const auto& [poly_openings_vec, point_refs] :
+         grouped_poly_openings_vec) {
+      // |commitments[0]| = [C₀, C₁, C₂]
+      // |commitments[1]| = [C₃]
+      // |commitments[2]| = [C₄]
+      std::vector<Commitment> commitments = base::Map(
+          poly_openings_vec,
+          [](const PolynomialOpenings<Poly, Commitment>& poly_openings) {
+            return *poly_openings.poly_oracle;
+          });
+      // |points[0]| = [x₀, x₁, x₂]
+      // |points[1]| = [x₂, x₃]
+      // |points[2]| = [x₄]
+      std::vector<Point> points = base::Map(
+          point_refs, [](const PointDeepRef& point_ref) { return *point_ref; });
+      // |diffs[0]| = [x₃, x₄]
+      // |diffs[1]| = [x₀, x₁, x₄]
+      // |diffs[2]| = [x₀, x₁, x₂, x₃]
+      std::vector<Point> diffs;
+      diffs.reserve(point_refs.size());
+      for (const PointDeepRef& point_ref : super_point_set) {
+        if (std::find(point_refs.begin(), point_refs.end(), point_ref) ==
+            point_refs.end()) {
+          diffs.push_back(*point_ref);
+        }
+      }
+
+      // z_diff_0 = (u - x₃)(u - x₄)
+      // z_diff_1 = (u - x₀)(u - x₁)(u - x₄)
+      // z_diff_2 = (u - x₀)(u - x₁)(u - x₂)(u - x₃)
+      Point z_diff_i = Poly::EvaluateVanishingPolyByRoots(std::move(diffs), u);
+      if (i == 0) {
+        // z₀ = (u - x₀)(u - x₁)(u - x₂)
+        first_z = Poly::EvaluateVanishingPolyByRoots(std::move(points), u);
+        // (u - x₃)(u - x₄)⁻¹
+        first_z_diff_inverse = z_diff_i.InverseInPlace();
+        z_diff_i = Field::One();
+      } else {
+        // z_diff_1 = (u - x₀)(u - x₁)(u - x₄)/(u - x₃)(u - x₄)
+        // z_diff_2 = (u - x₀)(u - x₁)(u - x₂)(u - x₃)/(u - x₃)(u - x₄)
+        z_diff_i *= first_z_diff_inverse;
+      }
+
+      // For example in i = 0:
+      // [R₀(u)]₁ = R₀(u) * G₁
+      // [R₁(u)]₁ = R₁(u) * G₁
+      // [R₂(u)]₁ = R₂(u) * G₁
+      // r_commitments = [R₀(u) * G₁, R₁(u) * G₁, R₂(u) * G₁]
+      std::vector<G1JacobianPointTy> r_commitments = base::Map(
+          poly_openings_vec,
+          [&points,
+           &u](const PolynomialOpenings<Poly, Commitment>& poly_openings) {
+            Poly r_i;
+            CHECK(math::LagrangeInterpolate(points, poly_openings.openings,
+                                            &r_i));
+            Field r = r_i.Evaluate(u);
+            return G1PointTy::Generator().ScalarMul(r);
+          });
+
+      // [L₀]₁ = (C₀ - [R₀(u)]₁) + y(C₁ - [R₁(u)]₁) + y²(C₂ - [R₂(u)]₁)
+      G1JacobianPointTy l_i = commitments.back() - r_commitments.back();
+      if (commitments.size() > 1) {
+        for (size_t j = commitments.size() - 2; j != SIZE_MAX; --j) {
+          l_i *= y;
+          l_i += (commitments[j] - r_commitments[j]);
+        }
+      }
+
+      // [L₀]₁ *= 1
+      // [L₁]₁ *= (u - x₀)(u - x₁)(u - x₄)/(u - x₃)(u - x₄)
+      // [L₂]₁ *= (u - x₀)(u - x₁)(u - x₂)(u - x₃)/(u - x₃)(u - x₄)
+      l_i *= z_diff_i;
+      l_commitments.push_back(l_i);
+      ++i;
+    }
+
+    // [L₀]₁ + v[L₁]₁ + v²[L₂]₁
+    G1JacobianPointTy linear_combination =
+        l_commitments[l_commitments.size() - 1];
+    if (l_commitments.size() > 1) {
+      for (size_t j = l_commitments.size() - 2; j != SIZE_MAX; --j) {
+        linear_combination *= v;
+        linear_combination += l_commitments[j];
+      }
+    }
+
+    // lhs_g1 = [L₀]₁ + v[L₁]₁ + v²[L₂]₁ - z₀[H]₁ + u[Q]₁
+    // lhs_g2 = G₂
+    G1JacobianPointTy lhs = linear_combination;
+
+    lhs -= (h * first_z);
+    lhs += (q * u);
+
+    std::vector<G1PointTy> lhs_g1 = {lhs.ToAffine()};
+    std::vector<G2Prepared> lhs_g2 = {
+        CurveTy::G2Prepared::From(G2PointTy::Generator())};
+    Fp12Ty lhs_pairing =
+        math::Pairing<CurveTy>(std::move(lhs_g1), std::move(lhs_g2));
+
+    // rhs_g1 = [Q]₁
+    // rhs_g2 = 𝜏G₂
+    std::vector<G1PointTy> rhs_g1 = {q};
+    std::vector<G2Prepared> rhs_g2 = {CurveTy::G2Prepared::From(tau_g2_)};
+    Fp12Ty rhs_pairing =
+        math::Pairing<CurveTy>(std::move(rhs_g1), std::move(rhs_g2));
+
+    // e(lhs_g1, rhs_g2) == e(rhs_g1, lhs_g2)
+    // lhs: e(G₁, G₂)^([L₀]₁ + v[L₁]₁ + v²[L₂]₁ - z₀[H]₁ + u[Q]₁)
+    // rhs: e(G₁, G₂)^(𝜏[Q]₁)
+    // [L₀]₁ + v[L₁]₁ + v²[L₂]₁ - z₀[H]₁ + u[Q]₁ ?= 𝜏[Q]₁
+    // [L₀]₁ + v[L₁]₁ + v²[L₂]₁ - z₀[H]₁ ?= (𝜏 - u)[Q]₁
+    return lhs_pairing == rhs_pairing;
+  }
+
   // KZGFamily methods
   [[nodiscard]] bool DoUnsafeSetupWithTau(size_t size,
                                           const Field& tau) override {
-    NOTIMPLEMENTED();
+    tau_g2_ = G2PointTy::Generator().ScalarMul(tau).ToAffine();
     return true;
   }
+
+  G2PointTy tau_g2_;
 };
 
-template <typename G1PointTy, typename G2PointTy, size_t MaxDegree,
-          typename _Commitment>
-struct VectorCommitmentSchemeTraits<
-    SHPlonk<G1PointTy, G2PointTy, MaxDegree, _Commitment>> {
+template <typename CurveTy, size_t MaxDegree, typename _Commitment>
+struct VectorCommitmentSchemeTraits<SHPlonk<CurveTy, MaxDegree, _Commitment>> {
  public:
   constexpr static size_t kMaxSize = MaxDegree + 1;
   constexpr static bool kIsTransparent = false;
 
+  using G1PointTy = typename CurveTy::G1Curve::AffinePointTy;
   using Field = typename G1PointTy::ScalarField;
   using Commitment = _Commitment;
 };

--- a/tachyon/crypto/commitments/kzg/shplonk.h
+++ b/tachyon/crypto/commitments/kzg/shplonk.h
@@ -37,6 +37,8 @@ class SHPlonk : public UnivariatePolynomialCommitmentScheme<
       SHPlonk<G1PointTy, G2PointTy, MaxDegree, Commitment>>;
   using Field = typename Base::Field;
   using Poly = typename Base::Poly;
+  using Point = typename Poly::Point;
+  using PointDeepRef = base::DeepRef<const Point>;
 
   SHPlonk() = default;
   explicit SHPlonk(KZG<G1PointTy, MaxDegree, Commitment>&& kzg)
@@ -55,9 +57,6 @@ class SHPlonk : public UnivariatePolynomialCommitmentScheme<
   [[nodiscard]] bool DoCreateOpeningProof(
       const ContainerTy& poly_openings,
       TranscriptWriter<Commitment>* writer) const {
-    using Point = typename Poly::Point;
-    using PointDeepRef = base::DeepRef<const Point>;
-
     PolynomialOpeningGrouper<Poly> grouper;
     grouper.GroupByPolyAndPoints(poly_openings);
 
@@ -138,7 +137,7 @@ class SHPlonk : public UnivariatePolynomialCommitmentScheme<
               grouped_poly_openings.poly_openings_vec,
               [&u, &low_degree_extensions](
                   size_t i, const PolynomialOpenings<Poly>& poly_openings) {
-                Poly poly = *poly_openings.poly;
+                Poly poly = *poly_openings.poly_oracle;
                 *poly[0] -= low_degree_extensions[i].Evaluate(u);
                 return poly;
               });

--- a/tachyon/crypto/commitments/kzg/shplonk.h
+++ b/tachyon/crypto/commitments/kzg/shplonk.h
@@ -113,12 +113,12 @@ class SHPlonk : public UnivariatePolynomialCommitmentScheme<
             size_t i,
             const GroupedPolynomialOpenings<Poly>& grouped_poly_openings) {
           absl::btree_set<PointDeepRef> diffs = super_point_set;
-          for (PointDeepRef point : grouped_poly_openings.points) {
-            diffs.erase(point);
+          for (PointDeepRef point_ref : grouped_poly_openings.point_refs) {
+            diffs.erase(point_ref);
           }
 
-          std::vector<Point> diffs_vec =
-              base::Map(diffs, [](PointDeepRef point) { return *point; });
+          std::vector<Point> diffs_vec = base::Map(
+              diffs, [](PointDeepRef point_ref) { return *point_ref; });
           // calculate difference vanishing polynomial evaluation
           // z₀ = Z₀(u) = (u - x₃)(u - x₄)
           // z₁ = Z₁(u) = (u - x₀)(u - x₁)(u - x₄)

--- a/tachyon/crypto/commitments/kzg/shplonk_unittest.cc
+++ b/tachyon/crypto/commitments/kzg/shplonk_unittest.cc
@@ -5,6 +5,7 @@
 #include "gtest/gtest.h"
 
 #include "tachyon/crypto/transcripts/simple_transcript.h"
+#include "tachyon/math/elliptic_curves/bn/bn254/bn254.h"
 #include "tachyon/math/elliptic_curves/bn/bn254/g1.h"
 #include "tachyon/math/elliptic_curves/bn/bn254/g2.h"
 #include "tachyon/math/polynomials/univariate/univariate_evaluation_domain_factory.h"
@@ -19,16 +20,21 @@ class SHPlonkTest : public testing::Test {
   constexpr static size_t N = size_t{1} << K;
   constexpr static size_t kMaxDegree = N - 1;
 
-  using PCS = SHPlonk<math::bn254::G1AffinePoint, math::bn254::G2AffinePoint,
-                      kMaxDegree, math::bn254::G1AffinePoint>;
+  using PCS =
+      SHPlonk<math::bn254::BN254Curve, kMaxDegree, math::bn254::G1AffinePoint>;
   using F = PCS::Field;
   using Poly = PCS::Poly;
   using Commitment = PCS::Commitment;
   using Point = Poly::Point;
   using PolyRef = base::DeepRef<const Poly>;
   using PointRef = base::DeepRef<const Point>;
+  using CommitmentRef = base::DeepRef<const Commitment>;
 
-  static void SetUpTestSuite() { math::bn254::G1Curve::Init(); }
+  static void SetUpTestSuite() {
+    math::bn254::BN254Curve::Init();
+    math::bn254::G1Curve::Init();
+    math::bn254::G2Curve::Init();
+  }
 
   SHPlonkTest() : writer_(base::Uint8VectorBuffer()) {}
 
@@ -40,52 +46,75 @@ class SHPlonkTest : public testing::Test {
     polys_ = base::CreateVector(5, []() { return Poly::Random(kMaxDegree); });
     points_ = {F(1), F(2), F(3), F(4), F(5)};
 
-    poly_openings_.reserve(8);
+    commitments_.reserve(5);
+    for (const Poly& poly : polys_) {
+      Commitment commitment;
+      CHECK(pcs_.Commit(poly, &commitment));
+      commitments_.emplace_back(std::move(commitment));
+    }
+
+    // clang-format off
+    prover_openings_.reserve(13);
     // {P₀, [x₀, x₁, x₂]}
-    poly_openings_.emplace_back(PolyRef(&polys_[0]), PointRef(&points_[0]),
-                                polys_[0].Evaluate(points_[0]));
-    poly_openings_.emplace_back(PolyRef(&polys_[0]), PointRef(&points_[1]),
-                                polys_[0].Evaluate(points_[1]));
-    poly_openings_.emplace_back(PolyRef(&polys_[0]), PointRef(&points_[2]),
-                                polys_[0].Evaluate(points_[2]));
+    prover_openings_.emplace_back(PolyRef(&polys_[0]), PointRef(&points_[0]), polys_[0].Evaluate(points_[0]));
+    prover_openings_.emplace_back(PolyRef(&polys_[0]), PointRef(&points_[1]), polys_[0].Evaluate(points_[1]));
+    prover_openings_.emplace_back(PolyRef(&polys_[0]), PointRef(&points_[2]), polys_[0].Evaluate(points_[2]));
     // (P₁, [x₀, x₁, x₂]}
-    poly_openings_.emplace_back(PolyRef(&polys_[1]), PointRef(&points_[0]),
-                                polys_[1].Evaluate(points_[0]));
-    poly_openings_.emplace_back(PolyRef(&polys_[1]), PointRef(&points_[1]),
-                                polys_[1].Evaluate(points_[1]));
-    poly_openings_.emplace_back(PolyRef(&polys_[1]), PointRef(&points_[2]),
-                                polys_[1].Evaluate(points_[2]));
+    prover_openings_.emplace_back(PolyRef(&polys_[1]), PointRef(&points_[0]), polys_[1].Evaluate(points_[0]));
+    prover_openings_.emplace_back(PolyRef(&polys_[1]), PointRef(&points_[1]), polys_[1].Evaluate(points_[1]));
+    prover_openings_.emplace_back(PolyRef(&polys_[1]), PointRef(&points_[2]), polys_[1].Evaluate(points_[2]));
     // (P₂, [x₀, x₁, x₂]}
-    poly_openings_.emplace_back(PolyRef(&polys_[2]), PointRef(&points_[0]),
-                                polys_[2].Evaluate(points_[0]));
-    poly_openings_.emplace_back(PolyRef(&polys_[2]), PointRef(&points_[1]),
-                                polys_[2].Evaluate(points_[1]));
-    poly_openings_.emplace_back(PolyRef(&polys_[2]), PointRef(&points_[2]),
-                                polys_[2].Evaluate(points_[2]));
+    prover_openings_.emplace_back(PolyRef(&polys_[2]), PointRef(&points_[0]), polys_[2].Evaluate(points_[0]));
+    prover_openings_.emplace_back(PolyRef(&polys_[2]), PointRef(&points_[1]), polys_[2].Evaluate(points_[1]));
+    prover_openings_.emplace_back(PolyRef(&polys_[2]), PointRef(&points_[2]), polys_[2].Evaluate(points_[2]));
     // (P₃, [x₂, x₃]}
-    poly_openings_.emplace_back(PolyRef(&polys_[3]), PointRef(&points_[2]),
-                                polys_[3].Evaluate(points_[2]));
-    poly_openings_.emplace_back(PolyRef(&polys_[3]), PointRef(&points_[3]),
-                                polys_[3].Evaluate(points_[3]));
+    prover_openings_.emplace_back(PolyRef(&polys_[3]), PointRef(&points_[2]), polys_[3].Evaluate(points_[2]));
+    prover_openings_.emplace_back(PolyRef(&polys_[3]), PointRef(&points_[3]), polys_[3].Evaluate(points_[3]));
     // (P₄, [x₃, x₄]}
-    poly_openings_.emplace_back(PolyRef(&polys_[4]), PointRef(&points_[3]),
-                                polys_[4].Evaluate(points_[3]));
-    poly_openings_.emplace_back(PolyRef(&polys_[4]), PointRef(&points_[4]),
-                                polys_[4].Evaluate(points_[4]));
+    prover_openings_.emplace_back(PolyRef(&polys_[4]), PointRef(&points_[3]), polys_[4].Evaluate(points_[3]));
+    prover_openings_.emplace_back(PolyRef(&polys_[4]), PointRef(&points_[4]), polys_[4].Evaluate(points_[4]));
+
+    verifier_openings_.reserve(13);
+    // {C₀, [x₀, x₁, x₂]}
+    verifier_openings_.emplace_back(CommitmentRef(&commitments_[0]), PointRef(&points_[0]), polys_[0].Evaluate(points_[0]));
+    verifier_openings_.emplace_back(CommitmentRef(&commitments_[0]), PointRef(&points_[1]), polys_[0].Evaluate(points_[1]));
+    verifier_openings_.emplace_back(CommitmentRef(&commitments_[0]), PointRef(&points_[2]), polys_[0].Evaluate(points_[2]));
+    // (C₁, [x₀, x₁, x₂]}
+    verifier_openings_.emplace_back(CommitmentRef(&commitments_[1]), PointRef(&points_[0]), polys_[1].Evaluate(points_[0]));
+    verifier_openings_.emplace_back(CommitmentRef(&commitments_[1]), PointRef(&points_[1]), polys_[1].Evaluate(points_[1]));
+    verifier_openings_.emplace_back(CommitmentRef(&commitments_[1]), PointRef(&points_[2]), polys_[1].Evaluate(points_[2]));
+    // (C₂, [x₀, x₁, x₂]}
+    verifier_openings_.emplace_back(CommitmentRef(&commitments_[2]), PointRef(&points_[0]), polys_[2].Evaluate(points_[0]));
+    verifier_openings_.emplace_back(CommitmentRef(&commitments_[2]), PointRef(&points_[1]), polys_[2].Evaluate(points_[1]));
+    verifier_openings_.emplace_back(CommitmentRef(&commitments_[2]), PointRef(&points_[2]), polys_[2].Evaluate(points_[2]));
+    // (C₃, [x₂, x₃]}
+    verifier_openings_.emplace_back(CommitmentRef(&commitments_[3]), PointRef(&points_[2]), polys_[3].Evaluate(points_[2]));
+    verifier_openings_.emplace_back(CommitmentRef(&commitments_[3]), PointRef(&points_[3]), polys_[3].Evaluate(points_[3]));
+    // (C₄, [x₃, x₄]}
+    verifier_openings_.emplace_back(CommitmentRef(&commitments_[4]), PointRef(&points_[3]), polys_[4].Evaluate(points_[3]));
+    verifier_openings_.emplace_back(CommitmentRef(&commitments_[4]), PointRef(&points_[4]), polys_[4].Evaluate(points_[4]));
+    // clang-format on
   }
 
  protected:
   PCS pcs_;
   std::vector<Poly> polys_;
   std::vector<F> points_;
-  std::vector<PolynomialOpening<Poly>> poly_openings_;
+  std::vector<Commitment> commitments_;
+  std::vector<PolynomialOpening<Poly>> prover_openings_;
+  std::vector<PolynomialOpening<Poly, Commitment>> verifier_openings_;
   SimpleTranscriptWriter<Commitment> writer_;
 };
 
 }  // namespace
 
-TEST_F(SHPlonkTest, CreateProof) {
-  ASSERT_TRUE(pcs_.CreateOpeningProof(poly_openings_, &writer_));
+TEST_F(SHPlonkTest, CreateAndVerifyProof) {
+  ASSERT_TRUE(pcs_.CreateOpeningProof(prover_openings_, &writer_));
+
+  base::Buffer read_buf(writer_.buffer().buffer(),
+                        writer_.buffer().buffer_len());
+  SimpleTranscriptReader<Commitment> reader(std::move(read_buf));
+  EXPECT_TRUE((pcs_.VerifyOpeningProof(verifier_openings_, &reader)));
 }
 
 }  // namespace tachyon::crypto

--- a/tachyon/crypto/commitments/kzg/shplonk_unittest.cc
+++ b/tachyon/crypto/commitments/kzg/shplonk_unittest.cc
@@ -34,7 +34,7 @@ class SHPlonkTest : public testing::Test {
 
   void SetUp() override {
     KZG<math::bn254::G1AffinePoint, kMaxDegree, math::bn254::G1AffinePoint> kzg;
-    pcs_ = PCS(std::move(kzg), &writer_);
+    pcs_ = PCS(std::move(kzg));
     ASSERT_TRUE(pcs_.UnsafeSetup(N));
 
     polys_ = base::CreateVector(5, []() { return Poly::Random(kMaxDegree); });
@@ -85,8 +85,7 @@ class SHPlonkTest : public testing::Test {
 }  // namespace
 
 TEST_F(SHPlonkTest, CreateProof) {
-  SHPlonkProof<Commitment> proof;
-  ASSERT_TRUE(pcs_.CreateOpeningProof(poly_openings_, &proof));
+  ASSERT_TRUE(pcs_.CreateOpeningProof(poly_openings_, &writer_));
 }
 
 }  // namespace tachyon::crypto

--- a/tachyon/crypto/commitments/polynomial_openings.h
+++ b/tachyon/crypto/commitments/polynomial_openings.h
@@ -15,55 +15,57 @@
 
 namespace tachyon::crypto {
 
-// A single polynomial with a single opening.
-template <typename Poly>
+// A single polynomial oracle with a single opening
+// The type of polynomial oracle can be either |Poly| in |CreateOpeningProof()|
+// and |Commitment| in |VerifyOpeningProof()|
+template <typename Poly, typename PolyOracle = Poly>
 struct PolynomialOpening {
   using Field = typename Poly::Field;
   using Point = typename Poly::Point;
 
-  // P₀
-  base::DeepRef<const Poly> poly;
-  // x₀
+  // polynomial Pᵢ or commitment Cᵢ
+  base::DeepRef<const PolyOracle> poly_oracle;
+  // xᵢ
   base::DeepRef<const Point> point;
-  // P₀(x₀)
+  // Pᵢ(xᵢ)
   Field opening;
 
   PolynomialOpening() = default;
-  PolynomialOpening(base::DeepRef<const Poly> poly,
+  PolynomialOpening(base::DeepRef<const PolyOracle> poly_oracle,
                     base::DeepRef<const Point> point, Field&& opening)
-      : poly(poly), point(point), opening(std::move(opening)) {}
+      : poly_oracle(poly_oracle), point(point), opening(std::move(opening)) {}
 };
 
-// A single polynomial with multi openings.
-template <typename Poly>
+// A single polynomial oracle with multi openings.
+template <typename Poly, typename PolyOracle = Poly>
 struct PolynomialOpenings {
   using Field = typename Poly::Field;
 
-  // P₀
-  base::DeepRef<const Poly> poly;
-  // [P₀(x₀), P₀(x₁), P₀(x₂)]
+  // polynomial Pᵢ or commitment Cᵢ
+  base::DeepRef<const PolyOracle> poly_oracle;
+  // [Pᵢ(x₀), Pᵢ(x₁), Pᵢ(x₂)]
   std::vector<Field> openings;
 
   PolynomialOpenings() = default;
-  PolynomialOpenings(base::DeepRef<const Poly> poly,
+  PolynomialOpenings(base::DeepRef<const PolyOracle> poly_oracle,
                      std::vector<Field>&& openings)
-      : poly(poly), openings(std::move(openings)) {}
+      : poly_oracle(poly_oracle), openings(std::move(openings)) {}
 };
 
-// Multi polynomials with multi openings grouped by shared points.
-template <typename Poly>
+// Multi polynomial openings grouped by shared points.
+template <typename Poly, typename PolyOracle = Poly>
 struct GroupedPolynomialOpenings {
   using Field = typename Poly::Field;
   using Point = typename Poly::Point;
 
   // [{P₀, [P₀(x₀), P₀(x₁), P₀(x₂)]}, {P₁, [P₁(x₀), P₁(x₁), P₁(x₂)]}]
-  std::vector<PolynomialOpenings<Poly>> poly_openings_vec;
+  std::vector<PolynomialOpenings<Poly, PolyOracle>> poly_openings_vec;
   // [x₀, x₁, x₂]
   std::vector<base::DeepRef<const Point>> points;
 
   GroupedPolynomialOpenings() = default;
   GroupedPolynomialOpenings(
-      std::vector<PolynomialOpenings<Poly>>&& poly_openings_vec,
+      std::vector<PolynomialOpenings<Poly, PolyOracle>>&& poly_openings_vec,
       std::vector<base::DeepRef<const Point>>&& points)
       : poly_openings_vec(std::move(poly_openings_vec)),
         points(std::move(points)) {}
@@ -108,12 +110,12 @@ struct GroupedPolynomialOpenings {
       const Field& r, const std::vector<Point>& owned_points,
       const std::vector<Poly>& low_degree_extensions) const {
     // numerators: [P₀(X) - R₀(X), P₁(X) - R₁(X), P₂(X) - R₂(X)]
-    std::vector<Poly> numerators =
-        base::Map(poly_openings_vec,
-                  [&low_degree_extensions](
-                      size_t i, const PolynomialOpenings<Poly>& poly_openings) {
-                    return *poly_openings.poly - low_degree_extensions[i];
-                  });
+    std::vector<Poly> numerators = base::Map(
+        poly_openings_vec,
+        [&low_degree_extensions](
+            size_t i, const PolynomialOpenings<Poly>& poly_openings) {
+          return *poly_openings.poly_oracle - low_degree_extensions[i];
+        });
 
     // Combine numerator polynomials with powers of |r|.
     // N(X) = (P₀(X) - R₀(X)) + r(P₁(X) - R₁(X)) + r²(P₂(X) - R₂(X))
@@ -126,15 +128,15 @@ struct GroupedPolynomialOpenings {
   }
 };
 
-template <typename Poly>
+template <typename Poly, typename PolyOracle = Poly>
 class PolynomialOpeningGrouper {
  public:
   using Field = typename Poly::Field;
   using Point = typename Poly::Point;
-  using PolyDeepRef = base::DeepRef<const Poly>;
+  using PolyOracleDeepRef = base::DeepRef<const PolyOracle>;
   using PointDeepRef = base::DeepRef<const Point>;
 
-  const std::vector<GroupedPolynomialOpenings<Poly>>&
+  const std::vector<GroupedPolynomialOpenings<Poly, PolyOracle>>&
   grouped_poly_openings_vec() const {
     return grouped_poly_openings_vec_;
   }
@@ -143,21 +145,22 @@ class PolynomialOpeningGrouper {
   }
 
   void GroupByPolyAndPoints(
-      const std::vector<PolynomialOpening<Poly>>& poly_openings) {
+      const std::vector<PolynomialOpening<Poly, PolyOracle>>& poly_openings) {
     // Group |poly_openings| by polynomial.
     // {P₀, [x₀, x₁, x₂]}
     // {P₁, [x₀, x₁, x₂]}
     // {P₂, [x₀, x₁, x₂]}
     // {P₃, [x₂, x₃]}
     // {P₄, [x₄]}
-    absl::flat_hash_map<PolyDeepRef, absl::btree_set<PointDeepRef>>
+    absl::flat_hash_map<PolyOracleDeepRef, absl::btree_set<PointDeepRef>>
         poly_openings_grouped_by_poly = GroupByPoly(poly_openings);
 
     // Group |poly_openings_grouped_by_poly| by points.
     // [x₀, x₁, x₂]: [P₀, P₁, P₂]
     // [x₂, x₃]: [P₃]
     // [x₄]: [P₄]
-    absl::flat_hash_map<absl::btree_set<PointDeepRef>, std::vector<PolyDeepRef>>
+    absl::flat_hash_map<absl::btree_set<PointDeepRef>,
+                        std::vector<PolyOracleDeepRef>>
         poly_openings_grouped_by_poly_and_points =
             GroupByPoints(poly_openings_grouped_by_poly);
 
@@ -173,32 +176,36 @@ class PolynomialOpeningGrouper {
  private:
   FRIEND_TEST(PolynomialOpeningsTest, GroupByPolyAndPoints);
 
-  absl::flat_hash_map<PolyDeepRef, absl::btree_set<PointDeepRef>> GroupByPoly(
-      const std::vector<PolynomialOpening<Poly>>& poly_openings) {
-    absl::flat_hash_map<PolyDeepRef, absl::btree_set<PointDeepRef>> ret;
-    for (const PolynomialOpening<Poly>& poly_opening : poly_openings) {
+  absl::flat_hash_map<PolyOracleDeepRef, absl::btree_set<PointDeepRef>>
+  GroupByPoly(
+      const std::vector<PolynomialOpening<Poly, PolyOracle>>& poly_openings) {
+    absl::flat_hash_map<PolyOracleDeepRef, absl::btree_set<PointDeepRef>> ret;
+    for (const PolynomialOpening<Poly, PolyOracle>& poly_opening :
+         poly_openings) {
       super_point_set_.insert(poly_opening.point);
-      ret[poly_opening.poly].insert(poly_opening.point);
+      ret[poly_opening.poly_oracle].insert(poly_opening.point);
     }
     return ret;
   }
 
-  absl::flat_hash_map<absl::btree_set<PointDeepRef>, std::vector<PolyDeepRef>>
-  GroupByPoints(
-      const absl::flat_hash_map<PolyDeepRef, absl::btree_set<PointDeepRef>>&
-          poly_openings_grouped_by_poly) {
-    absl::flat_hash_map<absl::btree_set<PointDeepRef>, std::vector<PolyDeepRef>>
+  absl::flat_hash_map<absl::btree_set<PointDeepRef>,
+                      std::vector<PolyOracleDeepRef>>
+  GroupByPoints(const absl::flat_hash_map<PolyOracleDeepRef,
+                                          absl::btree_set<PointDeepRef>>&
+                    poly_openings_grouped_by_poly) {
+    absl::flat_hash_map<absl::btree_set<PointDeepRef>,
+                        std::vector<PolyOracleDeepRef>>
         ret;
-    for (const auto& [poly, points] : poly_openings_grouped_by_poly) {
-      ret[points].push_back(poly);
+    for (const auto& [poly_oracle, points] : poly_openings_grouped_by_poly) {
+      ret[points].push_back(poly_oracle);
     }
     return ret;
   }
 
   void CreateMultiPolynomialOpenings(
-      const std::vector<PolynomialOpening<Poly>>& poly_openings,
+      const std::vector<PolynomialOpening<Poly, PolyOracle>>& poly_openings,
       const absl::flat_hash_map<absl::btree_set<PointDeepRef>,
-                                std::vector<PolyDeepRef>>&
+                                std::vector<PolyOracleDeepRef>>&
           poly_openings_grouped_by_poly_and_points) {
     grouped_poly_openings_vec_.reserve(
         poly_openings_grouped_by_poly_and_points.size());
@@ -207,27 +214,33 @@ class PolynomialOpeningGrouper {
          poly_openings_grouped_by_poly_and_points) {
       std::vector<PointDeepRef> points_vec(points.begin(), points.end());
 
-      std::vector<PolynomialOpenings<Poly>> poly_openings_vec =
-          base::Map(polys, [&poly_openings, &points_vec](PolyDeepRef poly) {
+      std::vector<PolynomialOpenings<Poly, PolyOracle>> poly_openings_vec =
+          base::Map(polys, [&poly_openings,
+                            &points_vec](PolyOracleDeepRef poly_oracle) {
             std::vector<Field> openings = base::Map(
-                points_vec, [poly, &poly_openings](PointDeepRef point) {
-                  return GetOpeningFromPolyOpenings(poly_openings, poly, point);
+                points_vec, [poly_oracle, &poly_openings](PointDeepRef point) {
+                  return GetOpeningFromPolyOpenings(poly_openings, poly_oracle,
+                                                    point);
                 });
-            return PolynomialOpenings<Poly>(poly, std::move(openings));
+            return PolynomialOpenings<Poly, PolyOracle>(poly_oracle,
+                                                        std::move(openings));
           });
 
-      grouped_poly_openings_vec_.push_back(GroupedPolynomialOpenings<Poly>(
-          std::move(poly_openings_vec), std::move(points_vec)));
+      grouped_poly_openings_vec_.push_back(
+          GroupedPolynomialOpenings<Poly, PolyOracle>(
+              std::move(poly_openings_vec), std::move(points_vec)));
     }
   }
 
   static Field GetOpeningFromPolyOpenings(
-      const std::vector<PolynomialOpening<Poly>>& poly_openings,
-      PolyDeepRef poly, PointDeepRef point) {
+      const std::vector<PolynomialOpening<Poly, PolyOracle>>& poly_openings,
+      PolyOracleDeepRef poly_oracle, PointDeepRef point) {
     auto it = std::find_if(
         poly_openings.begin(), poly_openings.end(),
-        [poly, point](const PolynomialOpening<Poly>& poly_opening) {
-          return poly_opening.poly == poly && poly_opening.point == point;
+        [poly_oracle,
+         point](const PolynomialOpening<Poly, PolyOracle>& poly_opening) {
+          return poly_opening.poly_oracle == poly_oracle &&
+                 poly_opening.point == point;
         });
     CHECK(it != poly_openings.end());
     return it->opening;
@@ -235,11 +248,12 @@ class PolynomialOpeningGrouper {
 
   // |grouped_poly_openings_vec_| is a list of
   // |GroupedPolynomialOpenings|, which is the result of list of
-  // |PolynomialOpening| grouped by poly and points.
+  // |PolynomialOpening| grouped by poly_oracle and points.
   // {[P₀, P₁, P₂], [x₀, x₁, x₂]}
   // {[P₃], [x₂, x₃]}
   // {[P₄], [x₄]}
-  std::vector<GroupedPolynomialOpenings<Poly>> grouped_poly_openings_vec_;
+  std::vector<GroupedPolynomialOpenings<Poly, PolyOracle>>
+      grouped_poly_openings_vec_;
   // |super_point_set_| is all the points that appear in opening.
   // [x₀, x₁, x₂, x₃, x₄]
   absl::btree_set<base::DeepRef<const Point>> super_point_set_;

--- a/tachyon/crypto/commitments/polynomial_openings.h
+++ b/tachyon/crypto/commitments/polynomial_openings.h
@@ -61,14 +61,14 @@ struct GroupedPolynomialOpenings {
   // [{P₀, [P₀(x₀), P₀(x₁), P₀(x₂)]}, {P₁, [P₁(x₀), P₁(x₁), P₁(x₂)]}]
   std::vector<PolynomialOpenings<Poly, PolyOracle>> poly_openings_vec;
   // [x₀, x₁, x₂]
-  std::vector<base::DeepRef<const Point>> points;
+  std::vector<base::DeepRef<const Point>> point_refs;
 
   GroupedPolynomialOpenings() = default;
   GroupedPolynomialOpenings(
       std::vector<PolynomialOpenings<Poly, PolyOracle>>&& poly_openings_vec,
-      std::vector<base::DeepRef<const Point>>&& points)
+      std::vector<base::DeepRef<const Point>>&& point_refs)
       : poly_openings_vec(std::move(poly_openings_vec)),
-        points(std::move(points)) {}
+        point_refs(std::move(point_refs)) {}
 
   // Create a low degree extension that is a linear combination with a set of
   // low degree extensions based on every |poly_openings_vec.openings| and
@@ -88,7 +88,7 @@ struct GroupedPolynomialOpenings {
   // indexing operator, if we use a vector of |base::DeepRef<const Point>| it
   // can't access as we expect.
   std::vector<Point> CreateOwnedPoints() const {
-    return base::Map(points,
+    return base::Map(point_refs,
                      [](const base::DeepRef<const Point>& p) { return *p; });
   }
 

--- a/tachyon/crypto/commitments/polynomial_openings_unittest.cc
+++ b/tachyon/crypto/commitments/polynomial_openings_unittest.cc
@@ -47,12 +47,12 @@ TEST_F(PolynomialOpeningsTest, CreateCombinedLowDegreeExtensions) {
       {PolyDeepRef(&polys_[1]),
        {polys_[1].Evaluate(points_[0]), polys_[1].Evaluate(points_[1])}},
   };
-  std::vector<PointDeepRef> points = {
+  std::vector<PointDeepRef> point_refs = {
       PointDeepRef(&points_[0]),
       PointDeepRef(&points_[1]),
   };
   GroupedPolynomialOpenings<Poly> grouped_poly_opening(
-      std::move(poly_openings_vec), std::move(points));
+      std::move(poly_openings_vec), std::move(point_refs));
 
   // NOTE(chokobole): Check whether the manually created low degree extensions
   // are constructed correctly.
@@ -64,8 +64,9 @@ TEST_F(PolynomialOpeningsTest, CreateCombinedLowDegreeExtensions) {
     const PolynomialOpenings<Poly>& poly_openings =
         grouped_poly_opening.poly_openings_vec[i];
     for (size_t j = 0; j < poly_openings.openings.size(); ++j) {
-      EXPECT_EQ(low_degree_extension.Evaluate(*grouped_poly_opening.points[j]),
-                poly_openings.openings[j]);
+      EXPECT_EQ(
+          low_degree_extension.Evaluate(*grouped_poly_opening.point_refs[j]),
+          poly_openings.openings[j]);
     }
   }
 
@@ -178,18 +179,18 @@ TEST_F(PolynomialOpeningsTest, GroupByPolyAndPoints) {
   };
   // TODO(chokobole): Test validity of
   // grouped_poly_openings_vec[i].poly_openings_vec
-  if (grouped_poly_openings_vec[0].points.size() == 2) {
-    EXPECT_EQ(grouped_poly_openings_vec[1].points.size(), 1);
-    EXPECT_THAT(grouped_poly_openings_vec[0].points,
+  if (grouped_poly_openings_vec[0].point_refs.size() == 2) {
+    EXPECT_EQ(grouped_poly_openings_vec[1].point_refs.size(), 1);
+    EXPECT_THAT(grouped_poly_openings_vec[0].point_refs,
                 testing::UnorderedElementsAreArray(expected_points_vec));
-    EXPECT_THAT(grouped_poly_openings_vec[1].points,
+    EXPECT_THAT(grouped_poly_openings_vec[1].point_refs,
                 testing::UnorderedElementsAreArray(expected_points_vec2));
   } else {
-    ASSERT_EQ(grouped_poly_openings_vec[0].points.size(), 1);
-    EXPECT_EQ(grouped_poly_openings_vec[1].points.size(), 2);
-    EXPECT_THAT(grouped_poly_openings_vec[0].points,
+    ASSERT_EQ(grouped_poly_openings_vec[0].point_refs.size(), 1);
+    EXPECT_EQ(grouped_poly_openings_vec[1].point_refs.size(), 2);
+    EXPECT_THAT(grouped_poly_openings_vec[0].point_refs,
                 testing::UnorderedElementsAreArray(expected_points_vec2));
-    EXPECT_THAT(grouped_poly_openings_vec[1].points,
+    EXPECT_THAT(grouped_poly_openings_vec[1].point_refs,
                 testing::UnorderedElementsAreArray(expected_points_vec));
   }
 }

--- a/tachyon/crypto/commitments/polynomial_openings_unittest.cc
+++ b/tachyon/crypto/commitments/polynomial_openings_unittest.cc
@@ -85,12 +85,12 @@ TEST_F(PolynomialOpeningsTest, CreateCombinedLowDegreeExtensions) {
   Point x = Point::Random();
   GF7 actual_eval = combined_low_degree_extension.Evaluate(x);
   GF7 expected_eval =
-      grouped_poly_opening.poly_openings_vec[0].poly->Evaluate(x) -
+      grouped_poly_opening.poly_openings_vec[0].poly_oracle->Evaluate(x) -
       low_degree_extensions[0].Evaluate(x);
   GF7 power = r;
   for (size_t i = 1; i < low_degree_extensions.size(); ++i) {
     expected_eval +=
-        (grouped_poly_opening.poly_openings_vec[i].poly->Evaluate(x) -
+        (grouped_poly_opening.poly_openings_vec[i].poly_oracle->Evaluate(x) -
          low_degree_extensions[i].Evaluate(x)) *
         power;
     power *= r;

--- a/tachyon/crypto/commitments/vector_commitment_scheme.h
+++ b/tachyon/crypto/commitments/vector_commitment_scheme.h
@@ -101,6 +101,14 @@ class VectorCommitmentScheme {
     const Derived* derived = static_cast<const Derived*>(this);
     return derived->DoVerifyOpeningProof(commitment, members, proof);
   }
+
+  // Verify multi-openings |proof|.
+  template <typename ContainerTy, typename Proof>
+  [[nodiscard]] bool VerifyOpeningProof(const ContainerTy& members,
+                                        Proof* proof) const {
+    const Derived* derived = static_cast<const Derived*>(this);
+    return derived->DoVerifyOpeningProof(members, proof);
+  }
 };
 
 }  // namespace tachyon::crypto

--- a/tachyon/zk/base/commitments/shplonk_extension.h
+++ b/tachyon/zk/base/commitments/shplonk_extension.h
@@ -57,10 +57,9 @@ class SHPlonkExtension
     return shplonk_.DoCommitLagrange(v, out);
   }
 
-  template <typename ContainerTy>
-  [[nodiscard]] bool DoCreateOpeningProof(
-      const ContainerTy& poly_openings,
-      crypto::SHPlonkProof<Commitment>* proof) const {
+  template <typename ContainerTy, typename Proof>
+  [[nodiscard]] bool DoCreateOpeningProof(const ContainerTy& poly_openings,
+                                          Proof* proof) const {
     return shplonk_.DoCreateOpeningProof(poly_openings, proof);
   }
 

--- a/tachyon/zk/base/commitments/shplonk_extension.h
+++ b/tachyon/zk/base/commitments/shplonk_extension.h
@@ -15,11 +15,11 @@
 namespace tachyon {
 namespace zk {
 
-template <typename G1PointTy, typename G2PointTy, size_t MaxDegree,
-          size_t MaxExtendedDegree, typename Commitment>
+template <typename CurveTy, size_t MaxDegree, size_t MaxExtendedDegree,
+          typename Commitment>
 class SHPlonkExtension
-    : public UnivariatePolynomialCommitmentSchemeExtension<SHPlonkExtension<
-          G1PointTy, G2PointTy, MaxDegree, MaxExtendedDegree, Commitment>> {
+    : public UnivariatePolynomialCommitmentSchemeExtension<
+          SHPlonkExtension<CurveTy, MaxDegree, MaxExtendedDegree, Commitment>> {
  public:
   // NOTE(dongchangYoo): The following value are pre-determined according to
   // the Commitment Opening Scheme.
@@ -27,11 +27,12 @@ class SHPlonkExtension
   // github.com/kroma-network/halo2/blob/7d0a36990452c8e7ebd600de258420781a9b7917/halo2_proofs/src/poly/kzg/multiopen/shplonk/prover.rs#L111
   constexpr static bool kQueryInstance = false;
 
+  using G1PointTy = typename CurveTy::G1Curve::AffinePointTy;
   using Field = typename G1PointTy::ScalarField;
 
   SHPlonkExtension() = default;
   explicit SHPlonkExtension(
-      crypto::SHPlonk<G1PointTy, G2PointTy, MaxDegree, Commitment>&& shplonk)
+      crypto::SHPlonk<CurveTy, MaxDegree, Commitment>&& shplonk)
       : shplonk_(std::move(shplonk)) {}
 
   size_t N() const { return shplonk_.N(); }
@@ -64,13 +65,13 @@ class SHPlonkExtension
   }
 
  private:
-  crypto::SHPlonk<G1PointTy, G2PointTy, MaxDegree, Commitment> shplonk_;
+  crypto::SHPlonk<CurveTy, MaxDegree, Commitment> shplonk_;
 };
 
-template <typename G1PointTy, typename G2PointTy, size_t MaxDegree,
-          size_t MaxExtendedDegree, typename Commitment>
-struct UnivariatePolynomialCommitmentSchemeExtensionTraits<SHPlonkExtension<
-    G1PointTy, G2PointTy, MaxDegree, MaxExtendedDegree, Commitment>> {
+template <typename CurveTy, size_t MaxDegree, size_t MaxExtendedDegree,
+          typename Commitment>
+struct UnivariatePolynomialCommitmentSchemeExtensionTraits<
+    SHPlonkExtension<CurveTy, MaxDegree, MaxExtendedDegree, Commitment>> {
  public:
   constexpr static size_t kMaxExtendedDegree = MaxExtendedDegree;
   constexpr static size_t kMaxExtendedSize = kMaxExtendedDegree + 1;
@@ -80,11 +81,12 @@ struct UnivariatePolynomialCommitmentSchemeExtensionTraits<SHPlonkExtension<
 
 namespace crypto {
 
-template <typename G1PointTy, typename G2PointTy, size_t MaxDegree,
-          size_t MaxExtendedDegree, typename _Commitment>
-struct VectorCommitmentSchemeTraits<zk::SHPlonkExtension<
-    G1PointTy, G2PointTy, MaxDegree, MaxExtendedDegree, _Commitment>> {
+template <typename CurveTy, size_t MaxDegree, size_t MaxExtendedDegree,
+          typename _Commitment>
+struct VectorCommitmentSchemeTraits<
+    zk::SHPlonkExtension<CurveTy, MaxDegree, MaxExtendedDegree, _Commitment>> {
  public:
+  using G1PointTy = typename CurveTy::G1Curve::AffinePointTy;
   using Field = typename G1PointTy::ScalarField;
   using Commitment = _Commitment;
 

--- a/tachyon/zk/plonk/halo2/BUILD.bazel
+++ b/tachyon/zk/plonk/halo2/BUILD.bazel
@@ -121,8 +121,7 @@ tachyon_cc_library(
     hdrs = ["prover_test.h"],
     deps = [
         ":prover",
-        "//tachyon/math/elliptic_curves/bn/bn254:g1",
-        "//tachyon/math/elliptic_curves/bn/bn254:g2",
+        "//tachyon/math/elliptic_curves/bn/bn254",
         "//tachyon/math/polynomials/univariate:univariate_evaluation_domain_factory",
         "//tachyon/zk/base:blinder",
         "//tachyon/zk/base/commitments:shplonk_extension",

--- a/tachyon/zk/plonk/halo2/prover_test.h
+++ b/tachyon/zk/plonk/halo2/prover_test.h
@@ -6,8 +6,7 @@
 
 #include "gtest/gtest.h"
 
-#include "tachyon/math/elliptic_curves/bn/bn254/g1.h"
-#include "tachyon/math/elliptic_curves/bn/bn254/g2.h"
+#include "tachyon/math/elliptic_curves/bn/bn254/bn254.h"
 #include "tachyon/math/polynomials/univariate/univariate_evaluation_domain_factory.h"
 #include "tachyon/zk/base/commitments/shplonk_extension.h"
 #include "tachyon/zk/plonk/halo2/blake2b_transcript.h"
@@ -22,8 +21,7 @@ class ProverTest : public testing::Test {
   constexpr static size_t kMaxExtendedDegree = (size_t{1} << 7) - 1;
   constexpr static size_t kMaxExtendedDomainSize = kMaxExtendedDegree + 1;
 
-  using PCS = SHPlonkExtension<math::bn254::G1AffinePoint,
-                               math::bn254::G2AffinePoint, kMaxDegree,
+  using PCS = SHPlonkExtension<math::bn254::BN254Curve, kMaxDegree,
                                kMaxExtendedDegree, math::bn254::G1AffinePoint>;
   using F = PCS::Field;
   using Commitment = PCS::Commitment;


### PR DESCRIPTION
# Description

Implemented SHPlonk multi-opening proof verifying logic.
See https://eprint.iacr.org/2020/081.pdf

### Refactoring
- Since the `transcripts` have been moved from zk to crypto namespace, 
   it doesn't need to return the value of proofs.
   It can write proofs directly into a transcript.

- Generalized `Poly` to `PolyOracle` for common use in `CreateOpeningProof()` and `VeriryOpeningProof()`.
  `CreateOpeningProof()` uses the `Poly` type, and `VerifyOpeningProof()` uses the `Commitment` type for `PolyOracle`.

- Changed SHPlonk template parameters from Point type to Curve type to use Pairing.

### Fix
- Replaced `absl::flat_hash_map` to `std::vector` since the order of `poly_openings` affects linear combinations.


