### PR TITLE
build(zk): add `TACYON_EXPORT` to `PermutationArgument`

### DIFF
--- a/tachyon/zk/plonk/permutation/BUILD.bazel
+++ b/tachyon/zk/plonk/permutation/BUILD.bazel
@@ -33,6 +33,7 @@ tachyon_cc_library(
     name = "permutation_argument",
     hdrs = ["permutation_argument.h"],
     deps = [
+        "//tachyon:export",
         "//tachyon/base/containers:contains",
         "//tachyon/zk/plonk/circuit:column_key",
     ],

--- a/tachyon/zk/plonk/permutation/permutation_argument.h
+++ b/tachyon/zk/plonk/permutation/permutation_argument.h
@@ -11,12 +11,13 @@
 #include <vector>
 
 #include "tachyon/base/containers/contains.h"
+#include "tachyon/export.h"
 #include "tachyon/zk/plonk/circuit/column_key.h"
 
 namespace tachyon::zk {
 
 // TODO(dongchangYoo): impl logics related to prove and verify.
-class PermutationArgument {
+class TACHYON_EXPORT PermutationArgument {
  public:
   PermutationArgument() = default;
   explicit PermutationArgument(const std::vector<AnyColumnKey>& columns)


### PR DESCRIPTION
# Description

This PR adds missing `TACHYON_EXPORT` macro.
