### PR TITLE
fix(zk): clone config before move

### DIFF
--- a/tachyon/zk/plonk/layout/floor_planner/v1/v1_floor_planner.h
+++ b/tachyon/zk/plonk/layout/floor_planner/v1/v1_floor_planner.h
@@ -47,7 +47,7 @@ class V1FloorPlanner : public FloorPlanner<Circuit> {
     MeasurementPass<F> measure;
     {
       V1Pass<F> pass(&measure);
-      circuit.WithoutWitness()->Synthesize(std::move(config), &pass);
+      circuit.WithoutWitness()->Synthesize(config.Clone(), &pass);
     }
     for (const typename MeasurementPass<F>::Region& region :
          measure.regions()) {


### PR DESCRIPTION
# Description

I found a bug while implementing fibonacci3 circuit, where `config` is being moved twice, but `Clone` wasn't called on the first case. This PR fixes such bug.
