### PR TITLE
refac: implement linear combination

### DIFF
--- a/tachyon/crypto/commitments/polynomial_openings.h
+++ b/tachyon/crypto/commitments/polynomial_openings.h
@@ -118,7 +118,8 @@ struct GroupedPolynomialOpenings {
 
     // Combine numerator polynomials with powers of |r|.
     // N(X) = (P₀(X) - R₀(X)) + r(P₁(X) - R₁(X)) + r²(P₂(X) - R₂(X))
-    Poly& n = Poly::LinearizeInPlace(numerators, r);
+    Poly& n = Poly::template LinearCombinationInPlace</*forward=*/false>(
+        numerators, r);
 
     // Divide combined polynomial by vanishing polynomial of evaluation points.
     // H(X) = N(X) / (X - x₀)(X - x₁)(X - x₂)

--- a/tachyon/math/base/BUILD.bazel
+++ b/tachyon/math/base/BUILD.bazel
@@ -100,6 +100,7 @@ tachyon_cc_library(
         ":big_int",
         ":bit_iterator",
         "//tachyon/base:bits",
+        "//tachyon/base:logging",
         "//tachyon/base:parallelize",
         "//tachyon/base/containers:adapters",
         "//tachyon/base/containers:container_util",

--- a/tachyon/math/base/BUILD.bazel
+++ b/tachyon/math/base/BUILD.bazel
@@ -63,7 +63,7 @@ tachyon_cc_library(
 tachyon_cc_library(
     name = "field",
     hdrs = ["field.h"],
-    deps = [":rings"],
+    deps = [":ring"],
 )
 
 tachyon_cc_library(
@@ -85,8 +85,8 @@ tachyon_cc_library(
 )
 
 tachyon_cc_library(
-    name = "rings",
-    hdrs = ["rings.h"],
+    name = "ring",
+    hdrs = ["ring.h"],
     deps = [
         ":groups",
         "//tachyon/base:parallelize",

--- a/tachyon/math/base/field.h
+++ b/tachyon/math/base/field.h
@@ -3,7 +3,7 @@
 
 #include <utility>
 
-#include "tachyon/math/base/rings.h"
+#include "tachyon/math/base/ring.h"
 
 namespace tachyon::math {
 

--- a/tachyon/math/base/ring.h
+++ b/tachyon/math/base/ring.h
@@ -52,6 +52,7 @@ class Ring : public AdditiveGroup<R>, public MultiplicativeSemigroup<R> {
                            });
   }
 
+  // Sum of products: a₁ * b₁ + a₂ * b₂ + ... + aₙ * bₙ
   template <typename ContainerA, typename ContainerB>
   constexpr static R SumOfProductsSerial(const ContainerA& a,
                                          const ContainerB& b) {

--- a/tachyon/math/base/ring.h
+++ b/tachyon/math/base/ring.h
@@ -20,8 +20,8 @@ namespace tachyon::math {
 
 // The Ring supports SumOfProducts, inheriting the properties of both
 // AdditiveGroup and MultiplicativeSemigroup.
-template <typename F>
-class Ring : public AdditiveGroup<F>, public MultiplicativeSemigroup<F> {
+template <typename R>
+class Ring : public AdditiveGroup<R>, public MultiplicativeSemigroup<R> {
  public:
   // This is taken and modified from
   // https://github.com/arkworks-rs/algebra/blob/5dfeedf560da6937a5de0a2163b7958bd32cd551/ff/src/fields/mod.rs#L298C1-L305
@@ -31,14 +31,14 @@ class Ring : public AdditiveGroup<F>, public MultiplicativeSemigroup<F> {
   // unittests. I think we need a some general threshold to check whether it is
   // good to doing parallelization.
   template <typename ContainerA, typename ContainerB>
-  constexpr static F SumOfProducts(const ContainerA& a, const ContainerB& b) {
+  constexpr static R SumOfProducts(const ContainerA& a, const ContainerB& b) {
     size_t size = std::size(a);
     CHECK_EQ(size, std::size(b));
     CHECK_NE(size, size_t{0});
-    std::vector<F> partial_sum_of_products = base::ParallelizeMap(
+    std::vector<R> partial_sum_of_products = base::ParallelizeMap(
         a,
-        [&b](absl::Span<const F> chunk, size_t chunk_idx, size_t chunk_size) {
-          F sum = F::Zero();
+        [&b](absl::Span<const R> chunk, size_t chunk_idx, size_t chunk_size) {
+          R sum = R::Zero();
           size_t i = chunk_idx * chunk_size;
           for (size_t j = 0; j < chunk.size(); ++j) {
             sum += (chunk[j] * b[i + j]);
@@ -46,14 +46,14 @@ class Ring : public AdditiveGroup<F>, public MultiplicativeSemigroup<F> {
           return sum;
         });
     return std::accumulate(partial_sum_of_products.begin(),
-                           partial_sum_of_products.end(), F::Zero(),
-                           [](F& acc, const F& partial_sum_of_product) {
+                           partial_sum_of_products.end(), R::Zero(),
+                           [](R& acc, const R& partial_sum_of_product) {
                              return acc += partial_sum_of_product;
                            });
   }
 
   template <typename ContainerA, typename ContainerB>
-  constexpr static F SumOfProductsSerial(const ContainerA& a,
+  constexpr static R SumOfProductsSerial(const ContainerA& a,
                                          const ContainerB& b) {
     size_t size = std::size(a);
     CHECK_EQ(size, std::size(b));
@@ -63,10 +63,10 @@ class Ring : public AdditiveGroup<F>, public MultiplicativeSemigroup<F> {
 
  private:
   template <typename ContainerA, typename ContainerB>
-  constexpr static F DoSumOfProductsSerial(const ContainerA& a,
+  constexpr static R DoSumOfProductsSerial(const ContainerA& a,
                                            const ContainerB& b) {
     size_t n = std::size(a);
-    F sum = F::Zero();
+    R sum = R::Zero();
     for (size_t i = 0; i < n; ++i) {
       sum += (a[i] * b[i]);
     }

--- a/tachyon/math/base/ring.h
+++ b/tachyon/math/base/ring.h
@@ -1,5 +1,5 @@
-#ifndef TACHYON_MATH_BASE_RINGS_H_
-#define TACHYON_MATH_BASE_RINGS_H_
+#ifndef TACHYON_MATH_BASE_RING_H_
+#define TACHYON_MATH_BASE_RING_H_
 
 #include <type_traits>
 #include <vector>

--- a/tachyon/math/polynomials/BUILD.bazel
+++ b/tachyon/math/polynomials/BUILD.bazel
@@ -15,7 +15,7 @@ tachyon_cc_library(
     ],
     deps = [
         ":polynomial_traits",
-        "//tachyon/math/base:rings",
+        "//tachyon/math/base:ring",
     ],
 )
 

--- a/tachyon/math/polynomials/polynomial.h
+++ b/tachyon/math/polynomials/polynomial.h
@@ -3,7 +3,7 @@
 
 #include <type_traits>
 
-#include "tachyon/math/base/rings.h"
+#include "tachyon/math/base/ring.h"
 #include "tachyon/math/polynomials/polynomial_traits.h"
 
 namespace tachyon::math {

--- a/tachyon/math/polynomials/polynomial_traits.h
+++ b/tachyon/math/polynomials/polynomial_traits.h
@@ -3,7 +3,7 @@
 
 #include <type_traits>
 
-#include "tachyon/math/base/rings.h"
+#include "tachyon/math/base/ring.h"
 
 namespace tachyon::math {
 

--- a/tachyon/math/polynomials/univariate/univariate_dense_coefficients.h
+++ b/tachyon/math/polynomials/univariate/univariate_dense_coefficients.h
@@ -254,9 +254,9 @@ class UnivariateDenseCoefficients {
   constexpr static F HornerEvaluate(absl::Span<const F> coefficients,
                                     const Point& point) {
     return std::accumulate(coefficients.rbegin(), coefficients.rend(),
-                           F::Zero(),
-                           [&point](const F& result, const F& coeff) {
-                             return result * point + coeff;
+                           F::Zero(), [&point](F& result, const F& coeff) {
+                             result *= point;
+                             return result += coeff;
                            });
   }
 

--- a/tachyon/math/polynomials/univariate/univariate_dense_polynomial_unittest.cc
+++ b/tachyon/math/polynomials/univariate/univariate_dense_polynomial_unittest.cc
@@ -62,29 +62,6 @@ TEST_F(UnivariateDensePolynomialTest, Random) {
   EXPECT_TRUE(success);
 }
 
-TEST_F(UnivariateDensePolynomialTest, Linearize) {
-  std::vector<Poly> polys = {
-      Poly::Random(kMaxDegree),
-      Poly::Random(kMaxDegree),
-      Poly::Random(kMaxDegree),
-  };
-  GF7 y = GF7::Random();
-  Poly linearized = Poly::Linearize(polys, y);
-
-  GF7 x = GF7::Random();
-  GF7 expected = polys[0].Evaluate(x);
-  GF7 power = y;
-  for (size_t i = 1; i < polys.size(); ++i) {
-    expected += polys[i].Evaluate(x) * power;
-    power *= y;
-  }
-
-  EXPECT_EQ(expected, linearized.Evaluate(x));
-
-  Poly linearized2 = Poly::LinearizeInPlace(polys, y);
-  EXPECT_EQ(linearized, linearized2);
-}
-
 TEST_F(UnivariateDensePolynomialTest, IndexingOperator) {
   struct {
     const Poly& poly;

--- a/tachyon/math/polynomials/univariate/univariate_polynomial.h
+++ b/tachyon/math/polynomials/univariate/univariate_polynomial.h
@@ -83,51 +83,6 @@ class UnivariatePolynomial final
     }
   }
 
-  // NOTE(chokobole): For a performance reason, I would recommend the
-  // |LinearizeInPlace()| if possible.
-  template <typename ContainerTy>
-  constexpr static UnivariatePolynomial Linearize(const ContainerTy& polys,
-                                                  const Field& r) {
-    CHECK(!polys.empty());
-    UnivariatePolynomial ret = polys[polys.size() - 1];
-    if (polys.size() > 1) {
-      for (size_t i = polys.size() - 2; i != SIZE_MAX; --i) {
-        ret *= r;
-        ret += polys[i];
-      }
-    }
-    return ret;
-  }
-
-  // NOTE(chokobole): This gives more performant result than |Linearize()|.
-  //
-  // clang-format off
-  //
-  // In normal case, you can linearize polynomials as follows:
-  //
-  //   const std::vector<UnivariatePolynomial> polys = {...};
-  //   UnivariatePolynomial ret = UnivariatePolynomial::Linearize(polys, Field::Random());
-  //
-  // If you can do like below, you can save additional allocation cost.
-  //
-  //   // Note that |polys| are going to be changed.
-  //   std::vector<UnivariatePolynomial> polys = {...};
-  //   UnivariatePolynomial& ret = UnivariatePolynomial::LinearizeInPlace(polys, Field::Random());
-  //
-  // clang-format off
-  template <typename ContainerTy>
-  constexpr static UnivariatePolynomial& LinearizeInPlace(ContainerTy& polys, const Field& r) {
-    CHECK(!polys.empty());
-    UnivariatePolynomial& ret = polys[polys.size() - 1];
-    if (polys.size() > 1) {
-      for (size_t i = polys.size() - 2; i != SIZE_MAX; --i) {
-        ret *= r;
-        ret += polys[i];
-      }
-    }
-    return ret;
-  }
-
   constexpr bool IsZero() const { return coefficients_.IsZero(); }
 
   constexpr bool IsOne() const { return coefficients_.IsOne(); }
@@ -176,7 +131,8 @@ class UnivariatePolynomial final
   // and summing them together.
   template <bool MulRandomWithEvens>
   constexpr UnivariatePolynomial Fold(const Field& r) const {
-    return UnivariatePolynomial(coefficients_.template Fold<MulRandomWithEvens>(r));
+    return UnivariatePolynomial(
+        coefficients_.template Fold<MulRandomWithEvens>(r));
   }
 
   auto ToSparse() const {

--- a/tachyon/math/polynomials/univariate/univariate_sparse_polynomial_unittest.cc
+++ b/tachyon/math/polynomials/univariate/univariate_sparse_polynomial_unittest.cc
@@ -68,29 +68,6 @@ TEST_F(UnivariateSparsePolynomialTest, Random) {
   EXPECT_TRUE(success);
 }
 
-TEST_F(UnivariateSparsePolynomialTest, Linearize) {
-  std::vector<Poly> polys = {
-      Poly::Random(kMaxDegree),
-      Poly::Random(kMaxDegree),
-      Poly::Random(kMaxDegree),
-  };
-  GF7 y = GF7::Random();
-  Poly linearized = Poly::Linearize(polys, y);
-
-  GF7 x = GF7::Random();
-  GF7 expected = polys[0].Evaluate(x);
-  GF7 power = y;
-  for (size_t i = 1; i < polys.size(); ++i) {
-    expected += polys[i].Evaluate(x) * power;
-    power *= y;
-  }
-
-  EXPECT_EQ(expected, linearized.Evaluate(x));
-
-  Poly linearized2 = Poly::LinearizeInPlace(polys, y);
-  EXPECT_EQ(linearized, linearized2);
-}
-
 TEST_F(UnivariateSparsePolynomialTest, IndexingOperator) {
   struct {
     const Poly& poly;

--- a/tachyon/zk/plonk/halo2/verifier.h
+++ b/tachyon/zk/plonk/halo2/verifier.h
@@ -308,13 +308,8 @@ class Verifier : public VerifierBase<PCSTy> {
                            std::make_move_iterator(lookup_expressions.end()));
       }
     }
-    const F& y = proof.y;
     F expected_h_eval =
-        std::accumulate(expressions.begin(), expressions.end(), F::Zero(),
-                        [&y](F& h_eval, const F& expression) {
-                          h_eval *= y;
-                          return h_eval += expression;
-                        });
+        F::template LinearCombination</*forward=*/true>(expressions, proof.y);
     return expected_h_eval /= (proof.x.Pow(this->pcs_.N()) - F::One());
   }
 };

--- a/tachyon/zk/plonk/vanishing/prover_vanishing_argument.h
+++ b/tachyon/zk/plonk/vanishing/prover_vanishing_argument.h
@@ -113,7 +113,8 @@ template <typename PCSTy, typename F, typename Commitment>
   using Poly = typename PCSTy::Poly;
   using Coeffs = typename Poly::Coefficients;
 
-  Poly h_poly = Poly::Linearize(constructed.h_pieces(), x_n);
+  Poly h_poly = Poly::template LinearCombination</*forward=*/false>(
+      constructed.h_pieces(), x_n);
 
   F h_blind = Poly(Coeffs(constructed.h_blinds())).Evaluate(x_n);
 


### PR DESCRIPTION
# Description

This replaces `Polynomial`'s `Linearize(InPlace)()` methods and manual linear combinations.
    
This method covers all 3 cases.
    
- AdditiveSemigroup's scalar multiplication e.g, affine point
- Ring's multiplication and addition e.g, polynomial
- Field's multiplication and addition e.g, prime field
