### PR TITLE
refac: convert `G2AffinePoint` to `G2Prepared` inside `Pairing()`

### DIFF
--- a/tachyon/crypto/commitments/kzg/shplonk.h
+++ b/tachyon/crypto/commitments/kzg/shplonk.h
@@ -40,7 +40,6 @@ class SHPlonk final : public UnivariatePolynomialCommitmentScheme<
       SHPlonk<Curve, MaxDegree, Commitment>>;
   using G1Point = typename Curve::G1Curve::AffinePoint;
   using G2Point = typename Curve::G2Curve::AffinePoint;
-  using G2Prepared = typename Curve::G2Prepared;
   using Fp12 = typename Curve::Fp12;
   using Field = typename Base::Field;
   using Poly = typename Base::Poly;
@@ -320,13 +319,13 @@ class SHPlonk final : public UnivariatePolynomialCommitmentScheme<
     lhs += (u * q);
 
     G1Point lhs_g1[] = {lhs.ToAffine()};
-    G2Prepared lhs_g2[] = {G2Prepared::From(G2Point::Generator())};
+    G2Point lhs_g2[] = {G2Point::Generator()};
     Fp12 lhs_pairing = math::Pairing<Curve>(lhs_g1, lhs_g2);
 
     // rhs_g1 = [Q(𝜏)]₁
     // rhs_g2 = [𝜏]₂
     G1Point rhs_g1[] = {std::move(q)};
-    G2Prepared rhs_g2[] = {G2Prepared::From(tau_g2_)};
+    G2Point rhs_g2[] = {tau_g2_};
     Fp12 rhs_pairing = math::Pairing<Curve>(rhs_g1, rhs_g2);
 
     // clang-format off

--- a/tachyon/math/elliptic_curves/pairing/BUILD.bazel
+++ b/tachyon/math/elliptic_curves/pairing/BUILD.bazel
@@ -26,6 +26,7 @@ tachyon_cc_library(
 tachyon_cc_library(
     name = "pairing",
     hdrs = ["pairing.h"],
+    deps = ["//tachyon/base/containers:container_util"],
 )
 
 tachyon_cc_library(

--- a/tachyon/math/elliptic_curves/pairing/pairing.h
+++ b/tachyon/math/elliptic_curves/pairing/pairing.h
@@ -1,12 +1,19 @@
 #ifndef TACHYON_MATH_ELLIPTIC_CURVES_PAIRING_PAIRING_H_
 #define TACHYON_MATH_ELLIPTIC_CURVES_PAIRING_PAIRING_H_
 
+#include "tachyon/base/containers/container_util.h"
+
 namespace tachyon::math {
 
 template <typename Curve, typename G1AffinePointContainer,
-          typename G2PreparedContainer>
-auto Pairing(const G1AffinePointContainer& a, const G2PreparedContainer& b) {
-  return Curve::FinalExponentiation(Curve::MultiMillerLoop(a, b));
+          typename G2AffinePointContainer>
+auto Pairing(const G1AffinePointContainer& a, const G2AffinePointContainer& b) {
+  using G2Prepared = typename Curve::G2Prepared;
+  using G2AffinePoint = typename Curve::G2Curve::AffinePoint;
+  return Curve::FinalExponentiation(
+      Curve::MultiMillerLoop(a, base::Map(b, [](const G2AffinePoint& point) {
+                               return G2Prepared::From(point);
+                             })));
 }
 
 }  // namespace tachyon::math

--- a/tachyon/math/elliptic_curves/pairing/pairing_unittest.cc
+++ b/tachyon/math/elliptic_curves/pairing/pairing_unittest.cc
@@ -29,7 +29,6 @@ TYPED_TEST(PairingTest, Bilinearity) {
   using G1AffinePoint = typename G1Curve::AffinePoint;
   using G2Curve = typename Curve::G2Curve;
   using G2AffinePoint = typename G2Curve::AffinePoint;
-  using G2Prepared = typename Curve::G2Prepared;
   using ScalarField = typename G1Curve::ScalarField;
   using Fp12 = typename Curve::Fp12;
 
@@ -41,14 +40,14 @@ TYPED_TEST(PairingTest, Bilinearity) {
   Fp12 result;
   {
     G1AffinePoint g1s[] = {(a * b * g1).ToAffine()};
-    G2Prepared g2s[] = {G2Prepared::From(g2)};
+    G2AffinePoint g2s[] = {g2};
     result = Pairing<Curve>(g1s, g2s);
   }
 
   Fp12 result2;
   {
     G1AffinePoint g1s[] = {(a * g1).ToAffine()};
-    G2Prepared g2s[] = {G2Prepared::From((b * g2).ToAffine())};
+    G2AffinePoint g2s[] = {(b * g2).ToAffine()};
     result2 = Pairing<Curve>(g1s, g2s);
   }
 
@@ -57,7 +56,7 @@ TYPED_TEST(PairingTest, Bilinearity) {
   Fp12 result3;
   {
     G1AffinePoint g1s[] = {(b * g1).ToAffine()};
-    G2Prepared g2s[] = {G2Prepared::From((a * g2).ToAffine())};
+    G2AffinePoint g2s[] = {(a * g2).ToAffine()};
     result3 = Pairing<Curve>(g1s, g2s);
   }
 
@@ -66,7 +65,7 @@ TYPED_TEST(PairingTest, Bilinearity) {
   Fp12 result4;
   {
     G1AffinePoint g1s[] = {g1};
-    G2Prepared g2s[] = {G2Prepared::From((a * b * g2).ToAffine())};
+    G2AffinePoint g2s[] = {(a * b * g2).ToAffine()};
     result4 = Pairing<Curve>(g1s, g2s);
   }
 


### PR DESCRIPTION
# Description

Previously, users should convert `G2AffinePoint` to `G2Prepared` on their own. Now what users have to do is to pass `G2AffinePoint`.
