### PR TITLE
feat: implement json for proof

### DIFF
--- a/tachyon/zk/lookup/BUILD.bazel
+++ b/tachyon/zk/lookup/BUILD.bazel
@@ -65,6 +65,7 @@ tachyon_cc_library(
 tachyon_cc_library(
     name = "lookup_pair",
     hdrs = ["lookup_pair.h"],
+    deps = ["//tachyon/base/json"],
 )
 
 tachyon_cc_library(

--- a/tachyon/zk/lookup/lookup_pair.h
+++ b/tachyon/zk/lookup/lookup_pair.h
@@ -7,10 +7,14 @@
 #ifndef TACHYON_ZK_LOOKUP_LOOKUP_PAIR_H_
 #define TACHYON_ZK_LOOKUP_LOOKUP_PAIR_H_
 
+#include <string>
 #include <utility>
 #include <vector>
 
-namespace tachyon::zk {
+#include "tachyon/base/json/json.h"
+
+namespace tachyon {
+namespace zk {
 
 template <typename T, typename U = T>
 class LookupPair {
@@ -38,6 +42,34 @@ class LookupPair {
 template <typename T, typename U = T>
 using LookupPairs = std::vector<LookupPair<T, U>>;
 
-}  // namespace tachyon::zk
+}  // namespace zk
+
+namespace base {
+
+template <typename T, typename U>
+class RapidJsonValueConverter<zk::LookupPair<T, U>> {
+ public:
+  template <typename Allocator>
+  static rapidjson::Value From(const zk::LookupPair<T, U>& value,
+                               Allocator& allocator) {
+    rapidjson::Value object(rapidjson::kObjectType);
+    AddJsonElement(object, "input", value.input(), allocator);
+    AddJsonElement(object, "table", value.table(), allocator);
+    return object;
+  }
+
+  static bool To(const rapidjson::Value& json_value, std::string_view key,
+                 zk::LookupPair<T, U>* value, std::string* error) {
+    T input;
+    U table;
+    if (!ParseJsonElement(json_value, "input", &input, error)) return false;
+    if (!ParseJsonElement(json_value, "table", &table, error)) return false;
+    *value = zk::LookupPair<T, U>(std::move(input), std::move(table));
+    return true;
+  }
+};
+
+}  // namespace base
+}  // namespace tachyon
 
 #endif  // TACHYON_ZK_LOOKUP_LOOKUP_PAIR_H_

--- a/tachyon/zk/plonk/halo2/BUILD.bazel
+++ b/tachyon/zk/plonk/halo2/BUILD.bazel
@@ -244,6 +244,7 @@ tachyon_cc_unittest(
         "pinned_verifying_key_unittest.cc",
         "poseidon_transcript_unittest.cc",
         "proof_serializer_unittest.cc",
+        "proof_unittest.cc",
         "random_field_generator_unittest.cc",
         "sha256_transcript_unittest.cc",
         "witness_collection_unittest.cc",

--- a/tachyon/zk/plonk/halo2/proof.h
+++ b/tachyon/zk/plonk/halo2/proof.h
@@ -49,6 +49,43 @@ struct Proof {
   F x_last;
   F x_n;
 
+  bool operator==(const Proof& other) const {
+    return advices_commitments_vec == other.advices_commitments_vec &&
+           challenges == other.challenges && theta == other.theta &&
+           lookup_permuted_commitments_vec ==
+               other.lookup_permuted_commitments_vec &&
+           beta == other.beta && gamma == other.gamma &&
+           permutation_product_commitments_vec ==
+               other.permutation_product_commitments_vec &&
+           lookup_product_commitments_vec ==
+               other.lookup_product_commitments_vec &&
+           vanishing_random_poly_commitment ==
+               other.vanishing_random_poly_commitment &&
+           y == other.y &&
+           vanishing_h_poly_commitments == other.vanishing_h_poly_commitments &&
+           x == other.x && instance_evals_vec == other.instance_evals_vec &&
+           advice_evals_vec == other.advice_evals_vec &&
+           fixed_evals == other.fixed_evals &&
+           vanishing_random_eval == other.vanishing_random_eval &&
+           common_permutation_evals == other.common_permutation_evals &&
+           permutation_product_evals_vec ==
+               other.permutation_product_evals_vec &&
+           permutation_product_next_evals_vec ==
+               other.permutation_product_next_evals_vec &&
+           permutation_product_last_evals_vec ==
+               other.permutation_product_last_evals_vec &&
+           lookup_product_evals_vec == other.lookup_product_evals_vec &&
+           lookup_product_next_evals_vec ==
+               other.lookup_product_next_evals_vec &&
+           lookup_permuted_input_evals_vec ==
+               other.lookup_permuted_input_evals_vec &&
+           lookup_permuted_input_inv_evals_vec ==
+               other.lookup_permuted_input_inv_evals_vec &&
+           lookup_permuted_table_evals_vec ==
+               other.lookup_permuted_table_evals_vec;
+  }
+  bool operator!=(const Proof& other) const { return !operator==(other); }
+
   VanishingVerificationData<F> ToVanishingVerificationData(size_t i) const {
     VanishingVerificationData<F> ret;
     ret.fixed_evals = absl::MakeConstSpan(fixed_evals);

--- a/tachyon/zk/plonk/halo2/proof.h
+++ b/tachyon/zk/plonk/halo2/proof.h
@@ -2,15 +2,18 @@
 #define TACHYON_ZK_PLONK_HALO2_PROOF_H_
 
 #include <optional>
+#include <string>
 #include <utility>
 #include <vector>
 
+#include "tachyon/base/json/json.h"
 #include "tachyon/zk/lookup/lookup_pair.h"
 #include "tachyon/zk/lookup/lookup_verification_data.h"
 #include "tachyon/zk/plonk/permutation/permutation_verification_data.h"
 #include "tachyon/zk/plonk/vanishing/vanishing_verification_data.h"
 
-namespace tachyon::zk::halo2 {
+namespace tachyon {
+namespace zk::halo2 {
 
 template <typename F, typename C>
 struct Proof {
@@ -148,6 +151,147 @@ struct Proof {
   }
 };
 
-}  // namespace tachyon::zk::halo2
+}  // namespace zk::halo2
+
+namespace base {
+
+template <typename F, typename C>
+class RapidJsonValueConverter<zk::halo2::Proof<F, C>> {
+ public:
+  template <typename Allocator>
+  static rapidjson::Value From(const zk::halo2::Proof<F, C>& value,
+                               Allocator& allocator) {
+    rapidjson::Value object(rapidjson::kObjectType);
+    AddJsonElement(object, "advices_commitments_vec",
+                   value.advices_commitments_vec, allocator);
+    AddJsonElement(object, "challenges", value.challenges, allocator);
+    AddJsonElement(object, "theta", value.theta, allocator);
+    AddJsonElement(object, "lookup_permuted_commitments_vec",
+                   value.lookup_permuted_commitments_vec, allocator);
+    AddJsonElement(object, "beta", value.beta, allocator);
+    AddJsonElement(object, "gamma", value.gamma, allocator);
+    AddJsonElement(object, "permutation_product_commitments_vec",
+                   value.permutation_product_commitments_vec, allocator);
+    AddJsonElement(object, "lookup_product_commitments_vec",
+                   value.lookup_product_commitments_vec, allocator);
+    AddJsonElement(object, "vanishing_random_poly_commitment",
+                   value.vanishing_random_poly_commitment, allocator);
+    AddJsonElement(object, "y", value.y, allocator);
+    AddJsonElement(object, "vanishing_h_poly_commitments",
+                   value.vanishing_h_poly_commitments, allocator);
+    AddJsonElement(object, "x", value.x, allocator);
+    AddJsonElement(object, "instance_evals_vec", value.instance_evals_vec,
+                   allocator);
+    AddJsonElement(object, "advice_evals_vec", value.advice_evals_vec,
+                   allocator);
+    AddJsonElement(object, "fixed_evals", value.fixed_evals, allocator);
+    AddJsonElement(object, "vanishing_random_eval", value.vanishing_random_eval,
+                   allocator);
+    AddJsonElement(object, "common_permutation_evals",
+                   value.common_permutation_evals, allocator);
+    AddJsonElement(object, "permutation_product_evals_vec",
+                   value.permutation_product_evals_vec, allocator);
+    AddJsonElement(object, "permutation_product_next_evals_vec",
+                   value.permutation_product_next_evals_vec, allocator);
+    AddJsonElement(object, "permutation_product_last_evals_vec",
+                   value.permutation_product_last_evals_vec, allocator);
+    AddJsonElement(object, "lookup_product_evals_vec",
+                   value.lookup_product_evals_vec, allocator);
+    AddJsonElement(object, "lookup_product_next_evals_vec",
+                   value.lookup_product_next_evals_vec, allocator);
+    AddJsonElement(object, "lookup_permuted_input_evals_vec",
+                   value.lookup_permuted_input_evals_vec, allocator);
+    AddJsonElement(object, "lookup_permuted_input_inv_evals_vec",
+                   value.lookup_permuted_input_inv_evals_vec, allocator);
+    AddJsonElement(object, "lookup_permuted_table_evals_vec",
+                   value.lookup_permuted_table_evals_vec, allocator);
+    return object;
+  }
+
+  static bool To(const rapidjson::Value& json_value, std::string_view key,
+                 zk::halo2::Proof<F, C>* proof_out, std::string* error) {
+    zk::halo2::Proof<F, C> proof;
+    if (!ParseJsonElement(json_value, "advices_commitments_vec",
+                          &proof.advices_commitments_vec, error))
+      return false;
+    if (!ParseJsonElement(json_value, "challenges", &proof.challenges, error))
+      return false;
+    if (!ParseJsonElement(json_value, "theta", &proof.theta, error))
+      return false;
+    if (!ParseJsonElement(json_value, "lookup_permuted_commitments_vec",
+                          &proof.lookup_permuted_commitments_vec, error))
+      return false;
+    if (!ParseJsonElement(json_value, "beta", &proof.beta, error)) return false;
+    if (!ParseJsonElement(json_value, "gamma", &proof.gamma, error))
+      return false;
+    if (!ParseJsonElement(json_value, "permutation_product_commitments_vec",
+                          &proof.permutation_product_commitments_vec, error))
+      return false;
+    if (!ParseJsonElement(json_value, "lookup_product_commitments_vec",
+                          &proof.lookup_product_commitments_vec, error))
+      return false;
+    if (!ParseJsonElement(json_value, "vanishing_random_poly_commitment",
+                          &proof.vanishing_random_poly_commitment, error))
+      return false;
+    if (!ParseJsonElement(json_value, "y", &proof.y, error)) return false;
+    if (!ParseJsonElement(json_value, "vanishing_h_poly_commitments",
+                          &proof.vanishing_h_poly_commitments, error))
+      return false;
+    if (!ParseJsonElement(json_value, "x", &proof.x, error)) return false;
+    if (!ParseJsonElement(json_value, "instance_evals_vec",
+                          &proof.instance_evals_vec, error))
+      return false;
+    if (!ParseJsonElement(json_value, "advice_evals_vec",
+                          &proof.advice_evals_vec, error))
+      return false;
+    if (!ParseJsonElement(json_value, "fixed_evals", &proof.fixed_evals, error))
+      return false;
+    if (!ParseJsonElement(json_value, "vanishing_random_eval",
+                          &proof.vanishing_random_eval, error))
+      return false;
+    if (!ParseJsonElement(json_value, "common_permutation_evals",
+                          &proof.common_permutation_evals, error))
+      return false;
+    if (!ParseJsonElement(json_value, "permutation_product_evals_vec",
+                          &proof.permutation_product_evals_vec, error))
+      return false;
+    if (!ParseJsonElement(json_value, "permutation_product_next_evals_vec",
+                          &proof.permutation_product_next_evals_vec, error))
+      return false;
+    if (!ParseJsonElement(json_value, "common_permutation_evals",
+                          &proof.common_permutation_evals, error))
+      return false;
+    if (!ParseJsonElement(json_value, "permutation_product_evals_vec",
+                          &proof.permutation_product_evals_vec, error))
+      return false;
+    if (!ParseJsonElement(json_value, "permutation_product_next_evals_vec",
+                          &proof.permutation_product_next_evals_vec, error))
+      return false;
+    if (!ParseJsonElement(json_value, "permutation_product_last_evals_vec",
+                          &proof.permutation_product_last_evals_vec, error))
+      return false;
+    if (!ParseJsonElement(json_value, "lookup_product_evals_vec",
+                          &proof.lookup_product_evals_vec, error))
+      return false;
+    if (!ParseJsonElement(json_value, "lookup_product_next_evals_vec",
+                          &proof.lookup_product_next_evals_vec, error))
+      return false;
+    if (!ParseJsonElement(json_value, "lookup_permuted_input_evals_vec",
+                          &proof.lookup_permuted_input_evals_vec, error))
+      return false;
+    if (!ParseJsonElement(json_value, "lookup_permuted_input_inv_evals_vec",
+                          &proof.lookup_permuted_input_inv_evals_vec, error))
+      return false;
+    if (!ParseJsonElement(json_value, "lookup_permuted_table_evals_vec",
+                          &proof.lookup_permuted_table_evals_vec, error))
+      return false;
+
+    *proof_out = std::move(proof);
+    return true;
+  }
+};
+
+}  // namespace base
+}  // namespace tachyon
 
 #endif  // TACHYON_ZK_PLONK_HALO2_PROOF_H_

--- a/tachyon/zk/plonk/halo2/proof_unittest.cc
+++ b/tachyon/zk/plonk/halo2/proof_unittest.cc
@@ -1,0 +1,97 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
+#include "tachyon/zk/plonk/halo2/proof.h"
+
+#include "gtest/gtest.h"
+
+#include "tachyon/base/containers/container_util.h"
+#include "tachyon/math/elliptic_curves/bn/bn254/bn254.h"
+#include "tachyon/zk/base/commitments/shplonk_extension.h"
+
+namespace tachyon::zk::halo2 {
+namespace {
+
+using F = math::bn254::Fr;
+using Commitment = math::bn254::G1AffinePoint;
+
+template <typename T>
+std::vector<std::vector<T>> CreateRandomElementsVec(size_t rows, size_t cols) {
+  return base::CreateVector(
+      rows, [cols]() { return base::CreateVector(cols, T::Random()); });
+}
+
+std::vector<std::vector<zk::LookupPair<Commitment>>> CreateRandomLookupPairsVec(
+    size_t rows, size_t cols) {
+  return base::CreateVector(rows, [cols]() {
+    return base::CreateVector(cols, []() {
+      return zk::LookupPair<Commitment>(Commitment::Random(),
+                                        Commitment::Random());
+    });
+  });
+}
+
+}  // namespace
+
+TEST(ProofTest, JsonValueConverter) {
+  math::bn254::G1Curve::Init();
+
+  size_t num_circuits_ = 2;
+  size_t num_elements_ = 3;
+
+  Proof<F, Commitment> expected_proof;
+  expected_proof.advices_commitments_vec =
+      CreateRandomElementsVec<Commitment>(num_circuits_, num_elements_);
+  expected_proof.challenges = base::CreateVector(num_circuits_, F::Random());
+  expected_proof.theta = F::Random();
+  expected_proof.lookup_permuted_commitments_vec =
+      CreateRandomLookupPairsVec(num_circuits_, num_elements_);
+  expected_proof.beta = F::Random();
+  expected_proof.gamma = F::Random();
+  expected_proof.permutation_product_commitments_vec =
+      CreateRandomElementsVec<Commitment>(num_circuits_, num_elements_);
+  expected_proof.lookup_product_commitments_vec =
+      CreateRandomElementsVec<Commitment>(num_circuits_, num_elements_);
+  expected_proof.vanishing_random_poly_commitment = Commitment::Random();
+  expected_proof.y = F::Random();
+  expected_proof.vanishing_h_poly_commitments =
+      base::CreateVector(5, Commitment::Random());
+  expected_proof.x = F::Random();
+  expected_proof.instance_evals_vec =
+      CreateRandomElementsVec<F>(num_circuits_, num_elements_);
+  expected_proof.advice_evals_vec =
+      CreateRandomElementsVec<F>(num_circuits_, num_elements_);
+  expected_proof.fixed_evals = base::CreateVector(num_circuits_, F::Random());
+  expected_proof.vanishing_random_eval = F::Random();
+  expected_proof.common_permutation_evals =
+      base::CreateVector(num_circuits_, F::Random());
+  expected_proof.permutation_product_evals_vec =
+      CreateRandomElementsVec<F>(num_circuits_, num_elements_);
+  expected_proof.permutation_product_next_evals_vec =
+      CreateRandomElementsVec<F>(num_circuits_, num_elements_);
+  expected_proof.permutation_product_last_evals_vec = {
+      base::CreateVector(5, std::optional<F>(F::Random())),
+      base::CreateVector(5, std::optional<F>())};
+  expected_proof.lookup_product_evals_vec =
+      CreateRandomElementsVec<F>(num_circuits_, num_elements_);
+  expected_proof.lookup_product_next_evals_vec =
+      CreateRandomElementsVec<F>(num_circuits_, num_elements_);
+  expected_proof.lookup_permuted_input_evals_vec =
+      CreateRandomElementsVec<F>(num_circuits_, num_elements_);
+  expected_proof.lookup_permuted_input_inv_evals_vec =
+      CreateRandomElementsVec<F>(num_circuits_, num_elements_);
+  expected_proof.lookup_permuted_table_evals_vec =
+      CreateRandomElementsVec<F>(num_circuits_, num_elements_);
+  std::string json = base::WriteToJson(expected_proof);
+
+  Proof<F, Commitment> proof;
+  std::string error;
+  ASSERT_TRUE(base::ParseJson(json, &proof, &error));
+  ASSERT_TRUE(error.empty());
+  EXPECT_EQ(proof, expected_proof);
+}
+
+}  // namespace tachyon::zk::halo2


### PR DESCRIPTION
In this PR, `RapidJsonValueConverters` for `Proof` implemented in `zk/plonk/halo2/proof.h` has been implemented.
From now on, the `Proof` can be written to a JSON file and read from the JSON file.