### PR TITLE
feat(math): add batch functions to points

### DIFF
--- a/tachyon/math/elliptic_curves/short_weierstrass/BUILD.bazel
+++ b/tachyon/math/elliptic_curves/short_weierstrass/BUILD.bazel
@@ -21,6 +21,7 @@ tachyon_cc_library(
         "projective_point_impl.h",
     ],
     deps = [
+        "//tachyon/base/containers:container_util",
         "//tachyon/math/base:groups",
         "//tachyon/math/elliptic_curves:points",
         "//tachyon/math/geometry:point2",

--- a/tachyon/math/elliptic_curves/short_weierstrass/affine_point_unittest.cc
+++ b/tachyon/math/elliptic_curves/short_weierstrass/affine_point_unittest.cc
@@ -112,6 +112,27 @@ TEST_F(AffinePointTest, ToPointXYZZ) {
   EXPECT_EQ(p.ToXYZZ(), test::PointXYZZ(GF7(3), GF7(2), GF7(1), GF7(1)));
 }
 
+TEST_F(AffinePointTest, BatchMapScalarFieldToPoint) {
+  std::vector<GF7> scalar_fields =
+      base::CreateVector(7, [](int i) { return GF7(i); });
+  test::AffinePoint point = test::AffinePoint::Generator();
+
+  std::vector<test::AffinePoint> affine_points;
+  affine_points.resize(6);
+  ASSERT_FALSE(test::AffinePoint::BatchMapScalarFieldToPoint(
+      point, scalar_fields, &affine_points));
+
+  affine_points.resize(7);
+  ASSERT_TRUE(test::AffinePoint::BatchMapScalarFieldToPoint(
+      point, scalar_fields, &affine_points));
+
+  std::vector<test::AffinePoint> expected_affine_points =
+      base::Map(scalar_fields, [&point](const GF7& scalar_field) {
+        return (scalar_field * point).ToAffine();
+      });
+  EXPECT_EQ(affine_points, expected_affine_points);
+}
+
 TEST_F(AffinePointTest, IsOnCurve) {
   test::AffinePoint invalid_point(GF7(1), GF7(2));
   EXPECT_FALSE(invalid_point.IsOnCurve());

--- a/tachyon/math/elliptic_curves/short_weierstrass/jacobian_point.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/jacobian_point.h
@@ -5,9 +5,11 @@
 #include <string>
 #include <type_traits>
 #include <utility>
+#include <vector>
 
 #include "absl/strings/substitute.h"
 
+#include "tachyon/base/containers/container_util.h"
 #include "tachyon/base/logging.h"
 #include "tachyon/math/base/groups.h"
 #include "tachyon/math/elliptic_curves/affine_point.h"
@@ -104,6 +106,36 @@ class JacobianPoint<
                          point.y_, point.z_);
   }
 
+  // TODO(chokobole): Implement parallel versioned |BatchNormalize| when doing
+  // chunking and zipping gets easier.
+  template <typename JacobianContainer, typename AffineContainer>
+  [[nodiscard]] constexpr static bool BatchNormalize(
+      const JacobianContainer& jacobian_points,
+      AffineContainer* affine_points) {
+    size_t size = std::size(jacobian_points);
+    if (size != std::size(*affine_points)) {
+      LOG(ERROR)
+          << "Size of |jacobian_points| and |affine_points| do not match";
+      return false;
+    }
+    std::vector<BaseField> z_inverses = base::Map(
+        jacobian_points, [](const JacobianPoint& point) { return point.z_; });
+    if (!BaseField::BatchInverseInPlaceSerial(z_inverses)) return false;
+    for (size_t i = 0; i < size; ++i) {
+      const BaseField& z_inv = z_inverses[i];
+      if (z_inv.IsZero()) {
+        (*affine_points)[i] = AffinePoint<Curve>::Zero();
+      } else if (z_inv.IsOne()) {
+        (*affine_points)[i] = {jacobian_points[i].x_, jacobian_points[i].y_};
+      } else {
+        BaseField z_inv_square = z_inv.Square();
+        (*affine_points)[i] = {jacobian_points[i].x_ * z_inv_square,
+                               jacobian_points[i].y_ * z_inv_square * z_inv};
+      }
+    }
+    return true;
+  }
+
   constexpr const BaseField& x() const { return x_; }
   constexpr const BaseField& y() const { return y_; }
   constexpr const BaseField& z() const { return z_; }
@@ -147,7 +179,7 @@ class JacobianPoint<
       return {x_, y_};
     } else {
       BaseField z_inv = z_.Inverse();
-      BaseField z_inv_square = z_inv * z_inv;
+      BaseField z_inv_square = z_inv.Square();
       return {x_ * z_inv_square, y_ * z_inv_square * z_inv};
     }
   }

--- a/tachyon/math/elliptic_curves/short_weierstrass/jacobian_point_unittest.cc
+++ b/tachyon/math/elliptic_curves/short_weierstrass/jacobian_point_unittest.cc
@@ -164,6 +164,27 @@ TEST_F(JacobianPointTest, ToXYZZ) {
             test::PointXYZZ(GF7(1), GF7(2), GF7(2), GF7(6)));
 }
 
