### PR TITLE
fix: handle point at infinity case

### DIFF
--- a/tachyon/c/zk/plonk/keys/buffer_reader.h
+++ b/tachyon/c/zk/plonk/keys/buffer_reader.h
@@ -70,6 +70,9 @@ class BufferReader<math::AffinePoint<Curve>> {
   static math::AffinePoint<Curve> Read(const base::ReadOnlyBuffer& buffer) {
     BaseField x = BufferReader<BaseField>::Read(buffer);
     BaseField y = BufferReader<BaseField>::Read(buffer);
+    if (x.IsZero() && y.IsZero()) {
+      return {};
+    }
     return {std::move(x), std::move(y)};
   }
 };

--- a/tachyon/zk/plonk/halo2/stringifiers/point_stringifier.h
+++ b/tachyon/zk/plonk/halo2/stringifiers/point_stringifier.h
@@ -20,7 +20,12 @@ class RustDebugStringifier<math::AffinePoint<Curve>> {
  public:
   static std::ostream& AppendToStream(std::ostream& os, RustFormatter& fmt,
                                       const math::AffinePoint<Curve>& value) {
-    return os << fmt.DebugTuple("").Field(value.x()).Field(value.y()).Finish();
+    if (value.infinity()) {
+      return os << "Infinity";
+    } else {
+      return os
+             << fmt.DebugTuple("").Field(value.x()).Field(value.y()).Finish();
+    }
   }
 };
 


### PR DESCRIPTION
# Description

When printing a debug string and when creating a point, Halo2 treats the point at infinity specially. This PR handles both cases.
