### PR TITLE
feat(zk): create halo2 proving key by deser

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "dd5a4e27a687085ef3f20a8bbbdbb76e1a424d193282263c4b95b42bd574c600",
+  "checksum": "ba3a401aa4da7f571c84122a60dc89d1f42be12df9d18eff822dae1683b0a824",
   "crates": {
     "ahash 0.8.3": {
       "name": "ahash",
@@ -3013,7 +3013,7 @@
         "Git": {
           "remote": "https://github.com/kroma-network/halo2.git",
           "commitish": {
-            "Rev": "6bf4e0a"
+            "Rev": "746e4ac"
           },
           "strip_prefix": "halo2_proofs"
         }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,7 +580,7 @@ dependencies = [
 [[package]]
 name = "halo2_proofs"
 version = "0.2.0"
-source = "git+https://github.com/kroma-network/halo2.git?rev=6bf4e0a#6bf4e0a51ccf907c6ff5d728a375d9922b065635"
+source = "git+https://github.com/kroma-network/halo2.git?rev=746e4ac#746e4ac62ea39e8fec9f711a6b5a359dfa596818"
 dependencies = [
  "ark-std 0.3.0",
  "blake2b_simd",

--- a/benchmark/msm/halo2/Cargo.toml
+++ b/benchmark/msm/halo2/Cargo.toml
@@ -18,5 +18,5 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-halo2_proofs = { git = "https://github.com/kroma-network/halo2.git", rev = "6bf4e0a" }
+halo2_proofs = { git = "https://github.com/kroma-network/halo2.git", rev = "746e4ac" }
 tachyon_rs = { path = "../../../tachyon/rs" }

--- a/tachyon/base/buffer/buffer.h
+++ b/tachyon/base/buffer/buffer.h
@@ -84,7 +84,7 @@ class TACHYON_EXPORT Buffer {
       typename Ptr, typename T = std::remove_pointer_t<Ptr>,
       std::enable_if_t<std::is_pointer_v<Ptr> &&
                        internal::IsBuiltinSerializable<T>::value>* = nullptr>
-  bool ReadAt(size_t buffer_offset, Ptr ptr) const {
+  [[nodiscard]] bool ReadAt(size_t buffer_offset, Ptr ptr) const {
     switch (endian_) {
       case Endian::kBig:
         if constexpr (sizeof(T) == 8) {
@@ -248,12 +248,12 @@ class TACHYON_EXPORT Buffer {
   [[nodiscard]] virtual bool Grow(size_t size) { return false; }
 
  protected:
-  bool Read16BEAt(size_t buffer_offset, uint16_t* ptr) const;
-  bool Read16LEAt(size_t buffer_offset, uint16_t* ptr) const;
-  bool Read32BEAt(size_t buffer_offset, uint32_t* ptr) const;
-  bool Read32LEAt(size_t buffer_offset, uint32_t* ptr) const;
-  bool Read64BEAt(size_t buffer_offset, uint64_t* ptr) const;
-  bool Read64LEAt(size_t buffer_offset, uint64_t* ptr) const;
+  [[nodiscard]] bool Read16BEAt(size_t buffer_offset, uint16_t* ptr) const;
+  [[nodiscard]] bool Read16LEAt(size_t buffer_offset, uint16_t* ptr) const;
+  [[nodiscard]] bool Read32BEAt(size_t buffer_offset, uint32_t* ptr) const;
+  [[nodiscard]] bool Read32LEAt(size_t buffer_offset, uint32_t* ptr) const;
+  [[nodiscard]] bool Read64BEAt(size_t buffer_offset, uint64_t* ptr) const;
+  [[nodiscard]] bool Read64LEAt(size_t buffer_offset, uint64_t* ptr) const;
 
   Endian endian_ = Endian::kNative;
 

--- a/tachyon/base/buffer/buffer.h
+++ b/tachyon/base/buffer/buffer.h
@@ -110,6 +110,13 @@ class TACHYON_EXPORT Buffer {
     return false;
   }
 
+  [[nodiscard]] bool Read16BEAt(size_t buffer_offset, uint16_t* ptr) const;
+  [[nodiscard]] bool Read16LEAt(size_t buffer_offset, uint16_t* ptr) const;
+  [[nodiscard]] bool Read32BEAt(size_t buffer_offset, uint32_t* ptr) const;
+  [[nodiscard]] bool Read32LEAt(size_t buffer_offset, uint32_t* ptr) const;
+  [[nodiscard]] bool Read64BEAt(size_t buffer_offset, uint64_t* ptr) const;
+  [[nodiscard]] bool Read64LEAt(size_t buffer_offset, uint64_t* ptr) const;
+
   template <
       typename T,
       std::enable_if_t<internal::IsNonBuiltinSerializable<T>::value>* = nullptr>
@@ -134,6 +141,30 @@ class TACHYON_EXPORT Buffer {
   template <typename T>
   [[nodiscard]] bool Read(T&& value) const {
     return ReadAt(buffer_offset_, std::forward<T>(value));
+  }
+
+  [[nodiscard]] bool Read16BE(uint16_t* ptr) const {
+    return Read16BEAt(buffer_offset_, ptr);
+  }
+
+  [[nodiscard]] bool Read16LE(uint16_t* ptr) const {
+    return Read16LEAt(buffer_offset_, ptr);
+  }
+
+  [[nodiscard]] bool Read32BE(uint32_t* ptr) const {
+    return Read32BEAt(buffer_offset_, ptr);
+  }
+
+  [[nodiscard]] bool Read32LE(uint32_t* ptr) const {
+    return Read32LEAt(buffer_offset_, ptr);
+  }
+
+  [[nodiscard]] bool Read64BE(uint64_t* ptr) const {
+    return Read64BEAt(buffer_offset_, ptr);
+  }
+
+  [[nodiscard]] bool Read64LE(uint64_t* ptr) const {
+    return Read64LEAt(buffer_offset_, ptr);
   }
 
   template <typename T>
@@ -166,6 +197,30 @@ class TACHYON_EXPORT Buffer {
   template <typename T>
   [[nodiscard]] bool Write(const T& value) {
     return WriteAt(buffer_offset_, value);
+  }
+
+  [[nodiscard]] bool Write16BE(uint16_t value) {
+    return Write16BEAt(buffer_offset_, value);
+  }
+
+  [[nodiscard]] bool Write16LE(uint16_t value) {
+    return Write16LEAt(buffer_offset_, value);
+  }
+
+  [[nodiscard]] bool Write32BE(uint32_t value) {
+    return Write32BEAt(buffer_offset_, value);
+  }
+
+  [[nodiscard]] bool Write32LE(uint32_t value) {
+    return Write32LEAt(buffer_offset_, value);
+  }
+
+  [[nodiscard]] bool Write64BE(uint64_t value) {
+    return Write64BEAt(buffer_offset_, value);
+  }
+
+  [[nodiscard]] bool Write64LE(uint64_t value) {
+    return Write64LEAt(buffer_offset_, value);
   }
 
   template <typename T>
@@ -248,13 +303,6 @@ class TACHYON_EXPORT Buffer {
   [[nodiscard]] virtual bool Grow(size_t size) { return false; }
 
  protected:
-  [[nodiscard]] bool Read16BEAt(size_t buffer_offset, uint16_t* ptr) const;
-  [[nodiscard]] bool Read16LEAt(size_t buffer_offset, uint16_t* ptr) const;
-  [[nodiscard]] bool Read32BEAt(size_t buffer_offset, uint32_t* ptr) const;
-  [[nodiscard]] bool Read32LEAt(size_t buffer_offset, uint32_t* ptr) const;
-  [[nodiscard]] bool Read64BEAt(size_t buffer_offset, uint64_t* ptr) const;
-  [[nodiscard]] bool Read64LEAt(size_t buffer_offset, uint64_t* ptr) const;
-
   Endian endian_ = Endian::kNative;
 
   void* buffer_ = nullptr;

--- a/tachyon/zk/lookup/lookup_argument.h
+++ b/tachyon/zk/lookup/lookup_argument.h
@@ -23,6 +23,12 @@ class LookupArgument {
  public:
   LookupArgument() = default;
   LookupArgument(std::string_view name,
+                 std::vector<std::unique_ptr<Expression<F>>> input_expressions,
+                 std::vector<std::unique_ptr<Expression<F>>> table_expressions)
+      : name_(std::string(name)),
+        input_expressions_(std::move(input_expressions)),
+        table_expressions_(std::move(table_expressions)) {}
+  LookupArgument(std::string_view name,
                  LookupPairs<std::unique_ptr<Expression<F>>> pairs)
       : name_(std::string(name)) {
     input_expressions_.reserve(pairs.size());

--- a/tachyon/zk/lookup/lookup_argument.h
+++ b/tachyon/zk/lookup/lookup_argument.h
@@ -22,7 +22,7 @@ template <typename F>
 class LookupArgument {
  public:
   LookupArgument() = default;
-  LookupArgument(const std::string_view& name,
+  LookupArgument(std::string_view name,
                  LookupPairs<std::unique_ptr<Expression<F>>> pairs)
       : name_(std::string(name)) {
     input_expressions_.reserve(pairs.size());

--- a/tachyon/zk/plonk/circuit/BUILD.bazel
+++ b/tachyon/zk/plonk/circuit/BUILD.bazel
@@ -120,6 +120,7 @@ tachyon_cc_library(
         ":selector",
         ":virtual_cell",
         "//tachyon/zk/expressions:expression",
+        "@com_google_absl//absl/strings",
     ],
 )
 

--- a/tachyon/zk/plonk/circuit/gate.h
+++ b/tachyon/zk/plonk/circuit/gate.h
@@ -6,6 +6,9 @@
 #include <utility>
 #include <vector>
 
+#include "absl/strings/str_join.h"
+#include "absl/strings/substitute.h"
+
 #include "tachyon/zk/expressions/expression.h"
 #include "tachyon/zk/plonk/circuit/selector.h"
 #include "tachyon/zk/plonk/circuit/virtual_cell.h"
@@ -54,6 +57,27 @@ class Gate {
     return true;
   }
   bool operator!=(const Gate& other) const { return !operator==(other); }
+
+  std::string ToString() const {
+    std::vector<std::string> polys_str =
+        base::Map(polys_, [](const std::unique_ptr<Expression<F>>& expr) {
+          return expr->ToString();
+        });
+    std::vector<std::string> queried_selectors_str =
+        base::Map(queried_selectors_,
+                  [](const Selector& selector) { return selector.ToString(); });
+    std::vector<std::string> queried_cells_str =
+        base::Map(queried_cells_, [](const VirtualCell& queried_cell) {
+          return queried_cell.ToString();
+        });
+    return absl::Substitute(
+        "name: $0, constraint_names: [$1], polys: [$2], queried_selectors: "
+        "[$3], queried_cells: [$4]",
+        name_, absl::StrJoin(constraint_names_, ", "),
+        absl::StrJoin(polys_str, ", "),
+        absl::StrJoin(queried_selectors_str, ", "),
+        absl::StrJoin(queried_cells_str, ", "));
+  }
 
  private:
   std::string name_;

--- a/tachyon/zk/plonk/constraint_system.h
+++ b/tachyon/zk/plonk/constraint_system.h
@@ -30,7 +30,15 @@
 #include "tachyon/zk/plonk/permutation/permutation_argument.h"
 #include "tachyon/zk/plonk/permutation/permutation_utils.h"
 
-namespace tachyon::zk {
+namespace tachyon {
+namespace halo2_api {
+
+template <typename PCS>
+class ProvingKeyImpl;
+
+}  // namespace halo2_api
+
+namespace zk {
 
 // This is a description of the circuit environment, such as the gate, column
 // and permutation arrangements.
@@ -516,6 +524,9 @@ class ConstraintSystem {
   }
 
  private:
+  template <typename PCS>
+  friend class halo2_api::ProvingKeyImpl;
+
   template <typename QueryData, typename ColumnTy>
   static bool QueryIndex(const std::vector<QueryData>& queries,
                          const ColumnTy& column, Rotation at,
@@ -602,6 +613,7 @@ class ConstraintSystem {
   mutable std::optional<size_t> cached_blinding_factors_;
 };
 
-}  // namespace tachyon::zk
+}  // namespace zk
+}  // namespace tachyon
 
 #endif  // TACHYON_ZK_PLONK_CONSTRAINT_SYSTEM_H_

--- a/tachyon/zk/plonk/halo2/pinned_verifying_key.h
+++ b/tachyon/zk/plonk/halo2/pinned_verifying_key.h
@@ -45,7 +45,7 @@ class PinnedVerifyingKey {
   const std::vector<Commitment>& fixed_commitments() const {
     return fixed_commitments_;
   }
-  const PermutationVerifyingKey<PCS>& permutation_verifying_key() const {
+  const PermutationVerifyingKey<Commitment>& permutation_verifying_key() const {
     return permutation_verifying_key_;
   }
 
@@ -55,7 +55,7 @@ class PinnedVerifyingKey {
   PinnedEvaluationDomain<F> domain_;
   PinnedConstraintSystem<F> constraint_system_;
   const std::vector<Commitment>& fixed_commitments_;
-  const PermutationVerifyingKey<PCS>& permutation_verifying_key_;
+  const PermutationVerifyingKey<Commitment>& permutation_verifying_key_;
 };
 
 }  // namespace zk::halo2

--- a/tachyon/zk/plonk/keys/proving_key.h
+++ b/tachyon/zk/plonk/keys/proving_key.h
@@ -16,7 +16,15 @@
 #include "tachyon/zk/plonk/permutation/permutation_proving_key.h"
 #include "tachyon/zk/plonk/vanishing/vanishing_argument.h"
 
-namespace tachyon::zk {
+namespace tachyon {
+namespace halo2_api {
+
+template <typename PCS>
+class ProvingKeyImpl;
+
+}  // namespace halo2_api
+
+namespace zk {
 
 template <typename PCS>
 class ProvingKey : public Key<PCS> {
@@ -63,6 +71,8 @@ class ProvingKey : public Key<PCS> {
   }
 
  private:
+  friend class halo2_api::ProvingKeyImpl<PCS>;
+
   bool DoLoad(ProverBase<PCS>* prover, PreLoadResult&& pre_load_result,
               VerifyingKeyLoadResult* vk_load_result) {
     using Domain = typename PCS::Domain;
@@ -167,6 +177,7 @@ class ProvingKey : public Key<PCS> {
   VanishingArgument<F> vanishing_argument_;
 };
 
-}  // namespace tachyon::zk
+}  // namespace zk
+}  // namespace tachyon
 
 #endif  // TACHYON_ZK_PLONK_KEYS_PROVING_KEY_H_

--- a/tachyon/zk/plonk/keys/verifying_key.h
+++ b/tachyon/zk/plonk/keys/verifying_key.h
@@ -44,7 +44,7 @@ class VerifyingKey : public Key<PCS> {
 
   const Commitments& fixed_commitments() const { return fixed_commitments_; }
 
-  const PermutationVerifyingKey<PCS>& permutation_verifying_key() const {
+  const PermutationVerifyingKey<Commitment>& permutation_verifying_key() const {
     return permutation_verifying_Key_;
   }
 
@@ -115,7 +115,7 @@ class VerifyingKey : public Key<PCS> {
   }
 
   Commitments fixed_commitments_;
-  PermutationVerifyingKey<PCS> permutation_verifying_Key_;
+  PermutationVerifyingKey<Commitment> permutation_verifying_Key_;
   ConstraintSystem<F> constraint_system_;
   // The representative of this |VerifyingKey| in transcripts.
   F transcript_repr_ = F::Zero();

--- a/tachyon/zk/plonk/keys/verifying_key.h
+++ b/tachyon/zk/plonk/keys/verifying_key.h
@@ -45,7 +45,7 @@ class VerifyingKey : public Key<PCS> {
   const Commitments& fixed_commitments() const { return fixed_commitments_; }
 
   const PermutationVerifyingKey<Commitment>& permutation_verifying_key() const {
-    return permutation_verifying_Key_;
+    return permutation_verifying_key_;
   }
 
   const ConstraintSystem<F>& constraint_system() const {
@@ -76,7 +76,7 @@ class VerifyingKey : public Key<PCS> {
     std::vector<Evals> permutations =
         pre_load_result.assembly.permutation().GeneratePermutations(
             entity->domain());
-    permutation_verifying_Key_ =
+    permutation_verifying_key_ =
         pre_load_result.assembly.permutation().BuildVerifyingKey(entity,
                                                                  permutations);
     if (load_result) {
@@ -115,7 +115,7 @@ class VerifyingKey : public Key<PCS> {
   }
 
   Commitments fixed_commitments_;
-  PermutationVerifyingKey<Commitment> permutation_verifying_Key_;
+  PermutationVerifyingKey<Commitment> permutation_verifying_key_;
   ConstraintSystem<F> constraint_system_;
   // The representative of this |VerifyingKey| in transcripts.
   F transcript_repr_ = F::Zero();

--- a/tachyon/zk/plonk/keys/verifying_key.h
+++ b/tachyon/zk/plonk/keys/verifying_key.h
@@ -20,7 +20,15 @@
 #include "tachyon/zk/plonk/keys/key.h"
 #include "tachyon/zk/plonk/permutation/permutation_verifying_key.h"
 
-namespace tachyon::zk {
+namespace tachyon {
+namespace halo2_api {
+
+template <typename PCS>
+class ProvingKeyImpl;
+
+}  // namespace halo2_api
+
+namespace zk {
 namespace halo2 {
 
 template <typename PCS>
@@ -64,6 +72,7 @@ class VerifyingKey : public Key<PCS> {
 
  private:
   friend class ProvingKey<PCS>;
+  friend class halo2_api::ProvingKeyImpl<PCS>;
 
   struct LoadResult {
     std::vector<Evals> permutations;
@@ -121,6 +130,7 @@ class VerifyingKey : public Key<PCS> {
   F transcript_repr_ = F::Zero();
 };
 
-}  // namespace tachyon::zk
+}  // namespace zk
+}  // namespace tachyon
 
 #endif  // TACHYON_ZK_PLONK_KEYS_VERIFYING_KEY_H_

--- a/tachyon/zk/plonk/permutation/permutation_assembly.h
+++ b/tachyon/zk/plonk/permutation/permutation_assembly.h
@@ -79,10 +79,10 @@ class PermutationAssembly {
   }
 
   // Returns |PermutationVerifyingKey| which has commitments for permutations.
-  constexpr PermutationVerifyingKey<PCS> BuildVerifyingKey(
+  constexpr PermutationVerifyingKey<Commitment> BuildVerifyingKey(
       const Entity<PCS>* entity, const std::vector<Evals>& permutations) const {
     const PCS& pcs = entity->pcs();
-    return PermutationVerifyingKey<PCS>(
+    return PermutationVerifyingKey<Commitment>(
         base::Map(permutations, [&pcs](const Evals& permutation) {
           Commitment commitment;
           CHECK(pcs.CommitLagrange(permutation, &commitment));

--- a/tachyon/zk/plonk/permutation/permutation_assembly_unittest.cc
+++ b/tachyon/zk/plonk/permutation/permutation_assembly_unittest.cc
@@ -55,7 +55,7 @@ TEST_F(PermutationAssemblyTest, BuildKeys) {
       assembly_.BuildProvingKey(prover_.get(), permutations);
   EXPECT_EQ(pk.permutations().size(), pk.polys().size());
 
-  PermutationVerifyingKey<PCS> vk =
+  PermutationVerifyingKey<Commitment> vk =
       assembly_.BuildVerifyingKey(prover_.get(), permutations);
   EXPECT_EQ(pk.permutations().size(), vk.commitments().size());
 

--- a/tachyon/zk/plonk/permutation/permutation_verifying_key.h
+++ b/tachyon/zk/plonk/permutation/permutation_verifying_key.h
@@ -15,10 +15,9 @@
 namespace tachyon {
 namespace zk {
 
-template <typename PCS>
+template <typename Commitment>
 class PermutationVerifyingKey {
  public:
-  using Commitment = typename PCS::Commitment;
   using Commitments = std::vector<Commitment>;
 
   PermutationVerifyingKey() = default;
@@ -47,23 +46,24 @@ class PermutationVerifyingKey {
 
 namespace base {
 
-template <typename PCS>
-class Copyable<zk::PermutationVerifyingKey<PCS>> {
+template <typename Commitment>
+class Copyable<zk::PermutationVerifyingKey<Commitment>> {
  public:
-  static bool WriteTo(const zk::PermutationVerifyingKey<PCS>& vk,
+  static bool WriteTo(const zk::PermutationVerifyingKey<Commitment>& vk,
                       Buffer* buffer) {
     return buffer->Write(vk.commitments());
   }
 
   static bool ReadFrom(const Buffer& buffer,
-                       zk::PermutationVerifyingKey<PCS>* vk) {
-    typename zk::PermutationVerifyingKey<PCS>::Commitments commitments;
+                       zk::PermutationVerifyingKey<Commitment>* vk) {
+    typename zk::PermutationVerifyingKey<Commitment>::Commitments commitments;
     if (!buffer.Read(&commitments)) return false;
-    *vk = zk::PermutationVerifyingKey<PCS>(std::move(commitments));
+    *vk = zk::PermutationVerifyingKey<Commitment>(std::move(commitments));
     return true;
   }
 
-  static size_t EstimateSize(const zk::PermutationVerifyingKey<PCS>& vk) {
+  static size_t EstimateSize(
+      const zk::PermutationVerifyingKey<Commitment>& vk) {
     return base::EstimateSize(vk.commitments());
   }
 };

--- a/tachyon/zk/plonk/permutation/permutation_verifying_key_stringifier.h
+++ b/tachyon/zk/plonk/permutation/permutation_verifying_key_stringifier.h
@@ -15,12 +15,12 @@
 
 namespace tachyon::base::internal {
 
-template <typename PCS>
-class RustDebugStringifier<zk::PermutationVerifyingKey<PCS>> {
+template <typename Commitment>
+class RustDebugStringifier<zk::PermutationVerifyingKey<Commitment>> {
  public:
   static std::ostream& AppendToStream(
       std::ostream& os, RustFormatter& fmt,
-      const zk::PermutationVerifyingKey<PCS>& vk) {
+      const zk::PermutationVerifyingKey<Commitment>& vk) {
     // NOTE(chokobole): See
     // https://github.com/kroma-network/halo2/blob/7d0a36990452c8e7ebd600de258420781a9b7917/halo2_proofs/src/plonk/permutation.rs#L80-L84
     return os << fmt.DebugStruct("VerifyingKey")

--- a/tachyon/zk/plonk/permutation/permutation_verifying_key_unittest.cc
+++ b/tachyon/zk/plonk/permutation/permutation_verifying_key_unittest.cc
@@ -17,7 +17,7 @@ namespace {
 
 class PermutationVerifyingKeyTest : public halo2::ProverTest {
  public:
-  using VerifyingKey = PermutationVerifyingKey<PCS>;
+  using VerifyingKey = PermutationVerifyingKey<Commitment>;
 };
 
 }  // namespace

--- a/vendors/halo2/BUILD.bazel
+++ b/vendors/halo2/BUILD.bazel
@@ -20,6 +20,7 @@ tachyon_rust_library(
         ":bn254_msm",
         ":bn254_msm_gpu",
         ":bn254_prover",
+        ":bn254_shplonk_proving_key",
         ":xor_shift_rng",
         ":xor_shift_rng_cxx_bridge",
     ],
@@ -70,6 +71,8 @@ tachyon_cc_library(
         "include/bn254_msm.h",
         "include/bn254_msm_gpu.h",
         "include/bn254_prover.h",
+        "include/bn254_shplonk_proving_key.h",
+        "include/proving_key_impl_forward.h",
     ],
     deps = ["@cxx.rs//:core"],
 )
@@ -114,6 +117,33 @@ tachyon_cc_library(
     deps = [
         ":bn254_api_hdrs",
         ":bn254_cxx_bridge/include",
+    ],
+)
+
+tachyon_cc_library(
+    name = "bn254_shplonk_proving_key",
+    srcs = [
+        "src/bn254_shplonk_proving_key.cc",
+        "src/buffer_reader.h",
+        "src/endian_auto_reset.h",
+        "src/shplonk_proving_key_impl.h",
+    ],
+    deps = [
+        ":bn254_api_hdrs",
+        ":bn254_cxx_bridge/include",
+        "//tachyon/base:logging",
+        "//tachyon/base/buffer",
+        "//tachyon/base/containers:container_util",
+        "//tachyon/math/elliptic_curves/bn/bn254",
+        "//tachyon/math/finite_fields:prime_field_base",
+        "//tachyon/math/polynomials/univariate:univariate_evaluations",
+        "//tachyon/math/polynomials/univariate:univariate_polynomial",
+        "//tachyon/zk/base/commitments:shplonk_extension",
+        "//tachyon/zk/plonk/circuit:column_key",
+        "//tachyon/zk/plonk/circuit:gate",
+        "//tachyon/zk/plonk/circuit:phase",
+        "//tachyon/zk/plonk/keys:proving_key",
+        "//tachyon/zk/plonk/permutation:permutation_argument",
     ],
 )
 

--- a/vendors/halo2/Cargo.toml
+++ b/vendors/halo2/Cargo.toml
@@ -17,7 +17,7 @@ publish = false
 [dependencies]
 cxx = "1.0"
 ff = "0.12"
-halo2_proofs = { git = "https://github.com/kroma-network/halo2.git", rev = "6bf4e0a" }
+halo2_proofs = { git = "https://github.com/kroma-network/halo2.git", rev = "746e4ac" }
 halo2curves = { git = "https://github.com/kroma-network/halo2curves.git", rev = "c0ac193" }
 tachyon_rs = { path = "../../tachyon/rs" }
 rand_core = { version = "0.6", default-features = false, features = [

--- a/vendors/halo2/include/bn254_shplonk_proving_key.h
+++ b/vendors/halo2/include/bn254_shplonk_proving_key.h
@@ -1,0 +1,36 @@
+#ifndef VENDORS_HALO2_INCLUDE_BN254_SHPLONK_PROVING_KEY_H_
+#define VENDORS_HALO2_INCLUDE_BN254_SHPLONK_PROVING_KEY_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <memory>
+
+#include "rust/cxx.h"
+
+namespace tachyon::halo2_api::bn254 {
+
+class SHPlonkProvingKey {
+ public:
+  explicit SHPlonkProvingKey(rust::Slice<const uint8_t> pk_bytes);
+
+  rust::Slice<const uint8_t> advice_column_phases() const;
+  size_t blinding_factors() const;
+  rust::Slice<const uint8_t> challenge_phases() const;
+  rust::Vec<size_t> constants() const;
+  size_t num_advice_columns() const;
+  size_t num_challenges() const;
+  size_t num_instance_columns() const;
+  rust::Vec<uint8_t> phases() const;
+
+ private:
+  class Impl;
+  std::shared_ptr<Impl> impl_;
+};
+
+std::unique_ptr<SHPlonkProvingKey> new_proving_key(
+    rust::Slice<const uint8_t> pk_bytes);
+
+}  // namespace tachyon::halo2_api::bn254
+
+#endif  // VENDORS_HALO2_INCLUDE_BN254_SHPLONK_PROVING_KEY_H_

--- a/vendors/halo2/include/proving_key_impl_forward.h
+++ b/vendors/halo2/include/proving_key_impl_forward.h
@@ -1,0 +1,11 @@
+#ifndef VENDORS_HALO2_INCLUDE_PROVING_KEY_IMPL_FORWARD_H_
+#define VENDORS_HALO2_INCLUDE_PROVING_KEY_IMPL_FORWARD_H_
+
+namespace tachyon::halo2_api {
+
+template <typename PCS>
+class ProvingKeyImpl;
+
+}  // namespace tachyon::halo2_api
+
+#endif  // VENDORS_HALO2_INCLUDE_PROVING_KEY_IMPL_FORWARD_H_

--- a/vendors/halo2/src/bn254_shplonk_proving_key.cc
+++ b/vendors/halo2/src/bn254_shplonk_proving_key.cc
@@ -1,0 +1,88 @@
+#include "vendors/halo2/include/bn254_shplonk_proving_key.h"
+
+#include "tachyon/base/containers/container_util.h"
+#include "tachyon/math/elliptic_curves/bn/bn254/bn254.h"
+#include "vendors/halo2/src/bn254.rs.h"
+#include "vendors/halo2/src/shplonk_proving_key_impl.h"
+
+namespace tachyon::halo2_api::bn254 {
+
+namespace {
+
+template <typename R, typename T>
+rust::Vec<R> ConvertCppVecToRustVec(const std::vector<T>& vec) {
+  rust::Vec<R> ret;
+  ret.reserve(vec.size());
+  for (const T& phase : vec) {
+    ret.push_back(phase.value());
+  }
+  return ret;
+}
+
+template <typename R, typename T>
+rust::Slice<const R> ConvertCppVecToRustSlice(const std::vector<T>& phases) {
+  return {reinterpret_cast<const R*>(phases.data()), phases.size()};
+}
+
+}  // namespace
+
+constexpr size_t kMaxDegree = (size_t{1} << 5) - 1;
+constexpr size_t kMaxExtendedDegree = (size_t{1} << 7) - 1;
+
+using PCS =
+    zk::SHPlonkExtension<math::bn254::BN254Curve, kMaxDegree,
+                         kMaxExtendedDegree, math::bn254::G1AffinePoint>;
+
+class SHPlonkProvingKey::Impl : public ProvingKeyImpl<PCS> {
+ public:
+  explicit Impl(rust::Slice<const uint8_t> bytes)
+      : ProvingKeyImpl<PCS>(bytes) {}
+};
+
+SHPlonkProvingKey::SHPlonkProvingKey(rust::Slice<const uint8_t> pk_bytes)
+    : impl_(new Impl(pk_bytes)) {}
+
+rust::Slice<const uint8_t> SHPlonkProvingKey::advice_column_phases() const {
+  return ConvertCppVecToRustSlice<uint8_t>(impl_->GetAdviceColumnPhases());
+}
+
+size_t SHPlonkProvingKey::blinding_factors() const {
+  return impl_->ComputeBlindingFactors();
+}
+
+rust::Slice<const uint8_t> SHPlonkProvingKey::challenge_phases() const {
+  return ConvertCppVecToRustSlice<uint8_t>(impl_->GetChallengePhases());
+}
+
+rust::Vec<size_t> SHPlonkProvingKey::constants() const {
+  const std::vector<zk::FixedColumnKey>& constants = impl_->GetConstants();
+  rust::Vec<size_t> ret;
+  ret.reserve(constants.size());
+  for (const zk::FixedColumnKey& column : constants) {
+    ret.push_back(column.index());
+  }
+  return ret;
+}
+
+size_t SHPlonkProvingKey::num_advice_columns() const {
+  return impl_->GetNumAdviceColumns();
+}
+
+size_t SHPlonkProvingKey::num_challenges() const {
+  return impl_->GetNumChallenges();
+}
+
+size_t SHPlonkProvingKey::num_instance_columns() const {
+  return impl_->GetNumInstanceColumns();
+}
+
+rust::Vec<uint8_t> SHPlonkProvingKey::phases() const {
+  return ConvertCppVecToRustVec<uint8_t>(impl_->GetPhases());
+}
+
+std::unique_ptr<SHPlonkProvingKey> new_proving_key(
+    rust::Slice<const uint8_t> pk_bytes) {
+  return std::make_unique<SHPlonkProvingKey>(pk_bytes);
+}
+
+}  // namespace tachyon::halo2_api::bn254

--- a/vendors/halo2/src/buffer_reader.h
+++ b/vendors/halo2/src/buffer_reader.h
@@ -1,0 +1,342 @@
+#ifndef VENDORS_HALO2_SRC_BUFFER_READER_H_
+#define VENDORS_HALO2_SRC_BUFFER_READER_H_
+
+#include <memory>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "tachyon/base/buffer/buffer.h"
+#include "tachyon/base/containers/container_util.h"
+#include "tachyon/base/logging.h"
+#include "tachyon/math/elliptic_curves/affine_point.h"
+#include "tachyon/math/finite_fields/prime_field_base.h"
+#include "tachyon/math/polynomials/univariate/univariate_evaluations.h"
+#include "tachyon/math/polynomials/univariate/univariate_polynomial.h"
+#include "tachyon/zk/expressions/expression_factory.h"
+#include "tachyon/zk/lookup/lookup_argument.h"
+#include "tachyon/zk/plonk/circuit/column_key.h"
+#include "tachyon/zk/plonk/circuit/gate.h"
+#include "tachyon/zk/plonk/circuit/phase.h"
+#include "tachyon/zk/plonk/permutation/permutation_argument.h"
+#include "vendors/halo2/src/endian_auto_reset.h"
+
+namespace tachyon::halo2_api {
+
+template <typename T, typename SFINAE = void>
+class BufferReader;
+
+template <typename T>
+void ReadBuffer(base::Buffer& buffer, T& value) {
+  value = BufferReader<T>::Read(buffer);
+}
+
+template <typename T>
+class BufferReader<T, std::enable_if_t<std::is_integral_v<T>>> {
+ public:
+  static T Read(base::Buffer& buffer) {
+    EndianAutoReset resetter(buffer, base::Endian::kBig);
+    T v;
+    CHECK(buffer.Read(&v));
+    return v;
+  }
+};
+
+bool ReadU8AsBool(base::Buffer& buffer) {
+  return BufferReader<uint8_t>::Read(buffer) != 0;
+}
+
+size_t ReadU32AsSizeT(base::Buffer& buffer) {
+  return size_t{BufferReader<uint32_t>::Read(buffer)};
+}
+
+template <typename T>
+class BufferReader<std::vector<T>> {
+ public:
+  static std::vector<T> Read(base::Buffer& buffer) {
+    return base::CreateVector(ReadU32AsSizeT(buffer), [&buffer]() {
+      return BufferReader<T>::Read(buffer);
+    });
+  }
+};
+
+template <typename Curve>
+class BufferReader<math::AffinePoint<Curve>> {
+ public:
+  using BaseField = typename math::AffinePoint<Curve>::BaseField;
+
+  static math::AffinePoint<Curve> Read(base::Buffer& buffer) {
+    BaseField x = BufferReader<BaseField>::Read(buffer);
+    BaseField y = BufferReader<BaseField>::Read(buffer);
+    return {std::move(x), std::move(y)};
+  }
+};
+
+template <typename T>
+class BufferReader<
+    T, std::enable_if_t<std::is_base_of_v<math::PrimeFieldBase<T>, T>>> {
+ public:
+  using BigInt = typename T::BigIntTy;
+
+  static T Read(base::Buffer& buffer) {
+    EndianAutoReset resetter(buffer, base::Endian::kLittle);
+    BigInt montgomery;
+    CHECK(buffer.Read(montgomery.limbs));
+    return T::FromMontgomery(montgomery);
+  }
+};
+
+template <typename F, size_t MaxDegree>
+class BufferReader<math::UnivariateDensePolynomial<F, MaxDegree>> {
+ public:
+  static math::UnivariateDensePolynomial<F, MaxDegree> Read(
+      base::Buffer& buffer) {
+    std::vector<F> coeffs;
+    ReadBuffer(buffer, coeffs);
+    return math::UnivariateDensePolynomial<F, MaxDegree>(
+        math::UnivariateDenseCoefficients<F, MaxDegree>(std::move(coeffs)));
+  }
+};
+
+template <typename F, size_t MaxDegree>
+class BufferReader<math::UnivariateEvaluations<F, MaxDegree>> {
+ public:
+  static math::UnivariateEvaluations<F, MaxDegree> Read(base::Buffer& buffer) {
+    std::vector<F> evals;
+    ReadBuffer(buffer, evals);
+    return math::UnivariateEvaluations<F, MaxDegree>(std::move(evals));
+  }
+};
+
+template <>
+class BufferReader<zk::Phase> {
+ public:
+  static zk::Phase Read(base::Buffer& buffer) {
+    return zk::Phase(BufferReader<uint8_t>::Read(buffer));
+  }
+};
+
+template <>
+class BufferReader<zk::Challenge> {
+ public:
+  static zk::Challenge Read(base::Buffer& buffer) {
+    size_t index = ReadU32AsSizeT(buffer);
+    zk::Phase phase = BufferReader<zk::Phase>::Read(buffer);
+    return {index, phase};
+  }
+};
+
+template <>
+class BufferReader<zk::Rotation> {
+ public:
+  static zk::Rotation Read(base::Buffer& buffer) {
+    return zk::Rotation(BufferReader<int32_t>::Read(buffer));
+  }
+};
+
+template <>
+class BufferReader<zk::Selector> {
+ public:
+  static zk::Selector Read(base::Buffer& buffer) {
+    size_t index = ReadU32AsSizeT(buffer);
+    bool is_simple = ReadU8AsBool(buffer);
+    return is_simple ? zk::Selector::Simple(index)
+                     : zk::Selector::Complex(index);
+  }
+};
+
+template <zk::ColumnType C>
+class BufferReader<zk::ColumnKey<C>> {
+ public:
+  static zk::ColumnKey<C> Read(base::Buffer& buffer) {
+    size_t index = ReadU32AsSizeT(buffer);
+    uint8_t kind = BufferReader<uint8_t>::Read(buffer);
+    if constexpr (C == zk::ColumnType::kAdvice) {
+      CHECK_EQ(kind, static_cast<int8_t>(C));
+      return zk::ColumnKey<C>(index, BufferReader<zk::Phase>::Read(buffer));
+    } else {
+      if constexpr (C == zk::ColumnType::kInstance ||
+                    C == zk::ColumnType::kFixed) {
+        CHECK_EQ(kind, static_cast<int8_t>(C));
+        return zk::ColumnKey<C>(index);
+      } else {
+        zk::Phase phase = BufferReader<zk::Phase>::Read(buffer);
+        switch (static_cast<zk::ColumnType>(kind)) {
+          case zk::ColumnType::kAdvice:
+            return zk::AdviceColumnKey(index, phase);
+          case zk::ColumnType::kInstance:
+            return zk::InstanceColumnKey(index);
+          case zk::ColumnType::kFixed:
+            return zk::FixedColumnKey(index);
+          case zk::ColumnType::kAny:
+            break;
+        }
+        NOTREACHED();
+        return zk::AnyColumnKey();
+      }
+    }
+  }
+};
+
+template <>
+class BufferReader<zk::VirtualCell> {
+ public:
+  static zk::VirtualCell Read(base::Buffer& buffer) {
+    zk::AnyColumnKey column = BufferReader<zk::AnyColumnKey>::Read(buffer);
+    zk::Rotation rotation = BufferReader<zk::Rotation>::Read(buffer);
+    return {column, rotation};
+  }
+};
+
+template <zk::ColumnType C>
+class BufferReader<zk::QueryData<C>> {
+ public:
+  static zk::QueryData<C> Read(base::Buffer& buffer) {
+    if constexpr (C == zk::ColumnType::kAny) {
+      NOTREACHED();
+    } else {
+      zk::ColumnKey<C> column = BufferReader<zk::ColumnKey<C>>::Read(buffer);
+      zk::Rotation rotation = BufferReader<zk::Rotation>::Read(buffer);
+      return {rotation, column};
+    }
+  }
+};
+
+template <zk::ColumnType C>
+class BufferReader<zk::Query<C>> {
+ public:
+  static zk::Query<C> Read(base::Buffer& buffer) {
+    size_t index = ReadU32AsSizeT(buffer);
+    size_t column_index = ReadU32AsSizeT(buffer);
+    zk::Rotation rotation = BufferReader<zk::Rotation>::Read(buffer);
+    if constexpr (C == zk::ColumnType::kAdvice) {
+      zk::Phase phase = BufferReader<zk::Phase>::Read(buffer);
+      return {
+          index,
+          rotation,
+          zk::ColumnKey<C>(column_index, phase),
+      };
+    } else {
+      if constexpr (C == zk::ColumnType::kInstance ||
+                    C == zk::ColumnType::kFixed) {
+        return {
+            index,
+            rotation,
+            zk::ColumnKey<C>(column_index),
+        };
+      } else {
+        NOTREACHED();
+      }
+    }
+  }
+};
+
+template <typename F>
+class BufferReader<std::unique_ptr<zk::Expression<F>>> {
+ public:
+  static std::unique_ptr<zk::Expression<F>> Read(base::Buffer& buffer) {
+    uint8_t kind = BufferReader<uint8_t>::Read(buffer);
+    switch (kind) {
+      case 0:
+        return zk::ExpressionFactory<F>::Constant(
+            BufferReader<F>::Read(buffer));
+      case 1:
+        return zk::ExpressionFactory<F>::Selector(
+            BufferReader<zk::Selector>::Read(buffer));
+      case 2:
+        return zk::ExpressionFactory<F>::Fixed(
+            BufferReader<zk::FixedQuery>::Read(buffer));
+      case 3:
+        return zk::ExpressionFactory<F>::Advice(
+            BufferReader<zk::AdviceQuery>::Read(buffer));
+      case 4:
+        return zk::ExpressionFactory<F>::Instance(
+            BufferReader<zk::InstanceQuery>::Read(buffer));
+      case 5:
+        return zk::ExpressionFactory<F>::Challenge(
+            BufferReader<zk::Challenge>::Read(buffer));
+      case 6:
+        return zk::ExpressionFactory<F>::Negated(
+            BufferReader<std::unique_ptr<zk::Expression<F>>>::Read(buffer));
+      case 7: {
+        std::unique_ptr<zk::Expression<F>> left;
+        ReadBuffer(buffer, left);
+        std::unique_ptr<zk::Expression<F>> right;
+        ReadBuffer(buffer, right);
+        return zk::ExpressionFactory<F>::Sum(std::move(left), std::move(right));
+      }
+      case 8: {
+        std::unique_ptr<zk::Expression<F>> left;
+        ReadBuffer(buffer, left);
+        std::unique_ptr<zk::Expression<F>> right;
+        ReadBuffer(buffer, right);
+        return zk::ExpressionFactory<F>::Product(std::move(left),
+                                                 std::move(right));
+      }
+      case 9: {
+        std::unique_ptr<zk::Expression<F>> expr;
+        ReadBuffer(buffer, expr);
+        F scale = BufferReader<F>::Read(buffer);
+        return zk::ExpressionFactory<F>::Scaled(std::move(expr),
+                                                std::move(scale));
+      }
+    }
+    NOTREACHED();
+    return nullptr;
+  }
+};
+
+template <typename F>
+class BufferReader<zk::Gate<F>> {
+ public:
+  static zk::Gate<F> Read(base::Buffer& buffer) {
+    std::vector<std::unique_ptr<zk::Expression<F>>> polys;
+    ReadBuffer(buffer, polys);
+    std::vector<zk::Selector> queried_selectors;
+    ReadBuffer(buffer, queried_selectors);
+    std::vector<zk::VirtualCell> queried_cells;
+    ReadBuffer(buffer, queried_cells);
+    return zk::Gate<F>("", {}, std::move(polys), std::move(queried_selectors),
+                       std::move(queried_cells));
+  }
+};
+
+template <>
+class BufferReader<zk::PermutationArgument> {
+ public:
+  static zk::PermutationArgument Read(base::Buffer& buffer) {
+    std::vector<zk::AnyColumnKey> column_keys;
+    ReadBuffer(buffer, column_keys);
+    return zk::PermutationArgument(std::move(column_keys));
+  }
+};
+
+template <typename F>
+class BufferReader<zk::LookupArgument<F>> {
+ public:
+  static zk::LookupArgument<F> Read(base::Buffer& buffer) {
+    std::vector<std::unique_ptr<zk::Expression<F>>> input_expressions;
+    ReadBuffer(buffer, input_expressions);
+    std::vector<std::unique_ptr<zk::Expression<F>>> table_expressions;
+    ReadBuffer(buffer, table_expressions);
+    return zk::LookupArgument<F>("", std::move(input_expressions),
+                                 std::move(table_expressions));
+  }
+};
+
+template <typename Poly, typename Evals>
+class BufferReader<zk::PermutationProvingKey<Poly, Evals>> {
+ public:
+  static zk::PermutationProvingKey<Poly, Evals> Read(base::Buffer& buffer) {
+    std::vector<Evals> permutations;
+    ReadBuffer(buffer, permutations);
+    std::vector<Poly> polys;
+    ReadBuffer(buffer, polys);
+    return zk::PermutationProvingKey<Poly, Evals>(std::move(permutations),
+                                                  std::move(polys));
+  }
+};
+
+}  // namespace tachyon::halo2_api
+
+#endif  // VENDORS_HALO2_SRC_BUFFER_READER_H_

--- a/vendors/halo2/src/endian_auto_reset.h
+++ b/vendors/halo2/src/endian_auto_reset.h
@@ -1,0 +1,21 @@
+#ifndef VENDORS_HALO2_SRC_ENDIAN_AUTO_RESET_H_
+#define VENDORS_HALO2_SRC_ENDIAN_AUTO_RESET_H_
+
+#include "tachyon/base/buffer/buffer.h"
+
+namespace tachyon::halo2_api {
+
+struct EndianAutoReset {
+  explicit EndianAutoReset(base::Buffer& buffer, base::Endian endian)
+      : buffer(buffer), old_endian(buffer.endian()) {
+    buffer.set_endian(endian);
+  }
+  ~EndianAutoReset() { buffer.set_endian(old_endian); }
+
+  base::Buffer& buffer;
+  base::Endian old_endian;
+};
+
+}  // namespace tachyon::halo2_api
+
+#endif  // VENDORS_HALO2_SRC_ENDIAN_AUTO_RESET_H_

--- a/vendors/halo2/src/lib.rs
+++ b/vendors/halo2/src/lib.rs
@@ -4,5 +4,6 @@ mod circuits;
 mod consts;
 mod msm;
 mod prover;
-mod xor_shift_rng;
+mod proving_key;
 mod transcript;
+mod xor_shift_rng;

--- a/vendors/halo2/src/proving_key.rs
+++ b/vendors/halo2/src/proving_key.rs
@@ -1,0 +1,52 @@
+#[cfg(test)]
+mod test {
+    use crate::bn254::SHPlonkProvingKey;
+    use crate::circuits::simple_circuit::SimpleCircuit;
+    use halo2_proofs::{circuit::Value, plonk::keygen_pk2, poly::kzg::commitment::ParamsKZG};
+    use halo2curves::bn256::{Bn256, Fr};
+
+    #[test]
+    fn test_proving_key() {
+        // ANCHOR: test-circuit
+        // The number of rows in our circuit cannot exceed 2ᵏ. Since our example
+        // circuit is very small, we can pick a very small value here.
+        let k = 4;
+
+        // Prepare the private and public inputs to the circuit!
+        let constant = Fr::from(7);
+        let a = Fr::from(2);
+        let b = Fr::from(3);
+
+        // Instantiate the circuit with the private inputs.
+        let circuit = SimpleCircuit {
+            constant,
+            a: Value::known(a),
+            b: Value::known(b),
+        };
+
+        // Given the correct public input, our circuit will verify.
+        let s = Fr::from(2);
+        let params = ParamsKZG::<Bn256>::unsafe_setup_with_s(k, s);
+        let pk = keygen_pk2(&params, &circuit).expect("vk should not fail");
+        let mut pk_bytes: Vec<u8> = vec![];
+        pk.write(&mut pk_bytes, halo2_proofs::SerdeFormat::RawBytesUnchecked)
+            .unwrap();
+        let tachyon_pk = SHPlonkProvingKey::from(pk_bytes.as_slice());
+
+        assert_eq!(
+            pk.vk.cs.advice_column_phase,
+            tachyon_pk.advice_column_phases()
+        );
+        assert_eq!(pk.vk.cs.blinding_factors(), tachyon_pk.blinding_factors());
+        assert_eq!(pk.vk.cs.challenge_phase, tachyon_pk.challenge_phases());
+        assert_eq!(pk.vk.cs.constants, tachyon_pk.constants());
+        assert_eq!(pk.vk.cs.num_advice_columns, tachyon_pk.num_advice_columns());
+        assert_eq!(pk.vk.cs.num_challenges, tachyon_pk.num_challenges());
+        assert_eq!(
+            pk.vk.cs.num_instance_columns,
+            tachyon_pk.num_instance_columns()
+        );
+        let phases = pk.vk.cs.phases().collect::<Vec<_>>();
+        assert_eq!(phases, tachyon_pk.phases());
+    }
+}

--- a/vendors/halo2/src/shplonk_proving_key_impl.h
+++ b/vendors/halo2/src/shplonk_proving_key_impl.h
@@ -1,0 +1,125 @@
+#ifndef VENDORS_HALO2_SRC_SHPLONK_PROVING_KEY_IMPL_H_
+#define VENDORS_HALO2_SRC_SHPLONK_PROVING_KEY_IMPL_H_
+
+#include <utility>
+#include <vector>
+
+#include "rust/cxx.h"
+
+#include "tachyon/base/buffer/buffer.h"
+#include "tachyon/zk/base/commitments/shplonk_extension.h"
+#include "tachyon/zk/plonk/keys/proving_key.h"
+#include "vendors/halo2/include/proving_key_impl_forward.h"
+#include "vendors/halo2/src/buffer_reader.h"
+
+namespace tachyon::halo2_api {
+
+template <typename Curve, size_t MaxDegree, size_t MaxExtendedDegree>
+class ProvingKeyImpl<
+    zk::SHPlonkExtension<Curve, MaxDegree, MaxExtendedDegree,
+                         math::AffinePoint<typename Curve::G1Curve>>> {
+ public:
+  using Commitment = math::AffinePoint<typename Curve::G1Curve>;
+  using PCS =
+      zk::SHPlonkExtension<Curve, MaxDegree, MaxExtendedDegree, Commitment>;
+  using F = typename PCS::Field;
+  using Evals = typename PCS::Evals;
+  using Poly = typename PCS::Poly;
+
+  explicit ProvingKeyImpl(rust::Slice<const uint8_t> bytes) {
+    base::Buffer buffer(const_cast<uint8_t*>(bytes.data()), bytes.size());
+    ReadProvingKey(buffer);
+  }
+
+  const std::vector<zk::Phase>& GetAdviceColumnPhases() const {
+    return GetConstraintSystem().advice_column_phases();
+  }
+
+  size_t ComputeBlindingFactors() const {
+    return GetConstraintSystem().ComputeBlindingFactors();
+  }
+
+  const std::vector<zk::Phase>& GetChallengePhases() const {
+    return GetConstraintSystem().challenge_phases();
+  }
+
+  const std::vector<zk::FixedColumnKey> GetConstants() const {
+    return GetConstraintSystem().constants();
+  }
+
+  size_t GetNumAdviceColumns() const {
+    return GetConstraintSystem().num_advice_columns();
+  }
+
+  size_t GetNumChallenges() const {
+    return GetConstraintSystem().num_challenges();
+  }
+
+  size_t GetNumInstanceColumns() const {
+    return GetConstraintSystem().num_instance_columns();
+  }
+
+  std::vector<zk::Phase> GetPhases() const {
+    return GetConstraintSystem().GetPhases();
+  }
+
+ private:
+  const zk::ConstraintSystem<F>& GetConstraintSystem() const {
+    return key_.verifying_key().constraint_system();
+  }
+
+  void ReadProvingKey(base::Buffer& buffer) {
+    ReadVerifyingKey(buffer, key_.verifying_key_);
+    ReadBuffer(buffer, key_.l_first_);
+    ReadBuffer(buffer, key_.l_last_);
+    ReadBuffer(buffer, key_.l_active_row_);
+    ReadBuffer(buffer, key_.fixed_columns_);
+    ReadBuffer(buffer, key_.fixed_polys_);
+    ReadBuffer(buffer, key_.permutation_proving_key_);
+    CHECK(buffer.Done());
+  }
+
+  static void ReadVerifyingKey(base::Buffer& buffer,
+                               zk::VerifyingKey<PCS>& vkey) {
+    // NOTE(chokobole): For k
+    ReadU32AsSizeT(buffer);
+    ReadBuffer(buffer, vkey.fixed_commitments_);
+    ReadConstraintSystem(buffer, vkey.constraint_system_);
+    size_t num_commitments =
+        vkey.constraint_system_.permutation().columns().size();
+    std::vector<Commitment> commitments;
+    commitments.resize(num_commitments);
+    for (size_t i = 0; i < num_commitments; ++i) {
+      ReadBuffer(buffer, commitments[i]);
+    }
+    vkey.permutation_verifying_key_ =
+        zk::PermutationVerifyingKey<Commitment>(std::move(commitments));
+  }
+
+  static void ReadConstraintSystem(base::Buffer& buffer,
+                                   zk::ConstraintSystem<F>& cs) {
+    cs.num_fixed_columns_ = ReadU32AsSizeT(buffer);
+    cs.num_advice_columns_ = ReadU32AsSizeT(buffer);
+    cs.num_instance_columns_ = ReadU32AsSizeT(buffer);
+    cs.num_selectors_ = ReadU32AsSizeT(buffer);
+    cs.num_challenges_ = ReadU32AsSizeT(buffer);
+    ReadBuffer(buffer, cs.advice_column_phases_);
+    ReadBuffer(buffer, cs.challenge_phases_);
+    ReadBuffer(buffer, cs.selector_map_);
+    ReadBuffer(buffer, cs.gates_);
+    ReadBuffer(buffer, cs.advice_queries_);
+    cs.num_advice_queries_ = base::CreateVector(
+        ReadU32AsSizeT(buffer), [&buffer]() { return ReadU32AsSizeT(buffer); });
+    ReadBuffer(buffer, cs.instance_queries_);
+    ReadBuffer(buffer, cs.fixed_queries_);
+    ReadBuffer(buffer, cs.permutation_);
+    ReadBuffer(buffer, cs.lookups_);
+    ReadBuffer(buffer, cs.constants_);
+  }
+
+  zk::ProvingKey<PCS> key_;
+};
+
+}  // namespace tachyon::halo2_api
+
+#endif  // VENDORS_HALO2_SRC_SHPLONK_PROVING_KEY_IMPL_H_


### PR DESCRIPTION
# Description

This PR creates Halo2 Proving Key by deserializing the byte array which is serialized from https://github.com/kroma-network/halo2/commit/746e4ac62ea39e8fec9f711a6b5a359dfa596818.

`permutation_proving_key_` and `vanishing_argument_` of the `ProvingKey` are going to be built internally after `Prover` binding is completed.