### PR TITLE
refac: add read only buffer

### DIFF
--- a/tachyon/base/buffer/BUILD.bazel
+++ b/tachyon/base/buffer/BUILD.bazel
@@ -6,12 +6,7 @@ tachyon_cc_library(
     name = "buffer",
     srcs = ["buffer.cc"],
     hdrs = ["buffer.h"],
-    deps = [
-        ":copyable_forward",
-        "//tachyon/base:endian",
-        "//tachyon/base/numerics:checked_math",
-        "@com_google_absl//absl/base:endian",
-    ],
+    deps = [":read_only_buffer"],
 )
 
 tachyon_cc_library(
@@ -28,6 +23,18 @@ tachyon_cc_library(
     name = "copyable_forward",
     hdrs = ["copyable_forward.h"],
     deps = ["//tachyon/base/types:cxx20_is_bounded_array"],
+)
+
+tachyon_cc_library(
+    name = "read_only_buffer",
+    srcs = ["read_only_buffer.cc"],
+    hdrs = ["read_only_buffer.h"],
+    deps = [
+        ":copyable_forward",
+        "//tachyon/base:endian",
+        "//tachyon/base/numerics:checked_math",
+        "@com_google_absl//absl/base:endian",
+    ],
 )
 
 tachyon_cc_library(

--- a/tachyon/base/buffer/buffer.cc
+++ b/tachyon/base/buffer/buffer.cc
@@ -6,61 +6,6 @@
 
 namespace tachyon::base {
 
-bool Buffer::ReadAt(size_t buffer_offset, uint8_t* ptr, size_t size) const {
-  base::CheckedNumeric<size_t> len = buffer_offset;
-  size_t size_needed;
-  if (!(len + size).AssignIfValid(&size_needed)) return false;
-  if (size_needed > buffer_len_) {
-    return false;
-  }
-  const char* buffer = reinterpret_cast<const char*>(buffer_);
-  memcpy(ptr, &buffer[buffer_offset], size);
-  buffer_offset_ = buffer_offset + size;
-  return true;
-}
-
-#define READ_BE_AT(bytes, bits, type)                                    \
-  bool Buffer::Read##bits##BEAt(size_t buffer_offset, type* ptr) const { \
-    base::CheckedNumeric<size_t> len = buffer_offset;                    \
-    size_t size_needed;                                                  \
-    if (!(len + bytes).AssignIfValid(&size_needed)) return false;        \
-    if (size_needed > buffer_len_) {                                     \
-      return false;                                                      \
-    }                                                                    \
-    const char* buffer = reinterpret_cast<char*>(buffer_);               \
-    type value = absl::big_endian::Load##bits(&buffer[buffer_offset]);   \
-    memcpy(ptr, &value, bytes);                                          \
-    buffer_offset_ = buffer_offset + bytes;                              \
-    return true;                                                         \
-  }
-
-READ_BE_AT(2, 16, uint16_t)
-READ_BE_AT(4, 32, uint32_t)
-READ_BE_AT(8, 64, uint64_t)
-
-#undef READ_BE_AT
-
-#define READ_LE_AT(bytes, bits, type)                                     \
-  bool Buffer::Read##bits##LEAt(size_t buffer_offset, type* ptr) const {  \
-    base::CheckedNumeric<size_t> len = buffer_offset;                     \
-    size_t size_needed;                                                   \
-    if (!(len + bytes).AssignIfValid(&size_needed)) return false;         \
-    if (size_needed > buffer_len_) {                                      \
-      return false;                                                       \
-    }                                                                     \
-    const char* buffer = reinterpret_cast<const char*>(buffer_);          \
-    type value = absl::little_endian::Load##bits(&buffer[buffer_offset]); \
-    memcpy(ptr, &value, bytes);                                           \
-    buffer_offset_ = buffer_offset + bytes;                               \
-    return true;                                                          \
-  }
-
-READ_LE_AT(2, 16, uint16_t)
-READ_LE_AT(4, 32, uint32_t)
-READ_LE_AT(8, 64, uint64_t)
-
-#undef READ_LE_AT
-
 bool Buffer::WriteAt(size_t buffer_offset, const uint8_t* ptr, size_t size) {
   base::CheckedNumeric<size_t> len = buffer_offset;
   size_t size_needed;

--- a/tachyon/base/buffer/buffer.h
+++ b/tachyon/base/buffer/buffer.h
@@ -4,7 +4,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include <iostream>
 #include <type_traits>
 #include <utility>
 

--- a/tachyon/base/buffer/buffer.h
+++ b/tachyon/base/buffer/buffer.h
@@ -73,7 +73,7 @@ class TACHYON_EXPORT Buffer {
 
   [[nodiscard]] bool Done() const { return buffer_offset_ == buffer_len_; }
 
-  // Returns false either
+  // Returns false when either
   // 1) |buffer_offset| + |size| overflows.
   // 2) if it tries to read more than |buffer_len_|.
   [[nodiscard]] bool ReadAt(size_t buffer_offset, uint8_t* ptr,
@@ -233,7 +233,7 @@ class TACHYON_EXPORT Buffer {
     return WriteMany(args...);
   }
 
-  // Returns false either
+  // Returns false when either
   // 1) |buffer_offset| + |size| overflows.
   // 2) if it is not growable and it tries to write more than
   // |buffer_len_|.

--- a/tachyon/base/buffer/buffer.h
+++ b/tachyon/base/buffer/buffer.h
@@ -1,193 +1,25 @@
 #ifndef TACHYON_BASE_BUFFER_BUFFER_H_
 #define TACHYON_BASE_BUFFER_BUFFER_H_
 
-#include <stddef.h>
-#include <stdint.h>
-
-#include <type_traits>
-#include <utility>
-
-#include "absl/base/internal/endian.h"
-
-#include "tachyon/base/buffer/copyable_forward.h"
-#include "tachyon/base/endian.h"
-#include "tachyon/base/logging.h"
+#include "tachyon/base/buffer/read_only_buffer.h"
 
 namespace tachyon::base {
-namespace internal {
 
-template <typename, typename = void>
-struct IsBuiltinSerializable : std::false_type {};
-
-template <typename T>
-struct IsBuiltinSerializable<
-    T, std::enable_if_t<std::is_fundamental_v<T> || std::is_enum_v<T>>>
-    : std::true_type {};
-
-template <typename, typename = void>
-struct IsNonBuiltinSerializable : std::false_type {};
-
-template <typename T>
-struct IsNonBuiltinSerializable<
-    T,
-    std::enable_if_t<!IsBuiltinSerializable<T>::value && IsCopyable<T>::value>>
-    : std::true_type {};
-
-}  // namespace internal
-
-// Buffer policy:
-// It tries to write / read as much as possible.
-// If errors occur during write or read, it is because the requested
-// buffer offset combined with the size would overflow.
-class TACHYON_EXPORT Buffer {
+class TACHYON_EXPORT Buffer : public ReadOnlyBuffer {
  public:
   Buffer() = default;
   Buffer(void* buffer, size_t buffer_len)
-      : buffer_(buffer), buffer_offset_(0), buffer_len_(buffer_len) {}
+      : ReadOnlyBuffer(buffer, buffer_len) {}
   Buffer(const Buffer& other) = delete;
   Buffer& operator=(const Buffer& other) = delete;
-  Buffer(Buffer&& other)
-      : buffer_(std::exchange(other.buffer_, nullptr)),
-        buffer_offset_(std::exchange(other.buffer_offset_, 0)),
-        buffer_len_(std::exchange(other.buffer_len_, 0)) {}
-  Buffer& operator=(Buffer&& other) {
-    buffer_ = std::exchange(other.buffer_, nullptr);
-    buffer_offset_ = std::exchange(other.buffer_offset_, 0);
-    buffer_len_ = std::exchange(other.buffer_len_, 0);
-    return *this;
-  }
+  Buffer(Buffer&& other) = default;
+  Buffer& operator=(Buffer&& other) = default;
   virtual ~Buffer() = default;
 
-  Endian endian() const { return endian_; }
-  void set_endian(Endian endian) { endian_ = endian; }
-
+  // NOTE(chokobole): Due to the existence of a constant getter named |buffer()|
+  // in the parent class, the name was chosen in snake case.
+  using ReadOnlyBuffer::buffer;
   void* buffer() { return buffer_; }
-  const void* buffer() const { return buffer_; }
-
-  size_t buffer_offset() const { return buffer_offset_; }
-  void set_buffer_offset(size_t buffer_offset) {
-    buffer_offset_ = buffer_offset;
-  }
-
-  size_t buffer_len() const { return buffer_len_; }
-
-  [[nodiscard]] bool Done() const { return buffer_offset_ == buffer_len_; }
-
-  // Returns false when either
-  // 1) |buffer_offset| + |size| overflows.
-  // 2) if it tries to read more than |buffer_len_|.
-  [[nodiscard]] bool ReadAt(size_t buffer_offset, uint8_t* ptr,
-                            size_t size) const;
-
-  template <
-      typename Ptr, typename T = std::remove_pointer_t<Ptr>,
-      std::enable_if_t<std::is_pointer_v<Ptr> &&
-                       internal::IsBuiltinSerializable<T>::value>* = nullptr>
-  [[nodiscard]] bool ReadAt(size_t buffer_offset, Ptr ptr) const {
-    switch (endian_) {
-      case Endian::kBig:
-        if constexpr (sizeof(T) == 8) {
-          return Read64BEAt(buffer_offset, reinterpret_cast<uint64_t*>(ptr));
-        } else if constexpr (sizeof(T) == 4) {
-          return Read32BEAt(buffer_offset, reinterpret_cast<uint32_t*>(ptr));
-        } else if constexpr (sizeof(T) == 2) {
-          return Read16BEAt(buffer_offset, reinterpret_cast<uint16_t*>(ptr));
-        }
-      case Endian::kLittle:
-        if constexpr (sizeof(T) == 8) {
-          return Read64LEAt(buffer_offset, reinterpret_cast<uint64_t*>(ptr));
-        } else if constexpr (sizeof(T) == 4) {
-          return Read32LEAt(buffer_offset, reinterpret_cast<uint32_t*>(ptr));
-        } else if constexpr (sizeof(T) == 2) {
-          return Read16LEAt(buffer_offset, reinterpret_cast<uint16_t*>(ptr));
-        }
-      case Endian::kNative:
-        return ReadAt(buffer_offset, reinterpret_cast<uint8_t*>(ptr),
-                      sizeof(T));
-    }
-    NOTREACHED();
-    return false;
-  }
-
-  [[nodiscard]] bool Read16BEAt(size_t buffer_offset, uint16_t* ptr) const;
-  [[nodiscard]] bool Read16LEAt(size_t buffer_offset, uint16_t* ptr) const;
-  [[nodiscard]] bool Read32BEAt(size_t buffer_offset, uint32_t* ptr) const;
-  [[nodiscard]] bool Read32LEAt(size_t buffer_offset, uint32_t* ptr) const;
-  [[nodiscard]] bool Read64BEAt(size_t buffer_offset, uint64_t* ptr) const;
-  [[nodiscard]] bool Read64LEAt(size_t buffer_offset, uint64_t* ptr) const;
-
-  template <
-      typename T,
-      std::enable_if_t<internal::IsNonBuiltinSerializable<T>::value>* = nullptr>
-  [[nodiscard]] bool ReadAt(size_t buffer_offset, T* value) const {
-    buffer_offset_ = buffer_offset;
-    return Copyable<T>::ReadFrom(*this, value);
-  }
-
-  template <typename T, size_t N>
-  [[nodiscard]] bool ReadAt(size_t buffer_offset, T (&array)[N]) const {
-    buffer_offset_ = buffer_offset;
-    for (size_t i = 0; i < N; ++i) {
-      if (!Read(&array[i])) return false;
-    }
-    return true;
-  }
-
-  [[nodiscard]] bool Read(uint8_t* ptr, size_t size) const {
-    return ReadAt(buffer_offset_, ptr, size);
-  }
-
-  template <typename T>
-  [[nodiscard]] bool Read(T&& value) const {
-    return ReadAt(buffer_offset_, std::forward<T>(value));
-  }
-
-  [[nodiscard]] bool Read16BE(uint16_t* ptr) const {
-    return Read16BEAt(buffer_offset_, ptr);
-  }
-
-  [[nodiscard]] bool Read16LE(uint16_t* ptr) const {
-    return Read16LEAt(buffer_offset_, ptr);
-  }
-
-  [[nodiscard]] bool Read32BE(uint32_t* ptr) const {
-    return Read32BEAt(buffer_offset_, ptr);
-  }
-
-  [[nodiscard]] bool Read32LE(uint32_t* ptr) const {
-    return Read32LEAt(buffer_offset_, ptr);
-  }
-
-  [[nodiscard]] bool Read64BE(uint64_t* ptr) const {
-    return Read64BEAt(buffer_offset_, ptr);
-  }
-
-  [[nodiscard]] bool Read64LE(uint64_t* ptr) const {
-    return Read64LEAt(buffer_offset_, ptr);
-  }
-
-  template <typename T>
-  [[nodiscard]] bool ReadMany(T&& value) const {
-    return Read(std::forward<T>(value));
-  }
-
-  template <typename T, typename... Args>
-  [[nodiscard]] bool ReadMany(T&& value, Args&&... args) const {
-    if (!Read(std::forward<T>(value))) return false;
-    return ReadMany(std::forward<Args>(args)...);
-  }
-
-  template <typename T, size_t N>
-  [[nodiscard]] bool ReadManyAt(size_t buffer_offset, T&& value) const {
-    return ReadAt(buffer_offset, std::forward<T>(value));
-  }
-
-  template <typename T, typename... Args>
-  [[nodiscard]] bool ReadManyAt(size_t buffer_offset, T&& value,
-                                Args&&... args) const {
-    if (!ReadAt(buffer_offset, std::forward<T>(value))) return false;
-    return ReadManyAt(buffer_offset, std::forward<Args>(args)...);
-  }
 
   [[nodiscard]] bool Write(const uint8_t* ptr, size_t size) {
     return WriteAt(buffer_offset_, ptr, size);
@@ -300,13 +132,6 @@ class TACHYON_EXPORT Buffer {
   }
 
   [[nodiscard]] virtual bool Grow(size_t size) { return false; }
-
- protected:
-  Endian endian_ = Endian::kNative;
-
-  void* buffer_ = nullptr;
-  mutable size_t buffer_offset_ = 0;
-  size_t buffer_len_ = 0;
 };
 
 }  // namespace tachyon::base

--- a/tachyon/base/buffer/copyable.h
+++ b/tachyon/base/buffer/copyable.h
@@ -31,7 +31,7 @@ class Copyable<std::basic_string_view<CharTy>> {
                          value.size());
   }
 
-  static bool ReadFrom(const Buffer& buffer,
+  static bool ReadFrom(const ReadOnlyBuffer& buffer,
                        std::basic_string_view<CharTy>* value) {
     NOTREACHED() << "Not supported ReadFrom for std::basic_string_view<CharTy>";
     return false;
@@ -51,7 +51,8 @@ class Copyable<std::basic_string<CharTy>> {
                          value.size());
   }
 
-  static bool ReadFrom(const Buffer& buffer, std::basic_string<CharTy>* value) {
+  static bool ReadFrom(const ReadOnlyBuffer& buffer,
+                       std::basic_string<CharTy>* value) {
     size_t size;
     if (!buffer.Read(&size)) return false;
     value->resize(size);
@@ -77,7 +78,7 @@ class Copyable<
                          length * sizeof(CharTy));
   }
 
-  static bool ReadFrom(const Buffer& buffer, const CharTy** value) {
+  static bool ReadFrom(const ReadOnlyBuffer& buffer, const CharTy** value) {
     NOTREACHED() << "Not supported ReadFrom for const CharTy*";
     return false;
   }
@@ -98,7 +99,7 @@ class Copyable<T[N]> {
     return true;
   }
 
-  static bool ReadFrom(const Buffer& buffer, T* values) {
+  static bool ReadFrom(const ReadOnlyBuffer& buffer, T* values) {
     for (size_t i = 0; i < N; ++i) {
       if (!buffer.Read(&values[i])) return false;
     }
@@ -124,7 +125,7 @@ class Copyable<std::vector<T>> {
     return true;
   }
 
-  static bool ReadFrom(const Buffer& buffer, std::vector<T>* values) {
+  static bool ReadFrom(const ReadOnlyBuffer& buffer, std::vector<T>* values) {
     size_t size;
     if (!buffer.Read(&size)) return false;
     values->resize(size);
@@ -152,7 +153,7 @@ class Copyable<std::array<T, N>> {
     return true;
   }
 
-  static bool ReadFrom(const Buffer& buffer, std::array<T, N>* values) {
+  static bool ReadFrom(const ReadOnlyBuffer& buffer, std::array<T, N>* values) {
     for (T& value : (*values)) {
       if (!buffer.Read(&value)) return false;
     }

--- a/tachyon/base/buffer/copyable_forward.h
+++ b/tachyon/base/buffer/copyable_forward.h
@@ -8,6 +8,7 @@
 namespace tachyon::base {
 
 class Buffer;
+class ReadOnlyBuffer;
 
 // NOTE: Do not implement for builtin serializable.
 // See tachyon/base/buffer.h
@@ -24,7 +25,7 @@ struct IsCopyable<
         decltype(Copyable<T>::WriteTo(std::declval<const T&>(),
                                       std::declval<Buffer*>())),
         decltype(Copyable<T>::ReadFrom(
-            std::declval<const Buffer&>(),
+            std::declval<const ReadOnlyBuffer&>(),
             std::declval<std::conditional_t<is_bounded_array_v<T>, T, T*>>())),
         decltype(Copyable<T>::EstimateSize(std::declval<const T&>()))>>
     : std::true_type {};

--- a/tachyon/base/buffer/copyable_forward.h
+++ b/tachyon/base/buffer/copyable_forward.h
@@ -11,7 +11,7 @@ class Buffer;
 class ReadOnlyBuffer;
 
 // NOTE: Do not implement for builtin serializable.
-// See tachyon/base/buffer.h
+// See tachyon/base/buffer/read_only_buffer.h
 template <typename T, typename SFINAE = void>
 class Copyable;
 

--- a/tachyon/base/buffer/read_only_buffer.cc
+++ b/tachyon/base/buffer/read_only_buffer.cc
@@ -1,0 +1,67 @@
+#include "tachyon/base/buffer/read_only_buffer.h"
+
+#include <string.h>
+
+#include "tachyon/base/numerics/checked_math.h"
+
+namespace tachyon::base {
+
+bool ReadOnlyBuffer::ReadAt(size_t buffer_offset, uint8_t* ptr,
+                            size_t size) const {
+  base::CheckedNumeric<size_t> len = buffer_offset;
+  size_t size_needed;
+  if (!(len + size).AssignIfValid(&size_needed)) return false;
+  if (size_needed > buffer_len_) {
+    return false;
+  }
+  const char* buffer = reinterpret_cast<const char*>(buffer_);
+  memcpy(ptr, &buffer[buffer_offset], size);
+  buffer_offset_ = buffer_offset + size;
+  return true;
+}
+
+#define READ_BE_AT(bytes, bits, type)                                    \
+  bool ReadOnlyBuffer::Read##bits##BEAt(size_t buffer_offset, type* ptr) \
+      const {                                                            \
+    base::CheckedNumeric<size_t> len = buffer_offset;                    \
+    size_t size_needed;                                                  \
+    if (!(len + bytes).AssignIfValid(&size_needed)) return false;        \
+    if (size_needed > buffer_len_) {                                     \
+      return false;                                                      \
+    }                                                                    \
+    const char* buffer = reinterpret_cast<char*>(buffer_);               \
+    type value = absl::big_endian::Load##bits(&buffer[buffer_offset]);   \
+    memcpy(ptr, &value, bytes);                                          \
+    buffer_offset_ = buffer_offset + bytes;                              \
+    return true;                                                         \
+  }
+
+READ_BE_AT(2, 16, uint16_t)
+READ_BE_AT(4, 32, uint32_t)
+READ_BE_AT(8, 64, uint64_t)
+
+#undef READ_BE_AT
+
+#define READ_LE_AT(bytes, bits, type)                                     \
+  bool ReadOnlyBuffer::Read##bits##LEAt(size_t buffer_offset, type* ptr)  \
+      const {                                                             \
+    base::CheckedNumeric<size_t> len = buffer_offset;                     \
+    size_t size_needed;                                                   \
+    if (!(len + bytes).AssignIfValid(&size_needed)) return false;         \
+    if (size_needed > buffer_len_) {                                      \
+      return false;                                                       \
+    }                                                                     \
+    const char* buffer = reinterpret_cast<const char*>(buffer_);          \
+    type value = absl::little_endian::Load##bits(&buffer[buffer_offset]); \
+    memcpy(ptr, &value, bytes);                                           \
+    buffer_offset_ = buffer_offset + bytes;                               \
+    return true;                                                          \
+  }
+
+READ_LE_AT(2, 16, uint16_t)
+READ_LE_AT(4, 32, uint32_t)
+READ_LE_AT(8, 64, uint64_t)
+
+#undef READ_LE_AT
+
+}  // namespace tachyon::base

--- a/tachyon/base/buffer/read_only_buffer.h
+++ b/tachyon/base/buffer/read_only_buffer.h
@@ -1,0 +1,199 @@
+#ifndef TACHYON_BASE_BUFFER_READ_ONLY_BUFFER_H_
+#define TACHYON_BASE_BUFFER_READ_ONLY_BUFFER_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <type_traits>
+#include <utility>
+
+#include "absl/base/internal/endian.h"
+
+#include "tachyon/base/buffer/copyable_forward.h"
+#include "tachyon/base/endian.h"
+#include "tachyon/base/logging.h"
+
+namespace tachyon::base {
+namespace internal {
+
+template <typename, typename = void>
+struct IsBuiltinSerializable : std::false_type {};
+
+template <typename T>
+struct IsBuiltinSerializable<
+    T, std::enable_if_t<std::is_fundamental_v<T> || std::is_enum_v<T>>>
+    : std::true_type {};
+
+template <typename, typename = void>
+struct IsNonBuiltinSerializable : std::false_type {};
+
+template <typename T>
+struct IsNonBuiltinSerializable<
+    T,
+    std::enable_if_t<!IsBuiltinSerializable<T>::value && IsCopyable<T>::value>>
+    : std::true_type {};
+
+}  // namespace internal
+
+class TACHYON_EXPORT ReadOnlyBuffer {
+ public:
+  ReadOnlyBuffer() = default;
+  ReadOnlyBuffer(const void* buffer, size_t buffer_len)
+      : buffer_(const_cast<void*>(buffer)),
+        buffer_offset_(0),
+        buffer_len_(buffer_len) {}
+  ReadOnlyBuffer(const ReadOnlyBuffer& other) = delete;
+  ReadOnlyBuffer& operator=(const ReadOnlyBuffer& other) = delete;
+  ReadOnlyBuffer(ReadOnlyBuffer&& other)
+      : buffer_(std::exchange(other.buffer_, nullptr)),
+        buffer_offset_(std::exchange(other.buffer_offset_, 0)),
+        buffer_len_(std::exchange(other.buffer_len_, 0)) {}
+  ReadOnlyBuffer& operator=(ReadOnlyBuffer&& other) {
+    buffer_ = std::exchange(other.buffer_, nullptr);
+    buffer_offset_ = std::exchange(other.buffer_offset_, 0);
+    buffer_len_ = std::exchange(other.buffer_len_, 0);
+    return *this;
+  }
+  ~ReadOnlyBuffer() = default;
+
+  Endian endian() const { return endian_; }
+  void set_endian(Endian endian) { endian_ = endian; }
+
+  const void* buffer() const { return buffer_; }
+
+  size_t buffer_offset() const { return buffer_offset_; }
+  void set_buffer_offset(size_t buffer_offset) {
+    buffer_offset_ = buffer_offset;
+  }
+
+  size_t buffer_len() const { return buffer_len_; }
+
+  [[nodiscard]] bool Done() const { return buffer_offset_ == buffer_len_; }
+
+  // Returns false when either
+  // 1) |buffer_offset| + |size| overflows.
+  // 2) if it tries to read more than |buffer_len_|.
+  [[nodiscard]] bool ReadAt(size_t buffer_offset, uint8_t* ptr,
+                            size_t size) const;
+
+  template <
+      typename Ptr, typename T = std::remove_pointer_t<Ptr>,
+      std::enable_if_t<std::is_pointer_v<Ptr> &&
+                       internal::IsBuiltinSerializable<T>::value>* = nullptr>
+  [[nodiscard]] bool ReadAt(size_t buffer_offset, Ptr ptr) const {
+    switch (endian_) {
+      case Endian::kBig:
+        if constexpr (sizeof(T) == 8) {
+          return Read64BEAt(buffer_offset, reinterpret_cast<uint64_t*>(ptr));
+        } else if constexpr (sizeof(T) == 4) {
+          return Read32BEAt(buffer_offset, reinterpret_cast<uint32_t*>(ptr));
+        } else if constexpr (sizeof(T) == 2) {
+          return Read16BEAt(buffer_offset, reinterpret_cast<uint16_t*>(ptr));
+        }
+      case Endian::kLittle:
+        if constexpr (sizeof(T) == 8) {
+          return Read64LEAt(buffer_offset, reinterpret_cast<uint64_t*>(ptr));
+        } else if constexpr (sizeof(T) == 4) {
+          return Read32LEAt(buffer_offset, reinterpret_cast<uint32_t*>(ptr));
+        } else if constexpr (sizeof(T) == 2) {
+          return Read16LEAt(buffer_offset, reinterpret_cast<uint16_t*>(ptr));
+        }
+      case Endian::kNative:
+        return ReadAt(buffer_offset, reinterpret_cast<uint8_t*>(ptr),
+                      sizeof(T));
+    }
+    NOTREACHED();
+    return false;
+  }
+
+  [[nodiscard]] bool Read16BEAt(size_t buffer_offset, uint16_t* ptr) const;
+  [[nodiscard]] bool Read16LEAt(size_t buffer_offset, uint16_t* ptr) const;
+  [[nodiscard]] bool Read32BEAt(size_t buffer_offset, uint32_t* ptr) const;
+  [[nodiscard]] bool Read32LEAt(size_t buffer_offset, uint32_t* ptr) const;
+  [[nodiscard]] bool Read64BEAt(size_t buffer_offset, uint64_t* ptr) const;
+  [[nodiscard]] bool Read64LEAt(size_t buffer_offset, uint64_t* ptr) const;
+
+  template <
+      typename T,
+      std::enable_if_t<internal::IsNonBuiltinSerializable<T>::value>* = nullptr>
+  [[nodiscard]] bool ReadAt(size_t buffer_offset, T* value) const {
+    buffer_offset_ = buffer_offset;
+    return Copyable<T>::ReadFrom(*this, value);
+  }
+
+  template <typename T, size_t N>
+  [[nodiscard]] bool ReadAt(size_t buffer_offset, T (&array)[N]) const {
+    buffer_offset_ = buffer_offset;
+    for (size_t i = 0; i < N; ++i) {
+      if (!Read(&array[i])) return false;
+    }
+    return true;
+  }
+
+  [[nodiscard]] bool Read(uint8_t* ptr, size_t size) const {
+    return ReadAt(buffer_offset_, ptr, size);
+  }
+
+  template <typename T>
+  [[nodiscard]] bool Read(T&& value) const {
+    return ReadAt(buffer_offset_, std::forward<T>(value));
+  }
+
+  [[nodiscard]] bool Read16BE(uint16_t* ptr) const {
+    return Read16BEAt(buffer_offset_, ptr);
+  }
+
+  [[nodiscard]] bool Read16LE(uint16_t* ptr) const {
+    return Read16LEAt(buffer_offset_, ptr);
+  }
+
+  [[nodiscard]] bool Read32BE(uint32_t* ptr) const {
+    return Read32BEAt(buffer_offset_, ptr);
+  }
+
+  [[nodiscard]] bool Read32LE(uint32_t* ptr) const {
+    return Read32LEAt(buffer_offset_, ptr);
+  }
+
+  [[nodiscard]] bool Read64BE(uint64_t* ptr) const {
+    return Read64BEAt(buffer_offset_, ptr);
+  }
+
+  [[nodiscard]] bool Read64LE(uint64_t* ptr) const {
+    return Read64LEAt(buffer_offset_, ptr);
+  }
+
+  template <typename T>
+  [[nodiscard]] bool ReadMany(T&& value) const {
+    return Read(std::forward<T>(value));
+  }
+
+  template <typename T, typename... Args>
+  [[nodiscard]] bool ReadMany(T&& value, Args&&... args) const {
+    if (!Read(std::forward<T>(value))) return false;
+    return ReadMany(std::forward<Args>(args)...);
+  }
+
+  template <typename T, size_t N>
+  [[nodiscard]] bool ReadManyAt(size_t buffer_offset, T&& value) const {
+    return ReadAt(buffer_offset, std::forward<T>(value));
+  }
+
+  template <typename T, typename... Args>
+  [[nodiscard]] bool ReadManyAt(size_t buffer_offset, T&& value,
+                                Args&&... args) const {
+    if (!ReadAt(buffer_offset, std::forward<T>(value))) return false;
+    return ReadManyAt(buffer_offset, std::forward<Args>(args)...);
+  }
+
+ protected:
+  Endian endian_ = Endian::kNative;
+
+  void* buffer_ = nullptr;
+  mutable size_t buffer_offset_ = 0;
+  size_t buffer_len_ = 0;
+};
+
+}  // namespace tachyon::base
+
+#endif  // TACHYON_BASE_BUFFER_READ_ONLY_BUFFER_H_

--- a/tachyon/base/buffer/read_only_buffer.h
+++ b/tachyon/base/buffer/read_only_buffer.h
@@ -57,7 +57,9 @@ class TACHYON_EXPORT ReadOnlyBuffer {
   ~ReadOnlyBuffer() = default;
 
   Endian endian() const { return endian_; }
-  void set_endian(Endian endian) { endian_ = endian; }
+  // NOTE(chokobole): This is changed to const method to ensure
+  // |const ReadOnlyBuffer&| calls this.
+  void set_endian(Endian endian) const { endian_ = endian; }
 
   const void* buffer() const { return buffer_; }
 
@@ -187,7 +189,7 @@ class TACHYON_EXPORT ReadOnlyBuffer {
   }
 
  protected:
-  Endian endian_ = Endian::kNative;
+  mutable Endian endian_ = Endian::kNative;
 
   void* buffer_ = nullptr;
   mutable size_t buffer_offset_ = 0;

--- a/tachyon/c/crypto/random/rng.cc
+++ b/tachyon/c/crypto/random/rng.cc
@@ -28,7 +28,7 @@ tachyon_rng* tachyon_rng_create_from_state(uint8_t type, const uint8_t* state,
   rng->type = type;
   if (type == TACHYON_RNG_XOR_SHIFT) {
     CHECK_EQ(state_len, crypto::XORShiftRNG::kStateSize);
-    base::Buffer buffer(const_cast<uint8_t*>(state), state_len);
+    base::ReadOnlyBuffer buffer(state, state_len);
     uint32_t x, y, z, w;
     CHECK(buffer.Read32LE(&x));
     CHECK(buffer.Read32LE(&y));

--- a/tachyon/c/crypto/random/rng.cc
+++ b/tachyon/c/crypto/random/rng.cc
@@ -34,6 +34,7 @@ tachyon_rng* tachyon_rng_create_from_state(uint8_t type, const uint8_t* state,
     CHECK(buffer.Read32LE(&y));
     CHECK(buffer.Read32LE(&z));
     CHECK(buffer.Read32LE(&w));
+    CHECK(buffer.Done());
     crypto::XORShiftRNG* xor_shift = new crypto::XORShiftRNG;
     *xor_shift = crypto::XORShiftRNG::FromState(x, y, z, w);
     rng->extra = xor_shift;

--- a/tachyon/c/zk/plonk/halo2/bn254_shplonk_prover.cc
+++ b/tachyon/c/zk/plonk/halo2/bn254_shplonk_prover.cc
@@ -124,7 +124,7 @@ tachyon_bn254_g1_jacobian* tachyon_halo2_bn254_shplonk_prover_commit_lagrange(
 void tachyon_halo2_bn254_shplonk_prover_set_rng_state(
     tachyon_halo2_bn254_shplonk_prover* prover, const uint8_t* state,
     size_t state_len) {
-  base::Buffer buffer(const_cast<uint8_t*>(state), state_len);
+  base::ReadOnlyBuffer buffer(state, state_len);
   uint32_t x, y, z, w;
   CHECK(buffer.Read32LE(&x));
   CHECK(buffer.Read32LE(&y));

--- a/tachyon/c/zk/plonk/keys/BUILD.bazel
+++ b/tachyon/c/zk/plonk/keys/BUILD.bazel
@@ -43,7 +43,7 @@ tachyon_cc_library(
     deps = [
         ":endian_auto_reset",
         "//tachyon/base:logging",
-        "//tachyon/base/buffer",
+        "//tachyon/base/buffer:read_only_buffer",
         "//tachyon/base/containers:container_util",
         "//tachyon/math/elliptic_curves:points",
         "//tachyon/math/finite_fields:prime_field_base",
@@ -70,7 +70,6 @@ tachyon_cc_library(
     hdrs = ["proving_key_impl_base.h"],
     deps = [
         ":buffer_reader",
-        "//tachyon/base/buffer",
         "//tachyon/zk/plonk/halo2:pinned_verifying_key",
         "//tachyon/zk/plonk/keys:proving_key",
         "@com_google_absl//absl/types:span",

--- a/tachyon/c/zk/plonk/keys/endian_auto_reset.h
+++ b/tachyon/c/zk/plonk/keys/endian_auto_reset.h
@@ -6,13 +6,14 @@
 namespace tachyon::c::zk {
 
 struct EndianAutoReset {
-  explicit EndianAutoReset(base::Buffer& buffer, base::Endian endian)
+  explicit EndianAutoReset(const base::ReadOnlyBuffer& buffer,
+                           base::Endian endian)
       : buffer(buffer), old_endian(buffer.endian()) {
     buffer.set_endian(endian);
   }
   ~EndianAutoReset() { buffer.set_endian(old_endian); }
 
-  base::Buffer& buffer;
+  const base::ReadOnlyBuffer& buffer;
   base::Endian old_endian;
 };
 

--- a/tachyon/c/zk/plonk/keys/proving_key_impl_base.h
+++ b/tachyon/c/zk/plonk/keys/proving_key_impl_base.h
@@ -6,7 +6,7 @@
 
 #include "absl/types/span.h"
 
-#include "tachyon/base/buffer/buffer.h"
+#include "tachyon/base/buffer/read_only_buffer.h"
 #include "tachyon/c/zk/plonk/keys/buffer_reader.h"
 #include "tachyon/zk/plonk/halo2/pinned_verifying_key.h"
 #include "tachyon/zk/plonk/keys/proving_key.h"
@@ -20,7 +20,7 @@ class ProvingKeyImplBase
   using F = typename Poly::Field;
 
   explicit ProvingKeyImplBase(absl::Span<const uint8_t> state) {
-    base::Buffer buffer(const_cast<uint8_t*>(state.data()), state.size());
+    base::ReadOnlyBuffer buffer(state.data(), state.size());
     ReadProvingKey(buffer);
   }
 
@@ -39,7 +39,7 @@ class ProvingKeyImplBase
   }
 
  private:
-  void ReadProvingKey(base::Buffer& buffer) {
+  void ReadProvingKey(const base::ReadOnlyBuffer& buffer) {
     ReadVerifyingKey(buffer, this->verifying_key_);
     ReadBuffer(buffer, this->l_first_);
     ReadBuffer(buffer, this->l_last_);
@@ -53,7 +53,7 @@ class ProvingKeyImplBase
     CHECK(buffer.Done());
   }
 
-  static void ReadVerifyingKey(base::Buffer& buffer,
+  static void ReadVerifyingKey(const base::ReadOnlyBuffer& buffer,
                                tachyon::zk::plonk::VerifyingKey<F, C>& vkey) {
     // NOTE(chokobole): For k
     ReadU32AsSizeT(buffer);
@@ -71,7 +71,8 @@ class ProvingKeyImplBase
   }
 
   static void ReadConstraintSystem(
-      base::Buffer& buffer, tachyon::zk::plonk::ConstraintSystem<F>& cs) {
+      const base::ReadOnlyBuffer& buffer,
+      tachyon::zk::plonk::ConstraintSystem<F>& cs) {
     cs.num_fixed_columns_ = ReadU32AsSizeT(buffer);
     cs.num_advice_columns_ = ReadU32AsSizeT(buffer);
     cs.num_instance_columns_ = ReadU32AsSizeT(buffer);

--- a/tachyon/crypto/commitments/kzg/kzg.h
+++ b/tachyon/crypto/commitments/kzg/kzg.h
@@ -174,7 +174,7 @@ class Copyable<crypto::KZG<G1Point, MaxDegree, Commitment>> {
                              pcs.g1_powers_of_tau_lagrange());
   }
 
-  static bool ReadFrom(const Buffer& buffer, PCS* pcs) {
+  static bool ReadFrom(const ReadOnlyBuffer& buffer, PCS* pcs) {
     std::vector<G1Point> g1_powers_of_tau;
     std::vector<G1Point> g1_powers_of_tau_lagrange;
     if (!buffer.ReadMany(&g1_powers_of_tau, &g1_powers_of_tau_lagrange)) {

--- a/tachyon/crypto/commitments/pedersen/pedersen.h
+++ b/tachyon/crypto/commitments/pedersen/pedersen.h
@@ -146,7 +146,7 @@ class Copyable<crypto::Pedersen<Point, MaxSize, Commitment>> {
     return buffer->WriteMany(pcs.h(), pcs.generators());
   }
 
-  static bool ReadFrom(const Buffer& buffer, PCS* pcs) {
+  static bool ReadFrom(const ReadOnlyBuffer& buffer, PCS* pcs) {
     Point h;
     std::vector<Point> generators;
     if (!buffer.ReadMany(&h, &generators)) {

--- a/tachyon/math/base/big_int.h
+++ b/tachyon/math/base/big_int.h
@@ -1007,7 +1007,7 @@ class Copyable<math::BigInt<N>> {
     return buffer->Write(bigint.limbs);
   }
 
-  static bool ReadFrom(const Buffer& buffer, math::BigInt<N>* bigint) {
+  static bool ReadFrom(const ReadOnlyBuffer& buffer, math::BigInt<N>* bigint) {
     return buffer.Read(bigint->limbs);
   }
 

--- a/tachyon/math/elliptic_curves/short_weierstrass/affine_point.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/affine_point.h
@@ -218,7 +218,8 @@ class Copyable<math::AffinePoint<
     return buffer->WriteMany(point.x(), point.y(), point.infinity());
   }
 
-  static bool ReadFrom(const Buffer& buffer, math::AffinePoint<Curve>* point) {
+  static bool ReadFrom(const ReadOnlyBuffer& buffer,
+                       math::AffinePoint<Curve>* point) {
     using BaseField = typename math::AffinePoint<Curve>::BaseField;
     BaseField x, y;
     bool infinity;

--- a/tachyon/math/elliptic_curves/short_weierstrass/jacobian_point.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/jacobian_point.h
@@ -248,7 +248,7 @@ class Copyable<math::JacobianPoint<
     return buffer->WriteMany(point.x(), point.y(), point.z());
   }
 
-  static bool ReadFrom(const Buffer& buffer,
+  static bool ReadFrom(const ReadOnlyBuffer& buffer,
                        math::JacobianPoint<Curve>* point) {
     using BaseField = typename math::JacobianPoint<Curve>::BaseField;
     BaseField x, y, z;

--- a/tachyon/math/elliptic_curves/short_weierstrass/point_xyzz.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/point_xyzz.h
@@ -265,7 +265,8 @@ class Copyable<math::PointXYZZ<
     return buffer->WriteMany(point.x(), point.y(), point.zz(), point.zzz());
   }
 
-  static bool ReadFrom(const Buffer& buffer, math::PointXYZZ<Curve>* point) {
+  static bool ReadFrom(const ReadOnlyBuffer& buffer,
+                       math::PointXYZZ<Curve>* point) {
     using BaseField = typename math::PointXYZZ<Curve>::BaseField;
     BaseField x, y, zz, zzz;
     if (!buffer.ReadMany(&x, &y, &zz, &zzz)) return false;

--- a/tachyon/math/elliptic_curves/short_weierstrass/projective_point.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/projective_point.h
@@ -245,7 +245,7 @@ class Copyable<math::ProjectivePoint<
     return buffer->WriteMany(point.x(), point.y(), point.z());
   }
 
-  static bool ReadFrom(const Buffer& buffer,
+  static bool ReadFrom(const ReadOnlyBuffer& buffer,
                        math::ProjectivePoint<Curve>* point) {
     using BaseField = typename math::ProjectivePoint<Curve>::BaseField;
     BaseField x, y, z;

--- a/tachyon/math/finite_fields/cubic_extension_field.h
+++ b/tachyon/math/finite_fields/cubic_extension_field.h
@@ -382,7 +382,7 @@ class Copyable<Derived, std::enable_if_t<std::is_base_of_v<
   }
 
   static bool ReadFrom(
-      const Buffer& buffer,
+      const ReadOnlyBuffer& buffer,
       math::CubicExtensionField<Derived>* cubic_extension_field) {
     typename Derived::BaseField c0;
     typename Derived::BaseField c1;

--- a/tachyon/math/finite_fields/prime_field_base.h
+++ b/tachyon/math/finite_fields/prime_field_base.h
@@ -175,7 +175,7 @@ class Copyable<
     return buffer->Write(prime_field.ToBigInt());
   }
 
-  static bool ReadFrom(const Buffer& buffer, T* prime_field) {
+  static bool ReadFrom(const ReadOnlyBuffer& buffer, T* prime_field) {
     using BigInt = typename T::BigIntTy;
     BigInt v;
     if (!buffer.Read(&v)) return false;

--- a/tachyon/math/finite_fields/quadratic_extension_field.h
+++ b/tachyon/math/finite_fields/quadratic_extension_field.h
@@ -324,7 +324,7 @@ class Copyable<Derived, std::enable_if_t<std::is_base_of_v<
   }
 
   static bool ReadFrom(
-      const Buffer& buffer,
+      const ReadOnlyBuffer& buffer,
       math::QuadraticExtensionField<Derived>* quadratic_extension_field) {
     typename Derived::BaseField c0;
     typename Derived::BaseField c1;

--- a/tachyon/math/geometry/point2.h
+++ b/tachyon/math/geometry/point2.h
@@ -54,7 +54,7 @@ class Copyable<math::Point2<T>> {
     return buffer->WriteMany(point.x, point.y);
   }
 
-  static bool ReadFrom(const Buffer& buffer, math::Point2<T>* point) {
+  static bool ReadFrom(const ReadOnlyBuffer& buffer, math::Point2<T>* point) {
     return buffer.ReadMany(&point->x, &point->y);
   }
 

--- a/tachyon/math/geometry/point3.h
+++ b/tachyon/math/geometry/point3.h
@@ -57,7 +57,7 @@ class Copyable<math::Point3<T>> {
     return buffer->WriteMany(point.x, point.y, point.z);
   }
 
-  static bool ReadFrom(const Buffer& buffer, math::Point3<T>* point) {
+  static bool ReadFrom(const ReadOnlyBuffer& buffer, math::Point3<T>* point) {
     return buffer.ReadMany(&point->x, &point->y, &point->z);
   }
 

--- a/tachyon/math/geometry/point4.h
+++ b/tachyon/math/geometry/point4.h
@@ -60,7 +60,7 @@ class Copyable<math::Point4<T>> {
     return buffer->WriteMany(point.x, point.y, point.z, point.w);
   }
 
-  static bool ReadFrom(const Buffer& buffer, math::Point4<T>* point) {
+  static bool ReadFrom(const ReadOnlyBuffer& buffer, math::Point4<T>* point) {
     return buffer.ReadMany(&point->x, &point->y, &point->z, &point->w);
   }
 

--- a/tachyon/math/polynomials/univariate/univariate_dense_coefficients.h
+++ b/tachyon/math/polynomials/univariate/univariate_dense_coefficients.h
@@ -308,7 +308,7 @@ class Copyable<math::UnivariateDenseCoefficients<F, MaxDegree>> {
   }
 
   static bool ReadFrom(
-      const Buffer& buffer,
+      const ReadOnlyBuffer& buffer,
       math::UnivariateDenseCoefficients<F, MaxDegree>* coeffs) {
     std::vector<F> raw_coeff;
     if (!buffer.Read(&raw_coeff)) return false;

--- a/tachyon/math/polynomials/univariate/univariate_evaluations.h
+++ b/tachyon/math/polynomials/univariate/univariate_evaluations.h
@@ -245,7 +245,7 @@ class Copyable<math::UnivariateEvaluations<F, MaxDegree>> {
     return buffer->Write(evals.evaluations());
   }
 
-  static bool ReadFrom(const Buffer& buffer,
+  static bool ReadFrom(const ReadOnlyBuffer& buffer,
                        math::UnivariateEvaluations<F, MaxDegree>* evals) {
     std::vector<F> evals_vec;
     if (!buffer.Read(&evals_vec)) return false;

--- a/tachyon/math/polynomials/univariate/univariate_polynomial.h
+++ b/tachyon/math/polynomials/univariate/univariate_polynomial.h
@@ -283,7 +283,7 @@ class Copyable<math::UnivariatePolynomial<Coefficients>> {
     return buffer->Write(poly.coefficients());
   }
 
-  static bool ReadFrom(const Buffer& buffer,
+  static bool ReadFrom(const ReadOnlyBuffer& buffer,
                        math::UnivariatePolynomial<Coefficients>* poly) {
     Coefficients coeff;
     if (!buffer.Read(&coeff)) return false;

--- a/tachyon/math/polynomials/univariate/univariate_sparse_coefficients.h
+++ b/tachyon/math/polynomials/univariate/univariate_sparse_coefficients.h
@@ -318,7 +318,7 @@ class Copyable<typename math::UnivariateTerm<F>> {
     return buffer->WriteMany(term.degree, term.coefficient);
   }
 
-  static bool ReadFrom(const Buffer& buffer, Term* term) {
+  static bool ReadFrom(const ReadOnlyBuffer& buffer, Term* term) {
     size_t degree;
     F coefficient;
     if (!buffer.ReadMany(&degree, &coefficient)) return false;
@@ -342,7 +342,7 @@ class Copyable<math::UnivariateSparseCoefficients<F, MaxDegree>> {
   }
 
   static bool ReadFrom(
-      const Buffer& buffer,
+      const ReadOnlyBuffer& buffer,
       math::UnivariateSparseCoefficients<F, MaxDegree>* coeffs) {
     std::vector<math::UnivariateTerm<F>> terms;
     if (!buffer.Read(&terms)) return false;

--- a/tachyon/rs/base/rust_vec.h
+++ b/tachyon/rs/base/rust_vec.h
@@ -52,7 +52,7 @@ class Copyable<rs::RustVec> {
     return false;
   }
 
-  static bool ReadFrom(const Buffer& buffer, rs::RustVec* rust_vec) {
+  static bool ReadFrom(const ReadOnlyBuffer& buffer, rs::RustVec* rust_vec) {
     uintptr_t ptr;
     size_t capacity;
     size_t length;

--- a/tachyon/rs/base/rust_vec.h
+++ b/tachyon/rs/base/rust_vec.h
@@ -1,5 +1,5 @@
-#ifndef TACHYON_RS_BASE_RUST_VEC_COPYABLE_H_
-#define TACHYON_RS_BASE_RUST_VEC_COPYABLE_H_
+#ifndef TACHYON_RS_BASE_RUST_VEC_H_
+#define TACHYON_RS_BASE_RUST_VEC_H_
 
 #include <stddef.h>
 #include <stdint.h>
@@ -74,4 +74,4 @@ class Copyable<rs::RustVec> {
 }  // namespace base
 }  // namespace tachyon
 
-#endif  // TACHYON_RS_BASE_RUST_VEC_COPYABLE_H_
+#endif  // TACHYON_RS_BASE_RUST_VEC_H_

--- a/tachyon/zk/plonk/halo2/blake2b_transcript.h
+++ b/tachyon/zk/plonk/halo2/blake2b_transcript.h
@@ -82,6 +82,7 @@ class Blake2bBase {
     CHECK(buffer.Write(state_impl->t_high));
     CHECK(buffer.Write(state_impl->block));
     CHECK(buffer.Write(state_impl->block_used));
+    CHECK(buffer.Done());
     return std::move(buffer).TakeOwnedBuffer();
   }
 
@@ -94,6 +95,7 @@ class Blake2bBase {
     CHECK(buffer.Read(&state_impl->t_high));
     CHECK(buffer.Read(state_impl->block));
     CHECK(buffer.Read(&state_impl->block_used));
+    CHECK(buffer.Done());
   }
 
   BLAKE2B_CTX state_;

--- a/tachyon/zk/plonk/halo2/blake2b_transcript.h
+++ b/tachyon/zk/plonk/halo2/blake2b_transcript.h
@@ -86,7 +86,7 @@ class Blake2bBase {
   }
 
   void DoSetState(absl::Span<const uint8_t> state) {
-    base::Buffer buffer(const_cast<uint8_t*>(state.data()), state.size());
+    base::ReadOnlyBuffer buffer(state.data(), state.size());
     buffer.set_endian(base::Endian::kLittle);
     blake2b_state_st* state_impl = reinterpret_cast<blake2b_state_st*>(&state_);
     CHECK(buffer.Read(state_impl->h));

--- a/tachyon/zk/plonk/permutation/permutation_proving_key.h
+++ b/tachyon/zk/plonk/permutation/permutation_proving_key.h
@@ -56,7 +56,7 @@ class Copyable<zk::plonk::PermutationProvingKey<Poly, Evals>> {
     return buffer->WriteMany(pk.permutations(), pk.polys());
   }
 
-  static bool ReadFrom(const Buffer& buffer,
+  static bool ReadFrom(const ReadOnlyBuffer& buffer,
                        zk::plonk::PermutationProvingKey<Poly, Evals>* pk) {
     std::vector<Evals> perms;
     std::vector<Poly> poly;

--- a/tachyon/zk/plonk/permutation/permutation_verifying_key.h
+++ b/tachyon/zk/plonk/permutation/permutation_verifying_key.h
@@ -54,7 +54,7 @@ class Copyable<zk::plonk::PermutationVerifyingKey<Commitment>> {
     return buffer->Write(vk.commitments());
   }
 
-  static bool ReadFrom(const Buffer& buffer,
+  static bool ReadFrom(const ReadOnlyBuffer& buffer,
                        zk::plonk::PermutationVerifyingKey<Commitment>* vk) {
     typename zk::plonk::PermutationVerifyingKey<Commitment>::Commitments
         commitments;

--- a/vendors/halo2/src/bn254_shplonk_prover.cc
+++ b/vendors/halo2/src/bn254_shplonk_prover.cc
@@ -157,6 +157,8 @@ void SHPlonkProver::create_proof(const ProvingKey& key,
       tachyon_halo2_bn254_argument_data_add_instance_poly(
           data, i, reinterpret_cast<Poly*>(instance_poly_ptr[j])->release());
     }
+
+    CHECK(buffer.Done());
   }
 
   tachyon_halo2_bn254_shplonk_prover_create_proof(prover_, key.pk(), data);


### PR DESCRIPTION
# Description

Recently, to deserialize `ProvingKey`, `XORShiftRng` and `Blake2bTranscript`, we used `Buffer`. Since `Buffer` takes `void*` as an argument, we casted const pointer to mutable pointer by force using `const_cast`. `Buffer` was designed as a read-write buffer so this cast is valid, but since`const_cast` should be avoided in general, this PR adds a separate `ReadOnlyBuffer`.