### PR TITLE
perf(zk): remove redundant assignment

### DIFF
--- a/tachyon/zk/plonk/halo2/verifier.h
+++ b/tachyon/zk/plonk/halo2/verifier.h
@@ -286,7 +286,7 @@ class Verifier : public VerifierBase<PCS> {
     const std::vector<LookupArgument<F>>& lookups = constraint_system.lookups();
     size_t polys_size = std::accumulate(gates.begin(), gates.end(), 0,
                                         [](size_t acc, const Gate<F>& gate) {
-                                          return acc += gate.polys().size();
+                                          return acc + gate.polys().size();
                                         });
     size_t expressions_size =
         num_circuits *


### PR DESCRIPTION
# Description

Since `acc` is contained in a register, addition can be done through 1 instruction. If you do `+=`, it returns a pointer, so on return inside lambda of `std::accumulate`, when assigning to `acc`, more instructions are needed such as loading address and copying values of pointer.