### PR TITLE
refac: fix row and k like members to 32bit

### DIFF
--- a/tachyon/crypto/commitments/fri/fri.h
+++ b/tachyon/crypto/commitments/fri/fri.h
@@ -4,6 +4,7 @@
 #ifndef TACHYON_CRYPTO_COMMITMENTS_FRI_FRI_H_
 #define TACHYON_CRYPTO_COMMITMENTS_FRI_FRI_H_
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include <memory>

--- a/tachyon/crypto/commitments/fri/fri.h
+++ b/tachyon/crypto/commitments/fri/fri.h
@@ -4,6 +4,8 @@
 #ifndef TACHYON_CRYPTO_COMMITMENTS_FRI_FRI_H_
 #define TACHYON_CRYPTO_COMMITMENTS_FRI_FRI_H_
 
+#include <stdint.h>
+
 #include <memory>
 #include <utility>
 #include <vector>
@@ -33,7 +35,7 @@ class FRI final
       : domain_(domain), storage_(storage), hasher_(hasher) {
     // This ensures last folding process.
     CHECK_GE(domain->size(), size_t{2}) << "Domain size must be at least 2";
-    size_t k = domain->log_size_of_group();
+    uint32_t k = domain->log_size_of_group();
     if (k > 1) {
       sub_domains_ = base::CreateVector(k - 1, [k](size_t i) {
         return Domain::Create(size_t{1} << (k - i - 1));
@@ -46,7 +48,7 @@ class FRI final
   size_t N() const { return domain_->size(); }
 
   [[nodiscard]] bool Commit(const Poly& poly, Transcript<F>* transcript) const {
-    size_t num_layers = domain_->log_size_of_group();
+    uint32_t num_layers = domain_->log_size_of_group();
     TranscriptWriter<F>* writer = transcript->ToWriter();
     BinaryMerkleTree<F, F, MaxDegree + 1> tree(storage_->GetLayer(0), hasher_);
     Evals evals = domain_->FFT(poly);
@@ -58,7 +60,7 @@ class FRI final
     F beta;
     Poly folded_poly;
     if (num_layers > 1) {
-      for (size_t i = 1; i < num_layers; ++i) {
+      for (uint32_t i = 1; i < num_layers; ++i) {
         // Pᵢ(X)   = Pᵢ_even(X²) + X * Pᵢ_odd(X²)
         // Pᵢ₊₁(X) = Pᵢ_even(X²) + β * Pᵢ_odd(X²)
         beta = writer->SqueezeChallenge();
@@ -82,8 +84,8 @@ class FRI final
   [[nodiscard]] bool DoCreateOpeningProof(size_t index,
                                           FRIProof<F>* fri_proof) const {
     size_t domain_size = domain_->size();
-    size_t num_layers = domain_->log_size_of_group();
-    for (size_t i = 0; i < num_layers; ++i) {
+    uint32_t num_layers = domain_->log_size_of_group();
+    for (uint32_t i = 0; i < num_layers; ++i) {
       size_t leaf_index = index % domain_size;
       BinaryMerkleTreeStorage<F>* layer = storage_->GetLayer(i);
       BinaryMerkleTree<F, F, MaxDegree + 1> tree(layer, hasher_);
@@ -115,14 +117,14 @@ class FRI final
                                           const FRIProof<F>& proof) const {
     TranscriptReader<F>* reader = transcript.ToReader();
     size_t domain_size = domain_->size();
-    size_t num_layers = domain_->log_size_of_group();
+    uint32_t num_layers = domain_->log_size_of_group();
     F root;
     F x;
     F beta;
     F evaluation;
     F evaluation_sym;
     F two_inv = F(2).Inverse();
-    for (size_t i = 0; i < num_layers; ++i) {
+    for (uint32_t i = 0; i < num_layers; ++i) {
       BinaryMerkleTreeStorage<F>* layer = storage_->GetLayer(i);
       BinaryMerkleTree<F, F, MaxDegree + 1> tree(layer, hasher_);
 

--- a/tachyon/crypto/commitments/vector_commitment_scheme.h
+++ b/tachyon/crypto/commitments/vector_commitment_scheme.h
@@ -2,6 +2,7 @@
 #define TACHYON_CRYPTO_COMMITMENTS_VECTOR_COMMITMENT_SCHEME_H_
 
 #include <stddef.h>
+#include <stdint.h>
 
 #include "tachyon/base/bits.h"
 #include "tachyon/crypto/commitments/batch_commitment_state.h"
@@ -22,7 +23,7 @@ class VectorCommitmentScheme {
   using Field = typename VectorCommitmentSchemeTraits<Derived>::Field;
   using Commitment = typename VectorCommitmentSchemeTraits<Derived>::Commitment;
 
-  size_t K() const {
+  uint32_t K() const {
     const Derived* derived = static_cast<const Derived*>(this);
     return base::bits::SafeLog2Ceiling(derived->N());
   }

--- a/tachyon/math/finite_fields/prime_field_base.h
+++ b/tachyon/math/finite_fields/prime_field_base.h
@@ -6,6 +6,7 @@
 #ifndef TACHYON_MATH_FINITE_FIELDS_PRIME_FIELD_BASE_H_
 #define TACHYON_MATH_FINITE_FIELDS_PRIME_FIELD_BASE_H_
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include <cmath>

--- a/tachyon/math/finite_fields/prime_field_base.h
+++ b/tachyon/math/finite_fields/prime_field_base.h
@@ -6,6 +6,8 @@
 #ifndef TACHYON_MATH_FINITE_FIELDS_PRIME_FIELD_BASE_H_
 #define TACHYON_MATH_FINITE_FIELDS_PRIME_FIELD_BASE_H_
 
+#include <stdint.h>
+
 #include <cmath>
 #include <string>
 #include <utility>
@@ -117,8 +119,7 @@ class PrimeFieldBase : public FiniteField<F> {
         omega.SquareInPlace();
       }
     } else {
-      uint64_t log_size_of_group =
-          static_cast<uint64_t>(base::bits::Log2Ceiling(n));
+      uint32_t log_size_of_group = base::bits::Log2Ceiling(n);
       uint64_t size = uint64_t{1} << log_size_of_group;
 
       if (n != size || log_size_of_group > Config::kTwoAdicity) {
@@ -126,7 +127,7 @@ class PrimeFieldBase : public FiniteField<F> {
       }
 
       omega = F::FromMontgomery(Config::kTwoAdicRootOfUnity);
-      for (size_t i = log_size_of_group; i < Config::kTwoAdicity; ++i) {
+      for (uint32_t i = log_size_of_group; i < Config::kTwoAdicity; ++i) {
         omega.SquareInPlace();
       }
     }

--- a/tachyon/zk/base/BUILD.bazel
+++ b/tachyon/zk/base/BUILD.bazel
@@ -47,6 +47,11 @@ tachyon_cc_library(
 )
 
 tachyon_cc_library(
+    name = "row_index",
+    hdrs = ["row_index.h"],
+)
+
+tachyon_cc_library(
     name = "univarate_polynomial_commitment_scheme_extension",
     hdrs = ["univarate_polynomial_commitment_scheme_extension.h"],
     deps = [

--- a/tachyon/zk/base/BUILD.bazel
+++ b/tachyon/zk/base/BUILD.bazel
@@ -5,7 +5,10 @@ package(default_visibility = ["//visibility:public"])
 tachyon_cc_library(
     name = "blinder",
     hdrs = ["blinder.h"],
-    deps = [":random_field_generator_base"],
+    deps = [
+        ":random_field_generator_base",
+        ":row_index",
+    ],
 )
 
 tachyon_cc_library(

--- a/tachyon/zk/base/blinder.h
+++ b/tachyon/zk/base/blinder.h
@@ -33,12 +33,13 @@ class Blinder {
   // Blinds |evals| at behind by |blinding_rows|.
   // Returns false if |evals.NumElements()| is less than |blinding_rows|.
   bool Blind(Evals& evals, bool include_last_row = false) {
-    size_t size = evals.NumElements();
+    // NOTE(chokobole): It's safe to downcast because domain is already checked.
+    RowIndex size = static_cast<RowIndex>(evals.NumElements());
     RowIndex blinding_rows = blinding_factors_;
     if (include_last_row) ++blinding_rows;
-    if (size < size_t{blinding_rows}) return false;
-    size_t start = size - blinding_rows;
-    for (size_t i = start; i < size; ++i) {
+    if (size < blinding_rows) return false;
+    RowIndex start = size - blinding_rows;
+    for (RowIndex i = start; i < size; ++i) {
       *evals[i] = random_field_generator_->Generate();
     }
     return true;

--- a/tachyon/zk/base/blinder.h
+++ b/tachyon/zk/base/blinder.h
@@ -3,8 +3,6 @@
 
 #include <stddef.h>
 
-#include <vector>
-
 #include "tachyon/zk/base/random_field_generator_base.h"
 #include "tachyon/zk/base/row_index.h"
 

--- a/tachyon/zk/base/blinder.h
+++ b/tachyon/zk/base/blinder.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "tachyon/zk/base/random_field_generator_base.h"
+#include "tachyon/zk/base/row_index.h"
 
 namespace tachyon::zk {
 
@@ -16,17 +17,17 @@ class Blinder {
   using Evals = typename PCS::Evals;
 
   Blinder(RandomFieldGeneratorBase<F>* random_field_generator,
-          size_t blinding_factors)
+          RowIndex blinding_factors)
       : random_field_generator_(random_field_generator),
         blinding_factors_(blinding_factors) {}
 
   const RandomFieldGeneratorBase<F>* random_field_generator() const {
     return random_field_generator_;
   }
-  void set_blinding_factors(size_t blinding_factors) {
+  void set_blinding_factors(RowIndex blinding_factors) {
     blinding_factors_ = blinding_factors;
   }
-  size_t blinding_factors() const { return blinding_factors_; }
+  RowIndex blinding_factors() const { return blinding_factors_; }
 
   // The number of |blinding_rows| is determined to be either
   // |blinding_factors_| or |blinding_factors_| + 1, depending on the
@@ -35,9 +36,9 @@ class Blinder {
   // Returns false if |evals.NumElements()| is less than |blinding_rows|.
   bool Blind(Evals& evals, bool include_last_row = false) {
     size_t size = evals.NumElements();
-    size_t blinding_rows =
-        include_last_row ? blinding_factors_ + 1 : blinding_factors_;
-    if (size < blinding_rows) return false;
+    RowIndex blinding_rows = blinding_factors_;
+    if (include_last_row) ++blinding_rows;
+    if (size < size_t{blinding_rows}) return false;
     size_t start = size - blinding_rows;
     for (size_t i = start; i < size; ++i) {
       *evals[i] = random_field_generator_->Generate();
@@ -50,7 +51,7 @@ class Blinder {
  private:
   // not owned
   RandomFieldGeneratorBase<F>* random_field_generator_ = nullptr;
-  size_t blinding_factors_ = 0;
+  RowIndex blinding_factors_ = 0;
 };
 
 }  // namespace tachyon::zk

--- a/tachyon/zk/base/blinder_unittest.cc
+++ b/tachyon/zk/base/blinder_unittest.cc
@@ -52,7 +52,7 @@ class FakeRandomFieldGenerator : public RandomFieldGeneratorBase<math::GF7> {
 }  // namespace
 
 TEST(BlinderUnittest, Blind) {
-  constexpr size_t kBlindingFactors = 10;
+  constexpr RowIndex kBlindingFactors = 10;
   std::vector<math::GF7> blinding_values = base::CreateVector(
       kBlindingFactors, []() { return math::GF7::Random(); });
   FakeRandomFieldGenerator generator(blinding_values);

--- a/tachyon/zk/base/blinder_unittest.cc
+++ b/tachyon/zk/base/blinder_unittest.cc
@@ -1,5 +1,7 @@
 #include "tachyon/zk/base/blinder.h"
 
+#include <vector>
+
 #include "gtest/gtest.h"
 
 #include "tachyon/base/containers/container_util.h"

--- a/tachyon/zk/base/entities/BUILD.bazel
+++ b/tachyon/zk/base/entities/BUILD.bazel
@@ -5,7 +5,11 @@ package(default_visibility = ["//visibility:public"])
 tachyon_cc_library(
     name = "entity",
     hdrs = ["entity.h"],
-    deps = ["//tachyon/crypto/transcripts:transcript"],
+    deps = [
+        "//tachyon/base:logging",
+        "//tachyon/crypto/transcripts:transcript",
+        "//tachyon/zk/base:row_index",
+    ],
 )
 
 tachyon_cc_library(
@@ -17,6 +21,7 @@ tachyon_cc_library(
         "//tachyon/crypto/commitments:vector_commitment_scheme_traits_forward",
         "//tachyon/zk/base:blinded_polynomial",
         "//tachyon/zk/base:blinder",
+        "//tachyon/zk/base:row_index",
     ],
 )
 

--- a/tachyon/zk/base/entities/entity.h
+++ b/tachyon/zk/base/entities/entity.h
@@ -7,10 +7,13 @@
 #ifndef TACHYON_ZK_BASE_ENTITIES_ENTITY_H_
 #define TACHYON_ZK_BASE_ENTITIES_ENTITY_H_
 
+#include <limits>
 #include <memory>
 #include <utility>
 
+#include "tachyon/base/logging.h"
 #include "tachyon/crypto/transcripts/transcript.h"
+#include "tachyon/zk/base/row_index.h"
 
 namespace tachyon::zk {
 
@@ -37,6 +40,7 @@ class Entity {
   const PCS& pcs() const { return pcs_; }
   PCS& pcs() { return pcs_; }
   void set_domain(std::unique_ptr<Domain> domain) {
+    CHECK_LE(domain->size(), size_t{std::numeric_limits<RowIndex>::max()});
     domain_ = std::move(domain);
   }
   const Domain* domain() const { return domain_.get(); }

--- a/tachyon/zk/base/entities/prover_base.h
+++ b/tachyon/zk/base/entities/prover_base.h
@@ -18,6 +18,7 @@
 #include "tachyon/zk/base/blinded_polynomial.h"
 #include "tachyon/zk/base/blinder.h"
 #include "tachyon/zk/base/entities/entity.h"
+#include "tachyon/zk/base/row_index.h"
 
 namespace tachyon::zk {
 
@@ -41,7 +42,7 @@ class ProverBase : public Entity<PCS> {
     return this->transcript()->ToWriter();
   }
 
-  size_t GetUsableRows() const {
+  RowIndex GetUsableRows() const {
     return this->domain_->size() - (blinder_.blinding_factors() + 1);
   }
 

--- a/tachyon/zk/base/row_index.h
+++ b/tachyon/zk/base/row_index.h
@@ -1,0 +1,12 @@
+#ifndef TACHYON_ZK_BASE_ROW_INDEX_H_
+#define TACHYON_ZK_BASE_ROW_INDEX_H_
+
+#include <stdint.h>
+
+namespace tachyon::zk {
+
+using RowIndex = uint32_t;
+
+}  // namespace tachyon::zk
+
+#endif  // TACHYON_ZK_BASE_ROW_INDEX_H_

--- a/tachyon/zk/expressions/evaluator/simple_evaluator_unittest.cc
+++ b/tachyon/zk/expressions/evaluator/simple_evaluator_unittest.cc
@@ -68,9 +68,9 @@ TEST_F(SimpleEvaluatorTest, Fixed) {
     int32_t size = simple_evaluator_->size();
     FixedQuery query(1, Rotation(test.rotation),
                      FixedColumnKey(test.column_index));
-    size_t evals_index = query.rotation().GetIndex(idx, rot_scale, size);
+    RowIndex row_index = query.rotation().GetIndex(idx, rot_scale, size);
 
-    const GF7* expected = fixed_columns_[test.column_index][evals_index];
+    const GF7* expected = fixed_columns_[test.column_index][row_index];
     Expr expr = ExpressionFactory<GF7>::Fixed(query);
     GF7 evaluated = simple_evaluator_->Evaluate(expr.get());
     EXPECT_EQ(evaluated, *expected);
@@ -94,9 +94,9 @@ TEST_F(SimpleEvaluatorTest, Advice) {
     int32_t size = simple_evaluator_->size();
     AdviceQuery query(1, Rotation(test.rotation),
                       AdviceColumnKey(test.column_index, Phase(0)));
-    size_t evals_index = query.rotation().GetIndex(idx, rot_scale, size);
+    RowIndex row_index = query.rotation().GetIndex(idx, rot_scale, size);
 
-    const GF7* expected = advice_columns_[test.column_index][evals_index];
+    const GF7* expected = advice_columns_[test.column_index][row_index];
     Expr expr = ExpressionFactory<GF7>::Advice(query);
     GF7 evaluated = simple_evaluator_->Evaluate(expr.get());
     EXPECT_EQ(evaluated, *expected);
@@ -120,9 +120,9 @@ TEST_F(SimpleEvaluatorTest, Instance) {
     int32_t size = simple_evaluator_->size();
     InstanceQuery query(1, Rotation(test.rotation),
                         InstanceColumnKey(test.column_index));
-    size_t evals_index = query.rotation().GetIndex(idx, rot_scale, size);
+    RowIndex row_index = query.rotation().GetIndex(idx, rot_scale, size);
 
-    const GF7* expected = instance_columns_[test.column_index][evals_index];
+    const GF7* expected = instance_columns_[test.column_index][row_index];
     Expr expr = ExpressionFactory<GF7>::Instance(query);
     GF7 evaluated = simple_evaluator_->Evaluate(expr.get());
     EXPECT_EQ(evaluated, *expected);

--- a/tachyon/zk/lookup/lookup_argument_runner_unittest.cc
+++ b/tachyon/zk/lookup/lookup_argument_runner_unittest.cc
@@ -63,7 +63,7 @@ TEST_F(LookupArgumentRunnerTest, ComputePermutationProduct) {
 
   // sanity check brought from halo2
   ASSERT_EQ(z[0], F::One());
-  for (size_t i = 0; i < prover_->GetUsableRows(); ++i) {
+  for (RowIndex i = 0; i < prover_->GetUsableRows(); ++i) {
     F left = z[i + 1];
 
     left *= (beta + *lookup_permuted.permuted_evals_pair().input()[i]);

--- a/tachyon/zk/lookup/permute_expression_pair_unittest.cc
+++ b/tachyon/zk/lookup/permute_expression_pair_unittest.cc
@@ -24,15 +24,16 @@ class PermuteExpressionPairTest : public halo2::ProverTest {};
 TEST_F(PermuteExpressionPairTest, PermuteExpressionPairTest) {
   prover_->blinder().set_blinding_factors(5);
   size_t n = prover_->pcs().N();
-  size_t usable_rows = prover_->GetUsableRows();
+  RowIndex usable_rows = prover_->GetUsableRows();
 
   std::vector<F> table_evals =
       base::CreateVector(n, []() { return F::Random(); });
 
-  std::vector<F> input_evals = base::CreateVector(n, [usable_rows,
-                                                      &table_evals]() {
-    return table_evals[base::Uniform(base::Range<size_t>::Until(usable_rows))];
-  });
+  std::vector<F> input_evals =
+      base::CreateVector(n, [usable_rows, &table_evals]() {
+        return table_evals[base::Uniform(
+            base::Range<RowIndex>::Until(usable_rows))];
+      });
 
   LookupPair<Evals> input(Evals(std::move(input_evals)),
                           Evals(std::move(table_evals)));

--- a/tachyon/zk/plonk/BUILD.bazel
+++ b/tachyon/zk/plonk/BUILD.bazel
@@ -9,6 +9,7 @@ tachyon_cc_library(
         "//tachyon/base/containers:container_util",
         "//tachyon/base/containers:contains",
         "//tachyon/base/functional:callback",
+        "//tachyon/zk/base:row_index",
         "//tachyon/zk/expressions/evaluator:simple_selector_finder",
         "//tachyon/zk/lookup:lookup_argument",
         "//tachyon/zk/plonk/circuit:constraint",

--- a/tachyon/zk/plonk/circuit/BUILD.bazel
+++ b/tachyon/zk/plonk/circuit/BUILD.bazel
@@ -265,6 +265,7 @@ tachyon_cc_library(
         "//tachyon/base/numerics:checked_math",
         "//tachyon/base/strings:string_number_conversions",
         "//tachyon/math/polynomials/univariate:univariate_evaluation_domain",
+        "//tachyon/zk/base:row_index",
     ],
 )
 

--- a/tachyon/zk/plonk/circuit/BUILD.bazel
+++ b/tachyon/zk/plonk/circuit/BUILD.bazel
@@ -7,6 +7,7 @@ tachyon_cc_library(
     hdrs = ["assigned_cell.h"],
     deps = [
         ":cell",
+        "//tachyon/zk/base:row_index",
         "//tachyon/zk/base:value",
     ],
 )
@@ -20,6 +21,7 @@ tachyon_cc_library(
         ":selector",
         "//tachyon/base/functional:callback",
         "//tachyon/math/base:rational_field",
+        "//tachyon/zk/base:row_index",
         "//tachyon/zk/base:value",
     ],
 )
@@ -30,6 +32,7 @@ tachyon_cc_library(
     deps = [
         ":column_key",
         "//tachyon:export",
+        "//tachyon/zk/base:row_index",
         "@com_google_absl//absl/strings",
     ],
 )
@@ -135,6 +138,7 @@ tachyon_cc_library(
         ":lookup_table",
         ":region",
         "//tachyon/base/functional:callback",
+        "//tachyon/zk/base:row_index",
         "//tachyon/zk/plonk:constraint_system",
     ],
 )
@@ -145,6 +149,7 @@ tachyon_cc_library(
     deps = [
         ":lookup_table_column",
         "//tachyon/math/base:rational_field",
+        "//tachyon/zk/base:row_index",
         "//tachyon/zk/base:value",
     ],
 )
@@ -237,6 +242,7 @@ tachyon_cc_library(
         ":selector",
         "//tachyon/base/functional:callback",
         "//tachyon/math/base:rational_field",
+        "//tachyon/zk/base:row_index",
         "//tachyon/zk/base:value",
     ],
 )
@@ -276,6 +282,7 @@ tachyon_cc_library(
     hdrs = ["selector.h"],
     deps = [
         "//tachyon:export",
+        "//tachyon/zk/base:row_index",
         "@com_google_absl//absl/hash",
         "@com_google_absl//absl/strings",
     ],

--- a/tachyon/zk/plonk/circuit/BUILD.bazel
+++ b/tachyon/zk/plonk/circuit/BUILD.bazel
@@ -213,8 +213,8 @@ tachyon_cc_library(
     deps = [
         ":assigned_cell",
         ":column_key",
-        ":selector",
         ":region_layouter",
+        ":selector",
         "//tachyon/base/functional:callback",
     ],
 )

--- a/tachyon/zk/plonk/circuit/assigned_cell.h
+++ b/tachyon/zk/plonk/circuit/assigned_cell.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <utility>
 
+#include "tachyon/zk/base/row_index.h"
 #include "tachyon/zk/base/value.h"
 #include "tachyon/zk/plonk/circuit/cell.h"
 
@@ -34,7 +35,7 @@ class AssignedCell {
   // Copies the value to a given advice cell and constrains them to be equal.
   AssignedCell<F> CopyAdvice(std::string_view, Region<F>& region,
                              const AdviceColumnKey& column,
-                             size_t offset) const;
+                             RowIndex offset) const;
 
   std::string ToString() const {
     return absl::Substitute("{cell: $0, value: $1}", cell_.ToString(),

--- a/tachyon/zk/plonk/circuit/assignment.h
+++ b/tachyon/zk/plonk/circuit/assignment.h
@@ -7,13 +7,12 @@
 #ifndef TACHYON_ZK_PLONK_CIRCUIT_ASSIGNMENT_H_
 #define TACHYON_ZK_PLONK_CIRCUIT_ASSIGNMENT_H_
 
-#include <stddef.h>
-
 #include <optional>
 #include <string>
 
 #include "tachyon/base/functional/callback.h"
 #include "tachyon/math/base/rational_field.h"
+#include "tachyon/zk/base/row_index.h"
 #include "tachyon/zk/base/value.h"
 #include "tachyon/zk/plonk/circuit/challenge.h"
 #include "tachyon/zk/plonk/circuit/column_key.h"
@@ -53,28 +52,29 @@ class Assignment {
 
   // Enables a selector at the given row.
   virtual void EnableSelector(std::string_view name, const Selector& selector,
-                              size_t row) {}
+                              RowIndex row) {}
 
   // Queries the cell of an instance column at a particular absolute row.
-  virtual Value<F> QueryInstance(const InstanceColumnKey& column, size_t row) {
+  virtual Value<F> QueryInstance(const InstanceColumnKey& column,
+                                 RowIndex row) {
     return Value<F>();
   }
 
   // Assign an advice column value (witness).
   virtual void AssignAdvice(std::string_view name,
-                            const AdviceColumnKey& column, size_t row,
+                            const AdviceColumnKey& column, RowIndex row,
                             AssignCallback assign) {}
 
   // Assign a fixed value.
   virtual void AssignFixed(std::string_view name, const FixedColumnKey& column,
-                           size_t row, AssignCallback assign) {}
+                           RowIndex row, AssignCallback assign) {}
 
   // Assign two cells to have the same value
-  virtual void Copy(const AnyColumnKey& left_column, size_t left_row,
-                    const AnyColumnKey& right_column, size_t right_row) {}
+  virtual void Copy(const AnyColumnKey& left_column, RowIndex left_row,
+                    const AnyColumnKey& right_column, RowIndex right_row) {}
 
   // Fills a fixed |column| starting from the given |row| with |value|.
-  virtual void FillFromRow(const FixedColumnKey& column, size_t row,
+  virtual void FillFromRow(const FixedColumnKey& column, RowIndex row,
                            const math::RationalField<F>& value) {}
 
   // Queries the value of the given challenge.

--- a/tachyon/zk/plonk/circuit/cell.h
+++ b/tachyon/zk/plonk/circuit/cell.h
@@ -14,6 +14,7 @@
 #include "absl/strings/substitute.h"
 
 #include "tachyon/export.h"
+#include "tachyon/zk/base/row_index.h"
 #include "tachyon/zk/plonk/circuit/column_key.h"
 
 namespace tachyon::zk {
@@ -22,11 +23,11 @@ namespace tachyon::zk {
 class TACHYON_EXPORT Cell {
  public:
   Cell() = default;
-  Cell(size_t region_index, size_t row_offset, const AnyColumnKey& column)
+  Cell(size_t region_index, RowIndex row_offset, const AnyColumnKey& column)
       : region_index_(region_index), row_offset_(row_offset), column_(column) {}
 
   size_t region_index() const { return region_index_; }
-  size_t row_offset() const { return row_offset_; }
+  RowIndex row_offset() const { return row_offset_; }
   const AnyColumnKey& column() const { return column_; }
 
   std::string ToString() const {
@@ -38,7 +39,7 @@ class TACHYON_EXPORT Cell {
   // Identifies the region in which this cell resides.
   size_t region_index_ = 0;
   // The relative offset of this cell within its region.
-  size_t row_offset_ = 0;
+  RowIndex row_offset_ = 0;
   // The column of this cell.
   AnyColumnKey column_;
 };

--- a/tachyon/zk/plonk/circuit/examples/simple_circuit.h
+++ b/tachyon/zk/plonk/circuit/examples/simple_circuit.h
@@ -158,7 +158,7 @@ class FieldChip {
   }
 
   void ExposePublic(Layouter<F>* layouter, const AssignedCell<F>& cell,
-                    size_t row) const {
+                    RowIndex row) const {
     layouter->ConstrainInstance(cell.cell(), config_.instance(), row);
   }
 

--- a/tachyon/zk/plonk/circuit/examples/simple_circuit_unittest.cc
+++ b/tachyon/zk/plonk/circuit/examples/simple_circuit_unittest.cc
@@ -137,7 +137,7 @@ TEST_F(SimpleCircuitTest, Configure) {
       AdviceQueryData(Rotation::Next(), AdviceColumnKey(0)),
   };
   EXPECT_EQ(constraint_system.advice_queries(), expected_advice_queries);
-  std::vector<size_t> expected_num_advice_queries = {2, 1};
+  std::vector<RowIndex> expected_num_advice_queries = {2, 1};
   EXPECT_EQ(constraint_system.num_advice_queries(),
             expected_num_advice_queries);
   std::vector<InstanceQueryData> expected_instance_queries = {

--- a/tachyon/zk/plonk/circuit/examples/simple_circuit_unittest.cc
+++ b/tachyon/zk/plonk/circuit/examples/simple_circuit_unittest.cc
@@ -234,7 +234,7 @@ TEST_F(SimpleCircuitTest, Synthesize) {
        false, false, false, false, false, false, false, false}};
   // clang-format on
   EXPECT_EQ(assembly.selectors(), expected_selectors);
-  EXPECT_EQ(assembly.usable_rows(), base::Range<size_t>::Until(10));
+  EXPECT_EQ(assembly.usable_rows(), base::Range<RowIndex>::Until(10));
 }
 
 TEST_F(SimpleCircuitTest, LoadVerifyingKey) {

--- a/tachyon/zk/plonk/circuit/examples/simple_lookup_circuit.h
+++ b/tachyon/zk/plonk/circuit/examples/simple_lookup_circuit.h
@@ -38,7 +38,7 @@ class SimpleLookupConfig {
   void Load(Layouter<F>* layouter) const {
     layouter->AssignLookupTable(
         absl::Substitute("$0-bit table", Bits), [this](LookupTable<F>& table) {
-          for (size_t row = 0; row < size_t{1} << Bits; ++row) {
+          for (RowIndex row = 0; row < RowIndex{1} << Bits; ++row) {
             if (!table.AssignCell(
                     absl::Substitute("row $0", row), table_, row,
                     [row]() { return Value<F>::Known(F(row + 1)); }))
@@ -101,7 +101,7 @@ class SimpleLookupCircuit : public Circuit<SimpleLookupConfig<F, Bits>> {
     constexpr static size_t kModulus = size_t{1} << Bits;
 
     layouter->AssignRegion("assign values", [this, &config](Region<F>& region) {
-      for (size_t offset = 0; offset < (size_t{1} << k_); ++offset) {
+      for (RowIndex offset = 0; offset < (RowIndex{1} << k_); ++offset) {
         config.selector().Enable(region, offset);
         region.AssignAdvice(
             absl::Substitute("offset $0", offset), config.advice(), offset,

--- a/tachyon/zk/plonk/circuit/examples/simple_lookup_circuit.h
+++ b/tachyon/zk/plonk/circuit/examples/simple_lookup_circuit.h
@@ -7,6 +7,7 @@
 #ifndef TACHYON_ZK_PLONK_CIRCUIT_EXAMPLES_SIMPLE_LOOKUP_CIRCUIT_H_
 #define TACHYON_ZK_PLONK_CIRCUIT_EXAMPLES_SIMPLE_LOOKUP_CIRCUIT_H_
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include <memory>

--- a/tachyon/zk/plonk/circuit/examples/simple_lookup_circuit.h
+++ b/tachyon/zk/plonk/circuit/examples/simple_lookup_circuit.h
@@ -7,6 +7,8 @@
 #ifndef TACHYON_ZK_PLONK_CIRCUIT_EXAMPLES_SIMPLE_LOOKUP_CIRCUIT_H_
 #define TACHYON_ZK_PLONK_CIRCUIT_EXAMPLES_SIMPLE_LOOKUP_CIRCUIT_H_
 
+#include <stdint.h>
+
 #include <memory>
 #include <utility>
 
@@ -61,7 +63,7 @@ class SimpleLookupCircuit : public Circuit<SimpleLookupConfig<F, Bits>> {
       _FloorPlanner<SimpleLookupCircuit<F, Bits, _FloorPlanner>>;
 
   SimpleLookupCircuit() = default;
-  explicit SimpleLookupCircuit(size_t k) : k_(k) {}
+  explicit SimpleLookupCircuit(uint32_t k) : k_(k) {}
 
   std::unique_ptr<Circuit<SimpleLookupConfig<F, Bits>>> WithoutWitness()
       const override {
@@ -109,7 +111,7 @@ class SimpleLookupCircuit : public Circuit<SimpleLookupConfig<F, Bits>> {
   }
 
  private:
-  size_t k_ = 0;
+  uint32_t k_ = 0;
 };
 
 }  // namespace tachyon::zk

--- a/tachyon/zk/plonk/circuit/examples/simple_lookup_circuit_unittest.cc
+++ b/tachyon/zk/plonk/circuit/examples/simple_lookup_circuit_unittest.cc
@@ -192,7 +192,7 @@ TEST_F(SimpleLookupCircuitTest, Synthesize) {
       false, false, false, false, false, false, false, false,
   }};
   EXPECT_EQ(assembly.selectors(), expected_selectors);
-  EXPECT_EQ(assembly.usable_rows(), base::Range<size_t>::Until(26));
+  EXPECT_EQ(assembly.usable_rows(), base::Range<RowIndex>::Until(26));
 }
 
 TEST_F(SimpleLookupCircuitTest, LoadVerifyingKey) {

--- a/tachyon/zk/plonk/circuit/examples/simple_lookup_circuit_unittest.cc
+++ b/tachyon/zk/plonk/circuit/examples/simple_lookup_circuit_unittest.cc
@@ -88,7 +88,7 @@ TEST_F(SimpleLookupCircuitTest, Configure) {
       AdviceQueryData(Rotation::Cur(), AdviceColumnKey(0)),
   };
   EXPECT_EQ(constraint_system.advice_queries(), expected_advice_queries);
-  std::vector<size_t> expected_num_advice_queries = {1};
+  std::vector<RowIndex> expected_num_advice_queries = {1};
   EXPECT_EQ(constraint_system.num_advice_queries(),
             expected_num_advice_queries);
   EXPECT_TRUE(constraint_system.instance_queries().empty());

--- a/tachyon/zk/plonk/circuit/examples/simple_lookup_v1_circuit_unittest.cc
+++ b/tachyon/zk/plonk/circuit/examples/simple_lookup_v1_circuit_unittest.cc
@@ -87,7 +87,7 @@ TEST_F(SimpleLookupV1CircuitTest, Configure) {
       AdviceQueryData(Rotation::Cur(), AdviceColumnKey(0)),
   };
   EXPECT_EQ(constraint_system.advice_queries(), expected_advice_queries);
-  std::vector<size_t> expected_num_advice_queries = {1};
+  std::vector<RowIndex> expected_num_advice_queries = {1};
   EXPECT_EQ(constraint_system.num_advice_queries(),
             expected_num_advice_queries);
   EXPECT_TRUE(constraint_system.instance_queries().empty());

--- a/tachyon/zk/plonk/circuit/examples/simple_lookup_v1_circuit_unittest.cc
+++ b/tachyon/zk/plonk/circuit/examples/simple_lookup_v1_circuit_unittest.cc
@@ -191,7 +191,7 @@ TEST_F(SimpleLookupV1CircuitTest, Synthesize) {
       false, false, false, false, false, false, false, false,
   }};
   EXPECT_EQ(assembly.selectors(), expected_selectors);
-  EXPECT_EQ(assembly.usable_rows(), base::Range<size_t>::Until(26));
+  EXPECT_EQ(assembly.usable_rows(), base::Range<RowIndex>::Until(26));
 }
 
 TEST_F(SimpleLookupV1CircuitTest, LoadVerifyingKey) {

--- a/tachyon/zk/plonk/circuit/examples/simple_v1_circuit_unittest.cc
+++ b/tachyon/zk/plonk/circuit/examples/simple_v1_circuit_unittest.cc
@@ -233,7 +233,7 @@ TEST_F(SimpleV1CircuitTest, Synthesize) {
        false, false, false, false, false, false, false, false}};
   // clang-format on
   EXPECT_EQ(assembly.selectors(), expected_selectors);
-  EXPECT_EQ(assembly.usable_rows(), base::Range<size_t>::Until(10));
+  EXPECT_EQ(assembly.usable_rows(), base::Range<RowIndex>::Until(10));
 }
 
 TEST_F(SimpleV1CircuitTest, LoadVerifyingKey) {

--- a/tachyon/zk/plonk/circuit/examples/simple_v1_circuit_unittest.cc
+++ b/tachyon/zk/plonk/circuit/examples/simple_v1_circuit_unittest.cc
@@ -136,7 +136,7 @@ TEST_F(SimpleV1CircuitTest, Configure) {
       AdviceQueryData(Rotation::Next(), AdviceColumnKey(0)),
   };
   EXPECT_EQ(constraint_system.advice_queries(), expected_advice_queries);
-  std::vector<size_t> expected_num_advice_queries = {2, 1};
+  std::vector<RowIndex> expected_num_advice_queries = {2, 1};
   EXPECT_EQ(constraint_system.num_advice_queries(),
             expected_num_advice_queries);
   std::vector<InstanceQueryData> expected_instance_queries = {

--- a/tachyon/zk/plonk/circuit/floor_planner/BUILD.bazel
+++ b/tachyon/zk/plonk/circuit/floor_planner/BUILD.bazel
@@ -5,7 +5,10 @@ package(default_visibility = ["//visibility:public"])
 tachyon_cc_library(
     name = "allocated_region",
     hdrs = ["allocated_region.h"],
-    deps = ["//tachyon:export"],
+    deps = [
+        "//tachyon:export",
+        "//tachyon/zk/base:row_index",
+    ],
 )
 
 tachyon_cc_library(
@@ -34,6 +37,7 @@ tachyon_cc_library(
     deps = [
         "//tachyon:export",
         "//tachyon/base:range",
+        "//tachyon/zk/base:row_index",
     ],
 )
 

--- a/tachyon/zk/plonk/circuit/floor_planner/allocated_region.h
+++ b/tachyon/zk/plonk/circuit/floor_planner/allocated_region.h
@@ -7,22 +7,21 @@
 #ifndef TACHYON_ZK_PLONK_CIRCUIT_FLOOR_PLANNER_ALLOCATED_REGION_H_
 #define TACHYON_ZK_PLONK_CIRCUIT_FLOOR_PLANNER_ALLOCATED_REGION_H_
 
-#include <stddef.h>
-
 #include "tachyon/export.h"
+#include "tachyon/zk/base/row_index.h"
 
 namespace tachyon::zk {
 
 // A region allocated within a column.
 class TACHYON_EXPORT AllocatedRegion {
  public:
-  constexpr AllocatedRegion(size_t start, size_t length)
+  constexpr AllocatedRegion(RowIndex start, RowIndex length)
       : start_(start), length_(length) {}
 
-  constexpr size_t start() const { return start_; }
-  constexpr size_t length() const { return length_; }
+  constexpr RowIndex start() const { return start_; }
+  constexpr RowIndex length() const { return length_; }
 
-  constexpr size_t End() const { return start_ + length_; }
+  constexpr RowIndex End() const { return start_ + length_; }
 
   constexpr bool operator<(const AllocatedRegion& other) const {
     return start_ < other.start_;
@@ -30,9 +29,9 @@ class TACHYON_EXPORT AllocatedRegion {
 
  private:
   // The starting position of the region.
-  size_t start_ = 0;
+  RowIndex start_ = 0;
   // The length of the region.
-  size_t length_ = 0;
+  RowIndex length_ = 0;
 };
 
 }  // namespace tachyon::zk

--- a/tachyon/zk/plonk/circuit/floor_planner/allocations.h
+++ b/tachyon/zk/plonk/circuit/floor_planner/allocations.h
@@ -7,8 +7,6 @@
 #ifndef TACHYON_ZK_PLONK_CIRCUIT_FLOOR_PLANNER_ALLOCATIONS_H_
 #define TACHYON_ZK_PLONK_CIRCUIT_FLOOR_PLANNER_ALLOCATIONS_H_
 
-#include <stddef.h>
-
 #include <algorithm>
 #include <vector>
 
@@ -29,7 +27,7 @@ class TACHYON_EXPORT Allocations {
   absl::btree_set<AllocatedRegion>& allocations() { return allocations_; }
 
   // Returns the row that forms the unbounded unallocated interval.
-  size_t UnboundedIntervalStart() const {
+  RowIndex UnboundedIntervalStart() const {
     if (allocations_.empty()) {
       return 0;
     }
@@ -38,17 +36,17 @@ class TACHYON_EXPORT Allocations {
 
   // Return all the *unallocated* non-empty intervals intersecting [|start|,
   // |end|). |end| = std::nullopt represents an unbounded end.
-  std::vector<EmptySpace> FreeIntervals(size_t start,
-                                        std::optional<size_t> end) const {
+  std::vector<EmptySpace> FreeIntervals(RowIndex start,
+                                        std::optional<RowIndex> end) const {
     std::vector<EmptySpace> result;
     result.reserve(allocations_.size() + 1);
-    size_t row = start;
+    RowIndex row = start;
     for (const AllocatedRegion& region : allocations_) {
       if (end.has_value() && region.start() >= end.value()) {
         break;
       }
       if (row < region.start()) {
-        result.emplace_back(row, std::optional<size_t>(region.start()));
+        result.emplace_back(row, std::optional<RowIndex>(region.start()));
       }
       row = std::max(row, region.End());
     }

--- a/tachyon/zk/plonk/circuit/floor_planner/empty_space.h
+++ b/tachyon/zk/plonk/circuit/floor_planner/empty_space.h
@@ -7,38 +7,37 @@
 #ifndef TACHYON_ZK_PLONK_CIRCUIT_FLOOR_PLANNER_EMPTY_SPACE_H_
 #define TACHYON_ZK_PLONK_CIRCUIT_FLOOR_PLANNER_EMPTY_SPACE_H_
 
-#include <stddef.h>
-
 #include <optional>
 
 #include "tachyon/base/range.h"
 #include "tachyon/export.h"
+#include "tachyon/zk/base/row_index.h"
 
 namespace tachyon::zk {
 
 // An area of empty space within a column.
 class TACHYON_EXPORT EmptySpace {
  public:
-  EmptySpace(size_t start, std::optional<size_t> end)
+  EmptySpace(RowIndex start, std::optional<RowIndex> end)
       : start_(start), end_(end) {}
 
-  size_t start() const { return start_; }
-  std::optional<size_t> end() const { return end_; }
+  RowIndex start() const { return start_; }
+  std::optional<RowIndex> end() const { return end_; }
 
-  constexpr std::optional<base::Range<size_t>> Range() const {
+  constexpr std::optional<base::Range<RowIndex>> Range() const {
     if (end_.has_value()) {
-      return std::optional<base::Range<size_t>>(
-          base::Range<size_t>(start_, end_.value()));
+      return std::optional<base::Range<RowIndex>>(
+          base::Range<RowIndex>(start_, end_.value()));
     }
     return std::nullopt;
   }
 
  private:
   // The starting position (inclusive) of the empty space.
-  size_t start_ = 0;
+  RowIndex start_ = 0;
   // The ending position (exclusive) of the empty space, or |std::nullopt| if
   // unbounded.
-  std::optional<size_t> end_ = std::nullopt;
+  std::optional<RowIndex> end_ = std::nullopt;
 };
 
 }  // namespace tachyon::zk

--- a/tachyon/zk/plonk/circuit/floor_planner/lookup_table_assigner.h
+++ b/tachyon/zk/plonk/circuit/floor_planner/lookup_table_assigner.h
@@ -1,8 +1,6 @@
 #ifndef TACHYON_ZK_PLONK_CIRCUIT_FLOOR_PLANNER_LOOKUP_TABLE_ASSIGNER_H_
 #define TACHYON_ZK_PLONK_CIRCUIT_FLOOR_PLANNER_LOOKUP_TABLE_ASSIGNER_H_
 
-#include <stddef.h>
-
 #include <optional>
 #include <utility>
 #include <vector>
@@ -45,8 +43,8 @@ class LookupTableAssigner {
         values = lookup_table_layouter.values();
     // Check that all table columns have the same length |first_unused|,
     // and all cells up to that length are assigned.
-    std::optional<size_t> first_unused;
-    std::vector<std::optional<size_t>> assigned_sizes = base::Map(
+    std::optional<RowIndex> first_unused;
+    std::vector<std::optional<RowIndex>> assigned_sizes = base::Map(
         values.begin(), values.end(),
         [](const std::pair<LookupTableColumn,
                            typename SimpleLookupTableLayouter<F>::Value>&
@@ -54,12 +52,12 @@ class LookupTableAssigner {
           const auto& [column, value] = entry;
           if (std::all_of(value.assigned.begin(), value.assigned.end(),
                           base::identity())) {
-            return std::optional<size_t>(value.assigned.size());
+            return std::optional<RowIndex>(value.assigned.size());
           } else {
-            return std::optional<size_t>();
+            return std::optional<RowIndex>();
           }
         });
-    for (const std::optional<size_t>& assigned_size : assigned_sizes) {
+    for (const std::optional<RowIndex>& assigned_size : assigned_sizes) {
       CHECK(assigned_size.has_value()) << "length is missing";
 
       if (first_unused.has_value()) {

--- a/tachyon/zk/plonk/circuit/floor_planner/plan_region.h
+++ b/tachyon/zk/plonk/circuit/floor_planner/plan_region.h
@@ -10,6 +10,7 @@
 #include <stddef.h>
 
 #include <utility>
+#include <vector>
 
 #include "tachyon/math/base/rational_field.h"
 #include "tachyon/zk/plonk/circuit/assignment.h"

--- a/tachyon/zk/plonk/circuit/floor_planner/plan_region.h
+++ b/tachyon/zk/plonk/circuit/floor_planner/plan_region.h
@@ -25,7 +25,7 @@ class PlanRegion : public RegionLayouter<F> {
  public:
   using AssignCallback = typename RegionLayouter<F>::AssignCallback;
 
-  PlanRegion(Assignment<F>* assignment, const std::vector<size_t>& regions,
+  PlanRegion(Assignment<F>* assignment, const std::vector<RowIndex>& regions,
              size_t region_index, Constants<F>& constant)
       : assignment_(assignment),
         regions_(regions),
@@ -36,7 +36,7 @@ class PlanRegion : public RegionLayouter<F> {
 
   // RegionLayouter methods
   void EnableSelector(std::string_view name, const Selector& selector,
-                      size_t offset) override {
+                      RowIndex offset) override {
     assignment_->EnableSelector(name, selector,
                                 regions_[region_index_] + offset);
   }
@@ -46,14 +46,14 @@ class PlanRegion : public RegionLayouter<F> {
   }
 
   Cell AssignAdvice(std::string_view name, const AdviceColumnKey& column,
-                    size_t offset, AssignCallback assign) override {
+                    RowIndex offset, AssignCallback assign) override {
     assignment_->AssignAdvice(name, column, regions_[region_index_] + offset,
                               std::move(assign));
     return {region_index_, offset, column};
   }
 
   Cell AssignAdviceFromConstant(
-      std::string_view name, const AdviceColumnKey& column, size_t offset,
+      std::string_view name, const AdviceColumnKey& column, RowIndex offset,
       const math::RationalField<F>& constant) override {
     Cell cell = AssignAdvice(name, column, offset, [&constant]() {
       return Value<math::RationalField<F>>::Known(constant);
@@ -64,9 +64,9 @@ class PlanRegion : public RegionLayouter<F> {
 
   AssignedCell<F> AssignAdviceFromInstance(std::string_view name,
                                            const InstanceColumnKey& instance,
-                                           size_t row,
+                                           RowIndex row,
                                            const AdviceColumnKey& advice,
-                                           size_t offset) override {
+                                           RowIndex offset) override {
     Value<F> value = assignment_->QueryInstance(instance, row);
 
     Cell cell = AssignAdvice(name, advice, offset, [&value]() {
@@ -82,7 +82,7 @@ class PlanRegion : public RegionLayouter<F> {
   }
 
   Cell AssignFixed(std::string_view name, const FixedColumnKey& column,
-                   size_t offset, AssignCallback assign) override {
+                   RowIndex offset, AssignCallback assign) override {
     assignment_->AssignFixed(name, column, regions_[region_index_] + offset,
                              std::move(assign));
     return {region_index_, offset, column};
@@ -102,7 +102,7 @@ class PlanRegion : public RegionLayouter<F> {
  private:
   // not owned
   Assignment<F>* const assignment_;
-  const std::vector<size_t>& regions_;
+  const std::vector<RowIndex>& regions_;
   const size_t region_index_;
   Constants<F>& constants_;
 };

--- a/tachyon/zk/plonk/circuit/floor_planner/simple_lookup_table_layouter.h
+++ b/tachyon/zk/plonk/circuit/floor_planner/simple_lookup_table_layouter.h
@@ -46,7 +46,7 @@ class SimpleLookupTableLayouter : public LookupTable<F>::Layouter {
 
   // LookupTable<F>::Layouter methods
   bool AssignCell(std::string_view name, const LookupTableColumn& column,
-                  size_t offset, AssignCallback assign) override {
+                  RowIndex offset, AssignCallback assign) override {
     if (base::Contains(*used_columns_, column)) {
       LOG(ERROR) << "column already has been assigned";
       return false;

--- a/tachyon/zk/plonk/circuit/floor_planner/single_chip_layouter.h
+++ b/tachyon/zk/plonk/circuit/floor_planner/single_chip_layouter.h
@@ -37,8 +37,8 @@ class SingleChipLayouter : public Layouter<F> {
 
   const Assignment<F>* assignment() const { return assignment_; }
   const std::vector<FixedColumnKey>& constants() const { return constants_; }
-  const std::vector<size_t>& regions() const { return regions_; }
-  const absl::flat_hash_map<RegionColumn, size_t>& columns() const {
+  const std::vector<RowIndex>& regions() const { return regions_; }
+  const absl::flat_hash_map<RegionColumn, RowIndex>& columns() const {
     return columns_;
   }
   const std::vector<LookupTableColumn>& lookup_table_columns() const {
@@ -59,7 +59,7 @@ class SingleChipLayouter : public Layouter<F> {
       Region<F> region(&shape);
       assign.Run(region);
     }
-    size_t row_count = shape.row_count();
+    RowIndex row_count = shape.row_count();
     bool log_region_info = row_count >= 40;
     DLOG_IF(INFO, log_region_info)
         << "Region row count \"" << name << "\": " << row_count;
@@ -107,7 +107,7 @@ class SingleChipLayouter : public Layouter<F> {
           << "Not enough columns for constants";
     } else {
       const FixedColumnKey& constants_column = constants_[0];
-      size_t& next_constant_row = columns_[RegionColumn(constants_column)];
+      RowIndex& next_constant_row = columns_[RegionColumn(constants_column)];
       for (const Constant<F>& constant : plan_region.constants()) {
         const math::RationalField<F>& value = constant.value;
         const Cell& advice = constant.cell;
@@ -132,7 +132,7 @@ class SingleChipLayouter : public Layouter<F> {
   }
 
   void ConstrainInstance(const Cell& cell, const InstanceColumnKey& column,
-                         size_t row) override {
+                         RowIndex row) override {
     assignment_->Copy(cell.column(),
                       regions_[cell.region_index()] + cell.row_offset(), column,
                       row);
@@ -157,9 +157,9 @@ class SingleChipLayouter : public Layouter<F> {
   Assignment<F>* const assignment_;
   std::vector<FixedColumnKey> constants_;
   // Stores the starting row for each region.
-  std::vector<size_t> regions_;
+  std::vector<RowIndex> regions_;
   // Stores the first empty row for each column.
-  absl::flat_hash_map<RegionColumn, size_t> columns_;
+  absl::flat_hash_map<RegionColumn, RowIndex> columns_;
   // Stores the table fixed columns.
   std::vector<LookupTableColumn> lookup_table_columns_;
 };

--- a/tachyon/zk/plonk/circuit/floor_planner/v1/assignment_pass.h
+++ b/tachyon/zk/plonk/circuit/floor_planner/v1/assignment_pass.h
@@ -50,7 +50,7 @@ class AssignmentPass {
   }
 
   void ConstrainInstance(const Cell& cell, const InstanceColumnKey& instance,
-                         size_t row) {
+                         RowIndex row) {
     plan_->assignment()->Copy(
         cell.column(),
         plan_->regions()[cell.region_index()] + cell.row_offset(), instance,

--- a/tachyon/zk/plonk/circuit/floor_planner/v1/v1_floor_planner.h
+++ b/tachyon/zk/plonk/circuit/floor_planner/v1/v1_floor_planner.h
@@ -70,9 +70,9 @@ class V1FloorPlanner : public FloorPlanner<Circuit> {
     plan.set_regions(std::move(result.region_starts));
 
     // - Determine how many rows our planned circuit will require.
-    size_t first_unassigned_row = 0;
+    RowIndex first_unassigned_row = 0;
     if (!result.column_allocations.empty()) {
-      std::vector<size_t> unbounded_interval_starts = base::Map(
+      std::vector<RowIndex> unbounded_interval_starts = base::Map(
           result.column_allocations,
           [](const std::pair<RegionColumn, Allocations>& column_allocation) {
             return column_allocation.second.UnboundedIntervalStart();
@@ -94,10 +94,10 @@ class V1FloorPlanner : public FloorPlanner<Circuit> {
           return base::FlatMap(
               fixed_allocation.rows.FreeIntervals(0, first_unassigned_row),
               [&column = fixed_allocation.column](const EmptySpace& space) {
-                std::optional<base::Range<size_t>> range = space.Range();
+                std::optional<base::Range<RowIndex>> range = space.Range();
                 return range.has_value()
                            ? base::Map(range.value(),
-                                       [&column](size_t row) {
+                                       [&column](RowIndex row) {
                                          return ConstantPosition(column, row);
                                        })
                            : std::vector<ConstantPosition>();
@@ -145,11 +145,11 @@ class V1FloorPlanner : public FloorPlanner<Circuit> {
   };
 
   struct ConstantPosition {
-    ConstantPosition(const FixedColumnKey& column, size_t row)
+    ConstantPosition(const FixedColumnKey& column, RowIndex row)
         : column(column), row(row) {}
 
     FixedColumnKey column;
-    size_t row;
+    RowIndex row;
   };
 };
 

--- a/tachyon/zk/plonk/circuit/floor_planner/v1/v1_floor_planner.h
+++ b/tachyon/zk/plonk/circuit/floor_planner/v1/v1_floor_planner.h
@@ -90,7 +90,7 @@ class V1FloorPlanner : public FloorPlanner<Circuit> {
 
     std::vector<ConstantPosition> constant_positions = base::FlatMap(
         fixed_allocations,
-        [&first_unassigned_row](const FixedAllocation& fixed_allocation) {
+        [first_unassigned_row](const FixedAllocation& fixed_allocation) {
           return base::FlatMap(
               fixed_allocation.rows.FreeIntervals(0, first_unassigned_row),
               [&column = fixed_allocation.column](const EmptySpace& space) {

--- a/tachyon/zk/plonk/circuit/floor_planner/v1/v1_floor_planner.h
+++ b/tachyon/zk/plonk/circuit/floor_planner/v1/v1_floor_planner.h
@@ -97,7 +97,7 @@ class V1FloorPlanner : public FloorPlanner<Circuit> {
                 std::optional<base::Range<size_t>> range = space.Range();
                 return range.has_value()
                            ? base::Map(range.value(),
-                                       [&column](const size_t& row) {
+                                       [&column](size_t row) {
                                          return ConstantPosition(column, row);
                                        })
                            : std::vector<ConstantPosition>();

--- a/tachyon/zk/plonk/circuit/floor_planner/v1/v1_pass.h
+++ b/tachyon/zk/plonk/circuit/floor_planner/v1/v1_pass.h
@@ -44,7 +44,7 @@ class V1Pass : public Layouter<F> {
   }
 
   void ConstrainInstance(const Cell& cell, const InstanceColumnKey& instance,
-                         size_t row) override {
+                         RowIndex row) override {
     if (std::holds_alternative<AssignmentPass<F>*>(pass_)) {
       std::get<AssignmentPass<F>*>(pass_)->ConstrainInstance(cell, instance,
                                                              row);

--- a/tachyon/zk/plonk/circuit/floor_planner/v1/v1_plan.h
+++ b/tachyon/zk/plonk/circuit/floor_planner/v1/v1_plan.h
@@ -7,8 +7,6 @@
 #ifndef TACHYON_ZK_PLONK_CIRCUIT_FLOOR_PLANNER_V1_V1_PLAN_H_
 #define TACHYON_ZK_PLONK_CIRCUIT_FLOOR_PLANNER_V1_V1_PLAN_H_
 
-#include <stddef.h>
-
 #include <utility>
 #include <vector>
 
@@ -26,8 +24,8 @@ class V1Plan {
   explicit V1Plan(Assignment<F>* assignment) : assignment_(assignment) {}
 
   Assignment<F>* assignment() { return assignment_; }
-  const std::vector<size_t>& regions() const { return regions_; }
-  void set_regions(std::vector<size_t>&& regions) {
+  const std::vector<RowIndex>& regions() const { return regions_; }
+  void set_regions(std::vector<RowIndex>&& regions) {
     regions_ = std::move(regions);
   }
   Constants<F>& constants() { return constants_; }
@@ -37,7 +35,7 @@ class V1Plan {
   // not owned
   Assignment<F>* const assignment_;
   // Stores the starting row for each region.
-  std::vector<size_t> regions_;
+  std::vector<RowIndex> regions_;
   // Stores the constants to be assigned, and the cells to which
   // they are copied.
   Constants<F> constants_;

--- a/tachyon/zk/plonk/circuit/floor_planner/v1/v1_strategy.cc
+++ b/tachyon/zk/plonk/circuit/floor_planner/v1/v1_strategy.cc
@@ -13,10 +13,10 @@ namespace tachyon::zk {
 // - |start| is the current start row of the region (not of this column).
 // - |slack| is the maximum number of rows the start could be moved down,
 // taking into account prior columns.
-std::optional<size_t> FirstFitRegion(
+std::optional<RowIndex> FirstFitRegion(
     CircuitAllocations* column_allocations,
-    const std::vector<RegionColumn>& region_columns, size_t region_length,
-    size_t start, std::optional<size_t> slack) {
+    const std::vector<RegionColumn>& region_columns, RowIndex region_length,
+    RowIndex start, std::optional<RowIndex> slack) {
   if (region_columns.empty()) {
     return start;
   }
@@ -25,7 +25,7 @@ std::optional<size_t> FirstFitRegion(
   std::vector<RegionColumn> remaining_columns(region_columns.begin() + 1,
                                               region_columns.end());
 
-  std::optional<size_t> end;
+  std::optional<RowIndex> end;
   if (slack.has_value()) {
     end = start + region_length + slack.value();
   }
@@ -44,9 +44,9 @@ std::optional<size_t> FirstFitRegion(
       CHECK_LE(s_slack.value(), static_cast<int64_t>(slack.value()));
     }
     if (!s_slack.has_value() || s_slack.value() >= 0) {
-      std::optional<size_t> row = FirstFitRegion(
+      std::optional<RowIndex> row = FirstFitRegion(
           column_allocations, remaining_columns, region_length, space.start(),
-          s_slack.has_value() ? std::optional<size_t>(s_slack.value())
+          s_slack.has_value() ? std::optional<RowIndex>(s_slack.value())
                               : std::nullopt);
       if (row.has_value()) {
         if (end.has_value()) {

--- a/tachyon/zk/plonk/circuit/layouter.h
+++ b/tachyon/zk/plonk/circuit/layouter.h
@@ -12,6 +12,7 @@
 #include <string>
 
 #include "tachyon/base/functional/callback.h"
+#include "tachyon/zk/base/row_index.h"
 #include "tachyon/zk/plonk/circuit/challenge.h"
 #include "tachyon/zk/plonk/circuit/lookup_table.h"
 #include "tachyon/zk/plonk/circuit/region.h"
@@ -51,7 +52,7 @@ class Layouter {
   // absolute position.
   virtual void ConstrainInstance(const Cell& cell,
                                  const InstanceColumnKey& column,
-                                 size_t row) = 0;
+                                 RowIndex row) = 0;
 
   // Queries the value of the given challenge.
   //

--- a/tachyon/zk/plonk/circuit/lookup_table.h
+++ b/tachyon/zk/plonk/circuit/lookup_table.h
@@ -11,6 +11,7 @@
 #include <utility>
 
 #include "tachyon/math/base/rational_field.h"
+#include "tachyon/zk/base/row_index.h"
 #include "tachyon/zk/base/value.h"
 #include "tachyon/zk/plonk/circuit/lookup_table_column.h"
 
@@ -33,7 +34,7 @@ class LookupTable {
     // Return false if the table cell has already been assigned.
     [[nodiscard]] virtual bool AssignCell(std::string_view name,
                                           const LookupTableColumn& column,
-                                          size_t offset,
+                                          RowIndex offset,
                                           AssignCallback assign) {
       return true;
     }
@@ -42,8 +43,8 @@ class LookupTable {
   explicit LookupTable(Layouter* layouter) : layouter_(layouter) {}
 
   [[nodiscard]] bool AssignCell(std::string_view name,
-                                const LookupTableColumn& column, size_t offset,
-                                AssignCallback assign) {
+                                const LookupTableColumn& column,
+                                RowIndex offset, AssignCallback assign) {
     return layouter_->AssignCell(name, column, offset, [&assign]() {
       return Value<math::RationalField<F>>::Known(
           math::RationalField<F>(std::move(assign).Run().value()));

--- a/tachyon/zk/plonk/circuit/namespaced_layouter.h
+++ b/tachyon/zk/plonk/circuit/namespaced_layouter.h
@@ -45,7 +45,7 @@ class NamespacedLayouter : public Layouter<F> {
   }
 
   void ConstrainInstance(const Cell& cell, const InstanceColumnKey& column,
-                         size_t row) override {
+                         RowIndex row) override {
     layouter_->ConstrainInstance(cell, column, row);
   }
 

--- a/tachyon/zk/plonk/circuit/region.h
+++ b/tachyon/zk/plonk/circuit/region.h
@@ -28,7 +28,7 @@ class Region {
 
   // See the comment above.
   void EnableSelector(std::string_view name, const Selector& selector,
-                      size_t offset) {
+                      RowIndex offset) {
     layouter_->EnableSelector(name, selector, offset);
   }
 
@@ -39,7 +39,7 @@ class Region {
 
   // See the comment above.
   AssignedCell<F> AssignAdvice(std::string_view name,
-                               const AdviceColumnKey& column, size_t offset,
+                               const AdviceColumnKey& column, RowIndex offset,
                                AssignCallback assign) {
     Value<F> value = Value<F>::Unknown();
     Cell cell =
@@ -53,7 +53,7 @@ class Region {
   // See the comment above.
   AssignedCell<F> AssignAdviceFromConstant(std::string_view name,
                                            const AdviceColumnKey& column,
-                                           size_t offset, const F& constant) {
+                                           RowIndex offset, const F& constant) {
     Cell cell = layouter_->AssignAdviceFromConstant(
         name, column, offset, math::RationalField<F>(constant));
     return {std::move(cell), Value<F>::Known(constant)};
@@ -62,16 +62,16 @@ class Region {
   // See the comment above.
   AssignedCell<F> AssignAdviceFromInstance(std::string_view name,
                                            const InstanceColumnKey& instance,
-                                           size_t row,
+                                           RowIndex row,
                                            const AdviceColumnKey& advice,
-                                           size_t offset) {
+                                           RowIndex offset) {
     return layouter_->AssignAdviceFromInstance(name, instance, row, advice,
                                                offset);
   }
 
   // See the comment above.
   AssignedCell<F> AssignFixed(std::string_view name,
-                              const FixedColumnKey& column, size_t offset,
+                              const FixedColumnKey& column, RowIndex offset,
                               AssignCallback assign) {
     Value<F> value = Value<F>::Unknown();
     Cell cell =
@@ -99,7 +99,7 @@ class Region {
 };
 
 template <typename F>
-void Selector::Enable(Region<F>& region, size_t offset) const {
+void Selector::Enable(Region<F>& region, RowIndex offset) const {
   region.EnableSelector("", *this, offset);
 }
 
@@ -107,7 +107,7 @@ template <typename F>
 AssignedCell<F> AssignedCell<F>::CopyAdvice(std::string_view name,
                                             Region<F>& region,
                                             const AdviceColumnKey& column,
-                                            size_t offset) const {
+                                            RowIndex offset) const {
   AssignedCell<F> ret =
       region.AssignAdvice(name, column, offset, [this]() { return value_; });
   region.ConstrainEqual(ret.cell_, cell_);

--- a/tachyon/zk/plonk/circuit/region_layouter.h
+++ b/tachyon/zk/plonk/circuit/region_layouter.h
@@ -7,10 +7,9 @@
 #ifndef TACHYON_ZK_PLONK_CIRCUIT_REGION_LAYOUTER_H_
 #define TACHYON_ZK_PLONK_CIRCUIT_REGION_LAYOUTER_H_
 
-#include <stddef.h>
-
 #include "tachyon/base/functional/callback.h"
 #include "tachyon/math/base/rational_field.h"
+#include "tachyon/zk/base/row_index.h"
 #include "tachyon/zk/base/value.h"
 #include "tachyon/zk/plonk/circuit/assigned_cell.h"
 #include "tachyon/zk/plonk/circuit/column_key.h"
@@ -27,7 +26,7 @@ class RegionLayouter {
 
   // Enables a |selector| at the given |offset|.
   virtual void EnableSelector(std::string_view name, const Selector& selector,
-                              size_t offset) {}
+                              RowIndex offset) {}
 
   // Allows the circuit implementer to name a Column within a Region
   // context.
@@ -38,7 +37,7 @@ class RegionLayouter {
 
   // Assign an advice column value (witness)
   virtual Cell AssignAdvice(std::string_view name,
-                            const AdviceColumnKey& column, size_t offset,
+                            const AdviceColumnKey& column, RowIndex offset,
                             AssignCallback assign) = 0;
 
   // Assigns a constant value to the column |advice| at |offset| within this
@@ -47,18 +46,18 @@ class RegionLayouter {
   // The constant value will be assigned to a cell within one of the fixed
   // columns configured via |ConstraintSystem::EnableConstant|.
   virtual Cell AssignAdviceFromConstant(
-      std::string_view name, const AdviceColumnKey& column, size_t offset,
+      std::string_view name, const AdviceColumnKey& column, RowIndex offset,
       const math::RationalField<F>& constant) = 0;
 
   // Assign the value of the instance column's cell at absolute location
   // |row| to the column |advice| at |offset| within this region.
   virtual AssignedCell<F> AssignAdviceFromInstance(
-      std::string_view name, const InstanceColumnKey& instance, size_t row,
-      const AdviceColumnKey& advice, size_t offset) = 0;
+      std::string_view name, const InstanceColumnKey& instance, RowIndex row,
+      const AdviceColumnKey& advice, RowIndex offset) = 0;
 
   // Assign a fixed value
   virtual Cell AssignFixed(std::string_view name, const FixedColumnKey& column,
-                           size_t offset, AssignCallback assign) = 0;
+                           RowIndex offset, AssignCallback assign) = 0;
 
   // Constrain a cell to have a constant value.
   virtual void ConstrainConstant(const Cell& cell,

--- a/tachyon/zk/plonk/circuit/region_shape.h
+++ b/tachyon/zk/plonk/circuit/region_shape.h
@@ -27,51 +27,51 @@ class RegionShape : public RegionLayouter<F> {
 
   size_t region_index() const { return region_index_; }
   const absl::flat_hash_set<RegionColumn>& columns() const { return columns_; }
-  size_t row_count() const { return row_count_; }
+  RowIndex row_count() const { return row_count_; }
 
   // RegionLayouter methods
   void EnableSelector(std::string_view, const Selector& selector,
-                      size_t offset) override {
+                      RowIndex offset) override {
     UpdateColumnsAndRowCount(selector, offset);
   }
 
   Cell AssignAdvice(std::string_view, const AdviceColumnKey& column,
-                    size_t offset, AssignCallback) override {
+                    RowIndex offset, AssignCallback) override {
     UpdateColumnsAndRowCount(column, offset);
     return {region_index_, offset, column};
   }
 
   Cell AssignAdviceFromConstant(
-      std::string_view name, const AdviceColumnKey& column, size_t offset,
+      std::string_view name, const AdviceColumnKey& column, RowIndex offset,
       const math::RationalField<F>& constant) override {
     return AssignAdvice(name, column, offset, AssignCallback());
   }
 
   AssignedCell<F> AssignAdviceFromInstance(std::string_view,
-                                           const InstanceColumnKey&, size_t,
+                                           const InstanceColumnKey&, RowIndex,
                                            const AdviceColumnKey& advice,
-                                           size_t offset) override {
+                                           RowIndex offset) override {
     UpdateColumnsAndRowCount(advice, offset);
     Cell cell(region_index_, offset, advice);
     return {std::move(cell), Value<F>::Unknown()};
   }
 
   Cell AssignFixed(std::string_view, const FixedColumnKey& column,
-                   size_t offset, AssignCallback) override {
+                   RowIndex offset, AssignCallback) override {
     UpdateColumnsAndRowCount(column, offset);
     return {region_index_, offset, column};
   }
 
  private:
   template <typename T>
-  void UpdateColumnsAndRowCount(const T& arg, size_t offset) {
+  void UpdateColumnsAndRowCount(const T& arg, RowIndex offset) {
     columns_.insert(RegionColumn(arg));
     row_count_ = std::max(row_count_, offset + 1);
   }
 
   size_t region_index_ = 0;
   absl::flat_hash_set<RegionColumn> columns_;
-  size_t row_count_ = 0;
+  RowIndex row_count_ = 0;
 };
 
 }  // namespace tachyon::zk

--- a/tachyon/zk/plonk/circuit/rotation.h
+++ b/tachyon/zk/plonk/circuit/rotation.h
@@ -7,14 +7,13 @@
 #ifndef TACHYON_ZK_PLONK_CIRCUIT_ROTATION_H_
 #define TACHYON_ZK_PLONK_CIRCUIT_ROTATION_H_
 
-#include <stdint.h>
-
 #include <string>
 
 #include "tachyon/base/logging.h"
 #include "tachyon/base/numerics/checked_math.h"
 #include "tachyon/base/strings/string_number_conversions.h"
 #include "tachyon/math/polynomials/univariate/univariate_evaluation_domain.h"
+#include "tachyon/zk/base/row_index.h"
 
 namespace tachyon::zk {
 
@@ -43,7 +42,7 @@ class TACHYON_EXPORT Rotation {
   std::string ToString() const { return base::NumberToString(value_); }
 
   // Returns (|idx| + |value_| * |scale|) modulo |size|.
-  size_t GetIndex(int32_t idx, int32_t scale, int32_t size) const {
+  RowIndex GetIndex(int32_t idx, int32_t scale, int32_t size) const {
     CHECK_GT(size, 0);
     base::CheckedNumeric<int32_t> value = value_;
     int32_t result = ((idx + value * scale) % size).ValueOrDie();

--- a/tachyon/zk/plonk/circuit/rotation_unittest.cc
+++ b/tachyon/zk/plonk/circuit/rotation_unittest.cc
@@ -10,7 +10,7 @@ TEST(RotationTest, GetRotationIdx) {
     Rotation rotation;
     int32_t scale;
     int32_t size;
-    int32_t expected;
+    RowIndex expected;
   } tests[] = {
       // (2 + 1 * 3) % 2 = 1
       {2, Rotation(1), 3, 2, 1},

--- a/tachyon/zk/plonk/circuit/selector.h
+++ b/tachyon/zk/plonk/circuit/selector.h
@@ -16,6 +16,7 @@
 #include "absl/strings/substitute.h"
 
 #include "tachyon/export.h"
+#include "tachyon/zk/base/row_index.h"
 
 namespace tachyon::zk {
 
@@ -38,7 +39,7 @@ class TACHYON_EXPORT Selector {
 
   // Defined in region.h
   template <typename F>
-  void Enable(Region<F>& region, size_t offset) const;
+  void Enable(Region<F>& region, RowIndex offset) const;
 
   std::string ToString() const {
     return absl::Substitute("{index: $0, is_simple: $1}", index_, is_simple_);

--- a/tachyon/zk/plonk/constraint_system.h
+++ b/tachyon/zk/plonk/constraint_system.h
@@ -21,6 +21,7 @@
 #include "tachyon/base/containers/container_util.h"
 #include "tachyon/base/containers/contains.h"
 #include "tachyon/base/functional/callback.h"
+#include "tachyon/zk/base/row_index.h"
 #include "tachyon/zk/expressions/evaluator/simple_selector_finder.h"
 #include "tachyon/zk/lookup/lookup_argument.h"
 #include "tachyon/zk/plonk/circuit/constraint.h"
@@ -477,21 +478,22 @@ class ConstraintSystem {
 
   // Compute the number of blinding factors necessary to perfectly blind
   // each of the prover's witness polynomials.
-  size_t ComputeBlindingFactors() const {
+  RowIndex ComputeBlindingFactors() const {
     if (!cached_blinding_factors_.has_value()) {
       // All of the prover's advice columns are evaluated at no more than
       auto max_num_advice_query_it = std::max_element(
           num_advice_queries_.begin(), num_advice_queries_.end());
-      size_t factors = max_num_advice_query_it == num_advice_queries_.end()
-                           ? 1
-                           : *max_num_advice_query_it;
+
+      RowIndex factors = max_num_advice_query_it == num_advice_queries_.end()
+                             ? 1
+                             : static_cast<RowIndex>(*max_num_advice_query_it);
       // distinct points during gate checks.
 
       // - The permutation argument witness polynomials are evaluated at most 3
       //   times.
       // - Each lookup argument has independent witness polynomials, and they
       //   are evaluated at most 2 times.
-      factors = std::max(size_t{3}, factors);
+      factors = std::max(RowIndex{3}, factors);
 
       // Each polynomial is evaluated at most an additional time during
       // multiopen (at x₃ to produce q_evals):
@@ -622,7 +624,7 @@ class ConstraintSystem {
   std::optional<size_t> minimum_degree_;
 
   mutable std::optional<size_t> cached_degree_;
-  mutable std::optional<size_t> cached_blinding_factors_;
+  mutable std::optional<RowIndex> cached_blinding_factors_;
 };
 
 }  // namespace zk

--- a/tachyon/zk/plonk/constraint_system.h
+++ b/tachyon/zk/plonk/constraint_system.h
@@ -7,6 +7,8 @@
 #ifndef TACHYON_ZK_PLONK_CONSTRAINT_SYSTEM_H_
 #define TACHYON_ZK_PLONK_CONSTRAINT_SYSTEM_H_
 
+#include <stdint.h>
+
 #include <algorithm>
 #include <memory>
 #include <optional>
@@ -455,11 +457,11 @@ class ConstraintSystem {
     return *cached_degree_;
   }
 
-  size_t ComputeExtendedDegree(size_t k) const {
+  uint32_t ComputeExtendedDegree(uint32_t k) const {
     size_t quotient_poly_degree = ComputeDegree() - 1;
     return std::max(
         base::bits::SafeLog2Ceiling((size_t{1} << k) * quotient_poly_degree),
-        static_cast<uint32_t>(k));
+        k);
   }
 
   // Compute the number of blinding factors necessary to perfectly blind

--- a/tachyon/zk/plonk/constraint_system.h
+++ b/tachyon/zk/plonk/constraint_system.h
@@ -457,7 +457,18 @@ class ConstraintSystem {
     return *cached_degree_;
   }
 
-  uint32_t ComputeExtendedDegree(uint32_t k) const {
+  // Compute the extended K. Since the degree of h(X) exceeds 2ᵏ - 1, h(X) will
+  // be split to h₀(X), h₁(X), ..., h_{d - 1}(X). The extended K denotes the K
+  // of the extended domain for these.
+  //
+  // h(X) = (gate₀(X) + y * gate₁(X) + ... + yⁱ * gateᵢ(X) + ...) / t(X)
+  //
+  // h₀(X) + Xⁿ * h₁(X) + ... + Xⁿ⁽ᵈ⁻¹⁾ * h_{d - 1}(X).
+  // H = [Commit(h₀(X)), Commit(h₁(X)), ..., Commit(h_{d - 1}(X))]
+  //
+  // See
+  // https://zcash.github.io/halo2/design/proving-system/vanishing.html#committing-to-hx.
+  uint32_t ComputeExtendedK(uint32_t k) const {
     size_t quotient_poly_degree = ComputeDegree() - 1;
     return std::max(
         base::bits::SafeLog2Ceiling((size_t{1} << k) * quotient_poly_degree),

--- a/tachyon/zk/plonk/constraint_system.h
+++ b/tachyon/zk/plonk/constraint_system.h
@@ -494,6 +494,7 @@ class ConstraintSystem {
       // - Each lookup argument has independent witness polynomials, and they
       //   are evaluated at most 2 times.
       factors = std::max(RowIndex{3}, factors);
+      CHECK_LE(factors, UINT32_MAX - 2);
 
       // Each polynomial is evaluated at most an additional time during
       // multiopen (at x₃ to produce q_evals):

--- a/tachyon/zk/plonk/constraint_system.h
+++ b/tachyon/zk/plonk/constraint_system.h
@@ -7,6 +7,7 @@
 #ifndef TACHYON_ZK_PLONK_CONSTRAINT_SYSTEM_H_
 #define TACHYON_ZK_PLONK_CONSTRAINT_SYSTEM_H_
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include <algorithm>

--- a/tachyon/zk/plonk/constraint_system.h
+++ b/tachyon/zk/plonk/constraint_system.h
@@ -85,7 +85,7 @@ class ConstraintSystem {
     return advice_queries_;
   }
 
-  const std::vector<size_t>& num_advice_queries() const {
+  const std::vector<RowIndex>& num_advice_queries() const {
     return num_advice_queries_;
   }
 
@@ -486,7 +486,7 @@ class ConstraintSystem {
 
       RowIndex factors = max_num_advice_query_it == num_advice_queries_.end()
                              ? 1
-                             : static_cast<RowIndex>(*max_num_advice_query_it);
+                             : *max_num_advice_query_it;
       // distinct points during gate checks.
 
       // - The permutation argument witness polynomials are evaluated at most 3
@@ -602,7 +602,7 @@ class ConstraintSystem {
   // Contains an integer for each advice column
   // identifying how many distinct queries it has
   // so far; should be same length as num_advice_columns.
-  std::vector<size_t> num_advice_queries_;
+  std::vector<RowIndex> num_advice_queries_;
   std::vector<InstanceQueryData> instance_queries_;
   std::vector<FixedQueryData> fixed_queries_;
 

--- a/tachyon/zk/plonk/constraint_system_unittest.cc
+++ b/tachyon/zk/plonk/constraint_system_unittest.cc
@@ -124,7 +124,7 @@ TYPED_TEST(ConstraintSystemTypedTest, EnableEquality) {
   std::vector<AnyColumnKey> expected_permutation_columns;
   std::vector<FixedQueryData> fixed_queries;
   std::vector<AdviceQueryData> advice_queries;
-  std::vector<size_t> num_advice_queries;
+  std::vector<RowIndex> num_advice_queries;
   std::vector<InstanceQueryData> instance_queries;
   EXPECT_EQ(constraint_system.permutation().columns(),
             expected_permutation_columns);

--- a/tachyon/zk/plonk/halo2/proof_unittest.cc
+++ b/tachyon/zk/plonk/halo2/proof_unittest.cc
@@ -11,6 +11,7 @@
 #include "tachyon/base/containers/container_util.h"
 #include "tachyon/math/elliptic_curves/bn/bn254/bn254.h"
 #include "tachyon/zk/base/commitments/shplonk_extension.h"
+#include "tachyon/zk/base/row_index.h"
 
 namespace tachyon::zk::halo2 {
 namespace {
@@ -19,13 +20,14 @@ using F = math::bn254::Fr;
 using Commitment = math::bn254::G1AffinePoint;
 
 template <typename T>
-std::vector<std::vector<T>> CreateRandomElementsVec(size_t rows, size_t cols) {
+std::vector<std::vector<T>> CreateRandomElementsVec(RowIndex rows,
+                                                    size_t cols) {
   return base::CreateVector(
       rows, [cols]() { return base::CreateVector(cols, T::Random()); });
 }
 
 std::vector<std::vector<zk::LookupPair<Commitment>>> CreateRandomLookupPairsVec(
-    size_t rows, size_t cols) {
+    RowIndex rows, size_t cols) {
   return base::CreateVector(rows, [cols]() {
     return base::CreateVector(cols, []() {
       return zk::LookupPair<Commitment>(Commitment::Random(),

--- a/tachyon/zk/plonk/halo2/prover.h
+++ b/tachyon/zk/plonk/halo2/prover.h
@@ -37,7 +37,7 @@ class Prover : public ProverBase<PCS> {
 
   static Prover CreateFromRandomSeed(
       PCS&& pcs, std::unique_ptr<crypto::TranscriptWriter<Commitment>> writer,
-      size_t blinding_factors) {
+      RowIndex blinding_factors) {
     auto rng = std::make_unique<crypto::XORShiftRNG>(
         crypto::XORShiftRNG::FromRandomSeed());
     return CreateFromRNG(std::move(pcs), std::move(writer), std::move(rng),
@@ -46,7 +46,7 @@ class Prover : public ProverBase<PCS> {
 
   static Prover CreateFromSeed(
       PCS&& pcs, std::unique_ptr<crypto::TranscriptWriter<Commitment>> writer,
-      const uint8_t seed[16], size_t blinding_factors) {
+      const uint8_t seed[16], RowIndex blinding_factors) {
     auto rng = std::make_unique<crypto::XORShiftRNG>(
         crypto::XORShiftRNG::FromSeed(seed));
     return CreateFromRNG(std::move(pcs), std::move(writer), std::move(rng),
@@ -55,7 +55,7 @@ class Prover : public ProverBase<PCS> {
 
   static Prover CreateFromRNG(
       PCS&& pcs, std::unique_ptr<crypto::TranscriptWriter<Commitment>> writer,
-      std::unique_ptr<crypto::XORShiftRNG> rng, size_t blinding_factors) {
+      std::unique_ptr<crypto::XORShiftRNG> rng, RowIndex blinding_factors) {
     auto generator = std::make_unique<RandomFieldGenerator<F>>(rng.get());
     Blinder<PCS> blinder(generator.get(), blinding_factors);
     return {std::move(pcs), std::move(writer), std::move(blinder),

--- a/tachyon/zk/plonk/halo2/verifier.h
+++ b/tachyon/zk/plonk/halo2/verifier.h
@@ -110,7 +110,7 @@ class Verifier : public VerifierBase<PCS> {
 
   void ComputeAuxValues(const ConstraintSystem<F>& constraint_system,
                         Proof<F, Commitment>& proof) {
-    size_t blinding_factors = constraint_system.ComputeBlindingFactors();
+    RowIndex blinding_factors = constraint_system.ComputeBlindingFactors();
     std::vector<F> l_evals = this->domain_->EvaluatePartialLagrangeCoefficients(
         proof.x, base::Range<int32_t, /*IsStartInclusive=*/true,
                              /*IsEndInclusive=*/true>(

--- a/tachyon/zk/plonk/halo2/witness_collection.h
+++ b/tachyon/zk/plonk/halo2/witness_collection.h
@@ -31,12 +31,12 @@ class WitnessCollection : public Assignment<typename PCS::Field> {
 
   WitnessCollection() = default;
   WitnessCollection(const Domain* domain, size_t num_advice_columns,
-                    size_t usable_rows, Phase current_phase,
+                    RowIndex usable_rows, Phase current_phase,
                     const absl::btree_map<size_t, F>& challenges,
                     const std::vector<Evals>& instance_columns)
       : advices_(base::CreateVector(num_advice_columns,
                                     domain->template Empty<RationalEvals>())),
-        usable_rows_(base::Range<size_t>::Until(usable_rows)),
+        usable_rows_(base::Range<RowIndex>::Until(usable_rows)),
         current_phase_(current_phase),
         challenges_(challenges),
         instance_columns_(instance_columns) {}
@@ -45,15 +45,16 @@ class WitnessCollection : public Assignment<typename PCS::Field> {
   // That's why, |WitnessCollection| will be released as soon as emitting it.
   std::vector<RationalEvals>&& TakeAdvices() && { return std::move(advices_); }
 
-  Value<F> QueryInstance(const InstanceColumnKey& column, size_t row) override {
+  Value<F> QueryInstance(const InstanceColumnKey& column,
+                         RowIndex row) override {
     CHECK(usable_rows_.Contains(row));
     CHECK_LT(column.index(), instance_columns_.size());
 
     return Value<F>::Known(*instance_columns_[column.index()][row]);
   }
 
-  void AssignAdvice(std::string_view, const AdviceColumnKey& column, size_t row,
-                    AssignCallback assign) override {
+  void AssignAdvice(std::string_view, const AdviceColumnKey& column,
+                    RowIndex row, AssignCallback assign) override {
     // Ignore assignment of advice column in different phase than current one.
     if (current_phase_ < column.phase()) return;
 
@@ -70,7 +71,7 @@ class WitnessCollection : public Assignment<typename PCS::Field> {
 
  private:
   std::vector<RationalEvals> advices_;
-  base::Range<size_t> usable_rows_;
+  base::Range<RowIndex> usable_rows_;
   Phase current_phase_;
   absl::btree_map<size_t, F> challenges_;
   std::vector<Evals> instance_columns_;

--- a/tachyon/zk/plonk/halo2/witness_collection_unittest.cc
+++ b/tachyon/zk/plonk/halo2/witness_collection_unittest.cc
@@ -46,7 +46,7 @@ class WitnessCollectionTest : public halo2::ProverTest {
 
 TEST_F(WitnessCollectionTest, QueryInstance) {
   size_t col = 0;
-  size_t row = 10;
+  RowIndex row = 10;
 
   // Query a value in specific instance column.
   Value<F> queried_value =
@@ -58,7 +58,7 @@ TEST_F(WitnessCollectionTest, QueryInstance) {
 TEST_F(WitnessCollectionTest, AssignAdvice) {
   math::RationalField<F> value_to_be_assign(F::Random());
   size_t col = 0;
-  size_t row = 10;
+  RowIndex row = 10;
 
   // Assign a random value to specific cell.
   witness_collection_.AssignAdvice(

--- a/tachyon/zk/plonk/keys/key.h
+++ b/tachyon/zk/plonk/keys/key.h
@@ -29,7 +29,8 @@ class Key {
   static Assembly<PCS> CreateAssembly(
       const Domain* domain, const ConstraintSystem<F>& constraint_system) {
     using RationalEvals = typename Assembly<PCS>::RationalEvals;
-    size_t n = domain->size();
+    // NOTE(chokobole): It's safe to downcast because domain is already checked.
+    RowIndex n = static_cast<RowIndex>(domain->size());
     return {
         base::CreateVector(constraint_system.num_fixed_columns(),
                            domain->template Empty<RationalEvals>()),
@@ -38,7 +39,7 @@ class Key {
                            base::CreateVector(n, false)),
         // NOTE(chokobole): Considering that this is called from a verifier,
         // then you can't load this number through |prover->GetUsableRows()|.
-        base::Range<size_t>::Until(
+        base::Range<RowIndex>::Until(
             n - (constraint_system.ComputeBlindingFactors() + 1))};
   }
 

--- a/tachyon/zk/plonk/keys/key.h
+++ b/tachyon/zk/plonk/keys/key.h
@@ -66,7 +66,7 @@ class Key {
                  << constraint_system.ComputeMinimumRows();
       return false;
     }
-    uint32_t extended_k = constraint_system.ComputeExtendedDegree(pcs.K());
+    uint32_t extended_k = constraint_system.ComputeExtendedK(pcs.K());
     entity->set_extended_domain(
         ExtendedDomain::Create(size_t{1} << extended_k));
 

--- a/tachyon/zk/plonk/keys/key.h
+++ b/tachyon/zk/plonk/keys/key.h
@@ -7,6 +7,7 @@
 #ifndef TACHYON_ZK_PLONK_KEYS_KEY_H_
 #define TACHYON_ZK_PLONK_KEYS_KEY_H_
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include <utility>

--- a/tachyon/zk/plonk/keys/key.h
+++ b/tachyon/zk/plonk/keys/key.h
@@ -7,6 +7,8 @@
 #ifndef TACHYON_ZK_PLONK_KEYS_KEY_H_
 #define TACHYON_ZK_PLONK_KEYS_KEY_H_
 
+#include <stdint.h>
+
 #include <utility>
 #include <vector>
 
@@ -64,7 +66,7 @@ class Key {
                  << constraint_system.ComputeMinimumRows();
       return false;
     }
-    size_t extended_k = constraint_system.ComputeExtendedDegree(pcs.K());
+    uint32_t extended_k = constraint_system.ComputeExtendedDegree(pcs.K());
     entity->set_extended_domain(
         ExtendedDomain::Create(size_t{1} << extended_k));
 

--- a/tachyon/zk/plonk/keys/proving_key.h
+++ b/tachyon/zk/plonk/keys/proving_key.h
@@ -131,7 +131,7 @@ class ProvingKey : public Key<PCS> {
     // | 5 | 0         |
     // | 6 | 0         |
     // | 7 | 0         |
-    size_t usable_rows = prover->GetUsableRows();
+    RowIndex usable_rows = prover->GetUsableRows();
     *evals[usable_rows] = F::One();
     l_last_ = domain->IFFT(evals);
     *evals[usable_rows] = F::Zero();

--- a/tachyon/zk/plonk/permutation/BUILD.bazel
+++ b/tachyon/zk/plonk/permutation/BUILD.bazel
@@ -26,7 +26,10 @@ tachyon_cc_library(
 tachyon_cc_library(
     name = "label",
     hdrs = ["label.h"],
-    deps = ["//tachyon:export"],
+    deps = [
+        "//tachyon:export",
+        "//tachyon/zk/base:row_index",
+    ],
 )
 
 tachyon_cc_library(

--- a/tachyon/zk/plonk/permutation/cycle_store.h
+++ b/tachyon/zk/plonk/permutation/cycle_store.h
@@ -89,10 +89,10 @@ class TACHYON_EXPORT CycleStore {
   };
 
   CycleStore() = default;
-  CycleStore(size_t cols, size_t rows) {
+  CycleStore(size_t cols, RowIndex rows) {
     mapping_ = Table(base::CreateVector(cols, [rows](size_t col) {
-      return base::CreateVector(rows,
-                                [col](size_t row) { return Label(col, row); });
+      return base::CreateVector(
+          rows, [col](RowIndex row) { return Label(col, row); });
     }));
     aux_ = mapping_;
     sizes_ =

--- a/tachyon/zk/plonk/permutation/cycle_store_unittest.cc
+++ b/tachyon/zk/plonk/permutation/cycle_store_unittest.cc
@@ -14,13 +14,13 @@ namespace tachyon::zk {
 
 TEST(CycleStoreTest, MergeCycle) {
   constexpr size_t kCols = 10;
-  constexpr size_t kRows = 10;
+  constexpr RowIndex kRows = 10;
 
   CycleStore store(kCols, kRows);
   std::vector<Label> labels;
   labels.reserve(kCols * kRows);
   for (size_t col = 0; col < kCols; ++col) {
-    for (size_t row = 0; row < kRows; ++row) {
+    for (RowIndex row = 0; row < kRows; ++row) {
       Label l(col, row);
       EXPECT_EQ(store.GetCycleBase(l), l);
       EXPECT_EQ(store.GetCycleSize(l), size_t{1});

--- a/tachyon/zk/plonk/permutation/grand_product_argument.h
+++ b/tachyon/zk/plonk/permutation/grand_product_argument.h
@@ -24,7 +24,7 @@ class GrandProductArgument {
     using Evals = typename PCS::Evals;
 
     size_t size = prover->pcs().N();
-    size_t blinding_factors = prover->blinder().blinding_factors();
+    RowIndex blinding_factors = prover->blinder().blinding_factors();
     Evals z = CreatePolynomial<Evals>(size, blinding_factors,
                                       std::move(numerator_callback),
                                       std::move(denominator_callback));
@@ -46,7 +46,7 @@ class GrandProductArgument {
     using Evals = typename PCS::Evals;
 
     size_t size = prover->pcs().N();
-    size_t blinding_factors = prover->blinder().blinding_factors();
+    RowIndex blinding_factors = prover->blinder().blinding_factors();
     Evals z = CreatePolynomialExcessive<Evals>(
         size, blinding_factors, num_cols, last_z, std::move(numerator_callback),
         std::move(denominator_callback));
@@ -58,7 +58,7 @@ class GrandProductArgument {
   FRIEND_TEST(LookupArgumentRunnerTest, ComputePermutationProduct);
 
   template <typename Evals, typename Callable>
-  static Evals CreatePolynomial(size_t size, size_t blinding_factors,
+  static Evals CreatePolynomial(size_t size, RowIndex blinding_factors,
                                 Callable numerator_callback,
                                 Callable denominator_callback) {
     using F = typename Evals::Field;
@@ -77,7 +77,7 @@ class GrandProductArgument {
   }
 
   template <typename Evals, typename F, typename Callable>
-  static Evals CreatePolynomialExcessive(size_t size, size_t blinding_factors,
+  static Evals CreatePolynomialExcessive(size_t size, RowIndex blinding_factors,
                                          size_t num_cols, F& last_z,
                                          Callable numerator_callback,
                                          Callable denominator_callback) {
@@ -100,7 +100,7 @@ class GrandProductArgument {
   template <typename Evals, typename F>
   static Evals DoCreatePolynomial(F& last_z, size_t size,
                                   const std::vector<F>& grand_product,
-                                  size_t blinding_factors) {
+                                  RowIndex blinding_factors) {
     std::vector<F> z;
     z.resize(size);
     z[0] = last_z;

--- a/tachyon/zk/plonk/permutation/label.h
+++ b/tachyon/zk/plonk/permutation/label.h
@@ -14,14 +14,15 @@
 #include "absl/strings/substitute.h"
 
 #include "tachyon/export.h"
+#include "tachyon/zk/base/row_index.h"
 
 namespace tachyon::zk {
 
 struct TACHYON_EXPORT Label {
   size_t col = 0;
-  size_t row = 0;
+  RowIndex row = 0;
 
-  Label(size_t col, size_t row) : col(col), row(row) {}
+  Label(size_t col, RowIndex row) : col(col), row(row) {}
 
   bool operator==(const Label& other) const {
     return col == other.col && row == other.row;

--- a/tachyon/zk/plonk/permutation/permutation_assembly.h
+++ b/tachyon/zk/plonk/permutation/permutation_assembly.h
@@ -38,23 +38,23 @@ class PermutationAssembly {
   PermutationAssembly() = default;
 
   // Constructor with |PermutationArgument|.
-  PermutationAssembly(const PermutationArgument& p, size_t rows)
+  PermutationAssembly(const PermutationArgument& p, RowIndex rows)
       : PermutationAssembly(p.columns(), rows) {}
 
   // Constructor with permutation columns.
-  PermutationAssembly(const std::vector<AnyColumnKey>& columns, size_t rows)
+  PermutationAssembly(const std::vector<AnyColumnKey>& columns, RowIndex rows)
       : columns_(columns),
         cycle_store_(CycleStore(columns_.size(), rows)),
         rows_(rows) {}
 
-  PermutationAssembly(std::vector<AnyColumnKey>&& columns, size_t rows)
+  PermutationAssembly(std::vector<AnyColumnKey>&& columns, RowIndex rows)
       : columns_(std::move(columns)),
         cycle_store_(CycleStore(columns_.size(), rows)),
         rows_(rows) {}
 
   static PermutationAssembly CreateForTesting(std::vector<AnyColumnKey> columns,
                                               CycleStore cycle_store,
-                                              size_t rows) {
+                                              RowIndex rows) {
     PermutationAssembly ret;
     ret.columns_ = std::move(columns);
     ret.cycle_store_ = std::move(cycle_store);
@@ -65,8 +65,8 @@ class PermutationAssembly {
   const std::vector<AnyColumnKey>& columns() const { return columns_; }
   const CycleStore& cycle_store() const { return cycle_store_; }
 
-  void Copy(const AnyColumnKey& left_column, size_t left_row,
-            const AnyColumnKey& right_column, size_t right_row) {
+  void Copy(const AnyColumnKey& left_column, RowIndex left_row,
+            const AnyColumnKey& right_column, RowIndex right_row) {
     CHECK_LE(left_row, rows_);
     CHECK_LE(right_row, rows_);
 
@@ -113,7 +113,7 @@ class PermutationAssembly {
   // permutations. Note that the permutation polynomials are in evaluation
   // form.
   std::vector<Evals> GeneratePermutations(const Domain* domain) const {
-    CHECK_EQ(domain->size(), rows_);
+    CHECK_EQ(domain->size(), size_t{rows_});
     UnpermutedTable<Evals> unpermuted_table =
         UnpermutedTable<Evals>::Construct(columns_.size(), rows_, domain);
 
@@ -144,7 +144,7 @@ class PermutationAssembly {
   // Columns that participate on the copy permutation argument.
   std::vector<AnyColumnKey> columns_;
   CycleStore cycle_store_;
-  size_t rows_ = 0;
+  RowIndex rows_ = 0;
 };
 
 }  // namespace tachyon::zk

--- a/tachyon/zk/plonk/permutation/unpermuted_table.h
+++ b/tachyon/zk/plonk/permutation/unpermuted_table.h
@@ -58,7 +58,7 @@ class UnpermutedTable {
   }
 
   template <typename Domain>
-  static UnpermutedTable Construct(size_t cols, size_t rows,
+  static UnpermutedTable Construct(size_t cols, RowIndex rows,
                                    const Domain* domain) {
     // The ω is gᵀ with order 2ˢ where modulus = 2ˢ * T + 1.
     std::vector<F> omega_powers =
@@ -77,7 +77,7 @@ class UnpermutedTable {
       std::vector<F> col = base::CreateVector(rows, F::Zero());
       // TODO(dongchangYoo): Optimize this with
       // https://github.com/kroma-network/tachyon/pull/115.
-      for (size_t j = 0; j < rows; ++j) {
+      for (RowIndex j = 0; j < rows; ++j) {
         col[j] = *unpermuted_table[i - 1][j] * delta;
       }
       unpermuted_table.push_back(Evals(std::move(col)));

--- a/tachyon/zk/plonk/permutation/unpermuted_table_unittest.cc
+++ b/tachyon/zk/plonk/permutation/unpermuted_table_unittest.cc
@@ -36,12 +36,12 @@ TEST_F(UnpermutedTableTest, Construct) {
   const Domain* domain = prover_->domain();
 
   const F& omega = domain->group_gen();
-  size_t n = prover_->pcs().N();
+  RowIndex n = static_cast<RowIndex>(prover_->pcs().N());
   std::vector<F> omega_powers = domain->GetRootsOfUnity(n, omega);
 
   const F delta = GetDelta<F>();
   for (size_t i = 1; i < kCols; ++i) {
-    for (size_t j = 0; j < n; ++j) {
+    for (RowIndex j = 0; j < n; ++j) {
       omega_powers[j] *= delta;
       EXPECT_EQ(omega_powers[j], unpermuted_table_[Label(i, j)]);
     }
@@ -53,21 +53,21 @@ TEST_F(UnpermutedTableTest, GetColumns) {
 
   const F& omega = domain->group_gen();
   const F delta = GetDelta<F>();
-  size_t n = prover_->pcs().N();
+  RowIndex n = static_cast<RowIndex>(prover_->pcs().N());
   std::vector<F> omega_powers = domain->GetRootsOfUnity(n, omega);
   for (F& omega_power : omega_powers) {
     omega_power *= delta;
   }
 
   base::Ref<const Evals> column = unpermuted_table_.GetColumn(1);
-  for (size_t i = 0; i < n; ++i) {
+  for (RowIndex i = 0; i < n; ++i) {
     EXPECT_EQ(omega_powers[i], *(*column)[i]);
   }
 
   std::vector<base::Ref<const Evals>> columns =
       unpermuted_table_.GetColumns(base::Range<size_t>(2, 4));
   for (size_t i = 0; i < 2; ++i) {
-    for (size_t j = 0; j < n; ++j) {
+    for (RowIndex j = 0; j < n; ++j) {
       omega_powers[j] *= delta;
       EXPECT_EQ(omega_powers[j], *(*columns[i])[j]);
     }

--- a/tachyon/zk/plonk/vanishing/circuit_polynomial_builder.h
+++ b/tachyon/zk/plonk/vanishing/circuit_polynomial_builder.h
@@ -147,8 +147,8 @@ class CircuitPolynomialBuilder {
           F zero = F::Zero();
           F table_value = ev.Evaluate(evaluation_input, idx, rot_scale_, zero);
 
-          size_t r_next = Rotation(1).GetIndex(idx, rot_scale_, n_);
-          size_t r_prev = Rotation(-1).GetIndex(idx, rot_scale_, n_);
+          RowIndex r_next = Rotation(1).GetIndex(idx, rot_scale_, n_);
+          RowIndex r_prev = Rotation(-1).GetIndex(idx, rot_scale_, n_);
 
           F a_minus_s = *input_coset[idx] - *table_coset[idx];
 
@@ -214,7 +214,7 @@ class CircuitPolynomialBuilder {
 
         // Except for the first set, enforce:
         // l_first(X) * (zᵢ(X) - zᵢ₋₁(w⁻¹X)) = 0
-        size_t r_last = last_rotation_.GetIndex(idx, rot_scale_, n_);
+        RowIndex r_last = last_rotation_.GetIndex(idx, rot_scale_, n_);
         for (size_t set_idx = 0; set_idx < product_cosets.size(); ++set_idx) {
           if (set_idx == 0) continue;
           chunk[i] *= *y_;
@@ -225,7 +225,7 @@ class CircuitPolynomialBuilder {
         // And for all the sets we enforce: (1 - (l_last(X) + l_blind(X))) *
         // (zᵢ(wX) * Πⱼ(p(X) + βsⱼ(X) + γ) - zᵢ(X) Πⱼ(p(X) + δʲβX + γ))
         F current_delta = delta_start_ * beta_term;
-        size_t r_next = Rotation(1).GetIndex(idx, rot_scale_, n_);
+        RowIndex r_next = Rotation(1).GetIndex(idx, rot_scale_, n_);
 
         const std::vector<AnyColumnKey>& column_keys =
             proving_key_->verifying_key()

--- a/tachyon/zk/plonk/vanishing/circuit_polynomial_builder.h
+++ b/tachyon/zk/plonk/vanishing/circuit_polynomial_builder.h
@@ -48,9 +48,9 @@ class CircuitPolynomialBuilder {
 
   static CircuitPolynomialBuilder Create(
       const Domain* domain, const ExtendedDomain* extended_domain, size_t n,
-      size_t blinding_factors, size_t cs_degree, const F* beta, const F* gamma,
-      const F* theta, const F* y, const F* zeta, absl::Span<const F> challenges,
-      const ProvingKey<PCS>* proving_key,
+      RowIndex blinding_factors, size_t cs_degree, const F* beta,
+      const F* gamma, const F* theta, const F* y, const F* zeta,
+      absl::Span<const F> challenges, const ProvingKey<PCS>* proving_key,
       const std::vector<PermutationCommitted<Poly>>* committed_permutations,
       const std::vector<std::vector<LookupCommitted<Poly>>>*
           committed_lookups_vec,

--- a/tachyon/zk/plonk/vanishing/vanishing_argument.h
+++ b/tachyon/zk/plonk/vanishing/vanishing_argument.h
@@ -7,6 +7,8 @@
 #ifndef TACHYON_ZK_PLONK_VANISHING_VANISHING_ARGUMENT_H_
 #define TACHYON_ZK_PLONK_VANISHING_VANISHING_ARGUMENT_H_
 
+#include <stdint.h>
+
 #include <memory>
 #include <utility>
 #include <vector>
@@ -93,7 +95,7 @@ class VanishingArgument {
       const std::vector<std::vector<LookupCommitted<Poly>>>&
           committed_lookups_vec,
       const std::vector<RefTable<Poly>>& poly_tables) const {
-    size_t blinding_factors = prover->blinder().blinding_factors();
+    RowIndex blinding_factors = prover->blinder().blinding_factors();
     size_t cs_degree =
         proving_key.verifying_key().constraint_system().ComputeDegree();
 

--- a/vendors/halo2/include/bn254_shplonk_proving_key.h
+++ b/vendors/halo2/include/bn254_shplonk_proving_key.h
@@ -21,7 +21,7 @@ class SHPlonkProvingKey {
   const SHPlonkProvingKeyImpl* impl() const { return impl_.get(); }
 
   rust::Slice<const uint8_t> advice_column_phases() const;
-  size_t blinding_factors() const;
+  uint32_t blinding_factors() const;
   rust::Slice<const uint8_t> challenge_phases() const;
   rust::Vec<size_t> constants() const;
   size_t num_advice_columns() const;

--- a/vendors/halo2/src/bn254.rs
+++ b/vendors/halo2/src/bn254.rs
@@ -86,7 +86,7 @@ pub mod ffi {
 
         fn new_proving_key(data: &[u8]) -> UniquePtr<SHPlonkProvingKey>;
         fn advice_column_phases(&self) -> &[u8];
-        fn blinding_factors(&self) -> usize;
+        fn blinding_factors(&self) -> u32;
         fn challenge_phases(&self) -> &[u8];
         fn constants(&self) -> Vec<usize>;
         fn num_advice_columns(&self) -> usize;
@@ -266,7 +266,7 @@ impl SHPlonkProvingKey {
     }
 
     // pk.vk.cs.blinding_factors()
-    pub fn blinding_factors(&self) -> usize {
+    pub fn blinding_factors(&self) -> u32 {
         self.inner.blinding_factors()
     }
 

--- a/vendors/halo2/src/bn254_shplonk_proving_key.cc
+++ b/vendors/halo2/src/bn254_shplonk_proving_key.cc
@@ -13,7 +13,7 @@ rust::Slice<const uint8_t> SHPlonkProvingKey::advice_column_phases() const {
   return rs::ConvertCppVecToRustSlice<uint8_t>(impl_->GetAdviceColumnPhases());
 }
 
-size_t SHPlonkProvingKey::blinding_factors() const {
+uint32_t SHPlonkProvingKey::blinding_factors() const {
   return impl_->ComputeBlindingFactors();
 }
 

--- a/vendors/halo2/src/prover.rs
+++ b/vendors/halo2/src/prover.rs
@@ -62,7 +62,7 @@ pub fn create_proof<'params, W: Write, ConcreteCircuit: Circuit<Fr>>(
                 .map(|values| {
                     let mut poly = prover.empty_evals();
                     assert_eq!(poly.len(), prover.n() as usize);
-                    if values.len() > (poly.len() - (pk.blinding_factors() + 1)) {
+                    if values.len() > (poly.len() - ((pk.blinding_factors() as usize) + 1)) {
                         return Err(Error::InstanceTooLarge);
                     }
 
@@ -262,7 +262,7 @@ pub fn create_proof<'params, W: Write, ConcreteCircuit: Circuit<Fr>>(
             vec![vec![prover.empty_rational_evals(); num_advice_columns]; instances.len()];
         let mut challenges = HashMap::<usize, Fr>::with_capacity(num_challenges);
 
-        let unusable_rows_start = prover.n() as usize - (pk.blinding_factors() + 1);
+        let unusable_rows_start = prover.n() as usize - ((pk.blinding_factors() as usize) + 1);
         for current_phase in pk.phases() {
             let column_indices = meta
                 .advice_column_phase

--- a/vendors/halo2/src/prover_impl.h
+++ b/vendors/halo2/src/prover_impl.h
@@ -28,7 +28,7 @@ class ProverImpl {
 
   const zk::halo2::Prover<PCS>& prover() const { return prover_; }
 
-  size_t K() const { return prover_.pcs().K(); }
+  uint32_t K() const { return prover_.pcs().K(); }
 
   size_t N() const { return prover_.pcs().N(); }
 
@@ -42,7 +42,7 @@ class ProverImpl {
   }
 
   void SetExtendedDomain(const zk::ConstraintSystem<Field>& constraint_system) {
-    size_t extended_k =
+    uint32_t extended_k =
         constraint_system.ComputeExtendedDegree(prover_.pcs().K());
     prover_.set_extended_domain(
         ExtendedDomain::Create(size_t{1} << extended_k));

--- a/vendors/halo2/src/prover_impl.h
+++ b/vendors/halo2/src/prover_impl.h
@@ -42,8 +42,7 @@ class ProverImpl {
   }
 
   void SetExtendedDomain(const zk::ConstraintSystem<Field>& constraint_system) {
-    uint32_t extended_k =
-        constraint_system.ComputeExtendedDegree(prover_.pcs().K());
+    uint32_t extended_k = constraint_system.ComputeExtendedK(prover_.pcs().K());
     prover_.set_extended_domain(
         ExtendedDomain::Create(size_t{1} << extended_k));
   }

--- a/vendors/halo2/src/prover_impl.h
+++ b/vendors/halo2/src/prover_impl.h
@@ -47,7 +47,7 @@ class ProverImpl {
         ExtendedDomain::Create(size_t{1} << extended_k));
   }
 
-  void SetBlindingFactors(size_t binding_factors) {
+  void SetBlindingFactors(uint32_t binding_factors) {
     prover_.blinder_.set_blinding_factors(binding_factors);
   }
 

--- a/vendors/halo2/src/proving_key.rs
+++ b/vendors/halo2/src/proving_key.rs
@@ -37,7 +37,10 @@ mod test {
             pk.vk.cs.advice_column_phase,
             tachyon_pk.advice_column_phases()
         );
-        assert_eq!(pk.vk.cs.blinding_factors(), tachyon_pk.blinding_factors());
+        assert_eq!(
+            pk.vk.cs.blinding_factors(),
+            tachyon_pk.blinding_factors() as usize
+        );
         assert_eq!(pk.vk.cs.challenge_phase, tachyon_pk.challenge_phases());
         assert_eq!(pk.vk.cs.constants, tachyon_pk.constants());
         assert_eq!(pk.vk.cs.num_advice_columns, tachyon_pk.num_advice_columns());

--- a/vendors/halo2/src/shplonk_proving_key_impl.h
+++ b/vendors/halo2/src/shplonk_proving_key_impl.h
@@ -119,7 +119,8 @@ class ProvingKeyImpl<
     ReadBuffer(buffer, cs.gates_);
     ReadBuffer(buffer, cs.advice_queries_);
     cs.num_advice_queries_ = base::CreateVector(
-        ReadU32AsSizeT(buffer), [&buffer]() { return ReadU32AsSizeT(buffer); });
+        ReadU32AsSizeT(buffer),
+        [&buffer]() { return BufferReader<uint32_t>::Read(buffer); });
     ReadBuffer(buffer, cs.instance_queries_);
     ReadBuffer(buffer, cs.fixed_queries_);
     ReadBuffer(buffer, cs.permutation_);


### PR DESCRIPTION
# Description

This PR fixes the type of `Row`, `K` like members to 32 bit. The reason why the index of the row is changed to 32 bit is because it is used as an exponent of the roots of unity.
