### PR TITLE
fix(zk): match the stringify method for a non-zero `Phase` with the rust-halo2

### DIFF
--- a/tachyon/zk/plonk/circuit/column_key_stringifier.h
+++ b/tachyon/zk/plonk/circuit/column_key_stringifier.h
@@ -15,6 +15,22 @@
 
 namespace tachyon::base::internal {
 
+struct AdviceColumnType {
+  zk::Phase phase;
+  explicit AdviceColumnType(zk::Phase phase) : phase(phase) {}
+};
+
+template <>
+class RustDebugStringifier<AdviceColumnType> {
+ public:
+  static std::ostream& AppendToStream(std::ostream& os, RustFormatter& fmt,
+                                      const AdviceColumnType& column_type) {
+    return os << fmt.DebugStruct("Advice")
+                     .Field("phase", column_type.phase)
+                     .Finish();
+  }
+};
+
 template <zk::ColumnType C>
 class RustDebugStringifier<zk::ColumnKey<C>> {
  public:
@@ -22,10 +38,22 @@ class RustDebugStringifier<zk::ColumnKey<C>> {
                                       const zk::ColumnKey<C>& column) {
     // NOTE(chokobole): See
     // https://github.com/kroma-network/halo2/blob/7d0a36990452c8e7ebd600de258420781a9b7917/halo2_proofs/src/plonk/circuit.rs#L26-L31.
-    return os << fmt.DebugStruct("Column")
-                     .Field("index", column.index())
-                     .Field("column_type", column.type())
-                     .Finish();
+    if (column.phase() == zk::kFirstPhase) {
+      return os << fmt.DebugStruct("Column")
+                       .Field("index", column.index())
+                       .Field("column_type", column.type())
+                       .Finish();
+    } else {
+      // NOTE(dongchangYoo): The |ColumnType| in rust-halo2 includes |Phase|.
+      // Example of stringify rules:
+      // - |ColumnType| with |Phase(0)| => "Advice",
+      // - |ColumnType| with the other phases => "Advice { phase: Phase(1) }"
+      AdviceColumnType advice_column_type(column.phase());
+      return os << fmt.DebugStruct("Column")
+                       .Field("index", column.index())
+                       .Field("column_type", advice_column_type)
+                       .Finish();
+    }
   }
 };
 


### PR DESCRIPTION
This PR solved the issue where the rule for converting a non-zero `ColumnKey` to a string was different from rust-halo2.
The `RustDebugStringifier` does not export `Phase` of advice column while the rust-halo2 does it when the phase is non-zero. (The `ColumnType` in rust-halo2 includes `Phase`.)

[FYI] Example of stringify rules of the rust halo2:
- `ColumnType` with `Phase(0)` => "Advice",
- `ColumnType` with the other phases => "Advice { phase: Phase(1) }"

This affects the representative value of the verifying key.