+TEST_F(JacobianPointTest, BatchNormalize) {
+  std::vector<test::JacobianPoint> jacobian_points = {
+      test::JacobianPoint(GF7(1), GF7(2), GF7(0)),
+      test::JacobianPoint(GF7(1), GF7(2), GF7(1)),
+      test::JacobianPoint(GF7(1), GF7(2), GF7(3))};
+
+  std::vector<test::AffinePoint> affine_points;
+  affine_points.resize(2);
+  ASSERT_FALSE(
+      test::JacobianPoint::BatchNormalize(jacobian_points, &affine_points));
+
+  affine_points.resize(3);
+  ASSERT_TRUE(
+      test::JacobianPoint::BatchNormalize(jacobian_points, &affine_points));
+
+  std::vector<test::AffinePoint> expected_affine_points = {
+      test::AffinePoint::Zero(), test::AffinePoint(GF7(1), GF7(2)),
+      test::AffinePoint(GF7(4), GF7(5))};
+  EXPECT_EQ(affine_points, expected_affine_points);
+}
+
 TEST_F(JacobianPointTest, IsOnCurve) {
   test::JacobianPoint invalid_point(GF7(1), GF7(2), GF7(1));
   EXPECT_FALSE(invalid_point.IsOnCurve());

--- a/tachyon/math/elliptic_curves/short_weierstrass/point_xyzz_unittest.cc
+++ b/tachyon/math/elliptic_curves/short_weierstrass/point_xyzz_unittest.cc
@@ -169,6 +169,25 @@ TEST_F(PointXYZZTest, ToJacobian) {
             test::JacobianPoint(GF7(2), GF7(2), GF7(5)));
 }
 
+TEST_F(PointXYZZTest, BatchNormalize) {
+  std::vector<test::PointXYZZ> point_xyzzs = {
+      test::PointXYZZ(GF7(1), GF7(2), GF7(0), GF7(0)),
+      test::PointXYZZ(GF7(1), GF7(2), GF7(1), GF7(1)),
+      test::PointXYZZ(GF7(1), GF7(2), GF7(2), GF7(6))};
+
+  std::vector<test::AffinePoint> affine_points;
+  affine_points.resize(2);
+  ASSERT_FALSE(test::PointXYZZ::BatchNormalize(point_xyzzs, &affine_points));
+
+  affine_points.resize(3);
+  ASSERT_TRUE(test::PointXYZZ::BatchNormalize(point_xyzzs, &affine_points));
+
+  std::vector<test::AffinePoint> expected_affine_points = {
+      test::AffinePoint::Zero(), test::AffinePoint(GF7(1), GF7(2)),
+      test::AffinePoint(GF7(4), GF7(5))};
+  EXPECT_EQ(affine_points, expected_affine_points);
+}
+
 TEST_F(PointXYZZTest, IsOnCurve) {
   test::PointXYZZ invalid_point(GF7(1), GF7(2), GF7(1), GF7(1));
   EXPECT_FALSE(invalid_point.IsOnCurve());

--- a/tachyon/math/elliptic_curves/short_weierstrass/projective_point_unittest.cc
+++ b/tachyon/math/elliptic_curves/short_weierstrass/projective_point_unittest.cc
@@ -167,6 +167,27 @@ TEST_F(ProjectivePointTest, ToXYZZ) {
             test::PointXYZZ(GF7(3), GF7(4), GF7(2), GF7(6)));
 }
 
+TEST_F(ProjectivePointTest, BatchNormalize) {
+  std::vector<test::ProjectivePoint> projective_points = {
+      test::ProjectivePoint(GF7(1), GF7(2), GF7(0)),
+      test::ProjectivePoint(GF7(1), GF7(2), GF7(1)),
+      test::ProjectivePoint(GF7(1), GF7(2), GF7(3))};
+
+  std::vector<test::AffinePoint> affine_points;
+  affine_points.resize(2);
+  ASSERT_FALSE(
+      test::ProjectivePoint::BatchNormalize(projective_points, &affine_points));
+
+  affine_points.resize(3);
+  ASSERT_TRUE(
+      test::ProjectivePoint::BatchNormalize(projective_points, &affine_points));
+
+  std::vector<test::AffinePoint> expected_affine_points = {
+      test::AffinePoint::Zero(), test::AffinePoint(GF7(1), GF7(2)),
+      test::AffinePoint(GF7(5), GF7(3))};
+  EXPECT_EQ(affine_points, expected_affine_points);
+}
+
 TEST_F(ProjectivePointTest, IsOnCurve) {
   test::ProjectivePoint invalid_point(GF7(1), GF7(2), GF7(1));
   EXPECT_FALSE(invalid_point.IsOnCurve());


### PR DESCRIPTION
# Description

This PR adds `BatchNormalize()` and `BatchMapScalarFieldToPoint`, which is needed by groth16 setup that is going to be implemented.
