### PR TITLE
build(math): fix to use different subgroup generator of bn254 Fr for …

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -87,9 +87,6 @@ build --//:has_exception
 # Enable polygon zkevm backend for prime field.
 build:polygon_zkevm_backend --//:polygon_zkevm_backend
 
-# Chromium things
-build:macos --define=enable_mach_absolute_time_ticks=true
-
 test --test_tag_filters -benchmark,-manual,-cuda,-rust
 
 build:linux --build_tag_filters -objc,-cuda,-rust

--- a/.bazelrc
+++ b/.bazelrc
@@ -93,6 +93,10 @@ build:linux --build_tag_filters -objc,-cuda,-rust
 build:macos --build_tag_filters -cuda,-rust
 build:windows --build_tag_filters -objc,-cuda,-rust
 
+# Halo2 uses subgroup generator of bn254 scalar field as 7.
+# See https://github.com/kroma-network/halo2curves/blob/c0ac1935e5da2a620204b5b011be2c924b1e0155/src/bn256/fr.rs#L68-L70
+build:halo2 --//tachyon/math/elliptic_curves/bn/bn254:fr_subgroup_generator=7
+
 # Config-specific options should come above this line.
 
 # Load rc file with user-specific options.

--- a/tachyon/base/time/BUILD.bazel
+++ b/tachyon/base/time/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("//bazel:tachyon.bzl", "if_macos", "if_posix")
 load(
     "//bazel:tachyon_cc.bzl",
@@ -5,11 +6,19 @@ load(
     "tachyon_cc_unittest",
     "tachyon_objc_library",
 )
-load(":time_buildflags.bzl", "time_buildflag_header")
+load(":time_buildflags.bzl", "ENABLE_MACH_ABSOLUTE_TIME_TICKS", "time_buildflag_header")
 
 package(default_visibility = ["//visibility:public"])
 
-time_buildflag_header(name = "time_buildflags")
+bool_flag(
+    name = ENABLE_MACH_ABSOLUTE_TIME_TICKS,
+    build_setting_default = True,
+)
+
+time_buildflag_header(
+    name = "time_buildflags",
+    enable_mach_absolute_time_ticks = ":" + ENABLE_MACH_ABSOLUTE_TIME_TICKS,
+)
 
 tachyon_cc_library(
     name = "time_base",

--- a/tachyon/base/time/time_buildflags.bzl
+++ b/tachyon/base/time/time_buildflags.bzl
@@ -1,18 +1,29 @@
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("//bazel:tachyon_cc.bzl", "tachyon_cc_library")
-load("//tachyon/build:buildflag.bzl", "attrs", "gen_buildflag_header_helper", "get_var")
+load("//tachyon/build:buildflag.bzl", "attrs", "gen_buildflag_header_helper")
+
+ENABLE_MACH_ABSOLUTE_TIME_TICKS = "enable_mach_absolute_time_ticks"
 
 def _gen_time_buildflag_header_impl(ctx):
-    names = ["ENABLE_MACH_ABSOLUTE_TIME_TICKS"]
-    return gen_buildflag_header_helper(ctx, ["%s=%s" % (name, get_var(ctx, name.lower())) for name in names])
+    names = [ENABLE_MACH_ABSOLUTE_TIME_TICKS]
+    values = [ctx.attr.enable_mach_absolute_time_ticks]
+
+    return gen_buildflag_header_helper(ctx, [
+        "%s=%s" % (pair[0].upper(), pair[1][BuildSettingInfo].value)
+        for pair in zip(names, values)
+    ])
 
 _gen_time_buildflag_header = rule(
     implementation = _gen_time_buildflag_header_impl,
     output_to_genfiles = True,
-    attrs = attrs(),
+    attrs = attrs() | {
+        ENABLE_MACH_ABSOLUTE_TIME_TICKS: attr.label(),
+    },
 )
 
-def time_buildflag_header(name):
+def time_buildflag_header(name, enable_mach_absolute_time_ticks):
     _gen_time_buildflag_header(
+        enable_mach_absolute_time_ticks = enable_mach_absolute_time_ticks,
         name = "gen_" + name,
         out = name + ".h",
     )

--- a/tachyon/build/buildflag.bzl
+++ b/tachyon/build/buildflag.bzl
@@ -1,6 +1,3 @@
-def get_var(ctx, name):
-    return name in ctx.var and ctx.var[name]
-
 def attrs():
     return {
         "out": attr.output(mandatory = True),

--- a/tachyon/math/elliptic_curves/bls12/bls12_381/BUILD.bazel
+++ b/tachyon/math/elliptic_curves/bls12/bls12_381/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("//tachyon/math/elliptic_curves/bls12/generator:build_defs.bzl", "generate_bls12_curves")
 load("//tachyon/math/elliptic_curves/short_weierstrass/generator:build_defs.bzl", "generate_ec_points")
 load(
@@ -6,31 +7,67 @@ load(
     "generate_fp2s",
     "generate_fp6s",
 )
-load("//tachyon/math/finite_fields/generator/prime_field_generator:build_defs.bzl", "generate_prime_fields")
+load(
+    "//tachyon/math/finite_fields/generator/prime_field_generator:build_defs.bzl",
+    "SMALL_SUBGROUP_ADICITY",
+    "SMALL_SUBGROUP_BASE",
+    "SUBGROUP_GENERATOR",
+    "generate_large_fft_prime_fields",
+)
 
 package(default_visibility = ["//visibility:public"])
 
+string_flag(
+    name = "fq_" + SMALL_SUBGROUP_ADICITY,
+    build_setting_default = "2",
+)
+
+string_flag(
+    name = "fq_" + SMALL_SUBGROUP_BASE,
+    build_setting_default = "3",
+)
+
+string_flag(
+    name = "fq_" + SUBGROUP_GENERATOR,
+    build_setting_default = "2",
+)
+
 # Parameters are from https://zips.z.cash/protocol/protocol.pdf#page=98 and https://github.com/arkworks-rs/curves/tree/master/bls12_381/src/fields
-generate_prime_fields(
+generate_large_fft_prime_fields(
     name = "fq",
     class_name = "Fq",
     # Hex: 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab
     modulus = "4002409555221667393417789825735904156556882819939007885332058136124031650490837864442687629129015664037894272559787",
     namespace = "tachyon::math::bls12_381",
-    small_subgroup_adicity = "2",
-    small_subgroup_base = "3",
-    subgroup_generator = "2",
+    small_subgroup_adicity = ":fq_" + SMALL_SUBGROUP_ADICITY,
+    small_subgroup_base = ":fq_" + SMALL_SUBGROUP_BASE,
+    subgroup_generator = ":fq_" + SUBGROUP_GENERATOR,
 )
 
-generate_prime_fields(
+string_flag(
+    name = "fr_" + SMALL_SUBGROUP_ADICITY,
+    build_setting_default = "1",
+)
+
+string_flag(
+    name = "fr_" + SMALL_SUBGROUP_BASE,
+    build_setting_default = "3",
+)
+
+string_flag(
+    name = "fr_" + SUBGROUP_GENERATOR,
+    build_setting_default = "7",
+)
+
+generate_large_fft_prime_fields(
     name = "fr",
     class_name = "Fr",
     # Hex: 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001
     modulus = "52435875175126190479447740508185965837690552500527637822603658699938581184513",
     namespace = "tachyon::math::bls12_381",
-    small_subgroup_adicity = "1",
-    small_subgroup_base = "3",
-    subgroup_generator = "7",
+    small_subgroup_adicity = ":fr_" + SMALL_SUBGROUP_ADICITY,
+    small_subgroup_base = ":fr_" + SMALL_SUBGROUP_BASE,
+    subgroup_generator = ":fr_" + SUBGROUP_GENERATOR,
 )
 
 generate_fp2s(

--- a/tachyon/math/elliptic_curves/bn/bn254/BUILD.bazel
+++ b/tachyon/math/elliptic_curves/bn/bn254/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("//bazel:tachyon.bzl", "if_polygon_zkevm_backend")
 load("//bazel:tachyon_cc.bzl", "tachyon_cc_library")
 load("//tachyon/math/elliptic_curves/bn/generator:build_defs.bzl", "generate_bn_curves")
@@ -8,12 +9,24 @@ load(
     "generate_fp2s",
     "generate_fp6s",
 )
-load("//tachyon/math/finite_fields/generator/prime_field_generator:build_defs.bzl", "generate_prime_fields")
+load(
+    "//tachyon/math/finite_fields/generator/prime_field_generator:build_defs.bzl",
+    "SMALL_SUBGROUP_ADICITY",
+    "SMALL_SUBGROUP_BASE",
+    "SUBGROUP_GENERATOR",
+    "generate_fft_prime_fields",
+    "generate_large_fft_prime_fields",
+)
 
 package(default_visibility = ["//visibility:public"])
 
+string_flag(
+    name = "fq_" + SUBGROUP_GENERATOR,
+    build_setting_default = "3",
+)
+
 # Parameters are from https://zips.z.cash/protocol/protocol.pdf#page=97 and https://github.com/arkworks-rs/curves/tree/master/bn254/src/fields
-generate_prime_fields(
+generate_fft_prime_fields(
     name = "fq",
     class_name = "Fq",
     hdr_include_override = """#if defined(TACHYON_POLYGON_ZKEVM_BACKEND)
@@ -35,14 +48,29 @@ generate_prime_fields(
 #else
   constexpr static bool kIsSpecialPrime = false;
 #endif""",
-    subgroup_generator = "3",
+    subgroup_generator = ":fq_" + SUBGROUP_GENERATOR,
     deps = if_polygon_zkevm_backend([
         ":prime_field_fq",
         "//tachyon/build:build_config",
     ]),
 )
 
-generate_prime_fields(
+string_flag(
+    name = "fr_" + SMALL_SUBGROUP_ADICITY,
+    build_setting_default = "2",
+)
+
+string_flag(
+    name = "fr_" + SMALL_SUBGROUP_BASE,
+    build_setting_default = "3",
+)
+
+string_flag(
+    name = "fr_" + SUBGROUP_GENERATOR,
+    build_setting_default = "5",
+)
+
+generate_large_fft_prime_fields(
     name = "fr",
     class_name = "Fr",
     hdr_include_override = """#if defined(TACHYON_POLYGON_ZKEVM_BACKEND)
@@ -54,8 +82,8 @@ generate_prime_fields(
     # Hex: 0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001
     modulus = "21888242871839275222246405745257275088548364400416034343698204186575808495617",
     namespace = "tachyon::math::bn254",
-    small_subgroup_adicity = "2",
-    small_subgroup_base = "3",
+    small_subgroup_adicity = ":fr_" + SMALL_SUBGROUP_ADICITY,
+    small_subgroup_base = ":fr_" + SMALL_SUBGROUP_BASE,
     special_prime_override = """#if defined(TACHYON_POLYGON_ZKEVM_BACKEND)
 #if ARCH_CPU_X86_64
   constexpr static bool kIsSpecialPrime = true;
@@ -66,7 +94,7 @@ generate_prime_fields(
 #else
   constexpr static bool kIsSpecialPrime = false;
 #endif""",
-    subgroup_generator = "5",
+    subgroup_generator = ":fr_" + SUBGROUP_GENERATOR,
     deps = if_polygon_zkevm_backend([
         ":prime_field_fr",
         "//tachyon/build:build_config",

--- a/tachyon/math/elliptic_curves/bn/bn384_small_two_adicity/BUILD.bazel
+++ b/tachyon/math/elliptic_curves/bn/bn384_small_two_adicity/BUILD.bazel
@@ -1,27 +1,64 @@
-load("//tachyon/math/finite_fields/generator/prime_field_generator:build_defs.bzl", "generate_prime_fields")
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+load(
+    "//tachyon/math/finite_fields/generator/prime_field_generator:build_defs.bzl",
+    "SMALL_SUBGROUP_ADICITY",
+    "SMALL_SUBGROUP_BASE",
+    "SUBGROUP_GENERATOR",
+    "generate_large_fft_prime_fields",
+)
 
 package(default_visibility = ["//visibility:public"])
 
+string_flag(
+    name = "fq_" + SMALL_SUBGROUP_ADICITY,
+    build_setting_default = "2",
+)
+
+string_flag(
+    name = "fq_" + SMALL_SUBGROUP_BASE,
+    build_setting_default = "3",
+)
+
+string_flag(
+    name = "fq_" + SUBGROUP_GENERATOR,
+    build_setting_default = "7",
+)
+
 # Parameters are from https://github.com/arkworks-rs/algebra/blob/master/test-curves/src/bn384_small_two_adicity/fq.rs
-generate_prime_fields(
+generate_large_fft_prime_fields(
     name = "fq",
     class_name = "Fq",
     # Hex: 0x26a192ce09033aefd13bdbf17786104ad304fe31dc79b326e86a281d61074bec649bdd411682c645207c4e269a431001
     modulus = "5945877603251831796258517492029536515488649313567122628447476625319762940580461319088175968449723373773214087057409",
     namespace = "tachyon::math::bn384_small_two_adicity",
-    small_subgroup_adicity = "2",
-    small_subgroup_base = "3",
-    subgroup_generator = "7",
+    small_subgroup_adicity = ":fq_" + SMALL_SUBGROUP_ADICITY,
+    small_subgroup_base = ":fq_" + SMALL_SUBGROUP_BASE,
+    subgroup_generator = ":fq_" + SUBGROUP_GENERATOR,
+)
+
+string_flag(
+    name = "fr_" + SMALL_SUBGROUP_ADICITY,
+    build_setting_default = "2",
+)
+
+string_flag(
+    name = "fr_" + SMALL_SUBGROUP_BASE,
+    build_setting_default = "3",
+)
+
+string_flag(
+    name = "fr_" + SUBGROUP_GENERATOR,
+    build_setting_default = "5",
 )
 
 # Parameters are from https://github.com/arkworks-rs/algebra/blob/master/test-curves/src/bn384_small_two_adicity/fr.rs
-generate_prime_fields(
+generate_large_fft_prime_fields(
     name = "fr",
     class_name = "Fr",
     # Hex: 0x26a192ce09033aefd13bdbf17786104ad304fe31dc79b32684f7e52225e599a5b91f07ba93282245f13a3723b4c31001
     modulus = "5945877603251831796258517492029536515488649313567122628445038208291596545947608789992834434053176523624102324539393",
     namespace = "tachyon::math::bn384_small_two_adicity",
-    small_subgroup_adicity = "2",
-    small_subgroup_base = "3",
-    subgroup_generator = "5",
+    small_subgroup_adicity = ":fr_" + SMALL_SUBGROUP_ADICITY,
+    small_subgroup_base = ":fr_" + SMALL_SUBGROUP_BASE,
+    subgroup_generator = ":fr_" + SUBGROUP_GENERATOR,
 )

--- a/tachyon/math/elliptic_curves/secp/secp256k1/BUILD.bazel
+++ b/tachyon/math/elliptic_curves/secp/secp256k1/BUILD.bazel
@@ -1,12 +1,34 @@
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("//bazel:tachyon.bzl", "if_polygon_zkevm_backend")
 load("//bazel:tachyon_cc.bzl", "tachyon_cc_library")
 load("//tachyon/math/elliptic_curves/short_weierstrass/generator:build_defs.bzl", "generate_ec_points")
-load("//tachyon/math/finite_fields/generator/prime_field_generator:build_defs.bzl", "generate_prime_fields")
+load(
+    "//tachyon/math/finite_fields/generator/prime_field_generator:build_defs.bzl",
+    "SMALL_SUBGROUP_ADICITY",
+    "SMALL_SUBGROUP_BASE",
+    "SUBGROUP_GENERATOR",
+    "generate_large_fft_prime_fields",
+)
 
 package(default_visibility = ["//visibility:public"])
 
+string_flag(
+    name = "fq_" + SMALL_SUBGROUP_ADICITY,
+    build_setting_default = "1",
+)
+
+string_flag(
+    name = "fq_" + SMALL_SUBGROUP_BASE,
+    build_setting_default = "3",
+)
+
+string_flag(
+    name = "fq_" + SUBGROUP_GENERATOR,
+    build_setting_default = "3",
+)
+
 # Parameters are from https://www.secg.org/sec2-v2.pdf#page=13 and https://github.com/arkworks-rs/curves/tree/master/secp256k1/src/fields
-generate_prime_fields(
+generate_large_fft_prime_fields(
     name = "fq",
     class_name = "Fq",
     hdr_include_override = """#if defined(TACHYON_POLYGON_ZKEVM_BACKEND)
@@ -18,8 +40,8 @@ generate_prime_fields(
     # Hex: 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f
     modulus = "115792089237316195423570985008687907853269984665640564039457584007908834671663",
     namespace = "tachyon::math::secp256k1",
-    small_subgroup_adicity = "1",
-    small_subgroup_base = "3",
+    small_subgroup_adicity = ":fq_" + SMALL_SUBGROUP_ADICITY,
+    small_subgroup_base = ":fq_" + SMALL_SUBGROUP_BASE,
     special_prime_override = """#if defined(TACHYON_POLYGON_ZKEVM_BACKEND)
 #if ARCH_CPU_X86_64
   constexpr static bool kIsSpecialPrime = true;
@@ -30,14 +52,29 @@ generate_prime_fields(
 #else
   constexpr static bool kIsSpecialPrime = false;
 #endif""",
-    subgroup_generator = "3",
+    subgroup_generator = ":fq_" + SUBGROUP_GENERATOR,
     deps = if_polygon_zkevm_backend([
         ":prime_field_fq",
         "//tachyon/build:build_config",
     ]),
 )
 
-generate_prime_fields(
+string_flag(
+    name = "fr_" + SMALL_SUBGROUP_ADICITY,
+    build_setting_default = "1",
+)
+
+string_flag(
+    name = "fr_" + SMALL_SUBGROUP_BASE,
+    build_setting_default = "3",
+)
+
+string_flag(
+    name = "fr_" + SUBGROUP_GENERATOR,
+    build_setting_default = "7",
+)
+
+generate_large_fft_prime_fields(
     name = "fr",
     class_name = "Fr",
     hdr_include_override = """#if defined(TACHYON_POLYGON_ZKEVM_BACKEND)
@@ -49,8 +86,8 @@ generate_prime_fields(
     # Hex: 0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141
     modulus = "115792089237316195423570985008687907852837564279074904382605163141518161494337",
     namespace = "tachyon::math::secp256k1",
-    small_subgroup_adicity = "1",
-    small_subgroup_base = "3",
+    small_subgroup_adicity = ":fr_" + SMALL_SUBGROUP_ADICITY,
+    small_subgroup_base = ":fr_" + SMALL_SUBGROUP_BASE,
     special_prime_override = """#if defined(TACHYON_POLYGON_ZKEVM_BACKEND)
 #if ARCH_CPU_X86_64
   constexpr static bool kIsSpecialPrime = true;
@@ -61,7 +98,7 @@ generate_prime_fields(
 #else
   constexpr static bool kIsSpecialPrime = false;
 #endif""",
-    subgroup_generator = "7",
+    subgroup_generator = ":fr_" + SUBGROUP_GENERATOR,
     deps = if_polygon_zkevm_backend([
         ":prime_field_fr",
         "//tachyon/build:build_config",

--- a/tachyon/math/finite_fields/goldilocks_prime/BUILD.bazel
+++ b/tachyon/math/finite_fields/goldilocks_prime/BUILD.bazel
@@ -1,10 +1,32 @@
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("//bazel:tachyon.bzl", "if_polygon_zkevm_backend")
 load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_unittest")
-load("//tachyon/math/finite_fields/generator/prime_field_generator:build_defs.bzl", "generate_prime_fields")
+load(
+    "//tachyon/math/finite_fields/generator/prime_field_generator:build_defs.bzl",
+    "SMALL_SUBGROUP_ADICITY",
+    "SMALL_SUBGROUP_BASE",
+    "SUBGROUP_GENERATOR",
+    "generate_large_fft_prime_fields",
+)
 
 package(default_visibility = ["//visibility:public"])
 
-generate_prime_fields(
+string_flag(
+    name = "fr_" + SMALL_SUBGROUP_ADICITY,
+    build_setting_default = "1",
+)
+
+string_flag(
+    name = "fr_" + SMALL_SUBGROUP_BASE,
+    build_setting_default = "3",
+)
+
+string_flag(
+    name = "fr_" + SUBGROUP_GENERATOR,
+    build_setting_default = "7",
+)
+
+generate_large_fft_prime_fields(
     name = "goldilocks",
     class_name = "Goldilocks",
     hdr_include_override = """#if defined(TACHYON_POLYGON_ZKEVM_BACKEND)
@@ -17,8 +39,8 @@ generate_prime_fields(
     # Hex: 0xffffffff00000001
     modulus = "18446744069414584321",
     namespace = "tachyon::math",
-    small_subgroup_adicity = "1",
-    small_subgroup_base = "3",
+    small_subgroup_adicity = ":fr_" + SMALL_SUBGROUP_ADICITY,
+    small_subgroup_base = ":fr_" + SMALL_SUBGROUP_BASE,
     special_prime_override = """#if defined(TACHYON_POLYGON_ZKEVM_BACKEND)
 #if ARCH_CPU_X86_64
   constexpr static bool kIsSpecialPrime = true;
@@ -29,7 +51,7 @@ generate_prime_fields(
 #else
   constexpr static bool kIsSpecialPrime = false;
 #endif""",
-    subgroup_generator = "7",
+    subgroup_generator = ":fr_" + SUBGROUP_GENERATOR,
     deps = if_polygon_zkevm_backend([
         ":prime_field_goldilocks",
         "//tachyon/build:build_config",

--- a/tachyon/math/finite_fields/test/BUILD.bazel
+++ b/tachyon/math/finite_fields/test/BUILD.bazel
@@ -1,19 +1,29 @@
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load(
     "//tachyon/math/finite_fields/generator/ext_prime_field_generator:build_defs.bzl",
     "generate_fp2s",
     "generate_fp3s",
 )
-load("//tachyon/math/finite_fields/generator/prime_field_generator:build_defs.bzl", "generate_prime_fields")
+load(
+    "//tachyon/math/finite_fields/generator/prime_field_generator:build_defs.bzl",
+    "SMALL_SUBGROUP_ADICITY",
+    "generate_fft_prime_fields",
+)
 
 package(default_visibility = ["//visibility:public"])
 
-generate_prime_fields(
+string_flag(
+    name = SMALL_SUBGROUP_ADICITY,
+    build_setting_default = "3",
+)
+
+generate_fft_prime_fields(
     name = "gf7",
     testonly = True,
     class_name = "GF7",
     modulus = "7",
     namespace = "tachyon::math",
-    subgroup_generator = "3",
+    subgroup_generator = ":" + SMALL_SUBGROUP_ADICITY,
 )
 
 generate_fp2s(

--- a/tachyon/node/test/.bazelrc
+++ b/tachyon/node/test/.bazelrc
@@ -16,9 +16,6 @@ build:macos_arm64 --config=macos
 build:macos_arm64 --cpu=darwin_arm64
 build:macos_arm64 --host_cpu=darwin_arm64
 
-# Chromium things
-build:macos --define=enable_mach_absolute_time_ticks=true
-
 build --@kroma_network_tachyon//:node_binding
 # See https://www.typescriptlang.org/tsconfig#skipLibCheck
 build --@aspect_rules_ts//ts:skipLibCheck=honor_tsconfig

--- a/tachyon/py/test/.bazelrc
+++ b/tachyon/py/test/.bazelrc
@@ -13,9 +13,6 @@ build:macos_arm64 --config=macos
 build:macos_arm64 --cpu=darwin_arm64
 build:macos_arm64 --host_cpu=darwin_arm64
 
-# Chromium things
-build:macos --define=enable_mach_absolute_time_ticks=true
-
 build --@kroma_network_tachyon//:py_binding
 
 # gmp needs exception.


### PR DESCRIPTION
# Description

I found this while implementing fibonacci4 circuit. By coincidence, value of (5ᵀ)^(2ˢ/n) and (7ᵀ)^(2ˢ/n) was same for bn254 Fr when n = 16, which made current tests pass well. However, with n = 2048, the values are different.
