### PR TITLE
feat(math): implement fixed base msm

### DIFF
--- a/benchmark/msm/BUILD.bazel
+++ b/benchmark/msm/BUILD.bazel
@@ -13,7 +13,7 @@ tachyon_cc_library(
     deps = [
         "//tachyon/base/console",
         "//tachyon/base/flag:flag_parser",
-        "//tachyon/math/elliptic_curves/msm/test:msm_test_set",
+        "//tachyon/math/elliptic_curves/msm/test:variable_base_msm_test_set",
     ],
 )
 

--- a/benchmark/msm/msm_benchmark.cc
+++ b/benchmark/msm/msm_benchmark.cc
@@ -45,7 +45,7 @@ int RealMain(int argc, char** argv) {
 
   std::cout << "Generating random points..." << std::endl;
   uint64_t max_point_num = point_nums.back();
-  MSMTestSet<bn254::G1AffinePoint> test_set;
+  VariableBaseMSMTestSet<bn254::G1AffinePoint> test_set;
   CHECK(config.GenerateTestSet(max_point_num, &test_set));
   std::cout << "Generation completed" << std::endl;
 

--- a/benchmark/msm/msm_benchmark_gpu.cc
+++ b/benchmark/msm/msm_benchmark_gpu.cc
@@ -9,7 +9,7 @@
 #include "tachyon/c/math/elliptic_curves/bn/bn254/g1_point_traits.h"
 #include "tachyon/c/math/elliptic_curves/bn/bn254/msm.h"
 #include "tachyon/c/math/elliptic_curves/bn/bn254/msm_gpu.h"
-#include "tachyon/math/elliptic_curves/msm/test/msm_test_set.h"
+#include "tachyon/math/elliptic_curves/msm/test/variable_base_msm_test_set.h"
 
 namespace tachyon {
 
@@ -34,7 +34,7 @@ int RealMain(int argc, char** argv) {
 
   std::cout << "Generating random points..." << std::endl;
   uint64_t max_point_num = point_nums.back();
-  MSMTestSet<bn254::G1AffinePoint> test_set;
+  VariableBaseMSMTestSet<bn254::G1AffinePoint> test_set;
   CHECK(config.GenerateTestSet(max_point_num, &test_set));
   std::cout << "Generation completed" << std::endl;
 

--- a/benchmark/msm/msm_config.h
+++ b/benchmark/msm/msm_config.h
@@ -6,7 +6,7 @@
 #include <string>
 #include <vector>
 
-#include "tachyon/math/elliptic_curves/msm/test/msm_test_set.h"
+#include "tachyon/math/elliptic_curves/msm/test/variable_base_msm_test_set.h"
 
 namespace tachyon {
 
@@ -45,15 +45,15 @@ class MSMConfig {
 
   template <typename Point, typename Bucket>
   bool GenerateTestSet(uint64_t size,
-                       math::MSMTestSet<Point, Bucket>* out) const {
+                       math::VariableBaseMSMTestSet<Point, Bucket>* out) const {
     switch (test_set_) {
       case TestSet::kRandom:
-        *out = math::MSMTestSet<Point, Bucket>::Random(size,
-                                                       math::MSMMethod::kNone);
+        *out = math::VariableBaseMSMTestSet<Point, Bucket>::Random(
+            size, math::VariableBaseMSMMethod::kNone);
         return true;
       case TestSet::kNonUniform:
-        *out = math::MSMTestSet<Point, Bucket>::NonUniform(
-            size, 1, math::MSMMethod::kNone);
+        *out = math::VariableBaseMSMTestSet<Point, Bucket>::NonUniform(
+            size, 1, math::VariableBaseMSMMethod::kNone);
         return true;
     }
     return false;

--- a/tachyon/c/math/elliptic_curves/msm/BUILD.bazel
+++ b/tachyon/c/math/elliptic_curves/msm/BUILD.bazel
@@ -62,7 +62,7 @@ tachyon_cc_unittest(
     deps = [
         "//tachyon/base:bits",
         "//tachyon/c/math/elliptic_curves/bn/bn254:msm",
-        "//tachyon/math/elliptic_curves/msm/test:msm_test_set",
+        "//tachyon/math/elliptic_curves/msm/test:variable_base_msm_test_set",
     ],
 )
 
@@ -72,7 +72,7 @@ tachyon_cuda_unittest(
     deps = [
         "//tachyon/base:bits",
         "//tachyon/c/math/elliptic_curves/bn/bn254:msm_gpu",
-        "//tachyon/math/elliptic_curves/msm/test:msm_test_set",
+        "//tachyon/math/elliptic_curves/msm/test:variable_base_msm_test_set",
     ],
 )
 

--- a/tachyon/c/math/elliptic_curves/msm/msm_gpu_unittest.cc
+++ b/tachyon/c/math/elliptic_curves/msm/msm_gpu_unittest.cc
@@ -7,7 +7,7 @@
 #include "tachyon/c/math/elliptic_curves/bn/bn254/g1_point_traits.h"
 #include "tachyon/c/math/elliptic_curves/msm/algorithm.h"
 #include "tachyon/cc/math/elliptic_curves/point_conversions.h"
-#include "tachyon/math/elliptic_curves/msm/test/msm_test_set.h"
+#include "tachyon/math/elliptic_curves/msm/test/variable_base_msm_test_set.h"
 
 namespace tachyon::math {
 
@@ -19,16 +19,17 @@ class MSMGpuTest : public testing::TestWithParam<int> {
     tachyon_bn254_g1_init();
 
     for (size_t n : kNums) {
-      test_sets_.push_back(
-          MSMTestSet<bn254::G1AffinePoint>::Random(n, MSMMethod::kNaive));
+      test_sets_.push_back(VariableBaseMSMTestSet<bn254::G1AffinePoint>::Random(
+          n, VariableBaseMSMMethod::kNaive));
     }
   }
 
  protected:
-  static std::vector<MSMTestSet<bn254::G1AffinePoint>> test_sets_;
+  static std::vector<VariableBaseMSMTestSet<bn254::G1AffinePoint>> test_sets_;
 };
 
-std::vector<MSMTestSet<bn254::G1AffinePoint>> MSMGpuTest::test_sets_;
+std::vector<VariableBaseMSMTestSet<bn254::G1AffinePoint>>
+    MSMGpuTest::test_sets_;
 
 INSTANTIATE_TEST_SUITE_P(BellmanMSM, MSMGpuTest,
                          testing::Values(TACHYON_MSM_ALGO_BELLMAN_MSM));
@@ -40,7 +41,8 @@ TEST_P(MSMGpuTest, MSMPoint2) {
   tachyon_bn254_g1_msm_gpu_ptr msm = tachyon_bn254_g1_create_msm_gpu(
       base::bits::Log2Ceiling(max_num), GetParam());
 
-  for (const MSMTestSet<bn254::G1AffinePoint>& t : this->test_sets_) {
+  for (const VariableBaseMSMTestSet<bn254::G1AffinePoint>& t :
+       this->test_sets_) {
     std::unique_ptr<tachyon_bn254_g1_jacobian> ret;
     std::vector<Point2<BigInt<4>>> bases = base::CreateVector(
         t.bases.size(), [&t](size_t i) { return t.bases[i].ToMontgomery(); });
@@ -58,7 +60,8 @@ TEST_P(MSMGpuTest, MSMG1Affine) {
   tachyon_bn254_g1_msm_gpu_ptr msm = tachyon_bn254_g1_create_msm_gpu(
       base::bits::Log2Ceiling(max_num), GetParam());
 
-  for (const MSMTestSet<bn254::G1AffinePoint>& t : this->test_sets_) {
+  for (const VariableBaseMSMTestSet<bn254::G1AffinePoint>& t :
+       this->test_sets_) {
     std::unique_ptr<tachyon_bn254_g1_jacobian> ret;
     ret.reset(tachyon_bn254_g1_affine_msm_gpu(
         msm, reinterpret_cast<const tachyon_bn254_g1_affine*>(t.bases.data()),

--- a/tachyon/c/math/elliptic_curves/msm/msm_unittest.cc
+++ b/tachyon/c/math/elliptic_curves/msm/msm_unittest.cc
@@ -6,7 +6,7 @@
 #include "tachyon/c/math/elliptic_curves/bn/bn254/fq_prime_field_traits.h"
 #include "tachyon/c/math/elliptic_curves/bn/bn254/g1_point_traits.h"
 #include "tachyon/cc/math/elliptic_curves/point_conversions.h"
-#include "tachyon/math/elliptic_curves/msm/test/msm_test_set.h"
+#include "tachyon/math/elliptic_curves/msm/test/variable_base_msm_test_set.h"
 
 namespace tachyon::math {
 
@@ -20,8 +20,8 @@ class MSMTest : public testing::Test {
     size_t max_num = *std::max_element(std::begin(kNums), std::end(kNums));
     msm_ = tachyon_bn254_g1_create_msm(base::bits::Log2Ceiling(max_num));
     for (size_t n : kNums) {
-      test_sets_.push_back(
-          MSMTestSet<bn254::G1AffinePoint>::Random(n, MSMMethod::kNaive));
+      test_sets_.push_back(VariableBaseMSMTestSet<bn254::G1AffinePoint>::Random(
+          n, VariableBaseMSMMethod::kNaive));
     }
   }
 
@@ -29,14 +29,14 @@ class MSMTest : public testing::Test {
 
  protected:
   static tachyon_bn254_g1_msm_ptr msm_;
-  static std::vector<MSMTestSet<bn254::G1AffinePoint>> test_sets_;
+  static std::vector<VariableBaseMSMTestSet<bn254::G1AffinePoint>> test_sets_;
 };
 
 tachyon_bn254_g1_msm_ptr MSMTest::msm_;
-std::vector<MSMTestSet<bn254::G1AffinePoint>> MSMTest::test_sets_;
+std::vector<VariableBaseMSMTestSet<bn254::G1AffinePoint>> MSMTest::test_sets_;
 
 TEST_F(MSMTest, MSMPoint2) {
-  for (const MSMTestSet<bn254::G1AffinePoint>& t : test_sets_) {
+  for (const VariableBaseMSMTestSet<bn254::G1AffinePoint>& t : test_sets_) {
     std::unique_ptr<tachyon_bn254_g1_jacobian> ret;
     std::vector<Point2<BigInt<4>>> bases = base::CreateVector(
         t.bases.size(), [&t](size_t i) { return t.bases[i].ToMontgomery(); });
@@ -49,7 +49,7 @@ TEST_F(MSMTest, MSMPoint2) {
 }
 
 TEST_F(MSMTest, MSMG1Affine) {
-  for (const MSMTestSet<bn254::G1AffinePoint>& t : test_sets_) {
+  for (const VariableBaseMSMTestSet<bn254::G1AffinePoint>& t : test_sets_) {
     std::unique_ptr<tachyon_bn254_g1_jacobian> ret;
     ret.reset(tachyon_bn254_g1_affine_msm(
         msm_, reinterpret_cast<const tachyon_bn254_g1_affine*>(t.bases.data()),

--- a/tachyon/math/base/BUILD.bazel
+++ b/tachyon/math/base/BUILD.bazel
@@ -143,7 +143,7 @@ tachyon_cc_unittest(
         ":sign",
         "//tachyon/base/buffer",
         "//tachyon/base/containers:container_util",
-        "//tachyon/math/elliptic_curves/msm/test:msm_test_set",
+        "//tachyon/math/elliptic_curves/msm/test:variable_base_msm_test_set",
         "//tachyon/math/elliptic_curves/short_weierstrass/test:sw_curve_config",
         "//tachyon/math/finite_fields/test:gf7",
         "@com_google_absl//absl/container:inlined_vector",

--- a/tachyon/math/base/semigroups_unittest.cc
+++ b/tachyon/math/base/semigroups_unittest.cc
@@ -4,7 +4,7 @@
 #include "gtest/gtest.h"
 
 #include "tachyon/base/containers/adapters.h"
-#include "tachyon/math/elliptic_curves/msm/test/msm_test_set.h"
+#include "tachyon/math/elliptic_curves/msm/test/variable_base_msm_test_set.h"
 #include "tachyon/math/elliptic_curves/short_weierstrass/test/sw_curve_config.h"
 
 namespace tachyon::math {
@@ -125,15 +125,15 @@ class MultiScalarMulTest : public testing::Test {
 #else
     size_t thread_nums = 1;
 #endif
-    test_set_ = MSMTestSet<test::AffinePoint>::Random(thread_nums * 5,
-                                                      MSMMethod::kNone);
+    test_set_ = VariableBaseMSMTestSet<test::AffinePoint>::Random(
+        thread_nums * 5, VariableBaseMSMMethod::kNone);
   }
 
  protected:
-  static MSMTestSet<test::AffinePoint> test_set_;
+  static VariableBaseMSMTestSet<test::AffinePoint> test_set_;
 };
 
-MSMTestSet<test::AffinePoint> MultiScalarMulTest::test_set_;
+VariableBaseMSMTestSet<test::AffinePoint> MultiScalarMulTest::test_set_;
 
 }  // namespace
 

--- a/tachyon/math/elliptic_curves/msm/BUILD.bazel
+++ b/tachyon/math/elliptic_curves/msm/BUILD.bazel
@@ -59,7 +59,7 @@ tachyon_cc_unittest(
         "//tachyon/math/elliptic_curves/bls12/bls12_381:g2",
         "//tachyon/math/elliptic_curves/bn/bn254:g1",
         "//tachyon/math/elliptic_curves/bn/bn254:g2",
-        "//tachyon/math/elliptic_curves/msm/test:msm_test_set",
+        "//tachyon/math/elliptic_curves/msm/test:variable_base_msm_test_set",
     ],
 )
 
@@ -72,6 +72,6 @@ tachyon_cuda_unittest(
         "//tachyon/device/gpu:scoped_mem_pool",
         "//tachyon/math/elliptic_curves/msm/kernels/bellman:bn254_bellman_msm_kernels",
         "//tachyon/math/elliptic_curves/msm/kernels/cuzk:bn254_cuzk_kernels",
-        "//tachyon/math/elliptic_curves/msm/test:msm_test_set",
+        "//tachyon/math/elliptic_curves/msm/test:variable_base_msm_test_set",
     ],
 )

--- a/tachyon/math/elliptic_curves/msm/BUILD.bazel
+++ b/tachyon/math/elliptic_curves/msm/BUILD.bazel
@@ -21,6 +21,12 @@ tachyon_cc_library(
 )
 
 tachyon_cc_library(
+    name = "msm_ctx",
+    hdrs = ["msm_ctx.h"],
+    deps = ["//tachyon:export"],
+)
+
+tachyon_cc_library(
     name = "msm_util",
     hdrs = ["msm_util.h"],
     deps = ["//tachyon/base:template_util"],

--- a/tachyon/math/elliptic_curves/msm/BUILD.bazel
+++ b/tachyon/math/elliptic_curves/msm/BUILD.bazel
@@ -9,6 +9,19 @@ load(
 package(default_visibility = ["//visibility:public"])
 
 tachyon_cc_library(
+    name = "fixed_base_msm",
+    hdrs = ["fixed_base_msm.h"],
+    deps = [
+        ":msm_ctx",
+        "//tachyon/base:parallelize",
+        "//tachyon/base/containers:container_util",
+        "//tachyon/math/base:bit_iterator",
+        "//tachyon/math/base:semigroups",
+        "//tachyon/math/elliptic_curves:points",
+    ],
+)
+
+tachyon_cc_library(
     name = "glv",
     hdrs = ["glv.h"],
     deps = [
@@ -50,6 +63,7 @@ tachyon_cc_library(
 tachyon_cc_unittest(
     name = "msm_unittests",
     srcs = [
+        "fixed_base_msm_unittest.cc",
         "glv_unittest.cc",
         "variable_base_msm_unittest.cc",
     ],
@@ -59,6 +73,7 @@ tachyon_cc_unittest(
         "//tachyon/math/elliptic_curves/bls12/bls12_381:g2",
         "//tachyon/math/elliptic_curves/bn/bn254:g1",
         "//tachyon/math/elliptic_curves/bn/bn254:g2",
+        "//tachyon/math/elliptic_curves/msm/test:fixed_base_msm_test_set",
         "//tachyon/math/elliptic_curves/msm/test:variable_base_msm_test_set",
     ],
 )

--- a/tachyon/math/elliptic_curves/msm/algorithms/BUILD.bazel
+++ b/tachyon/math/elliptic_curves/msm/algorithms/BUILD.bazel
@@ -6,6 +6,7 @@ tachyon_cc_library(
     name = "msm_algorithm",
     hdrs = ["msm_algorithm.h"],
     deps = [
+        "//tachyon/base:logging",
         "//tachyon/device/gpu:gpu_memory",
         "//tachyon/math/elliptic_curves:points",
     ],

--- a/tachyon/math/elliptic_curves/msm/algorithms/bellman/bellman_msm.h
+++ b/tachyon/math/elliptic_curves/msm/algorithms/bellman/bellman_msm.h
@@ -43,9 +43,10 @@ class BellmanMSM : public PippengerBase<AffinePoint<GpuCurve>>,
   BellmanMSM& operator=(const BellmanMSM& other) = delete;
 
   // MSMGpuAlgorithm methods
-  bool Run(const device::gpu::GpuMemory<AffinePoint<GpuCurve>>& bases,
-           const device::gpu::GpuMemory<ScalarField>& scalars, size_t size,
-           JacobianPoint<CpuCurve>* cpu_result) override {
+  [[nodiscard]] bool Run(
+      const device::gpu::GpuMemory<AffinePoint<GpuCurve>>& bases,
+      const device::gpu::GpuMemory<ScalarField>& scalars, size_t size,
+      JacobianPoint<CpuCurve>* cpu_result) override {
     bellman::ExecutionConfig<GpuCurve> config;
     config.mem_pool = mem_pool_;
     config.stream = stream_;

--- a/tachyon/math/elliptic_curves/msm/algorithms/cuzk/BUILD.bazel
+++ b/tachyon/math/elliptic_curves/msm/algorithms/cuzk/BUILD.bazel
@@ -59,6 +59,6 @@ tachyon_cuda_unittest(
     deps = [
         ":cuzk",
         "//tachyon/math/elliptic_curves/msm/kernels/cuzk:bn254_cuzk_kernels",
-        "//tachyon/math/elliptic_curves/msm/test:msm_test_set",
+        "//tachyon/math/elliptic_curves/msm/test:variable_base_msm_test_set",
     ],
 )

--- a/tachyon/math/elliptic_curves/msm/algorithms/cuzk/cuzk.h
+++ b/tachyon/math/elliptic_curves/msm/algorithms/cuzk/cuzk.h
@@ -17,8 +17,8 @@
 #include "tachyon/math/elliptic_curves/msm/algorithms/cuzk/cuzk_ell_sparse_matrix.h"
 #include "tachyon/math/elliptic_curves/msm/algorithms/msm_algorithm.h"
 #include "tachyon/math/elliptic_curves/msm/algorithms/pippenger/pippenger_base.h"
-#include "tachyon/math/elliptic_curves/msm/algorithms/pippenger/pippenger_ctx.h"
 #include "tachyon/math/elliptic_curves/msm/kernels/cuzk/cuzk_kernels.cu.h"
+#include "tachyon/math/elliptic_curves/msm/msm_ctx.h"
 
 namespace tachyon::math {
 
@@ -43,7 +43,7 @@ class CUZK : public PippengerBase<AffinePoint<GpuCurve>>,
   CUZK(const CUZK& other) = delete;
   CUZK& operator=(const CUZK& other) = delete;
 
-  void SetContextForTesting(const PippengerCtx& ctx) { ctx_ = ctx; }
+  void SetContextForTesting(const MSMCtx& ctx) { ctx_ = ctx; }
 
   void SetGroupsForTesting(unsigned int start_group, unsigned int end_group) {
     start_group_ = start_group;
@@ -83,7 +83,7 @@ class CUZK : public PippengerBase<AffinePoint<GpuCurve>>,
       error = LOG_IF_GPU_ERROR(cudaGetDevice(&device_id_),
                                "Failed to cudaGetDevice()");
     }
-    ctx_ = PippengerCtx::CreateDefault<ScalarField>(size);
+    ctx_ = MSMCtx::CreateDefault<ScalarField>(size);
     start_group_ =
         (ctx_.window_count + device_count_ - 1) / device_count_ * device_id_;
     end_group_ = (ctx_.window_count + device_count_ - 1) / device_count_ *
@@ -431,7 +431,7 @@ class CUZK : public PippengerBase<AffinePoint<GpuCurve>>,
   gpuMemPool_t mem_pool_ = nullptr;
   gpuStream_t stream_ = nullptr;
 
-  PippengerCtx ctx_;
+  MSMCtx ctx_;
   int device_count_ = 0;
   int device_id_ = 0;
   unsigned int grid_size_ = 0;

--- a/tachyon/math/elliptic_curves/msm/algorithms/cuzk/cuzk.h
+++ b/tachyon/math/elliptic_curves/msm/algorithms/cuzk/cuzk.h
@@ -56,18 +56,20 @@ class CUZK : public PippengerBase<AffinePoint<GpuCurve>>,
   }
 
   // MSMGpuAlgorithm methods
-  bool Run(const device::gpu::GpuMemory<AffinePoint<GpuCurve>>& bases,
-           const device::gpu::GpuMemory<ScalarField>& scalars, size_t size,
-           JacobianPoint<CpuCurve>* cpu_result) override {
+  [[nodiscard]] bool Run(
+      const device::gpu::GpuMemory<AffinePoint<GpuCurve>>& bases,
+      const device::gpu::GpuMemory<ScalarField>& scalars, size_t size,
+      JacobianPoint<CpuCurve>* cpu_result) override {
     PointXYZZ<CpuCurve> out;
     if (!Run(bases, scalars, size, &out)) return false;
     *cpu_result = out.ToJacobian();
     return true;
   }
 
-  bool Run(const device::gpu::GpuMemory<AffinePoint<GpuCurve>>& bases,
-           const device::gpu::GpuMemory<ScalarField>& scalars, size_t size,
-           PointXYZZ<CpuCurve>* cpu_result) {
+  [[nodiscard]] bool Run(
+      const device::gpu::GpuMemory<AffinePoint<GpuCurve>>& bases,
+      const device::gpu::GpuMemory<ScalarField>& scalars, size_t size,
+      PointXYZZ<CpuCurve>* cpu_result) {
     if (bases.size() < size) {
       LOG(ERROR) << "bases.size() is smaller than size";
       return false;

--- a/tachyon/math/elliptic_curves/msm/algorithms/cuzk/cuzk_unittest.cc
+++ b/tachyon/math/elliptic_curves/msm/algorithms/cuzk/cuzk_unittest.cc
@@ -32,7 +32,7 @@ class CUZKTest : public testing::Test {
 
 TEST_F(CUZKTest, ReduceBuckets) {
   size_t size = 1 << 10;
-  PippengerCtx ctx = PippengerCtx::CreateDefault<bn254::Fr>(size);
+  MSMCtx ctx = MSMCtx::CreateDefault<bn254::Fr>(size);
   size_t start_group = 0;
   size_t end_group = ctx.window_count;
   size_t window_length = ctx.GetWindowLength();

--- a/tachyon/math/elliptic_curves/msm/algorithms/cuzk/cuzk_unittest.cc
+++ b/tachyon/math/elliptic_curves/msm/algorithms/cuzk/cuzk_unittest.cc
@@ -10,7 +10,7 @@
 #include "tachyon/device/gpu/gpu_memory.h"
 #include "tachyon/math/elliptic_curves/bn/bn254/g1_gpu.h"
 #include "tachyon/math/elliptic_curves/msm/kernels/cuzk/bn254_cuzk_kernels.cu.h"
-#include "tachyon/math/elliptic_curves/msm/test/msm_test_set.h"
+#include "tachyon/math/elliptic_curves/msm/test/variable_base_msm_test_set.h"
 #include "tachyon/math/elliptic_curves/short_weierstrass/affine_point.h"
 #include "tachyon/math/elliptic_curves/short_weierstrass/point_xyzz.h"
 
@@ -67,8 +67,8 @@ TEST_F(CUZKTest, ReduceBuckets) {
 
 TEST_F(CUZKTest, RunWithRandom) {
   size_t size = 1 << 10;
-  auto test_set =
-      MSMTestSet<bn254::G1AffinePoint>::Random(size, MSMMethod::kMSM);
+  auto test_set = VariableBaseMSMTestSet<bn254::G1AffinePoint>::Random(
+      size, VariableBaseMSMMethod::kMSM);
 
   auto bases = gpu::GpuMemory<bn254::G1AffinePointGpu>::MallocManaged(size);
   for (size_t i = 0; i < bases.size(); ++i) {

--- a/tachyon/math/elliptic_curves/msm/algorithms/pippenger/BUILD.bazel
+++ b/tachyon/math/elliptic_curves/msm/algorithms/pippenger/BUILD.bazel
@@ -55,6 +55,7 @@ tachyon_cc_benchmark(
     srcs = ["pippenger_adapter_benchmark.cc"],
     deps = [
         ":pippenger_adapter",
+        "//tachyon/base:logging",
         "//tachyon/math/elliptic_curves/bn/bn254:g1",
         "//tachyon/math/elliptic_curves/msm/test:msm_test_set",
     ],

--- a/tachyon/math/elliptic_curves/msm/algorithms/pippenger/BUILD.bazel
+++ b/tachyon/math/elliptic_curves/msm/algorithms/pippenger/BUILD.bazel
@@ -12,9 +12,9 @@ tachyon_cc_library(
     hdrs = ["pippenger.h"],
     deps = [
         ":pippenger_base",
-        ":pippenger_ctx",
         "//tachyon/base:openmp_util",
         "//tachyon/base/containers:container_util",
+        "//tachyon/math/elliptic_curves/msm:msm_ctx",
         "//tachyon/math/elliptic_curves/msm:msm_util",
     ],
 )
@@ -34,12 +34,6 @@ tachyon_cc_library(
         "//tachyon/math/elliptic_curves:points",
         "@com_google_absl//absl/types:span",
     ],
-)
-
-tachyon_cc_library(
-    name = "pippenger_ctx",
-    hdrs = ["pippenger_ctx.h"],
-    deps = ["//tachyon:export"],
 )
 
 tachyon_cc_unittest(

--- a/tachyon/math/elliptic_curves/msm/algorithms/pippenger/BUILD.bazel
+++ b/tachyon/math/elliptic_curves/msm/algorithms/pippenger/BUILD.bazel
@@ -46,7 +46,7 @@ tachyon_cc_unittest(
         ":pippenger_adapter",
         "//tachyon/math/elliptic_curves/bls12/bls12_381:g1",
         "//tachyon/math/elliptic_curves/bn/bn254:g1",
-        "//tachyon/math/elliptic_curves/msm/test:msm_test_set",
+        "//tachyon/math/elliptic_curves/msm/test:variable_base_msm_test_set",
     ],
 )
 
@@ -57,7 +57,7 @@ tachyon_cc_benchmark(
         ":pippenger_adapter",
         "//tachyon/base:logging",
         "//tachyon/math/elliptic_curves/bn/bn254:g1",
-        "//tachyon/math/elliptic_curves/msm/test:msm_test_set",
+        "//tachyon/math/elliptic_curves/msm/test:variable_base_msm_test_set",
     ],
 )
 
@@ -67,6 +67,6 @@ tachyon_cc_benchmark(
     deps = [
         ":pippenger",
         "//tachyon/math/elliptic_curves/bn/bn254:g1",
-        "//tachyon/math/elliptic_curves/msm/test:msm_test_set",
+        "//tachyon/math/elliptic_curves/msm/test:variable_base_msm_test_set",
     ],
 )

--- a/tachyon/math/elliptic_curves/msm/algorithms/pippenger/pippenger.h
+++ b/tachyon/math/elliptic_curves/msm/algorithms/pippenger/pippenger.h
@@ -16,7 +16,7 @@
 #include "tachyon/base/openmp_util.h"
 #include "tachyon/math/base/big_int.h"
 #include "tachyon/math/elliptic_curves/msm/algorithms/pippenger/pippenger_base.h"
-#include "tachyon/math/elliptic_curves/msm/algorithms/pippenger/pippenger_ctx.h"
+#include "tachyon/math/elliptic_curves/msm/msm_ctx.h"
 #include "tachyon/math/elliptic_curves/msm/msm_util.h"
 #include "tachyon/math/elliptic_curves/semigroups.h"
 
@@ -84,7 +84,7 @@ class Pippenger : public PippengerBase<Point> {
       LOG(ERROR) << "bases_size and scalars_size don't match";
       return false;
     }
-    ctx_ = PippengerCtx::CreateDefault<ScalarField>(scalars_size);
+    ctx_ = MSMCtx::CreateDefault<ScalarField>(scalars_size);
 
     std::vector<BigInt<N>> scalars;
     scalars.resize(scalars_size);
@@ -222,7 +222,7 @@ class Pippenger : public PippengerBase<Point> {
 
   bool use_msm_window_naf_ = false;
   bool parallel_windows_ = false;
-  PippengerCtx ctx_;
+  MSMCtx ctx_;
 };
 
 }  // namespace tachyon::math

--- a/tachyon/math/elliptic_curves/msm/algorithms/pippenger/pippenger.h
+++ b/tachyon/math/elliptic_curves/msm/algorithms/pippenger/pippenger.h
@@ -75,9 +75,10 @@ class Pippenger : public PippengerBase<Point> {
   template <typename BaseInputIterator, typename ScalarInputIterator,
             std::enable_if_t<IsAbleToMSM<BaseInputIterator, ScalarInputIterator,
                                          Point, ScalarField>>* = nullptr>
-  bool Run(BaseInputIterator bases_first, BaseInputIterator bases_last,
-           ScalarInputIterator scalars_first, ScalarInputIterator scalars_last,
-           Bucket* ret) {
+  [[nodiscard]] bool Run(BaseInputIterator bases_first,
+                         BaseInputIterator bases_last,
+                         ScalarInputIterator scalars_first,
+                         ScalarInputIterator scalars_last, Bucket* ret) {
     size_t bases_size = std::distance(bases_first, bases_last);
     size_t scalars_size = std::distance(scalars_first, scalars_last);
     if (bases_size != scalars_size) {

--- a/tachyon/math/elliptic_curves/msm/algorithms/pippenger/pippenger_adapter.h
+++ b/tachyon/math/elliptic_curves/msm/algorithms/pippenger/pippenger_adapter.h
@@ -23,20 +23,22 @@ class PippengerAdapter {
   using Bucket = typename Pippenger<Point>::Bucket;
 
   template <typename BaseInputIterator, typename ScalarInputIterator>
-  bool Run(BaseInputIterator bases_first, BaseInputIterator bases_last,
-           ScalarInputIterator scalars_first, ScalarInputIterator scalars_last,
-           Bucket* ret) {
+  [[nodiscard]] bool Run(BaseInputIterator bases_first,
+                         BaseInputIterator bases_last,
+                         ScalarInputIterator scalars_first,
+                         ScalarInputIterator scalars_last, Bucket* ret) {
     return RunWithStrategy(std::move(bases_first), std::move(bases_last),
                            std::move(scalars_first), std::move(scalars_last),
                            PippengerParallelStrategy::kParallelWindow, ret);
   }
 
   template <typename BaseInputIterator, typename ScalarInputIterator>
-  bool RunWithStrategy(BaseInputIterator bases_first,
-                       BaseInputIterator bases_last,
-                       ScalarInputIterator scalars_first,
-                       ScalarInputIterator scalars_last,
-                       PippengerParallelStrategy strategy, Bucket* ret) {
+  [[nodiscard]] bool RunWithStrategy(BaseInputIterator bases_first,
+                                     BaseInputIterator bases_last,
+                                     ScalarInputIterator scalars_first,
+                                     ScalarInputIterator scalars_last,
+                                     PippengerParallelStrategy strategy,
+                                     Bucket* ret) {
     if (strategy == PippengerParallelStrategy::kNone ||
         strategy == PippengerParallelStrategy::kParallelWindow) {
       Pippenger<Point> pippenger;

--- a/tachyon/math/elliptic_curves/msm/algorithms/pippenger/pippenger_adapter.h
+++ b/tachyon/math/elliptic_curves/msm/algorithms/pippenger/pippenger_adapter.h
@@ -56,9 +56,9 @@ class PippengerAdapter {
 #if defined(TACHYON_HAS_OPENMP)
       int thread_nums = omp_get_max_threads();
       if (strategy == PippengerParallelStrategy::kParallelWindowAndTerm) {
-        size_t window_bits = PippengerCtx::ComputeWindowsBits(scalars_size);
+        size_t window_bits = MSMCtx::ComputeWindowsBits(scalars_size);
         size_t window_size =
-            PippengerCtx::ComputeWindowsCount<ScalarField>(window_bits);
+            MSMCtx::ComputeWindowsCount<ScalarField>(window_bits);
         thread_nums = std::max(thread_nums / static_cast<int>(window_size), 2);
       }
 #else

--- a/tachyon/math/elliptic_curves/msm/algorithms/pippenger/pippenger_adapter_benchmark.cc
+++ b/tachyon/math/elliptic_curves/msm/algorithms/pippenger/pippenger_adapter_benchmark.cc
@@ -1,5 +1,6 @@
 #include "benchmark/benchmark.h"
 
+#include "tachyon/base/logging.h"
 #include "tachyon/math/elliptic_curves/bn/bn254/g1.h"
 #include "tachyon/math/elliptic_curves/msm/test/msm_test_set.h"
 
@@ -20,9 +21,9 @@ void BM_PippengerAdapter(benchmark::State& state) {
   using Bucket = typename PippengerAdapter<Point>::Bucket;
   Bucket ret;
   for (auto _ : state) {
-    pippenger.RunWithStrategy(test_set.bases.begin(), test_set.bases.end(),
-                              test_set.scalars.begin(), test_set.scalars.end(),
-                              Strategy, &ret);
+    CHECK(pippenger.RunWithStrategy(
+        test_set.bases.begin(), test_set.bases.end(), test_set.scalars.begin(),
+        test_set.scalars.end(), Strategy, &ret));
   }
   benchmark::DoNotOptimize(ret);
 }

--- a/tachyon/math/elliptic_curves/msm/algorithms/pippenger/pippenger_adapter_benchmark.cc
+++ b/tachyon/math/elliptic_curves/msm/algorithms/pippenger/pippenger_adapter_benchmark.cc
@@ -2,7 +2,7 @@
 
 #include "tachyon/base/logging.h"
 #include "tachyon/math/elliptic_curves/bn/bn254/g1.h"
-#include "tachyon/math/elliptic_curves/msm/test/msm_test_set.h"
+#include "tachyon/math/elliptic_curves/msm/test/variable_base_msm_test_set.h"
 
 namespace tachyon::math {
 
@@ -10,12 +10,13 @@ template <typename Point, bool IsRandom,
           enum PippengerParallelStrategy Strategy>
 void BM_PippengerAdapter(benchmark::State& state) {
   Point::Curve::Init();
-  MSMTestSet<Point> test_set;
+  VariableBaseMSMTestSet<Point> test_set;
   if constexpr (IsRandom) {
-    test_set = MSMTestSet<Point>::Random(state.range(0), MSMMethod::kNone);
+    test_set = VariableBaseMSMTestSet<Point>::Random(
+        state.range(0), VariableBaseMSMMethod::kNone);
   } else {
-    test_set =
-        MSMTestSet<Point>::NonUniform(state.range(0), 10, MSMMethod::kNone);
+    test_set = VariableBaseMSMTestSet<Point>::NonUniform(
+        state.range(0), 10, VariableBaseMSMMethod::kNone);
   }
   PippengerAdapter<Point> pippenger;
   using Bucket = typename PippengerAdapter<Point>::Bucket;

--- a/tachyon/math/elliptic_curves/msm/algorithms/pippenger/pippenger_adapter_unittest.cc
+++ b/tachyon/math/elliptic_curves/msm/algorithms/pippenger/pippenger_adapter_unittest.cc
@@ -3,7 +3,7 @@
 #include "gtest/gtest.h"
 
 #include "tachyon/math/elliptic_curves/bn/bn254/g1.h"
-#include "tachyon/math/elliptic_curves/msm/test/msm_test_set.h"
+#include "tachyon/math/elliptic_curves/msm/test/variable_base_msm_test_set.h"
 
 namespace tachyon::math {
 
@@ -16,20 +16,21 @@ class PippengerAdapterTest : public testing::Test {
   static void SetUpTestSuite() { bn254::G1Curve::Init(); }
 
   PippengerAdapterTest()
-      : test_set_(
-            MSMTestSet<bn254::G1AffinePoint>::Random(kSize, MSMMethod::kMSM)) {}
+      : test_set_(VariableBaseMSMTestSet<bn254::G1AffinePoint>::Random(
+            kSize, VariableBaseMSMMethod::kMSM)) {}
   PippengerAdapterTest(const PippengerAdapterTest&) = delete;
   PippengerAdapterTest& operator=(const PippengerAdapterTest&) = delete;
   ~PippengerAdapterTest() override = default;
 
  protected:
-  MSMTestSet<bn254::G1AffinePoint> test_set_;
+  VariableBaseMSMTestSet<bn254::G1AffinePoint> test_set_;
 };
 
 }  // namespace
 
 TEST_F(PippengerAdapterTest, RunWithStrategy) {
-  const MSMTestSet<bn254::G1AffinePoint>& test_set = this->test_set_;
+  const VariableBaseMSMTestSet<bn254::G1AffinePoint>& test_set =
+      this->test_set_;
 
   for (PippengerParallelStrategy strategy :
        {PippengerParallelStrategy::kNone,

--- a/tachyon/math/elliptic_curves/msm/algorithms/pippenger/pippenger_benchmark.cc
+++ b/tachyon/math/elliptic_curves/msm/algorithms/pippenger/pippenger_benchmark.cc
@@ -1,5 +1,6 @@
 #include "benchmark/benchmark.h"
 
+#include "tachyon/base/logging.h"
 #include "tachyon/math/elliptic_curves/bn/bn254/g1.h"
 #include "tachyon/math/elliptic_curves/msm/test/msm_test_set.h"
 
@@ -19,8 +20,9 @@ void BM_Pippenger(benchmark::State& state) {
   using Bucket = typename Pippenger<Point>::Bucket;
   Bucket ret;
   for (auto _ : state) {
-    pippenger.Run(test_set.bases.begin(), test_set.bases.end(),
-                  test_set.scalars.begin(), test_set.scalars.end(), &ret);
+    CHECK(pippenger.Run(test_set.bases.begin(), test_set.bases.end(),
+                        test_set.scalars.begin(), test_set.scalars.end(),
+                        &ret));
   }
   benchmark::DoNotOptimize(ret);
 }

--- a/tachyon/math/elliptic_curves/msm/algorithms/pippenger/pippenger_benchmark.cc
+++ b/tachyon/math/elliptic_curves/msm/algorithms/pippenger/pippenger_benchmark.cc
@@ -2,19 +2,20 @@
 
 #include "tachyon/base/logging.h"
 #include "tachyon/math/elliptic_curves/bn/bn254/g1.h"
-#include "tachyon/math/elliptic_curves/msm/test/msm_test_set.h"
+#include "tachyon/math/elliptic_curves/msm/test/variable_base_msm_test_set.h"
 
 namespace tachyon::math {
 
 template <typename Point, bool IsRandom>
 void BM_Pippenger(benchmark::State& state) {
   Point::Curve::Init();
-  MSMTestSet<Point> test_set;
+  VariableBaseMSMTestSet<Point> test_set;
   if constexpr (IsRandom) {
-    test_set = MSMTestSet<Point>::Random(state.range(0), MSMMethod::kNone);
+    test_set = VariableBaseMSMTestSet<Point>::Random(
+        state.range(0), VariableBaseMSMMethod::kNone);
   } else {
-    test_set =
-        MSMTestSet<Point>::NonUniform(state.range(0), 10, MSMMethod::kNone);
+    test_set = VariableBaseMSMTestSet<Point>::NonUniform(
+        state.range(0), 10, VariableBaseMSMMethod::kNone);
   }
   Pippenger<Point> pippenger;
   using Bucket = typename Pippenger<Point>::Bucket;

--- a/tachyon/math/elliptic_curves/msm/algorithms/pippenger/pippenger_unittest.cc
+++ b/tachyon/math/elliptic_curves/msm/algorithms/pippenger/pippenger_unittest.cc
@@ -4,7 +4,7 @@
 
 #include "tachyon/math/elliptic_curves/bls12/bls12_381/g1.h"
 #include "tachyon/math/elliptic_curves/bn/bn254/g1.h"
-#include "tachyon/math/elliptic_curves/msm/test/msm_test_set.h"
+#include "tachyon/math/elliptic_curves/msm/test/variable_base_msm_test_set.h"
 
 namespace tachyon::math {
 
@@ -18,13 +18,14 @@ class PippengerTest : public testing::Test {
   static void SetUpTestSuite() { Point::Curve::Init(); }
 
   PippengerTest()
-      : test_set_(MSMTestSet<Point>::Random(kSize, MSMMethod::kNaive)) {}
+      : test_set_(VariableBaseMSMTestSet<Point>::Random(
+            kSize, VariableBaseMSMMethod::kNaive)) {}
   PippengerTest(const PippengerTest&) = delete;
   PippengerTest& operator=(const PippengerTest&) = delete;
   ~PippengerTest() override = default;
 
  protected:
-  MSMTestSet<Point> test_set_;
+  VariableBaseMSMTestSet<Point> test_set_;
 };
 
 }  // namespace
@@ -40,7 +41,7 @@ TYPED_TEST(PippengerTest, Run) {
   using Point = TypeParam;
   using Bucket = typename Pippenger<Point>::Bucket;
 
-  const MSMTestSet<Point>& test_set = this->test_set_;
+  const VariableBaseMSMTestSet<Point>& test_set = this->test_set_;
 
   struct {
     bool use_window_naf;

--- a/tachyon/math/elliptic_curves/msm/fixed_base_msm.h
+++ b/tachyon/math/elliptic_curves/msm/fixed_base_msm.h
@@ -1,0 +1,225 @@
+// Copyright 2022 arkworks contributors
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.arkworks and the LICENCE-APACHE.arkworks
+// file.
+
+#ifndef TACHYON_MATH_ELLIPTIC_CURVES_MSM_FIXED_BASE_MSM_H_
+#define TACHYON_MATH_ELLIPTIC_CURVES_MSM_FIXED_BASE_MSM_H_
+
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "tachyon/base/containers/container_util.h"
+#include "tachyon/base/parallelize.h"
+#include "tachyon/math/base/bit_iterator.h"
+#include "tachyon/math/base/semigroups.h"
+#include "tachyon/math/elliptic_curves/msm/msm_ctx.h"
+#include "tachyon/math/elliptic_curves/point_conversions.h"
+
+namespace tachyon::math {
+
+// MSM(Multi-Scalar Multiplication): s₀ * g⁰ + s₁ * g¹ + ... + sₙ₋₁ * gⁿ⁻¹
+// Fixed-base MSM is an operation that multiplies multiples of generators
+// with respective scalars, unlike the Variable-base MSM, which uses the
+// different base point for all multiplications.
+template <typename Point>
+class FixedBaseMSM {
+ public:
+  using AddResult = typename internal::AdditiveSemigroupTraits<Point>::ReturnTy;
+  using ScalarField = typename Point::ScalarField;
+
+  constexpr void Reset(size_t size, const Point& base) {
+    ctx_ = MSMCtx::CreateDefault<ScalarField>(size);
+    UpdateWindowTable(base);
+  }
+
+  constexpr AddResult ScalarMul(const ScalarField& scalar) const {
+    // modulus_bits = 254
+    // window_bits = 5
+    // window_count = (254 + 4) / 5 = 51
+    //
+    // clang-format off
+    // SG = ((2⁰S₀ + 2¹S₁ + 2²S₂ + 2³S₃ + 2⁴S₄) + 2⁵(2⁰S₅ + 2¹S₆ + 2²S₇ + 2³S₈ + 2⁴S₉) + ... +
+    //       2²⁴⁵(2⁰S₂₄₅ + 2¹S₂₄₆ + 2²S₂₄₇ + 2³S₂₄₈ + 2⁴S₂₄₉) + 2²⁵⁰(2⁰S₂₅₀ + 2¹S₂₅₁ + 2²S₂₅₂ + 2³S₂₅₃))G
+    // clang-format on
+    using BigInt = typename ScalarField::BigIntTy;
+
+    BigInt scalar_bigint = scalar.ToBigInt();
+    auto it = BitIteratorLE<BigInt>::begin(&scalar_bigint);
+
+    unsigned int modulus_bits = ScalarField::Config::kModulusBits;
+
+    AddResult ret;
+    for (size_t i = 0; i < ctx_.window_count; ++i) {
+      size_t j = 0;
+      for (size_t bit_offset = 0; bit_offset < ctx_.window_bits; ++bit_offset) {
+        size_t bit_index = i * ctx_.window_bits + bit_offset;
+        if (bit_index < modulus_bits && *(it++)) {
+          j |= (size_t{1} << bit_offset);
+        }
+      }
+      ret += base_multiples_[i][j];
+    }
+    return ret;
+  }
+
+  template <typename ScalarIterator, typename OutputIterator>
+  [[nodiscard]] bool RunSerial(ScalarIterator scalars_first,
+                               ScalarIterator scalars_last,
+                               OutputIterator outputs_first,
+                               OutputIterator outputs_last) {
+    if (std::distance(scalars_first, scalars_last) !=
+        std::distance(outputs_first, outputs_last)) {
+      LOG(ERROR) << "the size of scalar and output iterators don't match ";
+      return false;
+    }
+    auto scalars_it = scalars_first;
+    auto outputs_it = outputs_first;
+    while (scalars_it != scalars_last) {
+      *outputs_it = ScalarMul(*scalars_it);
+      ++scalars_it;
+      ++outputs_it;
+    }
+    return true;
+  }
+
+  template <typename ScalarContainer, typename OutputContainer>
+  [[nodiscard]] bool RunSerial(const ScalarContainer& scalars,
+                               OutputContainer& outputs) {
+    return RunSerial(std::begin(scalars), std::end(scalars),
+                     std::begin(outputs), std::end(outputs));
+  }
+
+  template <typename ScalarIterator, typename OutputIterator>
+  [[nodiscard]] bool Run(ScalarIterator scalars_first,
+                         ScalarIterator scalars_last,
+                         OutputIterator outputs_first,
+                         OutputIterator outputs_last) {
+    using scalar_iterator_category =
+        typename std::iterator_traits<ScalarIterator>::iterator_category;
+    using output_iterator_category =
+        typename std::iterator_traits<OutputIterator>::iterator_category;
+    return Run(std::move(scalars_first), std::move(scalars_last),
+               std::move(outputs_first), std::move(outputs_last),
+               scalar_iterator_category(), output_iterator_category());
+  }
+
+  template <typename ScalarContainer, typename OutputContainer>
+  [[nodiscard]] bool Run(const ScalarContainer& scalars,
+                         OutputContainer* outputs) {
+    return Run(std::begin(scalars), std::end(scalars), std::begin(*outputs),
+               std::end(*outputs));
+  }
+
+ private:
+  template <typename ScalarIterator, typename OutputIterator>
+  [[nodiscard]] bool Run(ScalarIterator scalars_first,
+                         ScalarIterator scalars_last,
+                         OutputIterator outputs_first,
+                         OutputIterator outputs_last,
+                         const std::random_access_iterator_tag&,
+                         const std::random_access_iterator_tag&) {
+    using difference_type =
+        typename std::iterator_traits<ScalarIterator>::difference_type;
+    difference_type size = std::distance(scalars_first, scalars_last);
+    if (size != std::distance(outputs_first, outputs_last)) {
+      LOG(ERROR) << "the size of scalar and output iterators don't match ";
+      return false;
+    }
+    OPENMP_PARALLEL_FOR(difference_type i = 0; i < size; ++i) {
+      *(outputs_first + i) = ScalarMul(*(scalars_first + i));
+    }
+    return true;
+  }
+
+  template <typename ScalarIterator, typename OutputIterator>
+  [[nodiscard]] bool Run(ScalarIterator scalars_first,
+                         ScalarIterator scalars_last,
+                         OutputIterator outputs_first,
+                         OutputIterator outputs_last,
+                         const std::input_iterator_tag&,
+                         const std::input_iterator_tag&) {
+    return RunSerial(std::move(scalars_first), std::move(scalars_last),
+                     std::move(outputs_first), std::move(outputs_last));
+  }
+
+  constexpr void UpdateWindowTable(const Point& base) {
+    AddResult window_base;
+    if constexpr (std::is_same_v<AddResult, Point>) {
+      window_base = base;
+    } else {
+      window_base = math::ConvertPoint<AddResult>(base);
+    }
+    unsigned int window_bits = ctx_.window_bits;
+    unsigned int window_count = ctx_.window_count;
+    unsigned int window_size =
+        static_cast<unsigned int>(size_t{1} << window_bits);
+    unsigned int modulus_bits = ScalarField::Config::kModulusBits;
+    unsigned int last_window_size = static_cast<unsigned int>(
+        size_t{1} << (modulus_bits - (window_count - 1) * window_bits));
+    // modulus_bits = 254
+    // window_bits = 5
+    // window_count = (254 + 4) / 5 = 51
+    // window_size = 2⁵ = 32
+    // last_window_size = 2^(254 - 50 * 5) = 2⁴ = 16
+    //
+    // The contents of |window_bases| looks like following:
+    //
+    // |   0   |   1   |  ...  |   49  |   50  |
+    // +-------+-------+-------+-------+-------+
+    // |  2⁰G  |  2⁵G  |  ...  | 2²⁴⁵G | 2²⁵⁰G |
+    // +-------+-------+-------+-------+-------+
+    std::vector<AddResult> window_bases =
+        base::CreateVector(window_count, [&window_base, window_bits]() {
+          AddResult window_base_copy = window_base;
+          for (size_t i = 0; i < window_bits; ++i) {
+            window_base.DoubleInPlace();
+          }
+          return window_base_copy;
+        });
+
+    // clang-format off
+    // SG = ((2⁰S₀ + 2¹S₁ + 2²S₂ + 2³S₃ + 2⁴S₄) + 2⁵(2⁰S₅ + 2¹S₆ + 2²S₇ + 2³S₈ + 2⁴S₉) + ... +
+    //       2²⁴⁵(2⁰S₂₄₅ + 2¹S₂₄₆ + 2²S₂₄₇ + 2³S₂₄₈ + 2⁴S₂₄₉) + 2²⁵⁰(2⁰S₂₅₀ + 2¹S₂₅₁ + 2²S₂₅₂ + 2³S₂₅₃))G
+    // clang-format on
+
+    // The contents of |base_multiples_| looks like following:
+    //
+    //  j \ i |     0     |     1     |  ...  |     49     |     50     |
+    // -------+-----------+-----------+-------+------------+------------+
+    //    0   |    2⁰G    |    2⁵G    |  ...  |    2²⁴⁵G   |    2²⁵⁰G   |
+    // -------+-----------+-----------+-------+------------+------------+
+    //    1   |  2 * 2⁰G  |  2 * 2⁵G  |  ...  |  2 * 2²⁴⁵G |  2 * 2²⁵⁰G |
+    // -------+-----------+-----------+-------+------------+------------+
+    //   ...  |    ...    |    ...    |  ...  |     ...    |     ...    |
+    // -------+-----------+-----------+-------+------------+------------+
+    //    30  |  30 * 2⁰G |  30 * 2⁵G |  ...  | 30 * 2²⁴⁵G |     0G     |
+    // -------+-----------+-----------+-------+------------+------------+
+    //    31  |  31 * 2⁰G |  31 * 2⁵G |  ...  | 31 * 2²⁴⁵G |     0G     |
+    // -------+-----------+-----------+-------+------------+------------+
+
+    base_multiples_ = base::CreateVector(window_count, [window_size]() {
+      return base::CreateVector(window_size, AddResult::Zero());
+    });
+    OPENMP_PARALLEL_FOR(size_t i = 0; i < window_count; ++i) {
+      size_t cur_window_size =
+          i == window_count - 1 ? last_window_size : window_size;
+
+      std::vector<AddResult>& cur_window = base_multiples_[i];
+      AddResult base_multiple = AddResult::Zero();
+      const AddResult& base_multiple_base = window_bases[i];
+      for (size_t j = 0; j < cur_window_size; ++j) {
+        cur_window[j] = base_multiple;
+        base_multiple += base_multiple_base;
+      }
+    }
+  }
+
+  MSMCtx ctx_;
+  std::vector<std::vector<AddResult>> base_multiples_;
+};
+
+}  // namespace tachyon::math
+
+#endif  // TACHYON_MATH_ELLIPTIC_CURVES_MSM_FIXED_BASE_MSM_H_

--- a/tachyon/math/elliptic_curves/msm/fixed_base_msm_unittest.cc
+++ b/tachyon/math/elliptic_curves/msm/fixed_base_msm_unittest.cc
@@ -1,0 +1,48 @@
+#include "gtest/gtest.h"
+
+#include "tachyon/math/elliptic_curves/bn/bn254/g1.h"
+#include "tachyon/math/elliptic_curves/msm/test/fixed_base_msm_test_set.h"
+
+namespace tachyon::math {
+
+namespace {
+
+const size_t kSize = 40;
+
+template <typename Point>
+class FixedBaseMSMTest : public testing::Test {
+ public:
+  static void SetUpTestSuite() { Point::Curve::Init(); }
+
+  FixedBaseMSMTest()
+      : test_set_(FixedBaseMSMTestSet<Point>::Random(
+            kSize, FixedBaseMSMMethod::kNaive)) {}
+  FixedBaseMSMTest(const FixedBaseMSMTest&) = delete;
+  FixedBaseMSMTest& operator=(const FixedBaseMSMTest&) = delete;
+  ~FixedBaseMSMTest() override = default;
+
+ protected:
+  FixedBaseMSMTestSet<Point> test_set_;
+};
+
+}  // namespace
+
+using PointTypes =
+    testing::Types<bn254::G1AffinePoint, bn254::G1ProjectivePoint,
+                   bn254::G1JacobianPoint, bn254::G1PointXYZZ>;
+TYPED_TEST_SUITE(FixedBaseMSMTest, PointTypes);
+
+TYPED_TEST(FixedBaseMSMTest, DoMSM) {
+  using Point = TypeParam;
+  using AddResult = typename internal::AdditiveSemigroupTraits<Point>::ReturnTy;
+
+  const FixedBaseMSMTestSet<Point>& test_set = this->test_set_;
+
+  FixedBaseMSM<Point> msm;
+  msm.Reset(test_set.scalars.size(), test_set.base);
+  std::vector<AddResult> ret(test_set.scalars.size());
+  EXPECT_TRUE(msm.Run(test_set.scalars, &ret));
+  EXPECT_EQ(ret, test_set.answer);
+}
+
+}  // namespace tachyon::math

--- a/tachyon/math/elliptic_curves/msm/kernels/cuzk/BUILD.bazel
+++ b/tachyon/math/elliptic_curves/msm/kernels/cuzk/BUILD.bazel
@@ -10,9 +10,9 @@ tachyon_cuda_library(
     deps = [
         "//tachyon/device/gpu/cuda:cuda_memory",
         "//tachyon/math/base:big_int",
+        "//tachyon/math/elliptic_curves/msm:msm_ctx",
         "//tachyon/math/elliptic_curves/msm/algorithms/cuzk:cuzk_csr_sparse_matrix",
         "//tachyon/math/elliptic_curves/msm/algorithms/cuzk:cuzk_ell_sparse_matrix",
-        "//tachyon/math/elliptic_curves/msm/algorithms/pippenger:pippenger_ctx",
         "//tachyon/math/elliptic_curves/short_weierstrass:points",
     ],
 )

--- a/tachyon/math/elliptic_curves/msm/kernels/cuzk/bn254_cuzk_kernels.cu.cc
+++ b/tachyon/math/elliptic_curves/msm/kernels/cuzk/bn254_cuzk_kernels.cu.cc
@@ -8,11 +8,11 @@
 namespace tachyon::math::cuzk {
 
 template __global__ void WriteBucketIndexesToELLMatrix<bn254::FrGpu>(
-    PippengerCtx ctx, unsigned int window_index, const bn254::FrGpu* scalars,
+    MSMCtx ctx, unsigned int window_index, const bn254::FrGpu* scalars,
     CUZKELLSparseMatrix matrix);
 
 template __global__ void MultiplyCSRMatrixWithOneVectorStep1<bn254::G1CurveGpu>(
-    PippengerCtx ctx, unsigned int z, CUZKCSRSparseMatrix csr_matrix,
+    MSMCtx ctx, unsigned int z, CUZKCSRSparseMatrix csr_matrix,
     const AffinePoint<bn254::G1CurveGpu>* bases,
     PointXYZZ<bn254::G1CurveGpu>* results, unsigned int bucket_index);
 
@@ -22,7 +22,7 @@ template __global__ void MultiplyCSRMatrixWithOneVectorStep2<bn254::G1CurveGpu>(
     PointXYZZ<bn254::G1CurveGpu>* max_intermediate_results);
 
 template __global__ void MultiplyCSRMatrixWithOneVectorStep3<bn254::G1CurveGpu>(
-    PippengerCtx ctx, unsigned int index, unsigned int count,
+    MSMCtx ctx, unsigned int index, unsigned int count,
     CUZKCSRSparseMatrix csr_matrix,
     const AffinePoint<bn254::G1CurveGpu>* __restrict__ bases,
     PointXYZZ<bn254::G1CurveGpu>* __restrict__ max_intermediate_results,
@@ -43,7 +43,7 @@ template __global__ void MultiplyCSRMatrixWithOneVectorStep5<bn254::G1CurveGpu>(
     PointXYZZ<bn254::G1CurveGpu>* __restrict__ results, unsigned int total);
 
 template __global__ void ReduceBucketsStep1<bn254::G1CurveGpu>(
-    PippengerCtx ctx, PointXYZZ<bn254::G1CurveGpu>* __restrict__ buckets,
+    MSMCtx ctx, PointXYZZ<bn254::G1CurveGpu>* __restrict__ buckets,
     PointXYZZ<bn254::G1CurveGpu>* __restrict__ intermediate_results,
     unsigned int group_grid);
 
@@ -52,8 +52,7 @@ template __global__ void ReduceBucketsStep2<bn254::G1CurveGpu>(
     unsigned int group_grid, unsigned int count);
 
 template __global__ void ReduceBucketsStep3<bn254::G1CurveGpu>(
-    PippengerCtx ctx,
-    PointXYZZ<bn254::G1CurveGpu>* __restrict__ intermediate_results,
+    MSMCtx ctx, PointXYZZ<bn254::G1CurveGpu>* __restrict__ intermediate_results,
     unsigned int start_group, unsigned int end_group, unsigned int gnum,
     PointXYZZ<bn254::G1CurveGpu>* result);
 

--- a/tachyon/math/elliptic_curves/msm/kernels/cuzk/bn254_cuzk_kernels.cu.h
+++ b/tachyon/math/elliptic_curves/msm/kernels/cuzk/bn254_cuzk_kernels.cu.h
@@ -12,12 +12,12 @@
 namespace tachyon::math::cuzk {
 
 extern template __global__ void WriteBucketIndexesToELLMatrix<bn254::FrGpu>(
-    PippengerCtx ctx, unsigned int window_index, const bn254::FrGpu* scalars,
+    MSMCtx ctx, unsigned int window_index, const bn254::FrGpu* scalars,
     CUZKELLSparseMatrix matrix);
 
 extern template __global__ void
 MultiplyCSRMatrixWithOneVectorStep1<bn254::G1CurveGpu>(
-    PippengerCtx ctx, unsigned int z, CUZKCSRSparseMatrix csr_matrix,
+    MSMCtx ctx, unsigned int z, CUZKCSRSparseMatrix csr_matrix,
     const AffinePoint<bn254::G1CurveGpu>* bases,
     PointXYZZ<bn254::G1CurveGpu>* results, unsigned int bucket_index);
 
@@ -29,7 +29,7 @@ MultiplyCSRMatrixWithOneVectorStep2<bn254::G1CurveGpu>(
 
 extern template __global__ void
 MultiplyCSRMatrixWithOneVectorStep3<bn254::G1CurveGpu>(
-    PippengerCtx ctx, unsigned int index, unsigned int count,
+    MSMCtx ctx, unsigned int index, unsigned int count,
     CUZKCSRSparseMatrix csr_matrix,
     const AffinePoint<bn254::G1CurveGpu>* __restrict__ bases,
     PointXYZZ<bn254::G1CurveGpu>* __restrict__ max_intermediate_results,
@@ -52,7 +52,7 @@ MultiplyCSRMatrixWithOneVectorStep5<bn254::G1CurveGpu>(
     PointXYZZ<bn254::G1CurveGpu>* __restrict__ results, unsigned int total);
 
 extern template __global__ void ReduceBucketsStep1<bn254::G1CurveGpu>(
-    PippengerCtx ctx, PointXYZZ<bn254::G1CurveGpu>* __restrict__ buckets,
+    MSMCtx ctx, PointXYZZ<bn254::G1CurveGpu>* __restrict__ buckets,
     PointXYZZ<bn254::G1CurveGpu>* __restrict__ intermediate_results,
     unsigned int group_grid);
 
@@ -61,8 +61,7 @@ extern template __global__ void ReduceBucketsStep2<bn254::G1CurveGpu>(
     unsigned int group_grid, unsigned int count);
 
 extern template __global__ void ReduceBucketsStep3<bn254::G1CurveGpu>(
-    PippengerCtx ctx,
-    PointXYZZ<bn254::G1CurveGpu>* __restrict__ intermediate_results,
+    MSMCtx ctx, PointXYZZ<bn254::G1CurveGpu>* __restrict__ intermediate_results,
     unsigned int start_group, unsigned int end_group, unsigned int gnum,
     PointXYZZ<bn254::G1CurveGpu>* result);
 

--- a/tachyon/math/elliptic_curves/msm/kernels/cuzk/cuzk_kernels.cu.h
+++ b/tachyon/math/elliptic_curves/msm/kernels/cuzk/cuzk_kernels.cu.h
@@ -11,7 +11,7 @@
 #include "tachyon/math/elliptic_curves/affine_point.h"
 #include "tachyon/math/elliptic_curves/msm/algorithms/cuzk/cuzk_csr_sparse_matrix.h"
 #include "tachyon/math/elliptic_curves/msm/algorithms/cuzk/cuzk_ell_sparse_matrix.h"
-#include "tachyon/math/elliptic_curves/msm/algorithms/pippenger/pippenger_ctx.h"
+#include "tachyon/math/elliptic_curves/msm/msm_ctx.h"
 #include "tachyon/math/elliptic_curves/point_xyzz.h"
 
 namespace tachyon::math::cuzk {
@@ -19,7 +19,7 @@ namespace tachyon::math::cuzk {
 // This is a pStoreECPoints in the Algorithm3 section from
 // https://eprint.iacr.org/2022/1321.pdf
 template <typename ScalarField>
-__global__ void WriteBucketIndexesToELLMatrix(PippengerCtx ctx,
+__global__ void WriteBucketIndexesToELLMatrix(MSMCtx ctx,
                                               unsigned int window_index,
                                               const ScalarField* scalars,
                                               CUZKELLSparseMatrix matrix) {
@@ -59,7 +59,7 @@ __global__ void ConvertELLToCSRTransposedStep5(CUZKELLSparseMatrix ell_matrix,
 
 template <typename Curve>
 __global__ void MultiplyCSRMatrixWithOneVectorStep1(
-    PippengerCtx ctx, unsigned int z, CUZKCSRSparseMatrix csr_matrix,
+    MSMCtx ctx, unsigned int z, CUZKCSRSparseMatrix csr_matrix,
     const AffinePoint<Curve>* bases, PointXYZZ<Curve>* results,
     unsigned int bucket_index) {
   unsigned int tid = blockDim.x * blockIdx.x + threadIdx.x;
@@ -95,7 +95,7 @@ __global__ void MultiplyCSRMatrixWithOneVectorStep2(
 
 template <typename Curve>
 __global__ void MultiplyCSRMatrixWithOneVectorStep3(
-    PippengerCtx ctx, unsigned int index, unsigned int count,
+    MSMCtx ctx, unsigned int index, unsigned int count,
     CUZKCSRSparseMatrix csr_matrix,
     const AffinePoint<Curve>* __restrict__ bases,
     PointXYZZ<Curve>* __restrict__ max_intermediate_results,
@@ -181,7 +181,7 @@ __global__ void MultiplyCSRMatrixWithOneVectorStep5(
 // from https://eprint.iacr.org/2022/1321.pdf
 template <typename Curve>
 __global__ void ReduceBucketsStep1(
-    PippengerCtx ctx, PointXYZZ<Curve>* __restrict__ buckets,
+    MSMCtx ctx, PointXYZZ<Curve>* __restrict__ buckets,
     PointXYZZ<Curve>* __restrict__ intermediate_results,
     unsigned int group_grid) {
   unsigned int gid = blockIdx.x / group_grid;
@@ -228,7 +228,7 @@ __global__ void ReduceBucketsStep2(
 
 template <typename Curve>
 __global__ void ReduceBucketsStep3(
-    PippengerCtx ctx, PointXYZZ<Curve>* __restrict__ intermediate_results,
+    MSMCtx ctx, PointXYZZ<Curve>* __restrict__ intermediate_results,
     unsigned int start_group, unsigned int end_group, unsigned int gnum,
     PointXYZZ<Curve>* result) {
   *result = PointXYZZ<Curve>::Zero();

--- a/tachyon/math/elliptic_curves/msm/msm_ctx.h
+++ b/tachyon/math/elliptic_curves/msm/msm_ctx.h
@@ -1,5 +1,5 @@
-#ifndef TACHYON_MATH_ELLIPTIC_CURVES_MSM_ALGORITHMS_PIPPENGER_PIPPENGER_CTX_H_
-#define TACHYON_MATH_ELLIPTIC_CURVES_MSM_ALGORITHMS_PIPPENGER_PIPPENGER_CTX_H_
+#ifndef TACHYON_MATH_ELLIPTIC_CURVES_MSM_MSM_CTX_H_
+#define TACHYON_MATH_ELLIPTIC_CURVES_MSM_MSM_CTX_H_
 
 #include <stddef.h>
 
@@ -9,7 +9,7 @@
 
 namespace tachyon::math {
 
-struct TACHYON_EXPORT PippengerCtx {
+struct TACHYON_EXPORT MSMCtx {
   unsigned int window_count = 0;
   unsigned int window_bits = 0;
   unsigned int size = 0;
@@ -17,8 +17,8 @@ struct TACHYON_EXPORT PippengerCtx {
   constexpr unsigned int GetWindowLength() const { return 1 << window_bits; }
 
   template <typename ScalarField>
-  constexpr static PippengerCtx CreateDefault(size_t size) {
-    PippengerCtx ctx;
+  constexpr static MSMCtx CreateDefault(size_t size) {
+    MSMCtx ctx;
     ctx.window_bits = ComputeWindowsBits(size);
     ctx.window_count = ComputeWindowsCount<ScalarField>(ctx.window_bits);
     ctx.size = size;
@@ -48,4 +48,4 @@ struct TACHYON_EXPORT PippengerCtx {
 
 }  // namespace tachyon::math
 
-#endif  // TACHYON_MATH_ELLIPTIC_CURVES_MSM_ALGORITHMS_PIPPENGER_PIPPENGER_CTX_H_
+#endif  // TACHYON_MATH_ELLIPTIC_CURVES_MSM_MSM_CTX_H_

--- a/tachyon/math/elliptic_curves/msm/test/BUILD.bazel
+++ b/tachyon/math/elliptic_curves/msm/test/BUILD.bazel
@@ -3,6 +3,19 @@ load("//bazel:tachyon_cc.bzl", "tachyon_cc_library")
 package(default_visibility = ["//visibility:public"])
 
 tachyon_cc_library(
+    name = "fixed_base_msm_test_set",
+    testonly = True,
+    hdrs = ["fixed_base_msm_test_set.h"],
+    deps = [
+        "//tachyon/base:logging",
+        "//tachyon/base/containers:container_util",
+        "//tachyon/base/files:file_util",
+        "//tachyon/math/elliptic_curves/msm:fixed_base_msm",
+        "//tachyon/math/elliptic_curves/test:random",
+    ],
+)
+
+tachyon_cc_library(
     name = "variable_base_msm_test_set",
     testonly = True,
     hdrs = ["variable_base_msm_test_set.h"],

--- a/tachyon/math/elliptic_curves/msm/test/BUILD.bazel
+++ b/tachyon/math/elliptic_curves/msm/test/BUILD.bazel
@@ -3,9 +3,9 @@ load("//bazel:tachyon_cc.bzl", "tachyon_cc_library")
 package(default_visibility = ["//visibility:public"])
 
 tachyon_cc_library(
-    name = "msm_test_set",
+    name = "variable_base_msm_test_set",
     testonly = True,
-    hdrs = ["msm_test_set.h"],
+    hdrs = ["variable_base_msm_test_set.h"],
     deps = [
         "//tachyon/base:logging",
         "//tachyon/base/containers:container_util",

--- a/tachyon/math/elliptic_curves/msm/test/BUILD.bazel
+++ b/tachyon/math/elliptic_curves/msm/test/BUILD.bazel
@@ -7,6 +7,7 @@ tachyon_cc_library(
     testonly = True,
     hdrs = ["msm_test_set.h"],
     deps = [
+        "//tachyon/base:logging",
         "//tachyon/base/containers:container_util",
         "//tachyon/base/files:file_util",
         "//tachyon/math/elliptic_curves/msm:variable_base_msm",

--- a/tachyon/math/elliptic_curves/msm/test/fixed_base_msm_test_set.h
+++ b/tachyon/math/elliptic_curves/msm/test/fixed_base_msm_test_set.h
@@ -1,0 +1,92 @@
+#ifndef TACHYON_MATH_ELLIPTIC_CURVES_MSM_TEST_FIXED_BASE_MSM_TEST_SET_H_
+#define TACHYON_MATH_ELLIPTIC_CURVES_MSM_TEST_FIXED_BASE_MSM_TEST_SET_H_
+
+#include <vector>
+
+#include "tachyon/base/containers/container_util.h"
+#include "tachyon/base/files/file_util.h"
+#include "tachyon/base/logging.h"
+#include "tachyon/math/base/semigroups.h"
+#include "tachyon/math/elliptic_curves/msm/fixed_base_msm.h"
+#include "tachyon/math/elliptic_curves/point_conversions.h"
+#include "tachyon/math/elliptic_curves/test/random.h"
+
+namespace tachyon::math {
+
+enum class FixedBaseMSMMethod {
+  kNone,
+  kMSM,
+  kNaive,
+};
+
+template <typename Point>
+struct FixedBaseMSMTestSet {
+  using AddResult = typename internal::AdditiveSemigroupTraits<Point>::ReturnTy;
+  using ScalarField = typename Point::ScalarField;
+
+  Point base;
+  std::vector<ScalarField> scalars;
+  std::vector<AddResult> answer;
+
+  constexpr size_t size() const { return scalars.size(); }
+
+  static FixedBaseMSMTestSet Random(size_t size, FixedBaseMSMMethod method) {
+    FixedBaseMSMTestSet test_set;
+    test_set.base = Point::Random();
+    test_set.scalars =
+        base::CreateVector(size, []() { return ScalarField::Random(); });
+    test_set.ComputeAnswer(method);
+    return test_set;
+  }
+
+  static FixedBaseMSMTestSet Easy(size_t size, FixedBaseMSMMethod method) {
+    FixedBaseMSMTestSet test_set;
+    test_set.base = Point::Random();
+    ScalarField s = ScalarField::One();
+    test_set.scalars = base::CreateVector(size, [&s]() {
+      ScalarField ret = s;
+      s += ScalarField::One();
+      return ret;
+    });
+    test_set.ComputeAnswer(method);
+    return test_set;
+  }
+
+  bool WriteToFile(const base::FilePath& dir) const {
+    {
+      std::stringstream ss;
+      ss << base.ToString() << std::endl;
+      if (!base::WriteFile(dir.Append("base.txt"), ss.str())) return false;
+    }
+    std::stringstream ss;
+    for (size_t i = 0; i < scalars.size(); ++i) {
+      ss << scalars[i].ToString() << std::endl;
+    }
+    return base::WriteFile(dir.Append("scalars.txt"), ss.str());
+  }
+
+ private:
+  void ComputeAnswer(FixedBaseMSMMethod method) {
+    switch (method) {
+      case FixedBaseMSMMethod::kNone:
+        break;
+      case FixedBaseMSMMethod::kMSM: {
+        FixedBaseMSM<Point> msm;
+        msm.Reset(scalars.size(), base);
+        answer.resize(scalars.size());
+        CHECK(msm.Run(scalars, &answer));
+        break;
+      }
+      case FixedBaseMSMMethod::kNaive: {
+        for (size_t i = 0; i < scalars.size(); ++i) {
+          answer.push_back(base * scalars[i]);
+        }
+        break;
+      }
+    }
+  }
+};
+
+}  // namespace tachyon::math
+
+#endif  // TACHYON_MATH_ELLIPTIC_CURVES_MSM_TEST_FIXED_BASE_MSM_TEST_SET_H_

--- a/tachyon/math/elliptic_curves/msm/test/msm_test_set.h
+++ b/tachyon/math/elliptic_curves/msm/test/msm_test_set.h
@@ -5,6 +5,7 @@
 
 #include "tachyon/base/containers/container_util.h"
 #include "tachyon/base/files/file_util.h"
+#include "tachyon/base/logging.h"
 #include "tachyon/math/base/semigroups.h"
 #include "tachyon/math/elliptic_curves/msm/variable_base_msm.h"
 #include "tachyon/math/elliptic_curves/point_conversions.h"
@@ -87,7 +88,7 @@ struct MSMTestSet {
         break;
       case MSMMethod::kMSM: {
         VariableBaseMSM<Point> msm;
-        msm.Run(bases, scalars, &answer);
+        CHECK(msm.Run(bases, scalars, &answer));
         break;
       }
       case MSMMethod::kNaive: {

--- a/tachyon/math/elliptic_curves/msm/test/variable_base_msm_test_set.h
+++ b/tachyon/math/elliptic_curves/msm/test/variable_base_msm_test_set.h
@@ -1,5 +1,5 @@
-#ifndef TACHYON_MATH_ELLIPTIC_CURVES_MSM_TEST_MSM_TEST_SET_H_
-#define TACHYON_MATH_ELLIPTIC_CURVES_MSM_TEST_MSM_TEST_SET_H_
+#ifndef TACHYON_MATH_ELLIPTIC_CURVES_MSM_TEST_VARIABLE_BASE_MSM_TEST_SET_H_
+#define TACHYON_MATH_ELLIPTIC_CURVES_MSM_TEST_VARIABLE_BASE_MSM_TEST_SET_H_
 
 #include <vector>
 
@@ -13,7 +13,7 @@
 
 namespace tachyon::math {
 
-enum class MSMMethod {
+enum class VariableBaseMSMMethod {
   kNone,
   kMSM,
   kNaive,
@@ -21,7 +21,7 @@ enum class MSMMethod {
 
 template <typename Point,
           typename Bucket = typename VariableBaseMSM<Point>::Bucket>
-struct MSMTestSet {
+struct VariableBaseMSMTestSet {
   using ScalarField = typename Point::ScalarField;
 
   std::vector<Point> bases;
@@ -30,8 +30,9 @@ struct MSMTestSet {
 
   constexpr size_t size() const { return bases.size(); }
 
-  static MSMTestSet Random(size_t size, MSMMethod method) {
-    MSMTestSet test_set;
+  static VariableBaseMSMTestSet Random(size_t size,
+                                       VariableBaseMSMMethod method) {
+    VariableBaseMSMTestSet test_set;
     test_set.bases = CreatePseudoRandomPoints<Point>(size);
     test_set.scalars =
         base::CreateVector(size, []() { return ScalarField::Random(); });
@@ -39,9 +40,9 @@ struct MSMTestSet {
     return test_set;
   }
 
-  static MSMTestSet NonUniform(size_t size, size_t scalar_size,
-                               MSMMethod method) {
-    MSMTestSet test_set;
+  static VariableBaseMSMTestSet NonUniform(size_t size, size_t scalar_size,
+                                           VariableBaseMSMMethod method) {
+    VariableBaseMSMTestSet test_set;
     test_set.bases = CreatePseudoRandomPoints<Point>(size);
     std::vector<ScalarField> scalar_sets =
         base::CreateVector(scalar_size, []() { return ScalarField::Random(); });
@@ -51,8 +52,9 @@ struct MSMTestSet {
     return test_set;
   }
 
-  static MSMTestSet Easy(size_t size, MSMMethod method) {
-    MSMTestSet test_set;
+  static VariableBaseMSMTestSet Easy(size_t size,
+                                     VariableBaseMSMMethod method) {
+    VariableBaseMSMTestSet test_set;
     test_set.bases =
         base::CreateVector(size, []() { return Point::Generator(); });
     ScalarField s = ScalarField::One();
@@ -81,17 +83,17 @@ struct MSMTestSet {
   }
 
  private:
-  void ComputeAnswer(MSMMethod method) {
+  void ComputeAnswer(VariableBaseMSMMethod method) {
     answer = Bucket::Zero();
     switch (method) {
-      case MSMMethod::kNone:
+      case VariableBaseMSMMethod::kNone:
         break;
-      case MSMMethod::kMSM: {
+      case VariableBaseMSMMethod::kMSM: {
         VariableBaseMSM<Point> msm;
         CHECK(msm.Run(bases, scalars, &answer));
         break;
       }
-      case MSMMethod::kNaive: {
+      case VariableBaseMSMMethod::kNaive: {
         using AddResult =
             typename internal::AdditiveSemigroupTraits<Point>::ReturnTy;
         AddResult sum = AddResult::Zero();
@@ -107,4 +109,4 @@ struct MSMTestSet {
 
 }  // namespace tachyon::math
 
-#endif  // TACHYON_MATH_ELLIPTIC_CURVES_MSM_TEST_MSM_TEST_SET_H_
+#endif  // TACHYON_MATH_ELLIPTIC_CURVES_MSM_TEST_VARIABLE_BASE_MSM_TEST_SET_H_

--- a/tachyon/math/elliptic_curves/msm/variable_base_msm.h
+++ b/tachyon/math/elliptic_curves/msm/variable_base_msm.h
@@ -6,17 +6,18 @@
 #include "tachyon/math/elliptic_curves/msm/algorithms/pippenger/pippenger_adapter.h"
 
 namespace tachyon::math {
+
+// MSM(Multi-Scalar Multiplication): s₀ * g₀ + s₁ * g₁ + ... + sₙ * gₙ
+// Variable-base MSM is an operation that multiplies different base points
+// with respective scalars, unlike the Fixed-base MSM, which uses the same
+// base point for all multiplications.
+// This implementation uses Pippenger's algorithm to compute the MSM.
 template <typename Point>
 class VariableBaseMSM {
  public:
   using ScalarField = typename Point::ScalarField;
   using Bucket = typename Pippenger<Point>::Bucket;
 
-  // MSM(Multi-Scalar Multiplication): s₀ * g₀ + s₁ * g₁ + ... + sₙ * gₙ
-  // Variable-base MSM is an operation that multiplies different base points
-  // with respective scalars, unlike the Fixed-base MSM, which uses the same
-  // base point for all multiplications.
-  // This implementation uses Pippenger's algorithm to compute the MSM.
   template <typename BaseInputIterator, typename ScalarInputIterator>
   bool Run(BaseInputIterator bases_first, BaseInputIterator bases_last,
            ScalarInputIterator scalars_first, ScalarInputIterator scalars_last,

--- a/tachyon/math/elliptic_curves/msm/variable_base_msm.h
+++ b/tachyon/math/elliptic_curves/msm/variable_base_msm.h
@@ -7,7 +7,7 @@
 
 namespace tachyon::math {
 
-// MSM(Multi-Scalar Multiplication): s₀ * g₀ + s₁ * g₁ + ... + sₙ * gₙ
+// MSM(Multi-Scalar Multiplication): s₀ * g₀ + s₁ * g₁ + ... + sₙ₋₁ * gₙ₋₁
 // Variable-base MSM is an operation that multiplies different base points
 // with respective scalars, unlike the Fixed-base MSM, which uses the same
 // base point for all multiplications.

--- a/tachyon/math/elliptic_curves/msm/variable_base_msm.h
+++ b/tachyon/math/elliptic_curves/msm/variable_base_msm.h
@@ -19,9 +19,10 @@ class VariableBaseMSM {
   using Bucket = typename Pippenger<Point>::Bucket;
 
   template <typename BaseInputIterator, typename ScalarInputIterator>
-  bool Run(BaseInputIterator bases_first, BaseInputIterator bases_last,
-           ScalarInputIterator scalars_first, ScalarInputIterator scalars_last,
-           Bucket* ret) {
+  [[nodiscard]] bool Run(BaseInputIterator bases_first,
+                         BaseInputIterator bases_last,
+                         ScalarInputIterator scalars_first,
+                         ScalarInputIterator scalars_last, Bucket* ret) {
     PippengerAdapter<Point> pippenger;
     return pippenger.Run(std::move(bases_first), std::move(bases_last),
                          std::move(scalars_first), std::move(scalars_last),
@@ -29,8 +30,8 @@ class VariableBaseMSM {
   }
 
   template <typename BaseContainer, typename ScalarContainer>
-  bool Run(const BaseContainer& bases, const ScalarContainer& scalars,
-           Bucket* ret) {
+  [[nodiscard]] bool Run(const BaseContainer& bases,
+                         const ScalarContainer& scalars, Bucket* ret) {
     return Run(std::begin(bases), std::end(bases), std::begin(scalars),
                std::end(scalars), ret);
   }

--- a/tachyon/math/elliptic_curves/msm/variable_base_msm_gpu_unittest.cc
+++ b/tachyon/math/elliptic_curves/msm/variable_base_msm_gpu_unittest.cc
@@ -10,7 +10,7 @@
 #include "tachyon/math/elliptic_curves/bn/bn254/g1_gpu.h"
 #include "tachyon/math/elliptic_curves/msm/kernels/bellman/bn254_bellman_msm_kernels.cu.h"
 #include "tachyon/math/elliptic_curves/msm/kernels/cuzk/bn254_cuzk_kernels.cu.h"
-#include "tachyon/math/elliptic_curves/msm/test/msm_test_set.h"
+#include "tachyon/math/elliptic_curves/msm/test/variable_base_msm_test_set.h"
 
 namespace tachyon::math {
 
@@ -28,8 +28,9 @@ class VariableMSMCorrectnessGpuTest : public testing::Test {
   static void SetUpTestSuite() {
     bn254::G1Curve::Init();
 
-    MSMTestSet<bn254::G1AffinePoint> test_set =
-        MSMTestSet<bn254::G1AffinePoint>::Random(kCount, MSMMethod::kMSM);
+    VariableBaseMSMTestSet<bn254::G1AffinePoint> test_set =
+        VariableBaseMSMTestSet<bn254::G1AffinePoint>::Random(
+            kCount, VariableBaseMSMMethod::kMSM);
 
     d_bases_ = gpu::GpuMemory<bn254::G1AffinePointGpu>::Malloc(kCount);
     d_scalars_ = gpu::GpuMemory<bn254::FrGpu>::Malloc(kCount);

--- a/tachyon/math/elliptic_curves/msm/variable_base_msm_unittest.cc
+++ b/tachyon/math/elliptic_curves/msm/variable_base_msm_unittest.cc
@@ -1,7 +1,7 @@
 #include "gtest/gtest.h"
 
 #include "tachyon/math/elliptic_curves/bn/bn254/g1.h"
-#include "tachyon/math/elliptic_curves/msm/test/msm_test_set.h"
+#include "tachyon/math/elliptic_curves/msm/test/variable_base_msm_test_set.h"
 
 namespace tachyon::math {
 
@@ -15,13 +15,14 @@ class VariableBaseMSMTest : public testing::Test {
   static void SetUpTestSuite() { Point::Curve::Init(); }
 
   VariableBaseMSMTest()
-      : test_set_(MSMTestSet<Point>::Random(kSize, MSMMethod::kNaive)) {}
+      : test_set_(VariableBaseMSMTestSet<Point>::Random(
+            kSize, VariableBaseMSMMethod::kNaive)) {}
   VariableBaseMSMTest(const VariableBaseMSMTest&) = delete;
   VariableBaseMSMTest& operator=(const VariableBaseMSMTest&) = delete;
   ~VariableBaseMSMTest() override = default;
 
  protected:
-  MSMTestSet<Point> test_set_;
+  VariableBaseMSMTestSet<Point> test_set_;
 };
 
 }  // namespace
@@ -35,7 +36,7 @@ TYPED_TEST(VariableBaseMSMTest, DoMSM) {
   using Point = TypeParam;
   using Bucket = typename VariableBaseMSM<Point>::Bucket;
 
-  const MSMTestSet<Point>& test_set = this->test_set_;
+  const VariableBaseMSMTestSet<Point>& test_set = this->test_set_;
 
   VariableBaseMSM<Point> msm;
   Bucket ret;


### PR DESCRIPTION
# Description

This PR adds `FixedBaseMSM` which is used by groth16. Existing `MSMXXX` is named to `VariableBaseMSMXXX` to differentiate it from `FixedBaseMSM`.
