### PR TITLE
fix: fix bug on copyable

### DIFF
--- a/tachyon/crypto/commitments/kzg/BUILD.bazel
+++ b/tachyon/crypto/commitments/kzg/BUILD.bazel
@@ -45,7 +45,7 @@ tachyon_cc_unittest(
     ],
     deps = [
         ":shplonk",
-        "//tachyon/base/buffer:vector_buffer",
+        "//tachyon/base/buffer",
         "//tachyon/crypto/transcripts:simple_transcript",
         "//tachyon/math/elliptic_curves/bn/bn254",
         "//tachyon/math/elliptic_curves/bn/bn254:g1",

--- a/tachyon/crypto/commitments/kzg/kzg_unittest.cc
+++ b/tachyon/crypto/commitments/kzg/kzg_unittest.cc
@@ -2,7 +2,7 @@
 
 #include "gtest/gtest.h"
 
-#include "tachyon/base/buffer/vector_buffer.h"
+#include "tachyon/base/buffer/buffer.h"
 #include "tachyon/math/elliptic_curves/bn/bn254/g1.h"
 #include "tachyon/math/polynomials/univariate/univariate_evaluation_domain_factory.h"
 
@@ -102,8 +102,11 @@ TEST_F(KZGTest, Copyable) {
   PCS expected;
   ASSERT_TRUE(expected.UnsafeSetup(N));
 
-  base::Uint8VectorBuffer write_buf;
+  std::vector<uint8_t> vec;
+  vec.resize(base::EstimateSize(expected));
+  base::Buffer write_buf(vec.data(), vec.size());
   ASSERT_TRUE(write_buf.Write(expected));
+  ASSERT_TRUE(write_buf.Done());
 
   write_buf.set_buffer_offset(0);
 

--- a/tachyon/crypto/commitments/pedersen/BUILD.bazel
+++ b/tachyon/crypto/commitments/pedersen/BUILD.bazel
@@ -23,7 +23,7 @@ tachyon_cc_unittest(
     srcs = ["pedersen_unittest.cc"],
     deps = [
         ":pedersen",
-        "//tachyon/base/buffer:vector_buffer",
+        "//tachyon/base/buffer",
         "//tachyon/math/elliptic_curves/bn/bn254:g1",
     ],
 )

--- a/tachyon/crypto/commitments/pedersen/pedersen_unittest.cc
+++ b/tachyon/crypto/commitments/pedersen/pedersen_unittest.cc
@@ -2,7 +2,7 @@
 
 #include "gtest/gtest.h"
 
-#include "tachyon/base/buffer/vector_buffer.h"
+#include "tachyon/base/buffer/buffer.h"
 #include "tachyon/math/elliptic_curves/bn/bn254/g1.h"
 
 namespace tachyon::crypto {
@@ -76,15 +76,16 @@ TEST_F(PedersenTest, Copyable) {
   VCS expected;
   ASSERT_TRUE(expected.Setup());
 
-  base::Uint8VectorBuffer write_buf;
+  std::vector<uint8_t> vec;
+  vec.resize(base::EstimateSize(expected));
+  base::Buffer write_buf(vec.data(), vec.size());
   ASSERT_TRUE(write_buf.Write(expected));
+  ASSERT_TRUE(write_buf.Done());
 
   write_buf.set_buffer_offset(0);
 
   VCS value;
   ASSERT_TRUE(write_buf.Read(&value));
-
-  EXPECT_EQ(expected.h(), value.h());
   EXPECT_EQ(expected.generators(), value.generators());
 }
 

--- a/tachyon/math/base/BUILD.bazel
+++ b/tachyon/math/base/BUILD.bazel
@@ -141,7 +141,7 @@ tachyon_cc_unittest(
         ":groups",
         ":rational_field",
         ":sign",
-        "//tachyon/base/buffer:vector_buffer",
+        "//tachyon/base/buffer:buffer",
         "//tachyon/base/containers:container_util",
         "//tachyon/math/elliptic_curves/msm/test:msm_test_set",
         "//tachyon/math/elliptic_curves/short_weierstrass/test:sw_curve_config",

--- a/tachyon/math/base/big_int_unittest.cc
+++ b/tachyon/math/base/big_int_unittest.cc
@@ -7,7 +7,7 @@
 #include "absl/types/span.h"
 #include "gtest/gtest.h"
 
-#include "tachyon/base/buffer/vector_buffer.h"
+#include "tachyon/base/buffer/buffer.h"
 
 namespace tachyon::math {
 
@@ -271,13 +271,16 @@ TEST(BigIntTest, Operations) {
 
 TEST(BigIntTest, Copyable) {
   BigInt<2> expected = BigInt<2>::Random();
-  BigInt<2> value;
 
-  base::Uint8VectorBuffer write_buf;
+  std::vector<uint8_t> vec;
+  vec.resize(base::EstimateSize(expected));
+  base::Buffer write_buf(vec.data(), vec.size());
   ASSERT_TRUE(write_buf.Write(expected));
+  ASSERT_TRUE(write_buf.Done());
 
   write_buf.set_buffer_offset(0);
 
+  BigInt<2> value;
   ASSERT_TRUE(write_buf.Read(&value));
   EXPECT_EQ(value, expected);
 }

--- a/tachyon/math/elliptic_curves/short_weierstrass/BUILD.bazel
+++ b/tachyon/math/elliptic_curves/short_weierstrass/BUILD.bazel
@@ -56,7 +56,7 @@ tachyon_cc_unittest(
     ],
     deps = [
         ":points",
-        "//tachyon/base/buffer:vector_buffer",
+        "//tachyon/base/buffer",
         "//tachyon/base/json",
         "//tachyon/math/elliptic_curves/short_weierstrass/test:sw_curve_config",
     ],

--- a/tachyon/math/elliptic_curves/short_weierstrass/affine_point_unittest.cc
+++ b/tachyon/math/elliptic_curves/short_weierstrass/affine_point_unittest.cc
@@ -2,7 +2,7 @@
 
 #include "gtest/gtest.h"
 
-#include "tachyon/base/buffer/vector_buffer.h"
+#include "tachyon/base/buffer/buffer.h"
 #include "tachyon/math/elliptic_curves/short_weierstrass/jacobian_point.h"
 #include "tachyon/math/elliptic_curves/short_weierstrass/point_xyzz.h"
 #include "tachyon/math/elliptic_curves/short_weierstrass/projective_point.h"
@@ -165,14 +165,17 @@ TEST_F(AffinePointTest, CreateFromX) {
 
 TEST_F(AffinePointTest, Copyable) {
   test::AffinePoint expected = test::AffinePoint::Random();
-  test::AffinePoint value;
 
-  base::Uint8VectorBuffer write_buf;
+  std::vector<uint8_t> vec;
+  vec.resize(base::EstimateSize(expected));
+  base::Buffer write_buf(vec.data(), vec.size());
   ASSERT_TRUE(write_buf.Write(expected));
+  ASSERT_TRUE(write_buf.Done());
 
   write_buf.set_buffer_offset(0);
-  ASSERT_TRUE(write_buf.Read(&value));
 
+  test::AffinePoint value;
+  ASSERT_TRUE(write_buf.Read(&value));
   EXPECT_EQ(expected, value);
 }
 

--- a/tachyon/math/elliptic_curves/short_weierstrass/jacobian_point_unittest.cc
+++ b/tachyon/math/elliptic_curves/short_weierstrass/jacobian_point_unittest.cc
@@ -5,7 +5,7 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-#include "tachyon/base/buffer/vector_buffer.h"
+#include "tachyon/base/buffer/buffer.h"
 #include "tachyon/math/elliptic_curves/short_weierstrass/affine_point.h"
 #include "tachyon/math/elliptic_curves/short_weierstrass/point_xyzz.h"
 #include "tachyon/math/elliptic_curves/short_weierstrass/projective_point.h"
@@ -217,14 +217,17 @@ TEST_F(JacobianPointTest, CreateFromX) {
 
 TEST_F(JacobianPointTest, Copyable) {
   test::JacobianPoint expected = test::JacobianPoint::Random();
-  test::JacobianPoint value;
 
-  base::Uint8VectorBuffer write_buf;
+  std::vector<uint8_t> vec;
+  vec.resize(base::EstimateSize(expected));
+  base::Buffer write_buf(vec.data(), vec.size());
   ASSERT_TRUE(write_buf.Write(expected));
+  ASSERT_TRUE(write_buf.Done());
 
   write_buf.set_buffer_offset(0);
-  ASSERT_TRUE(write_buf.Read(&value));
 
+  test::JacobianPoint value;
+  ASSERT_TRUE(write_buf.Read(&value));
   EXPECT_EQ(expected, value);
 }
 

--- a/tachyon/math/elliptic_curves/short_weierstrass/point_xyzz_unittest.cc
+++ b/tachyon/math/elliptic_curves/short_weierstrass/point_xyzz_unittest.cc
@@ -5,7 +5,7 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-#include "tachyon/base/buffer/vector_buffer.h"
+#include "tachyon/base/buffer/buffer.h"
 #include "tachyon/math/elliptic_curves/short_weierstrass/affine_point.h"
 #include "tachyon/math/elliptic_curves/short_weierstrass/jacobian_point.h"
 #include "tachyon/math/elliptic_curves/short_weierstrass/projective_point.h"
@@ -220,14 +220,17 @@ TEST_F(PointXYZZTest, CreateFromX) {
 
 TEST_F(PointXYZZTest, Copyable) {
   test::PointXYZZ expected = test::PointXYZZ::Random();
-  test::PointXYZZ value;
 
-  base::Uint8VectorBuffer write_buf;
+  std::vector<uint8_t> vec;
+  vec.resize(base::EstimateSize(expected));
+  base::Buffer write_buf(vec.data(), vec.size());
   ASSERT_TRUE(write_buf.Write(expected));
+  ASSERT_TRUE(write_buf.Done());
 
   write_buf.set_buffer_offset(0);
-  ASSERT_TRUE(write_buf.Read(&value));
 
+  test::PointXYZZ value;
+  ASSERT_TRUE(write_buf.Read(&value));
   EXPECT_EQ(expected, value);
 }
 

--- a/tachyon/math/elliptic_curves/short_weierstrass/projective_point_unittest.cc
+++ b/tachyon/math/elliptic_curves/short_weierstrass/projective_point_unittest.cc
@@ -5,7 +5,7 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-#include "tachyon/base/buffer/vector_buffer.h"
+#include "tachyon/base/buffer/buffer.h"
 #include "tachyon/math/elliptic_curves/short_weierstrass/affine_point.h"
 #include "tachyon/math/elliptic_curves/short_weierstrass/jacobian_point.h"
 #include "tachyon/math/elliptic_curves/short_weierstrass/point_xyzz.h"
@@ -220,14 +220,17 @@ TEST_F(ProjectivePointTest, CreateFromX) {
 
 TEST_F(ProjectivePointTest, Copyable) {
   test::ProjectivePoint expected = test::ProjectivePoint::Random();
-  test::ProjectivePoint value;
 
-  base::Uint8VectorBuffer write_buf;
+  std::vector<uint8_t> vec;
+  vec.resize(base::EstimateSize(expected));
+  base::Buffer write_buf(vec.data(), vec.size());
   ASSERT_TRUE(write_buf.Write(expected));
+  ASSERT_TRUE(write_buf.Done());
 
   write_buf.set_buffer_offset(0);
-  ASSERT_TRUE(write_buf.Read(&value));
 
+  test::ProjectivePoint value;
+  ASSERT_TRUE(write_buf.Read(&value));
   EXPECT_EQ(expected, value);
 }
 

--- a/tachyon/math/finite_fields/BUILD.bazel
+++ b/tachyon/math/finite_fields/BUILD.bazel
@@ -203,7 +203,7 @@ tachyon_cc_unittest(
     ],
     deps = [
         "//tachyon/base:bits",
-        "//tachyon/base/buffer:vector_buffer",
+        "//tachyon/base/buffer",
         "//tachyon/math/elliptic_curves/bn/bn254:fq12",
         "//tachyon/math/elliptic_curves/bn/bn254:fr",
         "//tachyon/math/finite_fields/test:gf7",

--- a/tachyon/math/finite_fields/cubic_extension_field.h
+++ b/tachyon/math/finite_fields/cubic_extension_field.h
@@ -396,9 +396,9 @@ class Copyable<Derived, std::enable_if_t<std::is_base_of_v<
 
   static size_t EstimateSize(
       const math::CubicExtensionField<Derived>& cubic_extension_field) {
-    return EstimateSize(cubic_extension_field.c0()) +
-           EstimateSize(cubic_extension_field.c1()) +
-           EstimateSize(cubic_extension_field.c2());
+    return base::EstimateSize(cubic_extension_field.c0()) +
+           base::EstimateSize(cubic_extension_field.c1()) +
+           base::EstimateSize(cubic_extension_field.c2());
   }
 };
 

--- a/tachyon/math/finite_fields/fp12_unittest.cc
+++ b/tachyon/math/finite_fields/fp12_unittest.cc
@@ -1,6 +1,6 @@
 #include "gtest/gtest.h"
 
-#include "tachyon/base/buffer/vector_buffer.h"
+#include "tachyon/base/buffer/buffer.h"
 #include "tachyon/math/elliptic_curves/bn/bn254/fq12.h"
 
 namespace tachyon::math {
@@ -23,12 +23,16 @@ TEST_F(Fp12Test, Copyable) {
   using F = bn254::Fq12;
 
   const F expected = F::Random();
-  F value;
 
-  base::Uint8VectorBuffer write_buf;
+  std::vector<uint8_t> vec;
+  vec.resize(base::EstimateSize(expected));
+  base::Buffer write_buf(vec.data(), vec.size());
   ASSERT_TRUE(write_buf.Write(expected));
+  ASSERT_TRUE(write_buf.Done());
 
   write_buf.set_buffer_offset(0);
+
+  F value;
   ASSERT_TRUE(write_buf.Read(&value));
   EXPECT_EQ(expected, value);
 }

--- a/tachyon/math/finite_fields/fp2_unittest.cc
+++ b/tachyon/math/finite_fields/fp2_unittest.cc
@@ -1,6 +1,6 @@
 #include "gtest/gtest.h"
 
-#include "tachyon/base/buffer/vector_buffer.h"
+#include "tachyon/base/buffer/buffer.h"
 #include "tachyon/math/elliptic_curves/bn/bn254/fq2.h"
 
 namespace tachyon::math {
@@ -23,12 +23,16 @@ TEST_F(Fp2Test, Copyable) {
   using F = bn254::Fq2;
 
   const F expected = F::Random();
-  F value;
 
-  base::Uint8VectorBuffer write_buf;
+  std::vector<uint8_t> vec;
+  vec.resize(base::EstimateSize(expected));
+  base::Buffer write_buf(vec.data(), vec.size());
   ASSERT_TRUE(write_buf.Write(expected));
+  ASSERT_TRUE(write_buf.Done());
 
   write_buf.set_buffer_offset(0);
+
+  F value;
   ASSERT_TRUE(write_buf.Read(&value));
   EXPECT_EQ(expected, value);
 }

--- a/tachyon/math/finite_fields/fp6_unittest.cc
+++ b/tachyon/math/finite_fields/fp6_unittest.cc
@@ -1,6 +1,6 @@
 #include "gtest/gtest.h"
 
-#include "tachyon/base/buffer/vector_buffer.h"
+#include "tachyon/base/buffer/buffer.h"
 #include "tachyon/math/elliptic_curves/bn/bn254/fq6.h"
 
 namespace tachyon::math {
@@ -23,12 +23,16 @@ TEST_F(Fp6Test, Copyable) {
   using F = bn254::Fq6;
 
   const F expected = F::Random();
-  F value;
 
-  base::Uint8VectorBuffer write_buf;
+  std::vector<uint8_t> vec;
+  vec.resize(base::EstimateSize(expected));
+  base::Buffer write_buf(vec.data(), vec.size());
   ASSERT_TRUE(write_buf.Write(expected));
+  ASSERT_TRUE(write_buf.Done());
 
   write_buf.set_buffer_offset(0);
+
+  F value;
   ASSERT_TRUE(write_buf.Read(&value));
   EXPECT_EQ(expected, value);
 }

--- a/tachyon/math/finite_fields/prime_field_unittest.cc
+++ b/tachyon/math/finite_fields/prime_field_unittest.cc
@@ -1,6 +1,6 @@
 #include "gtest/gtest.h"
 
-#include "tachyon/base/buffer/vector_buffer.h"
+#include "tachyon/base/buffer/buffer.h"
 #include "tachyon/math/finite_fields/test/gf7.h"
 
 namespace tachyon::math {
@@ -187,12 +187,16 @@ TEST_F(PrimeFieldTest, DivBy2Exp) {
 
 TEST_F(PrimeFieldTest, Copyable) {
   const GF7 expected = GF7::Random();
-  GF7 value;
 
-  base::Uint8VectorBuffer write_buf;
+  std::vector<uint8_t> vec;
+  vec.resize(base::EstimateSize(expected));
+  base::Buffer write_buf(vec.data(), vec.size());
   ASSERT_TRUE(write_buf.Write(expected));
+  ASSERT_TRUE(write_buf.Done());
 
   write_buf.set_buffer_offset(0);
+
+  GF7 value;
   ASSERT_TRUE(write_buf.Read(&value));
   EXPECT_EQ(expected, value);
 }

--- a/tachyon/math/finite_fields/quadratic_extension_field.h
+++ b/tachyon/math/finite_fields/quadratic_extension_field.h
@@ -337,8 +337,8 @@ class Copyable<Derived, std::enable_if_t<std::is_base_of_v<
 
   static size_t EstimateSize(
       const math::QuadraticExtensionField<Derived>& quadratic_extension_field) {
-    return EstimateSize(quadratic_extension_field.c0()) +
-           EstimateSize(quadratic_extension_field.c1());
+    return base::EstimateSize(quadratic_extension_field.c0()) +
+           base::EstimateSize(quadratic_extension_field.c1());
   }
 };
 

--- a/tachyon/math/geometry/BUILD.bazel
+++ b/tachyon/math/geometry/BUILD.bazel
@@ -43,7 +43,7 @@ tachyon_cc_unittest(
         ":point2",
         ":point3",
         ":point4",
-        "//tachyon/base/buffer:vector_buffer",
+        "//tachyon/base/buffer",
         "//tachyon/math/finite_fields/test:gf7",
     ],
 )

--- a/tachyon/math/geometry/point2_unittest.cc
+++ b/tachyon/math/geometry/point2_unittest.cc
@@ -1,8 +1,10 @@
 #include "tachyon/math/geometry/point2.h"
 
+#include <vector>
+
 #include "gtest/gtest.h"
 
-#include "tachyon/base/buffer/vector_buffer.h"
+#include "tachyon/base/buffer/buffer.h"
 #include "tachyon/math/finite_fields/test/gf7.h"
 
 namespace tachyon::math {
@@ -40,14 +42,17 @@ TEST(Point2Test, ToHexString) {
 
 TEST(Point2Test, Copyable) {
   Point2GF7 expected(GF7(1), GF7(2));
-  Point2GF7 value;
 
-  base::Uint8VectorBuffer write_buf;
+  std::vector<uint8_t> vec;
+  vec.resize(base::EstimateSize(expected));
+  base::Buffer write_buf(vec.data(), vec.size());
   ASSERT_TRUE(write_buf.Write(expected));
+  ASSERT_TRUE(write_buf.Done());
 
   write_buf.set_buffer_offset(0);
-  ASSERT_TRUE(write_buf.Read(&value));
 
+  Point2GF7 value;
+  ASSERT_TRUE(write_buf.Read(&value));
   EXPECT_EQ(expected, value);
 }
 

--- a/tachyon/math/geometry/point3_unittest.cc
+++ b/tachyon/math/geometry/point3_unittest.cc
@@ -1,8 +1,10 @@
 #include "tachyon/math/geometry/point3.h"
 
+#include <vector>
+
 #include "gtest/gtest.h"
 
-#include "tachyon/base/buffer/vector_buffer.h"
+#include "tachyon/base/buffer/buffer.h"
 #include "tachyon/math/finite_fields/test/gf7.h"
 
 namespace tachyon::math {
@@ -42,14 +44,17 @@ TEST(Point3Test, ToHexString) {
 
 TEST(Point3Test, Copyable) {
   Point3GF7 expected(GF7(1), GF7(2), GF7(3));
-  Point3GF7 value;
 
-  base::Uint8VectorBuffer write_buf;
+  std::vector<uint8_t> vec;
+  vec.resize(base::EstimateSize(expected));
+  base::Buffer write_buf(vec.data(), vec.size());
   ASSERT_TRUE(write_buf.Write(expected));
+  ASSERT_TRUE(write_buf.Done());
 
   write_buf.set_buffer_offset(0);
-  ASSERT_TRUE(write_buf.Read(&value));
 
+  Point3GF7 value;
+  ASSERT_TRUE(write_buf.Read(&value));
   EXPECT_EQ(expected, value);
 }
 

--- a/tachyon/math/geometry/point4_unittest.cc
+++ b/tachyon/math/geometry/point4_unittest.cc
@@ -1,8 +1,10 @@
 #include "tachyon/math/geometry/point4.h"
 
+#include <vector>
+
 #include "gtest/gtest.h"
 
-#include "tachyon/base/buffer/vector_buffer.h"
+#include "tachyon/base/buffer/buffer.h"
 #include "tachyon/math/finite_fields/test/gf7.h"
 
 namespace tachyon::math {
@@ -46,14 +48,17 @@ TEST(Point4Test, ToHexString) {
 
 TEST(Point4Test, Copyable) {
   Point4GF7 expected(GF7(1), GF7(2), GF7(3), GF7(4));
-  Point4GF7 value;
 
-  base::Uint8VectorBuffer write_buf;
+  std::vector<uint8_t> vec;
+  vec.resize(base::EstimateSize(expected));
+  base::Buffer write_buf(vec.data(), vec.size());
   ASSERT_TRUE(write_buf.Write(expected));
+  ASSERT_TRUE(write_buf.Done());
 
   write_buf.set_buffer_offset(0);
-  ASSERT_TRUE(write_buf.Read(&value));
 
+  Point4GF7 value;
+  ASSERT_TRUE(write_buf.Read(&value));
   EXPECT_EQ(expected, value);
 }
 

--- a/tachyon/math/polynomials/univariate/BUILD.bazel
+++ b/tachyon/math/polynomials/univariate/BUILD.bazel
@@ -124,7 +124,7 @@ tachyon_cc_unittest(
         ":mixed_radix_evaluation_domain",
         ":radix2_evaluation_domain",
         ":univariate_polynomial",
-        "//tachyon/base/buffer:vector_buffer",
+        "//tachyon/base/buffer",
         "//tachyon/base/containers:contains",
         "//tachyon/base/containers:cxx20_erase",
         "//tachyon/base/functional:function_ref",

--- a/tachyon/math/polynomials/univariate/univariate_dense_polynomial_unittest.cc
+++ b/tachyon/math/polynomials/univariate/univariate_dense_polynomial_unittest.cc
@@ -1,7 +1,7 @@
 #include "absl/hash/hash_testing.h"
 #include "gtest/gtest.h"
 
-#include "tachyon/base/buffer/vector_buffer.h"
+#include "tachyon/base/buffer/buffer.h"
 #include "tachyon/math/finite_fields/test/gf7.h"
 #include "tachyon/math/polynomials/univariate/univariate_polynomial.h"
 
@@ -379,15 +379,18 @@ TEST_F(UnivariateDensePolynomialTest, FoldOdd) {
 #undef GET_COEFF
 
 TEST_F(UnivariateDensePolynomialTest, Copyable) {
-  Poly expected(Coeffs({GF7(1), GF7(4), GF7(3), GF7(5)}));
+  Poly expected = Poly::Random(kMaxDegree);
+
+  std::vector<uint8_t> vec;
+  vec.resize(base::EstimateSize(expected));
+  base::Buffer write_buf(vec.data(), vec.size());
+  ASSERT_TRUE(write_buf.Write(expected));
+  ASSERT_TRUE(write_buf.Done());
+
+  write_buf.set_buffer_offset(0);
+
   Poly value;
-
-  base::Uint8VectorBuffer buf;
-  ASSERT_TRUE(buf.Write(expected));
-
-  buf.set_buffer_offset(0);
-  ASSERT_TRUE(buf.Read(&value));
-
+  ASSERT_TRUE(write_buf.Read(&value));
   EXPECT_EQ(expected, value);
 }
 

--- a/tachyon/math/polynomials/univariate/univariate_evaluations_unittest.cc
+++ b/tachyon/math/polynomials/univariate/univariate_evaluations_unittest.cc
@@ -3,7 +3,7 @@
 #include "absl/hash/hash_testing.h"
 #include "gtest/gtest.h"
 
-#include "tachyon/base/buffer/vector_buffer.h"
+#include "tachyon/base/buffer/buffer.h"
 #include "tachyon/math/finite_fields/test/gf7.h"
 
 namespace tachyon::math {
@@ -257,14 +257,19 @@ TEST_F(UnivariateEvaluationsTest, DivScalar) {
 }
 
 TEST_F(UnivariateEvaluationsTest, Copyable) {
-  base::Uint8VectorBuffer buf;
-  ASSERT_TRUE(buf.Write(polys_[0]));
+  Poly expected = Poly::Random(kMaxDegree);
 
-  buf.set_buffer_offset(0);
+  std::vector<uint8_t> vec;
+  vec.resize(base::EstimateSize(expected));
+  base::Buffer write_buf(vec.data(), vec.size());
+  ASSERT_TRUE(write_buf.Write(expected));
+  ASSERT_TRUE(write_buf.Done());
+
+  write_buf.set_buffer_offset(0);
+
   Poly value;
-  ASSERT_TRUE(buf.Read(&value));
-
-  EXPECT_EQ(polys_[0], value);
+  ASSERT_TRUE(write_buf.Read(&value));
+  EXPECT_EQ(expected, value);
 }
 
 TEST_F(UnivariateEvaluationsTest, Hash) {

--- a/tachyon/math/polynomials/univariate/univariate_sparse_polynomial_unittest.cc
+++ b/tachyon/math/polynomials/univariate/univariate_sparse_polynomial_unittest.cc
@@ -3,7 +3,7 @@
 #include "absl/hash/hash_testing.h"
 #include "gtest/gtest.h"
 
-#include "tachyon/base/buffer/vector_buffer.h"
+#include "tachyon/base/buffer/buffer.h"
 #include "tachyon/base/containers/cxx20_erase_vector.h"
 #include "tachyon/math/finite_fields/test/gf7.h"
 #include "tachyon/math/polynomials/univariate/univariate_polynomial.h"
@@ -431,15 +431,18 @@ TEST_F(UnivariateSparsePolynomialTest, FoldOdd) {
 #undef GET_COEFF
 
 TEST_F(UnivariateSparsePolynomialTest, Copyable) {
-  Poly expected(Coeffs({{0, GF7(3)}, {1, GF7(1)}}));
+  Poly expected = Poly::Random(kMaxDegree);
+
+  std::vector<uint8_t> vec;
+  vec.resize(base::EstimateSize(expected));
+  base::Buffer write_buf(vec.data(), vec.size());
+  ASSERT_TRUE(write_buf.Write(expected));
+  ASSERT_TRUE(write_buf.Done());
+
+  write_buf.set_buffer_offset(0);
+
   Poly value;
-
-  base::Uint8VectorBuffer buf;
-  ASSERT_TRUE(buf.Write(expected));
-
-  buf.set_buffer_offset(0);
-  ASSERT_TRUE(buf.Read(&value));
-
+  ASSERT_TRUE(write_buf.Read(&value));
   EXPECT_EQ(expected, value);
 }
 

--- a/tachyon/zk/plonk/permutation/BUILD.bazel
+++ b/tachyon/zk/plonk/permutation/BUILD.bazel
@@ -203,7 +203,7 @@ tachyon_cc_unittest(
         ":permutation_argument_runner",
         ":permutation_assembly",
         ":permutation_table_store",
-        "//tachyon/base/buffer:vector_buffer",
+        "//tachyon/base/buffer",
         "//tachyon/math/elliptic_curves/bn/bn254:fq",
         "//tachyon/zk/plonk/halo2:prover_test",
     ],

--- a/tachyon/zk/plonk/permutation/permutation_proving_key_unittest.cc
+++ b/tachyon/zk/plonk/permutation/permutation_proving_key_unittest.cc
@@ -8,7 +8,7 @@
 
 #include "gtest/gtest.h"
 
-#include "tachyon/base/buffer/vector_buffer.h"
+#include "tachyon/base/buffer/buffer.h"
 #include "tachyon/zk/plonk/halo2/prover_test.h"
 
 namespace tachyon::zk {
@@ -24,14 +24,20 @@ class PermutationProvingKeyTest : public halo2::ProverTest {
 
 TEST_F(PermutationProvingKeyTest, Copyable) {
   const Domain* domain = prover_->domain();
-  ProvingKey expected({domain->Random<Evals>()}, {domain->Random<Poly>()});
-  ProvingKey value;
+  ProvingKey expected(
+      {domain->Random<Evals>(), domain->Random<Evals>(),
+       domain->Random<Evals>()},
+      {domain->Random<Poly>(), domain->Random<Poly>(), domain->Random<Poly>()});
 
-  base::Uint8VectorBuffer write_buf;
+  std::vector<uint8_t> vec;
+  vec.resize(base::EstimateSize(expected));
+  base::Buffer write_buf(vec.data(), vec.size());
   ASSERT_TRUE(write_buf.Write(expected));
+  ASSERT_TRUE(write_buf.Done());
 
   write_buf.set_buffer_offset(0);
 
+  ProvingKey value;
   ASSERT_TRUE(write_buf.Read(&value));
   EXPECT_EQ(value, expected);
 }

--- a/tachyon/zk/plonk/permutation/permutation_verifying_key_unittest.cc
+++ b/tachyon/zk/plonk/permutation/permutation_verifying_key_unittest.cc
@@ -8,7 +8,7 @@
 
 #include "gtest/gtest.h"
 
-#include "tachyon/base/buffer/vector_buffer.h"
+#include "tachyon/base/buffer/buffer.h"
 #include "tachyon/zk/plonk/halo2/prover_test.h"
 
 namespace tachyon::zk {
@@ -23,14 +23,19 @@ class PermutationVerifyingKeyTest : public halo2::ProverTest {
 }  // namespace
 
 TEST_F(PermutationVerifyingKeyTest, Copyable) {
-  VerifyingKey expected({math::bn254::G1AffinePoint::Random()});
-  VerifyingKey value;
+  VerifyingKey expected({math::bn254::G1AffinePoint::Random(),
+                         math::bn254::G1AffinePoint::Random(),
+                         math::bn254::G1AffinePoint::Random()});
 
-  base::Uint8VectorBuffer write_buf;
+  std::vector<uint8_t> vec;
+  vec.resize(base::EstimateSize(expected));
+  base::Buffer write_buf(vec.data(), vec.size());
   ASSERT_TRUE(write_buf.Write(expected));
+  ASSERT_TRUE(write_buf.Done());
 
   write_buf.set_buffer_offset(0);
 
+  VerifyingKey value;
   ASSERT_TRUE(write_buf.Read(&value));
   EXPECT_EQ(value, expected);
 }


### PR DESCRIPTION
The existing tests for `Copyable`s did not cover the entire logic.
1. No test for `EstimateSize()`.
2. It did not verify that the serialized bytes are equal to the size of the object.
In this PR, I have enhanced the tests for all `Copyable`s and fixed a few bugs that were discovered.