### PR TITLE
perf: allocate poly in c++ memory when proving

### DIFF
--- a/tachyon/math/polynomials/univariate/BUILD.bazel
+++ b/tachyon/math/polynomials/univariate/BUILD.bazel
@@ -74,6 +74,7 @@ tachyon_cc_library(
         "univariate_evaluations_ops.h",
     ],
     deps = [
+        ":univariate_evaluation_domain_forwards",
         "//tachyon/base:logging",
         "//tachyon/base:openmp_util",
         "//tachyon/base/buffer:copyable",

--- a/vendors/halo2/BUILD.bazel
+++ b/vendors/halo2/BUILD.bazel
@@ -17,8 +17,10 @@ tachyon_rust_library(
         "//tachyon/rs:tachyon_rs",
         ":bn254_blake2b_writer",
         ":bn254_cxx_bridge",
+        ":bn254_evals",
         ":bn254_msm",
         ":bn254_msm_gpu",
+        ":bn254_poly",
         ":bn254_shplonk_prover",
         ":bn254_shplonk_proving_key",
         ":xor_shift_rng",
@@ -68,8 +70,10 @@ tachyon_cc_library(
     name = "bn254_api_hdrs",
     hdrs = [
         "include/bn254_blake2b_writer.h",
+        "include/bn254_evals.h",
         "include/bn254_msm.h",
         "include/bn254_msm_gpu.h",
+        "include/bn254_poly.h",
         "include/bn254_shplonk_prover.h",
         "include/bn254_shplonk_proving_key.h",
         "include/proving_key_impl_forward.h",
@@ -89,6 +93,21 @@ tachyon_cc_library(
         "//tachyon/math/elliptic_curves/bn/bn254:g1",
         "//tachyon/rs/base:container_util",
         "//tachyon/zk/plonk/halo2:blake2b_transcript",
+    ],
+)
+
+tachyon_cc_library(
+    name = "bn254_evals",
+    srcs = [
+        "src/bn254_evals.cc",
+        "src/bn254_evals_impl.h",
+    ],
+    deps = [
+        ":bn254_api_hdrs",
+        ":bn254_cxx_bridge/include",
+        ":degrees",
+        "//tachyon/math/elliptic_curves/bn/bn254:g1",
+        "//tachyon/math/polynomials/univariate:univariate_evaluations",
     ],
 )
 
@@ -113,11 +132,28 @@ tachyon_cc_library(
 )
 
 tachyon_cc_library(
+    name = "bn254_poly",
+    srcs = [
+        "src/bn254_poly.cc",
+        "src/bn254_poly_impl.h",
+    ],
+    deps = [
+        ":bn254_api_hdrs",
+        ":bn254_cxx_bridge/include",
+        ":degrees",
+        "//tachyon/c/math/elliptic_curves/bn/bn254:g1",
+        "//tachyon/math/polynomials/univariate:univariate_polynomial",
+    ],
+)
+
+tachyon_cc_library(
     name = "bn254_shplonk_prover",
     srcs = ["src/bn254_shplonk_prover.cc"],
     deps = [
         ":bn254_api_hdrs",
         ":bn254_cxx_bridge/include",
+        ":bn254_evals",
+        ":bn254_poly",
         ":bn254_shplonk_prover_impl",
         ":bn254_shplonk_proving_key_impl",
         "//tachyon/base/buffer",

--- a/vendors/halo2/BUILD.bazel
+++ b/vendors/halo2/BUILD.bazel
@@ -23,6 +23,7 @@ tachyon_rust_library(
         ":bn254_poly",
         ":bn254_shplonk_prover",
         ":bn254_shplonk_proving_key",
+        ":bn254_rational_evals",
         ":xor_shift_rng",
         ":xor_shift_rng_cxx_bridge",
     ],
@@ -74,6 +75,7 @@ tachyon_cc_library(
         "include/bn254_msm.h",
         "include/bn254_msm_gpu.h",
         "include/bn254_poly.h",
+        "include/bn254_rational_evals.h",
         "include/bn254_shplonk_prover.h",
         "include/bn254_shplonk_proving_key.h",
         "include/proving_key_impl_forward.h",
@@ -147,6 +149,22 @@ tachyon_cc_library(
 )
 
 tachyon_cc_library(
+    name = "bn254_rational_evals",
+    srcs = [
+        "src/bn254_rational_evals.cc",
+        "src/bn254_rational_evals_impl.h",
+    ],
+    deps = [
+        ":bn254_api_hdrs",
+        ":bn254_cxx_bridge/include",
+        ":degrees",
+        "//tachyon/math/base:rational_field",
+        "//tachyon/math/elliptic_curves/bn/bn254:g1",
+        "//tachyon/math/polynomials/univariate:univariate_evaluations",
+    ],
+)
+
+tachyon_cc_library(
     name = "bn254_shplonk_prover",
     srcs = ["src/bn254_shplonk_prover.cc"],
     deps = [
@@ -154,6 +172,7 @@ tachyon_cc_library(
         ":bn254_cxx_bridge/include",
         ":bn254_evals",
         ":bn254_poly",
+        ":bn254_rational_evals",
         ":bn254_shplonk_prover_impl",
         ":bn254_shplonk_proving_key_impl",
         "//tachyon/base/buffer",

--- a/vendors/halo2/include/bn254_evals.h
+++ b/vendors/halo2/include/bn254_evals.h
@@ -19,10 +19,13 @@ class Evals {
 
   size_t len() const;
   void set_value(size_t idx, const Fr& value);
+  std::unique_ptr<Evals> clone() const;
 
  private:
   std::shared_ptr<EvalsImpl> impl_;
 };
+
+std::unique_ptr<Evals> zero_evals();
 
 }  // namespace tachyon::halo2_api::bn254
 

--- a/vendors/halo2/include/bn254_evals.h
+++ b/vendors/halo2/include/bn254_evals.h
@@ -1,0 +1,29 @@
+#ifndef VENDORS_HALO2_INCLUDE_BN254_EVALS_H_
+#define VENDORS_HALO2_INCLUDE_BN254_EVALS_H_
+
+#include <stddef.h>
+
+#include <memory>
+
+namespace tachyon::halo2_api::bn254 {
+
+struct Fr;
+class EvalsImpl;
+
+class Evals {
+ public:
+  Evals();
+
+  EvalsImpl* impl() { return impl_.get(); }
+  const EvalsImpl* impl() const { return impl_.get(); }
+
+  size_t len() const;
+  void set_value(size_t idx, const Fr& value);
+
+ private:
+  std::shared_ptr<EvalsImpl> impl_;
+};
+
+}  // namespace tachyon::halo2_api::bn254
+
+#endif  // VENDORS_HALO2_INCLUDE_BN254_EVALS_H_

--- a/vendors/halo2/include/bn254_poly.h
+++ b/vendors/halo2/include/bn254_poly.h
@@ -1,0 +1,22 @@
+#ifndef VENDORS_HALO2_INCLUDE_BN254_POLY_H_
+#define VENDORS_HALO2_INCLUDE_BN254_POLY_H_
+
+#include <memory>
+
+namespace tachyon::halo2_api::bn254 {
+
+class PolyImpl;
+
+class Poly {
+ public:
+  Poly();
+
+  PolyImpl* impl() { return impl_.get(); }
+
+ private:
+  std::shared_ptr<PolyImpl> impl_;
+};
+
+}  // namespace tachyon::halo2_api::bn254
+
+#endif  // VENDORS_HALO2_INCLUDE_BN254_POLY_H_

--- a/vendors/halo2/include/bn254_poly.h
+++ b/vendors/halo2/include/bn254_poly.h
@@ -12,6 +12,7 @@ class Poly {
   Poly();
 
   PolyImpl* impl() { return impl_.get(); }
+  const PolyImpl* impl() const { return impl_.get(); }
 
  private:
   std::shared_ptr<PolyImpl> impl_;

--- a/vendors/halo2/include/bn254_rational_evals.h
+++ b/vendors/halo2/include/bn254_rational_evals.h
@@ -1,0 +1,32 @@
+#ifndef VENDORS_HALO2_INCLUDE_BN254_RATIONAL_EVALS_H_
+#define VENDORS_HALO2_INCLUDE_BN254_RATIONAL_EVALS_H_
+
+#include <stddef.h>
+
+#include <memory>
+
+namespace tachyon::halo2_api::bn254 {
+
+struct Fr;
+class RationalEvalsImpl;
+
+class RationalEvals {
+ public:
+  RationalEvals();
+
+  RationalEvalsImpl* impl() { return impl_.get(); }
+  const RationalEvalsImpl* impl() const { return impl_.get(); }
+
+  size_t len() const;
+  void set_zero(size_t idx);
+  void set_trivial(size_t idx, const Fr& numerator);
+  void set_rational(size_t idx, const Fr& numerator, const Fr& denominator);
+  std::unique_ptr<RationalEvals> clone() const;
+
+ private:
+  std::shared_ptr<RationalEvalsImpl> impl_;
+};
+
+}  // namespace tachyon::halo2_api::bn254
+
+#endif  // VENDORS_HALO2_INCLUDE_BN254_RATIONAL_EVALS_H_

--- a/vendors/halo2/include/bn254_shplonk_prover.h
+++ b/vendors/halo2/include/bn254_shplonk_prover.h
@@ -16,6 +16,7 @@ struct AdviceSingle;
 class SHPlonkProverImpl;
 class SHPlonkProvingKey;
 class Evals;
+class RationalEvals;
 class Poly;
 
 class SHPlonkProver {
@@ -26,11 +27,14 @@ class SHPlonkProver {
 
   uint32_t k() const;
   uint64_t n() const;
-  rust::Box<G1JacobianPoint> commit(rust::Slice<const Fr> scalars) const;
-  rust::Box<G1JacobianPoint> commit_lagrange(
-      rust::Slice<const Fr> scalars) const;
+  rust::Box<G1JacobianPoint> commit(const Poly& poly) const;
+  rust::Box<G1JacobianPoint> commit_lagrange(const Evals& evals) const;
   std::unique_ptr<Evals> empty_evals() const;
+  std::unique_ptr<RationalEvals> empty_rational_evals() const;
   std::unique_ptr<Poly> ifft(const Evals& evals) const;
+  void batch_evaluate(
+      rust::Slice<std::unique_ptr<RationalEvals>> rational_evals,
+      rust::Slice<std::unique_ptr<Evals>> evals) const;
   void set_rng(rust::Slice<const uint8_t> state);
   void set_transcript(rust::Slice<const uint8_t> state);
   void set_extended_domain(const SHPlonkProvingKey& pk);

--- a/vendors/halo2/include/bn254_shplonk_prover.h
+++ b/vendors/halo2/include/bn254_shplonk_prover.h
@@ -15,6 +15,8 @@ struct InstanceSingle;
 struct AdviceSingle;
 class SHPlonkProverImpl;
 class SHPlonkProvingKey;
+class Evals;
+class Poly;
 
 class SHPlonkProver {
  public:
@@ -27,6 +29,8 @@ class SHPlonkProver {
   rust::Box<G1JacobianPoint> commit(rust::Slice<const Fr> scalars) const;
   rust::Box<G1JacobianPoint> commit_lagrange(
       rust::Slice<const Fr> scalars) const;
+  std::unique_ptr<Evals> empty_evals() const;
+  std::unique_ptr<Poly> ifft(const Evals& evals) const;
   void set_rng(rust::Slice<const uint8_t> state);
   void set_transcript(rust::Slice<const uint8_t> state);
   void set_extended_domain(const SHPlonkProvingKey& pk);

--- a/vendors/halo2/src/bn254.rs
+++ b/vendors/halo2/src/bn254.rs
@@ -208,23 +208,11 @@ pub struct SHPlonkProvingKey {
     inner: cxx::UniquePtr<ffi::SHPlonkProvingKey>,
 }
 
-impl Deref for SHPlonkProvingKey {
-    type Target = ffi::SHPlonkProvingKey;
-
-    fn deref(&self) -> &Self::Target {
-        &self.inner
-    }
-}
-
 impl SHPlonkProvingKey {
     pub fn from(data: &[u8]) -> SHPlonkProvingKey {
         SHPlonkProvingKey {
             inner: ffi::new_proving_key(data),
         }
-    }
-
-    pub fn inner(&self) -> &ffi::SHPlonkProvingKey {
-        &self.inner
     }
 
     // NOTE(chokobole): We name this as plural since it contains multi phases.
@@ -291,7 +279,7 @@ impl SHPlonkProvingKey {
     pub fn transcript_repr(&mut self, prover: &SHPlonkProver) -> halo2curves::bn256::Fr {
         *unsafe {
             std::mem::transmute::<_, Box<halo2curves::bn256::Fr>>(
-                self.inner.pin_mut().transcript_repr(prover.inner()),
+                self.inner.pin_mut().transcript_repr(&prover.inner),
             )
         }
     }
@@ -307,10 +295,6 @@ impl SHPlonkProver {
         SHPlonkProver {
             inner: ffi::new_shplonk_prover(k, cpp_s),
         }
-    }
-
-    pub(crate) fn inner(&self) -> &ffi::SHPlonkProver {
-        &self.inner
     }
 
     pub fn k(&self) -> u32 {
@@ -352,7 +336,7 @@ impl SHPlonkProver {
     }
 
     pub fn set_extended_domain(&mut self, pk: &SHPlonkProvingKey) {
-        self.inner.pin_mut().set_extended_domain(pk.inner())
+        self.inner.pin_mut().set_extended_domain(&pk.inner)
     }
 
     pub fn create_proof(
@@ -364,7 +348,7 @@ impl SHPlonkProver {
     ) {
         self.inner
             .pin_mut()
-            .create_proof(key, instance_singles, advice_singles, challenges)
+            .create_proof(&key.inner, instance_singles, advice_singles, challenges)
     }
 
     pub fn finalize_transcript(&mut self) -> Vec<u8> {

--- a/vendors/halo2/src/bn254.rs
+++ b/vendors/halo2/src/bn254.rs
@@ -1,13 +1,12 @@
 use std::{
     io::{self, Write},
     marker::PhantomData,
-    ops::Deref,
 };
 
 use ff::PrimeField;
 use halo2_proofs::{
     plonk::{sealed, Column, Fixed},
-    poly::{Coeff, LagrangeCoeff, Polynomial},
+    poly::commitment::Blind,
     transcript::{
         Challenge255, EncodedChallenge, Transcript, TranscriptWrite, TranscriptWriterBuffer,
     },
@@ -27,9 +26,10 @@ pub struct InstanceSingle {
     pub instance_values: Vec<Evals>,
     pub instance_polys: Vec<Poly>,
 }
+#[derive(Clone)]
 pub struct AdviceSingle {
-    pub advice_polys: Vec<Vec<Fr>>,
-    pub advice_blinds: Vec<Fr>,
+    pub advice_polys: Vec<Evals>,
+    pub advice_blinds: Vec<Blind<halo2curves::bn256::Fr>>,
 }
 
 #[cxx::bridge(namespace = "tachyon::halo2_api::bn254")]
@@ -101,8 +101,26 @@ pub mod ffi {
 
         type Evals;
 
+        fn zero_evals() -> UniquePtr<Evals>;
         fn len(&self) -> usize;
         fn set_value(self: Pin<&mut Evals>, idx: usize, value: &Fr);
+        fn clone(&self) -> UniquePtr<Evals>;
+    }
+
+    unsafe extern "C++" {
+        include!("vendors/halo2/include/bn254_rational_evals.h");
+
+        type RationalEvals;
+
+        fn set_zero(self: Pin<&mut RationalEvals>, idx: usize);
+        fn set_trivial(self: Pin<&mut RationalEvals>, idx: usize, numerator: &Fr);
+        fn set_rational(
+            self: Pin<&mut RationalEvals>,
+            idx: usize,
+            numerator: &Fr,
+            denominator: &Fr,
+        );
+        fn clone(&self) -> UniquePtr<RationalEvals>;
     }
 
     unsafe extern "C++" {
@@ -119,10 +137,16 @@ pub mod ffi {
         fn new_shplonk_prover(k: u32, s: &Fr) -> UniquePtr<SHPlonkProver>;
         fn k(&self) -> u32;
         fn n(&self) -> u64;
-        fn commit(&self, scalars: &[Fr]) -> Box<G1JacobianPoint>;
-        fn commit_lagrange(&self, scalars: &[Fr]) -> Box<G1JacobianPoint>;
+        fn commit(&self, poly: &Poly) -> Box<G1JacobianPoint>;
+        fn commit_lagrange(&self, evals: &Evals) -> Box<G1JacobianPoint>;
         fn empty_evals(&self) -> UniquePtr<Evals>;
+        fn empty_rational_evals(&self) -> UniquePtr<RationalEvals>;
         fn ifft(&self, evals: &Evals) -> UniquePtr<Poly>;
+        fn batch_evaluate(
+            &self,
+            rational_evals: &mut [UniquePtr<RationalEvals>],
+            evals: &mut [UniquePtr<Evals>],
+        );
         fn set_rng(self: Pin<&mut SHPlonkProver>, state: &[u8]);
         fn set_transcript(self: Pin<&mut SHPlonkProver>, state: &[u8]);
         fn set_extended_domain(self: Pin<&mut SHPlonkProver>, pk: &SHPlonkProvingKey);
@@ -307,6 +331,10 @@ pub struct Evals {
 }
 
 impl Evals {
+    pub fn zero() -> Evals {
+        Self::new(ffi::zero_evals())
+    }
+
     pub fn new(inner: cxx::UniquePtr<ffi::Evals>) -> Evals {
         Evals { inner }
     }
@@ -318,6 +346,54 @@ impl Evals {
     pub fn set_value(&mut self, idx: usize, fr: &halo2curves::bn256::Fr) {
         let cpp_fr = unsafe { std::mem::transmute::<_, &Fr>(fr) };
         self.inner.pin_mut().set_value(idx, cpp_fr)
+    }
+}
+
+impl Clone for Evals {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+pub struct RationalEvals {
+    inner: cxx::UniquePtr<ffi::RationalEvals>,
+}
+
+impl RationalEvals {
+    pub fn new(inner: cxx::UniquePtr<ffi::RationalEvals>) -> RationalEvals {
+        RationalEvals { inner }
+    }
+
+    pub fn set_zero(&mut self, idx: usize) {
+        self.inner.pin_mut().set_zero(idx)
+    }
+
+    pub fn set_trivial(&mut self, idx: usize, numerator: &halo2curves::bn256::Fr) {
+        let cpp_numerator = unsafe { std::mem::transmute::<_, &Fr>(numerator) };
+        self.inner.pin_mut().set_trivial(idx, cpp_numerator)
+    }
+
+    pub fn set_rational(
+        &mut self,
+        idx: usize,
+        numerator: &halo2curves::bn256::Fr,
+        denominator: &halo2curves::bn256::Fr,
+    ) {
+        let cpp_numerator = unsafe { std::mem::transmute::<_, &Fr>(numerator) };
+        let cpp_denominator = unsafe { std::mem::transmute::<_, &Fr>(denominator) };
+        self.inner
+            .pin_mut()
+            .set_rational(idx, cpp_numerator, cpp_denominator)
+    }
+}
+
+impl Clone for RationalEvals {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
     }
 }
 
@@ -351,30 +427,35 @@ impl SHPlonkProver {
         self.inner.n()
     }
 
-    pub fn commit(
-        &self,
-        poly: &Polynomial<halo2curves::bn256::Fr, Coeff>,
-    ) -> halo2curves::bn256::G1 {
+    pub fn commit(&self, poly: &Poly) -> halo2curves::bn256::G1 {
         *unsafe {
-            let scalars: &[Fr] = std::mem::transmute(poly.deref());
-            std::mem::transmute::<_, Box<halo2curves::bn256::G1>>(self.inner.commit(scalars))
+            std::mem::transmute::<_, Box<halo2curves::bn256::G1>>(self.inner.commit(&poly.inner))
         }
     }
 
-    pub fn commit_lagrange(
-        &self,
-        poly: &Polynomial<halo2curves::bn256::Fr, LagrangeCoeff>,
-    ) -> halo2curves::bn256::G1 {
+    pub fn commit_lagrange(&self, evals: &Evals) -> halo2curves::bn256::G1 {
         *unsafe {
-            let scalars: &[Fr] = std::mem::transmute(poly.deref());
             std::mem::transmute::<_, Box<halo2curves::bn256::G1>>(
-                self.inner.commit_lagrange(scalars),
+                self.inner.commit_lagrange(&evals.inner),
             )
         }
     }
 
     pub fn empty_evals(&self) -> Evals {
         Evals::new(self.inner.empty_evals())
+    }
+
+    pub fn empty_rational_evals(&self) -> RationalEvals {
+        RationalEvals::new(self.inner.empty_rational_evals())
+    }
+
+    pub fn batch_evaluate(&self, rational_evals: &mut [RationalEvals], evals: &mut [Evals]) {
+        unsafe {
+            let rational_evals: &mut [cxx::UniquePtr<ffi::RationalEvals>] =
+                std::mem::transmute(rational_evals);
+            let evals: &mut [cxx::UniquePtr<ffi::Evals>] = std::mem::transmute(evals);
+            self.inner.batch_evaluate(rational_evals, evals)
+        }
     }
 
     pub fn ifft(&self, evals: &Evals) -> Poly {

--- a/vendors/halo2/src/bn254_evals.cc
+++ b/vendors/halo2/src/bn254_evals.cc
@@ -14,4 +14,12 @@ void Evals::set_value(size_t idx, const Fr& fr) {
       reinterpret_cast<const math::bn254::Fr&>(fr);
 }
 
+std::unique_ptr<Evals> Evals::clone() const {
+  std::unique_ptr<Evals> ret(new Evals);
+  ret->impl()->evals() = impl_->evals();
+  return ret;
+}
+
+std::unique_ptr<Evals> zero_evals() { return std::make_unique<Evals>(); }
+
 }  // namespace tachyon::halo2_api::bn254

--- a/vendors/halo2/src/bn254_evals.cc
+++ b/vendors/halo2/src/bn254_evals.cc
@@ -1,0 +1,17 @@
+#include "vendors/halo2/include/bn254_evals.h"
+
+#include "vendors/halo2/src/bn254.rs.h"
+#include "vendors/halo2/src/bn254_evals_impl.h"
+
+namespace tachyon::halo2_api::bn254 {
+
+Evals::Evals() : impl_(new EvalsImpl()) {}
+
+size_t Evals::len() const { return impl_->evals().evaluations().size(); }
+
+void Evals::set_value(size_t idx, const Fr& fr) {
+  impl_->evals().evaluations()[idx] =
+      reinterpret_cast<const math::bn254::Fr&>(fr);
+}
+
+}  // namespace tachyon::halo2_api::bn254

--- a/vendors/halo2/src/bn254_evals_impl.h
+++ b/vendors/halo2/src/bn254_evals_impl.h
@@ -1,0 +1,27 @@
+#ifndef VENDORS_HALO2_SRC_BN254_EVALS_IMPL_H_
+#define VENDORS_HALO2_SRC_BN254_EVALS_IMPL_H_
+
+#include <utility>
+
+#include "tachyon/math/elliptic_curves/bn/bn254/g1.h"
+#include "tachyon/math/polynomials/univariate/univariate_evaluations.h"
+#include "vendors/halo2/src/degrees.h"
+
+namespace tachyon::halo2_api::bn254 {
+
+class EvalsImpl {
+ public:
+  using Evals = math::UnivariateEvaluations<math::bn254::Fr, kMaxDegree>;
+
+  Evals& evals() { return evals_; }
+  const Evals& evals() const { return evals_; }
+
+  Evals&& TakeEvals() && { return std::move(evals_); }
+
+ private:
+  Evals evals_;
+};
+
+}  // namespace tachyon::halo2_api::bn254
+
+#endif  // VENDORS_HALO2_SRC_BN254_EVALS_IMPL_H_

--- a/vendors/halo2/src/bn254_poly.cc
+++ b/vendors/halo2/src/bn254_poly.cc
@@ -1,0 +1,9 @@
+#include "vendors/halo2/include/bn254_poly.h"
+
+#include "vendors/halo2/src/bn254_poly_impl.h"
+
+namespace tachyon::halo2_api::bn254 {
+
+Poly::Poly() : impl_(new PolyImpl()) {}
+
+}  // namespace tachyon::halo2_api::bn254

--- a/vendors/halo2/src/bn254_poly_impl.h
+++ b/vendors/halo2/src/bn254_poly_impl.h
@@ -1,0 +1,27 @@
+#ifndef VENDORS_HALO2_SRC_BN254_POLY_IMPL_H_
+#define VENDORS_HALO2_SRC_BN254_POLY_IMPL_H_
+
+#include <utility>
+
+#include "tachyon/math/elliptic_curves/bn/bn254/g1.h"
+#include "tachyon/math/polynomials/univariate/univariate_polynomial.h"
+#include "vendors/halo2/src/degrees.h"
+
+namespace tachyon::halo2_api::bn254 {
+
+class PolyImpl {
+ public:
+  using Poly = math::UnivariateDensePolynomial<math::bn254::Fr, kMaxDegree>;
+
+  Poly& poly() { return poly_; }
+  const Poly& poly() const { return poly_; }
+
+  Poly&& TakePoly() && { return std::move(poly_); }
+
+ private:
+  Poly poly_;
+};
+
+}  // namespace tachyon::halo2_api::bn254
+
+#endif  // VENDORS_HALO2_SRC_BN254_POLY_IMPL_H_

--- a/vendors/halo2/src/bn254_rational_evals.cc
+++ b/vendors/halo2/src/bn254_rational_evals.cc
@@ -1,0 +1,38 @@
+#include "vendors/halo2/include/bn254_rational_evals.h"
+
+#include "vendors/halo2/src/bn254.rs.h"
+#include "vendors/halo2/src/bn254_rational_evals_impl.h"
+
+namespace tachyon::halo2_api::bn254 {
+
+RationalEvals::RationalEvals() : impl_(new RationalEvalsImpl()) {}
+
+size_t RationalEvals::len() const {
+  return impl_->evals().evaluations().size();
+}
+
+void RationalEvals::set_zero(size_t idx) {
+  impl_->evals().evaluations()[idx] =
+      math::RationalField<math::bn254::Fr>::Zero();
+}
+
+void RationalEvals::set_trivial(size_t idx, const Fr& numerator) {
+  impl_->evals().evaluations()[idx] = math::RationalField<math::bn254::Fr>(
+      reinterpret_cast<const math::bn254::Fr&>(numerator));
+}
+
+void RationalEvals::set_rational(size_t idx, const Fr& numerator,
+                                 const Fr& denominator) {
+  impl_->evals().evaluations()[idx] = {
+      reinterpret_cast<const math::bn254::Fr&>(numerator),
+      reinterpret_cast<const math::bn254::Fr&>(denominator),
+  };
+}
+
+std::unique_ptr<RationalEvals> RationalEvals::clone() const {
+  std::unique_ptr<RationalEvals> ret(new RationalEvals);
+  ret->impl()->evals() = impl_->evals();
+  return ret;
+}
+
+}  // namespace tachyon::halo2_api::bn254

--- a/vendors/halo2/src/bn254_rational_evals_impl.h
+++ b/vendors/halo2/src/bn254_rational_evals_impl.h
@@ -1,0 +1,30 @@
+#ifndef VENDORS_HALO2_SRC_BN254_RATIONAL_EVALS_IMPL_H_
+#define VENDORS_HALO2_SRC_BN254_RATIONAL_EVALS_IMPL_H_
+
+#include <utility>
+
+#include "tachyon/math/base/rational_field.h"
+#include "tachyon/math/elliptic_curves/bn/bn254/g1.h"
+#include "tachyon/math/polynomials/univariate/univariate_evaluations.h"
+#include "vendors/halo2/src/degrees.h"
+
+namespace tachyon::halo2_api::bn254 {
+
+class RationalEvalsImpl {
+ public:
+  using RationalEvals =
+      math::UnivariateEvaluations<math::RationalField<math::bn254::Fr>,
+                                  kMaxDegree>;
+
+  RationalEvals& evals() { return evals_; }
+  const RationalEvals& evals() const { return evals_; }
+
+  RationalEvals&& TakeEvals() && { return std::move(evals_); }
+
+ private:
+  RationalEvals evals_;
+};
+
+}  // namespace tachyon::halo2_api::bn254
+
+#endif  // VENDORS_HALO2_SRC_BN254_RATIONAL_EVALS_IMPL_H_

--- a/vendors/halo2/src/circuits/simple_circuit.rs
+++ b/vendors/halo2/src/circuits/simple_circuit.rs
@@ -388,7 +388,6 @@ mod test {
                 .unwrap();
             let mut tachyon_pk = TachyonSHPlonkProvingKey::from(pk_bytes.as_slice());
             let mut transcript = TachyonBlake2bWrite::init(vec![]);
-            let domain = &pk.vk.domain;
 
             tachyon_create_proof::<_, _>(
                 &mut prover,
@@ -397,7 +396,6 @@ mod test {
                 public_inputs3.as_slice(),
                 rng,
                 &mut transcript,
-                &domain,
             )
             .expect("proof generation should not fail");
 

--- a/vendors/halo2/src/circuits/simple_lookup_circuit.rs
+++ b/vendors/halo2/src/circuits/simple_lookup_circuit.rs
@@ -161,7 +161,6 @@ mod test {
                 .unwrap();
             let mut tachyon_pk = TachyonSHPlonkProvingKey::from(pk_bytes.as_slice());
             let mut transcript = TachyonBlake2bWrite::init(vec![]);
-            let domain = &pk.vk.domain;
 
             tachyon_create_proof::<_, _>(
                 &mut prover,
@@ -170,7 +169,6 @@ mod test {
                 public_inputs2.as_slice(),
                 rng,
                 &mut transcript,
-                &domain,
             )
             .expect("proof generation should not fail");
 


### PR DESCRIPTION
# Description

This PR fixes to allocate memory for `Polynomial` and `Evaluations` inside c++ memory so that it can avoid copying rust memory which usually takes a lot.