### PR TITLE
fix(zk): fix `RustDebugStringifier` for `zk::Expression<F>`

### DIFF
--- a/tachyon/zk/plonk/halo2/stringifiers/BUILD.bazel
+++ b/tachyon/zk/plonk/halo2/stringifiers/BUILD.bazel
@@ -37,6 +37,7 @@ tachyon_cc_library(
         ":field_stringifier",
         ":phase_stringifier",
         ":rotation_stringifier",
+        ":selector_stringifier",
         "//tachyon/zk/expressions:advice_expression",
         "//tachyon/zk/expressions:challenge_expression",
         "//tachyon/zk/expressions:constant_expression",
@@ -120,5 +121,14 @@ tachyon_cc_library(
     deps = [
         "//tachyon/base/strings:rust_stringifier",
         "//tachyon/zk/base:rotation",
+    ],
+)
+
+tachyon_cc_library(
+    name = "selector_stringifier",
+    hdrs = ["selector_stringifier.h"],
+    deps = [
+        "//tachyon/base/strings:rust_stringifier",
+        "//tachyon/zk/plonk/constraint_system:selector",
     ],
 )

--- a/tachyon/zk/plonk/halo2/stringifiers/expression_stringifier.h
+++ b/tachyon/zk/plonk/halo2/stringifiers/expression_stringifier.h
@@ -21,6 +21,7 @@
 #include "tachyon/zk/plonk/halo2/stringifiers/field_stringifier.h"
 #include "tachyon/zk/plonk/halo2/stringifiers/phase_stringifier.h"
 #include "tachyon/zk/plonk/halo2/stringifiers/rotation_stringifier.h"
+#include "tachyon/zk/plonk/halo2/stringifiers/selector_stringifier.h"
 
 namespace tachyon::base::internal {
 
@@ -37,8 +38,7 @@ class RustDebugStringifier<zk::Expression<F>> {
       }
       case zk::ExpressionType::kSelector: {
         zk::plonk::Selector selector = expression.ToSelector()->selector();
-        return os
-               << fmt.DebugTuple("Selector").Field(selector.index()).Finish();
+        return os << fmt.DebugTuple("Selector").Field(selector).Finish();
       }
       case zk::ExpressionType::kFixed: {
         const zk::plonk::FixedQuery& query = expression.ToFixed()->query();

--- a/tachyon/zk/plonk/halo2/stringifiers/selector_stringifier.h
+++ b/tachyon/zk/plonk/halo2/stringifiers/selector_stringifier.h
@@ -1,0 +1,31 @@
+// Copyright 2020-2022 The Electric Coin Company
+// Copyright 2022 The Halo2 developers
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.halo2 and the LICENCE-APACHE.halo2
+// file.
+
+#ifndef TACHYON_ZK_PLONK_HALO2_STRINGIFIERS_SELECTOR_STRINGIFIER_H_
+#define TACHYON_ZK_PLONK_HALO2_STRINGIFIERS_SELECTOR_STRINGIFIER_H_
+
+#include <ostream>
+
+#include "tachyon/base/strings/rust_stringifier.h"
+#include "tachyon/zk/plonk/constraint_system/selector.h"
+
+namespace tachyon::base::internal {
+
+template <>
+class RustDebugStringifier<zk::plonk::Selector> {
+ public:
+  static std::ostream& AppendToStream(std::ostream& os, RustFormatter& fmt,
+                                      zk::plonk::Selector selector) {
+    return os << fmt.DebugTuple("Selector")
+                     .Field(selector.index())
+                     .Field(selector.is_simple())
+                     .Finish();
+  }
+};
+
+}  // namespace tachyon::base::internal
+
+#endif  // TACHYON_ZK_PLONK_HALO2_STRINGIFIERS_SELECTOR_STRINGIFIER_H_


### PR DESCRIPTION
# Description
This PR fixes a bug in RustDebugStringifier. 

See https://github.com/kroma-network/halo2/blob/7d0a36990452c8e7ebd600de258420781a9b7917/halo2_proofs/src/plonk/circuit.rs#L1099


