### PR TITLE
test(crypto): reinforce `polynomial_openings_unittest`

### DIFF
--- a/tachyon/crypto/commitments/polynomial_openings_unittest.cc
+++ b/tachyon/crypto/commitments/polynomial_openings_unittest.cc
@@ -113,11 +113,11 @@ TEST_F(PolynomialOpeningsTest, GroupByPolyOracleAndPoints) {
   poly_openings.emplace_back(PolyRef(&polys_[0]), PointDeepRef(&points_[1]),
                              polys_[0].Evaluate(points_[1]));
   poly_openings.emplace_back(PolyRef(&polys_[1]), PointDeepRef(&points_[0]),
-                             polys_[0].Evaluate(points_[0]));
+                             polys_[1].Evaluate(points_[0]));
   poly_openings.emplace_back(PolyRef(&polys_[1]), PointDeepRef(&points_[1]),
-                             polys_[0].Evaluate(points_[1]));
+                             polys_[1].Evaluate(points_[1]));
   poly_openings.emplace_back(PolyRef(&polys_[2]), PointDeepRef(&points_[2]),
-                             polys_[0].Evaluate(points_[2]));
+                             polys_[2].Evaluate(points_[2]));
   PolynomialOpeningGrouper<Poly> grouper;
   std::vector<GroupedPolyOraclePair> poly_openings_grouped_by_poly =
       grouper.GroupByPolyOracle(poly_openings);

--- a/tachyon/crypto/commitments/polynomial_openings_unittest.cc
+++ b/tachyon/crypto/commitments/polynomial_openings_unittest.cc
@@ -25,8 +25,13 @@ class PolynomialOpeningsTest : public testing::Test {
   static void SetUpTestSuite() { GF7::Init(); }
 
   void SetUp() override {
+    // NOTE(Insun35): For testing, I added the same polynomial to |polys_[2]|
+    // and |polys_[3]| on purpose. Even if they have the same value, they should
+    // be grouped separately because they are ShallowRef in
+    // |PolynomialOpenings|.
     polys_.push_back(Poly(Coeffs({GF7(3), GF7(6), GF7(4), GF7(6), GF7(6)})));
     polys_.push_back(Poly(Coeffs({GF7(3), GF7(4), GF7(5), GF7(0), GF7(2)})));
+    polys_.push_back(Poly(Coeffs({GF7(1), GF7(5), GF7(3), GF7(6), GF7(6)})));
     polys_.push_back(Poly(Coeffs({GF7(1), GF7(5), GF7(3), GF7(6), GF7(6)})));
     points_.push_back(GF7(1));
     points_.push_back(GF7(2));
@@ -118,9 +123,16 @@ TEST_F(PolynomialOpeningsTest, GroupByPolyOracleAndPoints) {
                              polys_[1].Evaluate(points_[1]));
   poly_openings.emplace_back(PolyRef(&polys_[2]), PointDeepRef(&points_[2]),
                              polys_[2].Evaluate(points_[2]));
+  poly_openings.emplace_back(PolyRef(&polys_[3]), PointDeepRef(&points_[2]),
+                             polys_[3].Evaluate(points_[2]));
   PolynomialOpeningGrouper<Poly> grouper;
   std::vector<GroupedPolyOraclePair> poly_openings_grouped_by_poly =
       grouper.GroupByPolyOracle(poly_openings);
+
+  // NOTE(Insun35): Although |polys_[2]| and |polys_[3]| have the same value,
+  // they should be grouped separately because they are ShallowRef in
+  // |PolynomialOpenings|.
+  EXPECT_EQ(poly_openings_grouped_by_poly.size(), 4);
 
   for (const auto& poly_oracle_grouped_pair : poly_openings_grouped_by_poly) {
     absl::btree_set<PointDeepRef> expected_points;
@@ -160,6 +172,7 @@ TEST_F(PolynomialOpeningsTest, GroupByPolyOracleAndPoints) {
     } else {
       expected_polys = {
           PolyRef(&polys_[2]),
+          PolyRef(&polys_[3]),
       };
     }
     EXPECT_EQ(point_grouped_pair.polys, expected_polys);
@@ -177,14 +190,31 @@ TEST_F(PolynomialOpeningsTest, GroupByPolyOracleAndPoints) {
   std::vector<PointDeepRef> expected_points_vec2 = {
       PointDeepRef(&points_[2]),
   };
-  // TODO(chokobole): Test validity of
-  // grouped_poly_openings_vec[i].poly_openings_vec
+  std::vector<PolyRef> expected_polys_vec = {
+      PolyRef(&polys_[0]),
+      PolyRef(&polys_[1]),
+  };
+  std::vector<PolyRef> expected_polys_vec2 = {
+      PolyRef(&polys_[2]),
+      PolyRef(&polys_[3]),
+  };
+
   if (grouped_poly_openings_vec[0].point_refs.size() == 2) {
     EXPECT_EQ(grouped_poly_openings_vec[1].point_refs.size(), 1);
     EXPECT_THAT(grouped_poly_openings_vec[0].point_refs,
                 testing::UnorderedElementsAreArray(expected_points_vec));
     EXPECT_THAT(grouped_poly_openings_vec[1].point_refs,
                 testing::UnorderedElementsAreArray(expected_points_vec2));
+    for (const PolynomialOpenings<Poly>& poly_openings :
+         grouped_poly_openings_vec[0].poly_openings_vec) {
+      EXPECT_THAT(expected_polys_vec,
+                  testing::Contains(poly_openings.poly_oracle));
+    }
+    for (const PolynomialOpenings<Poly>& poly_openings :
+         grouped_poly_openings_vec[1].poly_openings_vec) {
+      EXPECT_THAT(expected_polys_vec2,
+                  testing::Contains(poly_openings.poly_oracle));
+    }
   } else {
     ASSERT_EQ(grouped_poly_openings_vec[0].point_refs.size(), 1);
     EXPECT_EQ(grouped_poly_openings_vec[1].point_refs.size(), 2);
@@ -192,6 +222,16 @@ TEST_F(PolynomialOpeningsTest, GroupByPolyOracleAndPoints) {
                 testing::UnorderedElementsAreArray(expected_points_vec2));
     EXPECT_THAT(grouped_poly_openings_vec[1].point_refs,
                 testing::UnorderedElementsAreArray(expected_points_vec));
+    for (const PolynomialOpenings<Poly>& poly_openings :
+         grouped_poly_openings_vec[0].poly_openings_vec) {
+      EXPECT_THAT(expected_polys_vec2,
+                  testing::Contains(poly_openings.poly_oracle));
+    }
+    for (const PolynomialOpenings<Poly>& poly_openings :
+         grouped_poly_openings_vec[1].poly_openings_vec) {
+      EXPECT_THAT(expected_polys_vec,
+                  testing::Contains(poly_openings.poly_oracle));
+    }
   }
 }
 


### PR DESCRIPTION
- Add a test polynomial with the same value as another polynomial but with a different address to test if `ShallowRefs` are correctly distinguished.
- Add logic to check the validity of each `poly_openings_vec` of `grouped_poly_openings_vec`.