### PR TITLE
fix: fix bug on create proof

### DIFF
--- a/tachyon/zk/plonk/circuit/examples/simple_circuit_unittest.cc
+++ b/tachyon/zk/plonk/circuit/examples/simple_circuit_unittest.cc
@@ -646,8 +646,8 @@ TEST_F(SimpleCircuitTest, CreateProof) {
 
   F c = constant * a.Square() * b.Square();
   std::vector<F> instance_column = {std::move(c)};
-  std::vector<std::vector<F>> instance_columns = {std::move(instance_column)};
-  std::vector<std::vector<std::vector<F>>> instance_columns_vec = {
+  std::vector<Evals> instance_columns = {Evals(std::move(instance_column))};
+  std::vector<std::vector<Evals>> instance_columns_vec = {
       std::move(instance_columns)};
 
   ProvingKey<PCS> pkey;

--- a/tachyon/zk/plonk/circuit/examples/simple_lookup_circuit_unittest.cc
+++ b/tachyon/zk/plonk/circuit/examples/simple_lookup_circuit_unittest.cc
@@ -531,8 +531,8 @@ TEST_F(SimpleLookupCircuitTest, CreateProof) {
   std::vector<SimpleLookupCircuit<F, kBits, SimpleFloorPlanner>> circuits = {
       std::move(circuit)};
 
-  std::vector<std::vector<F>> instance_columns;
-  std::vector<std::vector<std::vector<F>>> instance_columns_vec = {
+  std::vector<Evals> instance_columns;
+  std::vector<std::vector<Evals>> instance_columns_vec = {
       std::move(instance_columns)};
 
   ProvingKey<PCS> pkey;

--- a/tachyon/zk/plonk/circuit/examples/simple_lookup_v1_circuit_unittest.cc
+++ b/tachyon/zk/plonk/circuit/examples/simple_lookup_v1_circuit_unittest.cc
@@ -530,8 +530,8 @@ TEST_F(SimpleLookupV1CircuitTest, CreateProof) {
   std::vector<SimpleLookupCircuit<F, kBits, V1FloorPlanner>> circuits = {
       std::move(circuit)};
 
-  std::vector<std::vector<F>> instance_columns;
-  std::vector<std::vector<std::vector<F>>> instance_columns_vec = {
+  std::vector<Evals> instance_columns;
+  std::vector<std::vector<Evals>> instance_columns_vec = {
       std::move(instance_columns)};
 
   ProvingKey<PCS> pkey;

--- a/tachyon/zk/plonk/circuit/examples/simple_v1_circuit_unittest.cc
+++ b/tachyon/zk/plonk/circuit/examples/simple_v1_circuit_unittest.cc
@@ -644,8 +644,8 @@ TEST_F(SimpleV1CircuitTest, CreateProof) {
 
   F c = constant * a.Square() * b.Square();
   std::vector<F> instance_column = {std::move(c)};
-  std::vector<std::vector<F>> instance_columns = {std::move(instance_column)};
-  std::vector<std::vector<std::vector<F>>> instance_columns_vec = {
+  std::vector<Evals> instance_columns = {Evals(std::move(instance_column))};
+  std::vector<std::vector<Evals>> instance_columns_vec = {
       std::move(instance_columns)};
 
   ProvingKey<PCS> pkey;

--- a/tachyon/zk/plonk/halo2/argument.h
+++ b/tachyon/zk/plonk/halo2/argument.h
@@ -38,21 +38,16 @@ class Argument {
         GenerateInstancePolys(prover, instance_columns_vec);
 
     // Generate instance columns
+    size_t n = prover->pcs().N();
     std::vector<std::vector<Evals>> instance_columns_vec_with_leading_zero =
         base::Map(instance_columns_vec,
-                  [prover](std::vector<std::vector<F>>& instances_vec) {
-                    return base::Map(
-                        instances_vec, [prover](std::vector<F>& instances) {
-                          // Append leading zeros to |instances|.
-                          std::vector<F> leading_zeros = base::CreateVector(
-                              prover->pcs().N() - instances.size(), F::Zero());
-                          instances.reserve(prover->pcs().N());
-                          instances.insert(
-                              instances.end(),
-                              std::make_move_iterator(leading_zeros.begin()),
-                              std::make_move_iterator(leading_zeros.end()));
-                          return Evals(std::move(instances));
-                        });
+                  [n](std::vector<std::vector<F>>& instances_vec) {
+                    return base::Map(instances_vec,
+                                     [n](std::vector<F>& instances) {
+                                       // Append leading zeros to |instances|.
+                                       instances.resize(n);
+                                       return Evals(std::move(instances));
+                                     });
                   });
 
     // Generate advice poly by synthesizing circuit and write it to transcript.

--- a/tachyon/zk/plonk/halo2/argument.h
+++ b/tachyon/zk/plonk/halo2/argument.h
@@ -325,7 +325,7 @@ class Argument {
                                   i * num_instance_columns + j);
             instance_polys.push_back(prover->domain()->IFFT(instance_column));
           } else {
-            CHECK(prover->GetWriter()->WriteToTranscript(instance_column));
+            prover->CommitAndWriteToTranscript(instance_column);
             instance_polys.push_back(prover->domain()->IFFT(instance_column));
           }
         } else {

--- a/tachyon/zk/plonk/halo2/prover.h
+++ b/tachyon/zk/plonk/halo2/prover.h
@@ -67,16 +67,14 @@ class Prover : public ProverBase<PCS> {
   }
 
   template <typename Circuit>
-  void CreateProof(
-      const ProvingKey<PCS>& proving_key,
-      std::vector<std::vector<std::vector<F>>>&& instance_columns_vec,
-      std::vector<Circuit>& circuits) {
+  void CreateProof(const ProvingKey<PCS>& proving_key,
+                   std::vector<std::vector<Evals>>&& instance_columns_vec,
+                   std::vector<Circuit>& circuits) {
     size_t num_circuits = circuits.size();
 
     // Check length of instances.
     CHECK_EQ(num_circuits, instance_columns_vec.size());
-    for (const std::vector<std::vector<F>>& instances_vec :
-         instance_columns_vec) {
+    for (const std::vector<Evals>& instances_vec : instance_columns_vec) {
       CHECK_EQ(instances_vec.size(), proving_key.verifying_key()
                                          .constraint_system()
                                          .num_instance_columns());


### PR DESCRIPTION
In this PR, the missing reviews of [PR#238](https://github.com/kroma-network/tachyon/pull/238) are applied. (related to `Argument::GenerateInstancePolys()`)
- The bug where the wrong method was called.
- has been refactored for removing redundant code.
- The Instance type required for calling `CreateProof()` has been changed.