### PR TITLE
refac: add `at` to polynomials

### DIFF
--- a/tachyon/c/math/polynomials/univariate/bn254_univariate_dense_polynomial_unittest.cc
+++ b/tachyon/c/math/polynomials/univariate/bn254_univariate_dense_polynomial_unittest.cc
@@ -35,16 +35,18 @@ class UnivariateDensePolynomialTest : public testing::Test {
 }  // namespace
 
 TEST_F(UnivariateDensePolynomialTest, Clone) {
-  if (reinterpret_cast<Poly&>(*poly_)[0] != nullptr) {
+  if (reinterpret_cast<Poly&>(*poly_).NumElements() > 0) {
     tachyon_bn254_univariate_dense_polynomial* poly_clone =
         tachyon_bn254_univariate_dense_polynomial_clone(poly_);
-    *reinterpret_cast<Poly&>(*poly_)[0] += bn254::Fr::One();
+    // NOTE(chokobole): It's safe to access since we checked |NumElements()| is
+    // greater than 0.
+    reinterpret_cast<Poly&>(*poly_).at(0) += bn254::Fr::One();
     EXPECT_NE((reinterpret_cast<Poly&>(*poly_))[0],
               (reinterpret_cast<Poly&>(*poly_clone))[0]);
     tachyon_bn254_univariate_dense_polynomial_destroy(poly_clone);
   } else {
     GTEST_SKIP() << "This test assumes that the coefficient for the 0th degree "
-                    "is not zero";
+                    "is not empty";
   }
 }
 

--- a/tachyon/c/math/polynomials/univariate/bn254_univariate_evaluation_domain.cc
+++ b/tachyon/c/math/polynomials/univariate/bn254_univariate_evaluation_domain.cc
@@ -29,7 +29,7 @@ tachyon_bn254_univariate_evaluation_domain_empty_evals(
     const tachyon_bn254_univariate_evaluation_domain* domain) {
   return reinterpret_cast<tachyon_bn254_univariate_evaluations*>(
       new Domain::Evals(
-          reinterpret_cast<const Domain*>(domain)->Empty<Domain::Evals>()));
+          reinterpret_cast<const Domain*>(domain)->Zero<Domain::Evals>()));
 }
 
 tachyon_bn254_univariate_dense_polynomial*
@@ -37,7 +37,7 @@ tachyon_bn254_univariate_evaluation_domain_empty_poly(
     const tachyon_bn254_univariate_evaluation_domain* domain) {
   return reinterpret_cast<tachyon_bn254_univariate_dense_polynomial*>(
       new Domain::DensePoly(
-          reinterpret_cast<const Domain*>(domain)->Empty<Domain::DensePoly>()));
+          reinterpret_cast<const Domain*>(domain)->Zero<Domain::DensePoly>()));
 }
 
 tachyon_bn254_univariate_rational_evaluations*
@@ -45,7 +45,7 @@ tachyon_bn254_univariate_evaluation_domain_empty_rational_evals(
     const tachyon_bn254_univariate_evaluation_domain* domain) {
   return reinterpret_cast<tachyon_bn254_univariate_rational_evaluations*>(
       new RationalEvals(
-          reinterpret_cast<const Domain*>(domain)->Empty<RationalEvals>()));
+          reinterpret_cast<const Domain*>(domain)->Zero<RationalEvals>()));
 }
 
 tachyon_bn254_univariate_evaluations*

--- a/tachyon/c/math/polynomials/univariate/bn254_univariate_evaluation_domain_unittest.cc
+++ b/tachyon/c/math/polynomials/univariate/bn254_univariate_evaluation_domain_unittest.cc
@@ -38,7 +38,7 @@ class UnivariateEvaluationDomainTest : public testing::Test {
 
 TEST_F(UnivariateEvaluationDomainTest, EmptyEvals) {
   Domain::Evals cpp_evals =
-      reinterpret_cast<Domain*>(domain_)->Empty<Domain::Evals>();
+      reinterpret_cast<Domain*>(domain_)->Zero<Domain::Evals>();
   tachyon_bn254_univariate_evaluations* evals =
       tachyon_bn254_univariate_evaluation_domain_empty_evals(domain_);
   EXPECT_EQ(cpp_evals, reinterpret_cast<Domain::Evals&>(*evals));
@@ -47,7 +47,7 @@ TEST_F(UnivariateEvaluationDomainTest, EmptyEvals) {
 
 TEST_F(UnivariateEvaluationDomainTest, EmptyPoly) {
   Domain::DensePoly cpp_poly =
-      reinterpret_cast<Domain*>(domain_)->Empty<Domain::DensePoly>();
+      reinterpret_cast<Domain*>(domain_)->Zero<Domain::DensePoly>();
   tachyon_bn254_univariate_dense_polynomial* poly =
       tachyon_bn254_univariate_evaluation_domain_empty_poly(domain_);
   EXPECT_EQ(cpp_poly, reinterpret_cast<Domain::DensePoly&>(*poly));
@@ -56,7 +56,7 @@ TEST_F(UnivariateEvaluationDomainTest, EmptyPoly) {
 
 TEST_F(UnivariateEvaluationDomainTest, EmptyRationalEvals) {
   RationalEvals cpp_evals =
-      reinterpret_cast<Domain*>(domain_)->Empty<RationalEvals>();
+      reinterpret_cast<Domain*>(domain_)->Zero<RationalEvals>();
   tachyon_bn254_univariate_rational_evaluations* evals =
       tachyon_bn254_univariate_evaluation_domain_empty_rational_evals(domain_);
   EXPECT_EQ(cpp_evals, reinterpret_cast<RationalEvals&>(*evals));

--- a/tachyon/c/math/polynomials/univariate/bn254_univariate_evaluations.cc
+++ b/tachyon/c/math/polynomials/univariate/bn254_univariate_evaluations.cc
@@ -33,6 +33,7 @@ size_t tachyon_bn254_univariate_evaluations_len(
 void tachyon_bn254_univariate_evaluations_set_value(
     tachyon_bn254_univariate_evaluations* evals, size_t i,
     const tachyon_bn254_fr* value) {
-  *reinterpret_cast<Evals&>(*evals)[i] =
+  // NOTE(chokobole): Boundary check is the responsibility of API callers.
+  reinterpret_cast<Evals&>(*evals).at(i) =
       reinterpret_cast<const bn254::Fr&>(*value);
 }

--- a/tachyon/c/math/polynomials/univariate/bn254_univariate_evaluations_unittest.cc
+++ b/tachyon/c/math/polynomials/univariate/bn254_univariate_evaluations_unittest.cc
@@ -39,7 +39,8 @@ class UnivariateEvaluationsTest : public testing::Test {
 TEST_F(UnivariateEvaluationsTest, Clone) {
   tachyon_bn254_univariate_evaluations* evals_clone =
       tachyon_bn254_univariate_evaluations_clone(evals_);
-  *reinterpret_cast<Evals&>(*evals_)[0] += bn254::Fr::One();
+  // NOTE(chokobole): It's safe to access since we created |kDegree| |evals_|.
+  reinterpret_cast<Evals&>(*evals_).at(0) += bn254::Fr::One();
   EXPECT_NE((reinterpret_cast<Evals&>(*evals_))[0],
             (reinterpret_cast<Evals&>(*evals_clone))[0]);
   tachyon_bn254_univariate_evaluations_destroy(evals_clone);
@@ -53,7 +54,8 @@ TEST_F(UnivariateEvaluationsTest, SetValue) {
   bn254::Fr cpp_value = bn254::Fr::Random();
   tachyon_bn254_fr value = cc::math::ToCPrimeField(cpp_value);
   tachyon_bn254_univariate_evaluations_set_value(evals_, 0, &value);
-  EXPECT_EQ(*reinterpret_cast<Evals&>(*evals_)[0], cpp_value);
+  // NOTE(chokobole): It's safe to access since we created |kDegree| |evals_|.
+  EXPECT_EQ(reinterpret_cast<Evals&>(*evals_)[0], cpp_value);
 }
 
 }  // namespace tachyon::math

--- a/tachyon/c/math/polynomials/univariate/bn254_univariate_rational_evaluations.cc
+++ b/tachyon/c/math/polynomials/univariate/bn254_univariate_rational_evaluations.cc
@@ -42,21 +42,24 @@ size_t tachyon_bn254_univariate_rational_evaluations_len(
 
 void tachyon_bn254_univariate_rational_evaluations_set_zero(
     tachyon_bn254_univariate_rational_evaluations* evals, size_t i) {
-  *reinterpret_cast<RationalEvals&>(*evals)[i] =
+  // NOTE(chokobole): Boundary check is the responsibility of API callers.
+  reinterpret_cast<RationalEvals&>(*evals).at(i) =
       RationalField<bn254::Fr>::Zero();
 }
 
 void tachyon_bn254_univariate_rational_evaluations_set_trivial(
     tachyon_bn254_univariate_rational_evaluations* evals, size_t i,
     const tachyon_bn254_fr* numerator) {
-  *reinterpret_cast<RationalEvals&>(*evals)[i] =
+  // NOTE(chokobole): Boundary check is the responsibility of API callers.
+  reinterpret_cast<RationalEvals&>(*evals).at(i) =
       RationalField<bn254::Fr>(reinterpret_cast<const bn254::Fr&>(*numerator));
 }
 
 void tachyon_bn254_univariate_rational_evaluations_set_rational(
     tachyon_bn254_univariate_rational_evaluations* evals, size_t i,
     const tachyon_bn254_fr* numerator, const tachyon_bn254_fr* denominator) {
-  *reinterpret_cast<RationalEvals&>(*evals)[i] = {
+  // NOTE(chokobole): Boundary check is the responsibility of API callers.
+  reinterpret_cast<RationalEvals&>(*evals).at(i) = {
       reinterpret_cast<const bn254::Fr&>(*numerator),
       reinterpret_cast<const bn254::Fr&>(*denominator),
   };

--- a/tachyon/c/math/polynomials/univariate/bn254_univariate_rational_evaluations_unittest.cc
+++ b/tachyon/c/math/polynomials/univariate/bn254_univariate_rational_evaluations_unittest.cc
@@ -47,7 +47,8 @@ class UnivariateRationalEvaluationsTest : public testing::Test {
 TEST_F(UnivariateRationalEvaluationsTest, Clone) {
   tachyon_bn254_univariate_rational_evaluations* evals_clone =
       tachyon_bn254_univariate_rational_evaluations_clone(evals_);
-  *reinterpret_cast<RationalEvals&>(*evals_)[0] +=
+  // NOTE(chokobole): It's safe to access since we created |kDegree| |evals_|.
+  reinterpret_cast<RationalEvals&>(*evals_).at(0) +=
       RationalField<bn254::Fr>::One();
   EXPECT_NE((reinterpret_cast<RationalEvals&>(*evals_))[0],
             (reinterpret_cast<RationalEvals&>(*evals_clone))[0]);
@@ -61,7 +62,7 @@ TEST_F(UnivariateRationalEvaluationsTest, Len) {
 
 TEST_F(UnivariateRationalEvaluationsTest, SetZero) {
   tachyon_bn254_univariate_rational_evaluations_set_zero(evals_, 0);
-  EXPECT_TRUE(reinterpret_cast<RationalEvals&>(*evals_)[0]->IsZero());
+  EXPECT_TRUE(reinterpret_cast<RationalEvals&>(*evals_)[0].IsZero());
 }
 
 TEST_F(UnivariateRationalEvaluationsTest, SetTrivial) {
@@ -70,7 +71,7 @@ TEST_F(UnivariateRationalEvaluationsTest, SetTrivial) {
   tachyon_bn254_fr numerator = cc::math::ToCPrimeField(expected.numerator());
   tachyon_bn254_univariate_rational_evaluations_set_trivial(evals_, 0,
                                                             &numerator);
-  EXPECT_EQ(*reinterpret_cast<RationalEvals&>(*evals_)[0], expected);
+  EXPECT_EQ(reinterpret_cast<RationalEvals&>(*evals_)[0], expected);
 }
 
 TEST_F(UnivariateRationalEvaluationsTest, SetRational) {
@@ -80,7 +81,7 @@ TEST_F(UnivariateRationalEvaluationsTest, SetRational) {
       cc::math::ToCPrimeField(expected.denominator());
   tachyon_bn254_univariate_rational_evaluations_set_rational(
       evals_, 0, &numerator, &denominator);
-  EXPECT_EQ(*reinterpret_cast<RationalEvals&>(*evals_)[0], expected);
+  EXPECT_EQ(reinterpret_cast<RationalEvals&>(*evals_)[0], expected);
 }
 
 TEST_F(UnivariateRationalEvaluationsTest, BatchEvaluate) {

--- a/tachyon/crypto/commitments/fri/fri.h
+++ b/tachyon/crypto/commitments/fri/fri.h
@@ -82,9 +82,7 @@ class FRI final
     VLOG(2) << "FRI(beta[" << num_layers - 1
             << "]): " << beta.ToHexString(true);
     folded_poly = cur_poly->template Fold<false>(beta);
-    const F* constant = folded_poly[0];
-    root = constant ? *constant : F::Zero();
-    return writer->WriteToProof(root);
+    return writer->WriteToProof(folded_poly[0]);
   }
 
   [[nodiscard]] bool DoCreateOpeningProof(size_t index,

--- a/tachyon/crypto/commitments/kzg/shplonk.h
+++ b/tachyon/crypto/commitments/kzg/shplonk.h
@@ -166,9 +166,18 @@ class SHPlonk final : public UnivariatePolynomialCommitmentScheme<
               grouped_poly_openings.poly_openings_vec,
               [&u, &low_degree_extensions](
                   size_t i, const PolynomialOpenings<Poly>& poly_openings) {
+                using Coefficients = typename Poly::Coefficients;
+
                 Poly poly = *poly_openings.poly_oracle;
-                *poly[0] -= low_degree_extensions[i].Evaluate(u);
-                return poly;
+                if (poly.NumElements() > 0) {
+                  // NOTE(chokobole): It's safe to access since we checked
+                  // |NumElements()| is greater than 0.
+                  poly.at(0) -= low_degree_extensions[i].Evaluate(u);
+                  return poly;
+                }
+
+                return Poly(
+                    Coefficients({-low_degree_extensions[i].Evaluate(u)}));
               });
 
           // clang-format off

--- a/tachyon/math/polynomials/multivariate/multilinear_dense_evaluations.h
+++ b/tachyon/math/polynomials/multivariate/multilinear_dense_evaluations.h
@@ -75,11 +75,11 @@ class MultilinearDenseEvaluations {
     return !operator==(other);
   }
 
-  constexpr F* Get(size_t i) {
-    return const_cast<F*>(std::as_const(*this).Get(i));
+  constexpr F* operator[](size_t i) {
+    return const_cast<F*>(std::as_const(*this)[i]);
   }
 
-  constexpr const F* Get(size_t i) const {
+  constexpr const F* operator[](size_t i) const {
     if (i < evaluations_.size()) {
       return &evaluations_[i];
     }

--- a/tachyon/math/polynomials/multivariate/multilinear_dense_evaluations.h
+++ b/tachyon/math/polynomials/multivariate/multilinear_dense_evaluations.h
@@ -26,6 +26,7 @@ template <typename F, size_t MaxDegree>
 class MultilinearDenseEvaluations {
  public:
   constexpr static size_t kMaxDegree = MaxDegree;
+  constexpr static F kZero = F::Zero();
 
   using Field = F;
   using Point = std::vector<F>;
@@ -75,15 +76,18 @@ class MultilinearDenseEvaluations {
     return !operator==(other);
   }
 
-  constexpr F* operator[](size_t i) {
-    return const_cast<F*>(std::as_const(*this)[i]);
+  constexpr F& at(size_t i) {
+    CHECK_LT(i, evaluations_.size());
+    return evaluations_[i];
   }
 
-  constexpr const F* operator[](size_t i) const {
+  constexpr const F& at(size_t i) const { return (*this)[i]; }
+
+  constexpr const F& operator[](size_t i) const {
     if (i < evaluations_.size()) {
-      return &evaluations_[i];
+      return evaluations_[i];
     }
-    return nullptr;
+    return kZero;
   }
 
   constexpr bool IsZero() const {

--- a/tachyon/math/polynomials/multivariate/multilinear_dense_evaluations_unittest.cc
+++ b/tachyon/math/polynomials/multivariate/multilinear_dense_evaluations_unittest.cc
@@ -76,9 +76,9 @@ TEST_F(MultilinearDenseEvaluationsTest, IndexingOperator) {
   for (const auto& test : tests) {
     for (size_t i = 0; i < kMaxDegree; ++i) {
       if (i < test.evaluations.size()) {
-        EXPECT_EQ(*test.poly[i], GF7(test.evaluations[i]));
+        EXPECT_EQ(test.poly[i], GF7(test.evaluations[i]));
       } else {
-        EXPECT_EQ(test.poly[i], nullptr);
+        EXPECT_EQ(test.poly[i], GF7::Zero());
       }
     }
   }
@@ -109,10 +109,10 @@ TEST_F(MultilinearDenseEvaluationsTest, Evaluate) {
   for (const Poly& poly : polys_) {
     size_t degree = poly.Degree();
     for (size_t i = 0; i < (size_t{1} << degree); ++i) {
-      const GF7* elem = poly[i];
-      if (!elem) break;
+      const GF7& elem = poly[i];
+      if (elem.IsZero()) break;
       Point point = convert_to_le(i, degree);
-      EXPECT_EQ(poly.Evaluate(point), *elem);
+      EXPECT_EQ(poly.Evaluate(point), elem);
     }
   }
 }

--- a/tachyon/math/polynomials/multivariate/multilinear_extension.h
+++ b/tachyon/math/polynomials/multivariate/multilinear_extension.h
@@ -63,9 +63,17 @@ class MultilinearExtension final
     return !operator==(other);
   }
 
-  constexpr Field* operator[](size_t i) { return evaluations_[i]; }
+  // Returns a reference to the coefficient for the given |i| if it exists.
+  // Otherwise, it terminates the program.
+  constexpr Field& at(size_t i) { return evaluations_.at(i); }
 
-  constexpr const Field* operator[](size_t i) const { return evaluations_[i]; }
+  // Returns a reference to the coefficient for the given |i| if it exists.
+  // Otherwise, returns a reference to the |Field::Zero()|.
+  constexpr const Field& at(size_t i) const { return evaluations_.at(i); }
+
+  // Returns a reference to the coefficient for the given |i| if it exists.
+  // Otherwise, returns a reference to the |Field::Zero()|.
+  constexpr const Field& operator[](size_t i) const { return evaluations_[i]; }
 
   constexpr size_t Degree() const { return evaluations_.Degree(); }
 

--- a/tachyon/math/polynomials/multivariate/multilinear_extension.h
+++ b/tachyon/math/polynomials/multivariate/multilinear_extension.h
@@ -63,11 +63,9 @@ class MultilinearExtension final
     return !operator==(other);
   }
 
-  constexpr Field* operator[](size_t i) { return evaluations_.Get(i); }
+  constexpr Field* operator[](size_t i) { return evaluations_[i]; }
 
-  constexpr const Field* operator[](size_t i) const {
-    return evaluations_.Get(i);
-  }
+  constexpr const Field* operator[](size_t i) const { return evaluations_[i]; }
 
   constexpr size_t Degree() const { return evaluations_.Degree(); }
 

--- a/tachyon/math/polynomials/multivariate/multivariate_polynomial.h
+++ b/tachyon/math/polynomials/multivariate/multivariate_polynomial.h
@@ -62,11 +62,11 @@ class MultivariatePolynomial final
   }
 
   constexpr Field* operator[](const Literal& literal) {
-    return coefficients_.Get(literal);
+    return coefficients_[literal];
   }
 
   constexpr const Field* operator[](const Literal& literal) const {
-    return coefficients_.Get(literal);
+    return coefficients_[literal];
   }
 
   constexpr const Field* GetLeadingCoefficient() const {

--- a/tachyon/math/polynomials/multivariate/multivariate_polynomial.h
+++ b/tachyon/math/polynomials/multivariate/multivariate_polynomial.h
@@ -61,15 +61,27 @@ class MultivariatePolynomial final
     return !operator==(other);
   }
 
-  constexpr Field* operator[](const Literal& literal) {
+  // Returns a reference to the coefficient for the given |i| if it exists.
+  // Otherwise, it terminates the program.
+  constexpr Field& at(const Literal& literal) {
+    return coefficients_.at(literal);
+  }
+
+  // Returns a reference to the coefficient for the given |i| if it exists.
+  // Otherwise, returns a reference to the |Field::Zero()|.
+  constexpr const Field& at(const Literal& literal) const {
+    return coefficients_.at(literal);
+  }
+
+  // Returns a reference to the coefficient for the given |i| if it exists.
+  // Otherwise, returns a reference to the |Field::Zero()|.
+  constexpr const Field& operator[](const Literal& literal) const {
     return coefficients_[literal];
   }
 
-  constexpr const Field* operator[](const Literal& literal) const {
-    return coefficients_[literal];
-  }
-
-  constexpr const Field* GetLeadingCoefficient() const {
+  // Returns a reference to the leading coefficient if it exists.
+  // Otherwise, returns a reference to the |Field::Zero()|.
+  constexpr const Field& GetLeadingCoefficient() const {
     return coefficients_.GetLeadingCoefficient();
   }
 

--- a/tachyon/math/polynomials/multivariate/multivariate_polynomial_unittest.cc
+++ b/tachyon/math/polynomials/multivariate/multivariate_polynomial_unittest.cc
@@ -292,7 +292,7 @@ TEST_F(MultivariatePolynomialTest, IndexingOperator) {
   };
 
   for (const auto& test : tests) {
-    EXPECT_EQ(*test.poly[test.literal], test.expected);
+    EXPECT_EQ(test.poly[test.literal], test.expected);
   }
 }
 

--- a/tachyon/math/polynomials/multivariate/multivariate_sparse_coefficients.h
+++ b/tachyon/math/polynomials/multivariate/multivariate_sparse_coefficients.h
@@ -237,11 +237,11 @@ class MultivariateSparseCoefficients {
     return !operator==(other);
   }
 
-  constexpr F* Get(const Literal& literal) {
-    return const_cast<F*>(std::as_const(*this).Get(literal));
+  constexpr F* operator[](const Literal& literal) {
+    return const_cast<F*>(std::as_const(*this)[literal]);
   }
 
-  constexpr const F* Get(const Literal& literal) const {
+  constexpr const F* operator[](const Literal& literal) const {
     auto it = std::lower_bound(terms_.begin(), terms_.end(), literal,
                                [](const Term& term, const Literal& literal) {
                                  return term.literal < literal;

--- a/tachyon/math/polynomials/multivariate/multivariate_sparse_coefficients.h
+++ b/tachyon/math/polynomials/multivariate/multivariate_sparse_coefficients.h
@@ -28,6 +28,7 @@ template <typename F, size_t MaxDegree>
 class MultivariateSparseCoefficients {
  public:
   constexpr static size_t kMaxDegree = MaxDegree;
+  constexpr static F kZero = F::Zero();
 
   using Field = F;
   using Point = std::vector<F>;
@@ -237,24 +238,25 @@ class MultivariateSparseCoefficients {
     return !operator==(other);
   }
 
-  constexpr F* operator[](const Literal& literal) {
-    return const_cast<F*>(std::as_const(*this)[literal]);
+  constexpr F& at(const Literal& literal) {
+    const F* ptr = const_cast<F*>(std::as_const(*this).GetCoefficient(literal));
+    if (ptr) return *ptr;
+    return kZero;
   }
 
-  constexpr const F* operator[](const Literal& literal) const {
-    auto it = std::lower_bound(terms_.begin(), terms_.end(), literal,
-                               [](const Term& term, const Literal& literal) {
-                                 return term.literal < literal;
-                               });
-    if (it != terms_.end() && it->literal == literal) {
-      return &it->coefficient;
-    }
-    return nullptr;
+  constexpr const F& at(const Literal& literal) const {
+    return (*this)[literal];
   }
 
-  constexpr const F* GetLeadingCoefficient() const {
-    if (IsZero()) return nullptr;
-    return &terms_.begin().coefficient;
+  constexpr const F& operator[](const Literal& literal) const {
+    const F* ptr = GetCoefficient(literal);
+    if (ptr) return *ptr;
+    return kZero;
+  }
+
+  constexpr const F& GetLeadingCoefficient() const {
+    if (IsZero()) return kZero;
+    return terms_.begin().coefficient;
   }
 
   constexpr bool IsZero() const { return terms_.empty(); }
@@ -332,6 +334,17 @@ class MultivariateSparseCoefficients {
  private:
   friend class internal::MultivariatePolynomialOp<
       MultivariateSparseCoefficients<F, MaxDegree>>;
+
+  constexpr const F* GetCoefficient(const Literal& literal) const {
+    auto it = std::lower_bound(terms_.begin(), terms_.end(), literal,
+                               [](const Term& term, const Literal& literal) {
+                                 return term.literal < literal;
+                               });
+    if (it != terms_.end() && it->literal == literal) {
+      return &it->coefficient;
+    }
+    return nullptr;
+  }
 
   static F EvaluateSerial(absl::Span<const Term> terms, const Point& points) {
     return std::accumulate(

--- a/tachyon/math/polynomials/univariate/mixed_radix_evaluation_domain.h
+++ b/tachyon/math/polynomials/univariate/mixed_radix_evaluation_domain.h
@@ -225,10 +225,10 @@ class MixedRadixEvaluationDomain
       std::vector<bool> seen(n, false);
       for (size_t k = 0; k < n; ++k) {
         size_t i = k;
-        F& a_i = *a[i];
+        F& a_i = a.at(i);
         while (!seen[i]) {
           size_t dest = MixedRadixFFTPermute(two_adicity, q_adicity, q, n, i);
-          std::swap(*a[dest], a_i);
+          std::swap(a.at(dest), a_i);
           seen[i] = true;
           i = dest;
         }
@@ -248,20 +248,20 @@ class MixedRadixEvaluationDomain
         for (size_t k = 0; k < n; k += q * m) {
           F w_j = F::One();  // ωⱼ is ωₘʲ
           for (size_t j = 0; j < m; ++j) {
-            const F& base_term = *a[k + j];
+            const F& base_term = a[k + j];
             F w_j_i = w_j;
             for (size_t i = 1; i < q; ++i) {
-              terms[i - 1] = *a[k + j + i * m];
+              terms[i - 1] = a[k + j + i * m];
               terms[i - 1] *= w_j_i;
               w_j_i *= w_j;
             }
 
             for (size_t i = 0; i < q; ++i) {
-              *a[k + j + i * m] = base_term;
+              a.at(k + j + i * m) = base_term;
               for (size_t l = 1; l < q; ++l) {
                 F tmp = terms[l - 1];
                 tmp *= qth_roots[(i * l) % q];
-                *a[k + j + i * m] += tmp;
+                a.at(k + j + i * m) += tmp;
               }
             }
 
@@ -282,7 +282,7 @@ class MixedRadixEvaluationDomain
         F w = F::One();
         for (size_t j = 0; j < m; ++j) {
           UnivariateEvaluationDomain<F, MaxDegree>::ButterflyFnOutIn(
-              *a[k + j], *a[(k + m) + j], w);
+              a.at(k + j), a.at((k + m) + j), w);
           w *= w_m;
         }
       }
@@ -359,10 +359,10 @@ class MixedRadixEvaluationDomain
           size_t idx = i + (c * coset_size);
           // t = the value of a corresponding to the ith element of
           // the sth coset.
-          F t = *a[idx];
+          F t = a[idx];
           // elt = g^{k * idx}
           t *= elt;
-          *kth_poly_coeffs[i] += t;
+          kth_poly_coeffs.at(i) += t;
           elt *= omega_step;
         }
         elt *= omega_k;
@@ -377,7 +377,7 @@ class MixedRadixEvaluationDomain
     // shuffle the values computed above into a
     // The evaluations of a should be ordered as (1, g, g², ...)
     for (size_t i = 0; i < a.NumElements(); ++i) {
-      *a[i] = *tmp[i % num_cosets][i / num_cosets];
+      a.at(i) = tmp[i % num_cosets][i / num_cosets];
     }
   }
 #endif

--- a/tachyon/math/polynomials/univariate/radix2_evaluation_domain.h
+++ b/tachyon/math/polynomials/univariate/radix2_evaluation_domain.h
@@ -219,13 +219,13 @@ class Radix2EvaluationDomain : public UnivariateEvaluationDomain<F, MaxDegree> {
       if (gap > kMinGapSizeForParallelization && chunk_size < thread_nums) {
         OPENMP_PARALLEL_FOR(size_t j = 0; j < gap; ++j) {
           if (j * step < roots.size()) {
-            fn(*poly_or_evals[i + j], *poly_or_evals[i + j + gap],
+            fn(poly_or_evals.at(i + j), poly_or_evals.at(i + j + gap),
                roots[j * step]);
           }
         }
       } else {
         for (size_t j = 0, k = 0; j < gap && k < roots.size(); ++j, k += step) {
-          fn(*poly_or_evals[i + j], *poly_or_evals[i + j + gap], roots[k]);
+          fn(poly_or_evals.at(i + j), poly_or_evals.at(i + j + gap), roots[k]);
         }
       }
     }

--- a/tachyon/math/polynomials/univariate/univariate_dense_coefficients.h
+++ b/tachyon/math/polynomials/univariate/univariate_dense_coefficients.h
@@ -126,7 +126,7 @@ class UnivariateDenseCoefficients {
   }
 
   constexpr F* operator[](size_t i) {
-    return const_cast<F*>(std::as_const(*this).operator[](i));
+    return const_cast<F*>(std::as_const(*this)[i]);
   }
 
   constexpr const F* operator[](size_t i) const {

--- a/tachyon/math/polynomials/univariate/univariate_dense_coefficients.h
+++ b/tachyon/math/polynomials/univariate/univariate_dense_coefficients.h
@@ -42,6 +42,8 @@ class UnivariateDenseCoefficients {
  public:
   constexpr static size_t kMaxDegree = MaxDegree;
 
+  constexpr static F kZero = F::Zero();
+
   using Field = F;
   using Point = F;
 
@@ -125,20 +127,22 @@ class UnivariateDenseCoefficients {
     return !operator==(other);
   }
 
-  constexpr F* operator[](size_t i) {
-    return const_cast<F*>(std::as_const(*this)[i]);
+  constexpr F& at(size_t i) {
+    CHECK_LT(i, coefficients_.size());
+    return coefficients_[i];
   }
+  constexpr const F& at(size_t i) const { return (*this)[i]; }
 
-  constexpr const F* operator[](size_t i) const {
+  constexpr const F& operator[](size_t i) const {
     if (i < coefficients_.size()) {
-      return &coefficients_[i];
+      return coefficients_[i];
     }
-    return nullptr;
+    return kZero;
   }
 
-  constexpr const F* GetLeadingCoefficient() const {
-    if (IsZero()) return nullptr;
-    return &coefficients_.back();
+  constexpr const F& GetLeadingCoefficient() const {
+    if (IsZero()) return kZero;
+    return coefficients_.back();
   }
 
   constexpr bool IsZero() const { return coefficients_.empty(); }

--- a/tachyon/math/polynomials/univariate/univariate_dense_polynomial_unittest.cc
+++ b/tachyon/math/polynomials/univariate/univariate_dense_polynomial_unittest.cc
@@ -74,9 +74,9 @@ TEST_F(UnivariateDensePolynomialTest, IndexingOperator) {
   for (const auto& test : tests) {
     for (size_t i = 0; i < kMaxDegree; ++i) {
       if (i < test.coefficients.size()) {
-        EXPECT_EQ(*test.poly[i], GF7(test.coefficients[i]));
+        EXPECT_EQ(test.poly[i], GF7(test.coefficients[i]));
       } else {
-        EXPECT_EQ(test.poly[i], nullptr);
+        EXPECT_EQ(test.poly[i], GF7::Zero());
       }
     }
   }
@@ -328,55 +328,38 @@ TEST_F(UnivariateDensePolynomialTest, EvaluateVanishingPolyByRoots) {
             poly.Evaluate(point));
 }
 
-#define GET_COEFF(poly, degree)                \
-  ({                                           \
-    GF7* coeff = poly[degree];                 \
-    (coeff == nullptr) ? GF7::Zero() : *coeff; \
-  })
-
 TEST_F(UnivariateDensePolynomialTest, FoldEven) {
   Poly poly = Poly::Random(kMaxDegree);
   GF7 r = GF7::Random();
   Poly folded = poly.Fold<true>(r);
-  EXPECT_EQ(folded,
-            Poly(Coeffs({r * GET_COEFF(poly, 0) + GET_COEFF(poly, 1),
-                         r * GET_COEFF(poly, 2) + GET_COEFF(poly, 3),
-                         r * GET_COEFF(poly, 4) + GET_COEFF(poly, 5)})));
+  EXPECT_EQ(folded, Poly(Coeffs({r * poly[0] + poly[1], r * poly[2] + poly[3],
+                                 r * poly[4] + poly[5]})));
 
   GF7 r2 = GF7::Random();
   Poly folded2 = folded.Fold<true>(r2);
   EXPECT_EQ(folded2,
-            Poly(Coeffs({r2 * GET_COEFF(folded, 0) + GET_COEFF(folded, 1),
-                         r2 * GET_COEFF(folded, 2)})));
+            Poly(Coeffs({r2 * folded[0] + folded[1], r2 * folded[2]})));
 
   GF7 r3 = GF7::Random();
   Poly folded3 = folded2.Fold<true>(r3);
-  EXPECT_EQ(folded3,
-            Poly(Coeffs({r3 * GET_COEFF(folded2, 0) + GET_COEFF(folded2, 1)})));
+  EXPECT_EQ(folded3, Poly(Coeffs({r3 * folded2[0] + folded2[1]})));
 }
 
 TEST_F(UnivariateDensePolynomialTest, FoldOdd) {
   Poly poly = Poly::Random(kMaxDegree);
   GF7 r = GF7::Random();
   Poly folded = poly.Fold<false>(r);
-  EXPECT_EQ(folded,
-            Poly(Coeffs({GET_COEFF(poly, 0) + r * GET_COEFF(poly, 1),
-                         GET_COEFF(poly, 2) + r * GET_COEFF(poly, 3),
-                         GET_COEFF(poly, 4) + r * GET_COEFF(poly, 5)})));
+  EXPECT_EQ(folded, Poly(Coeffs({poly[0] + r * poly[1], poly[2] + r * poly[3],
+                                 poly[4] + r * poly[5]})));
 
   GF7 r2 = GF7::Random();
   Poly folded2 = folded.Fold<false>(r2);
-  EXPECT_EQ(folded2,
-            Poly(Coeffs({GET_COEFF(folded, 0) + r2 * GET_COEFF(folded, 1),
-                         GET_COEFF(folded, 2)})));
+  EXPECT_EQ(folded2, Poly(Coeffs({folded[0] + r2 * folded[1], folded[2]})));
 
   GF7 r3 = GF7::Random();
   Poly folded3 = folded2.Fold<false>(r3);
-  EXPECT_EQ(folded3,
-            Poly(Coeffs({GET_COEFF(folded2, 0) + r3 * GET_COEFF(folded2, 1)})));
+  EXPECT_EQ(folded3, Poly(Coeffs({folded2[0] + r3 * folded2[1]})));
 }
-
-#undef GET_COEFF
 
 TEST_F(UnivariateDensePolynomialTest, Copyable) {
   Poly expected = Poly::Random(kMaxDegree);

--- a/tachyon/math/polynomials/univariate/univariate_evaluation_domain.h
+++ b/tachyon/math/polynomials/univariate/univariate_evaluation_domain.h
@@ -337,7 +337,7 @@ class UnivariateEvaluationDomain : public EvaluationDomain<F, MaxDegree> {
       F pow = c * g.Pow(i);
       for (size_t j = 0; j < num_elems_per_thread; ++j) {
         if (i + j >= size) break;
-        (*poly_or_evals[i + j]) *= pow;
+        poly_or_evals.at(i + j) *= pow;
         pow *= g;
       }
     }
@@ -428,7 +428,7 @@ class UnivariateEvaluationDomain : public EvaluationDomain<F, MaxDegree> {
     for (size_t idx = 1; idx < size; ++idx) {
       size_t ridx = base::bits::BitRev(idx) >> (sizeof(size_t) * 8 - log_len);
       if (idx < ridx) {
-        std::swap(*poly_or_evals[idx], *poly_or_evals[ridx]);
+        std::swap(poly_or_evals.at(idx), poly_or_evals.at(ridx));
       }
     }
   }

--- a/tachyon/math/polynomials/univariate/univariate_evaluation_domain.h
+++ b/tachyon/math/polynomials/univariate/univariate_evaluation_domain.h
@@ -101,7 +101,7 @@ class UnivariateEvaluationDomain : public EvaluationDomain<F, MaxDegree> {
   }
 
   template <typename T>
-  constexpr T Empty() const {
+  constexpr T Zero() const {
     return T::Zero(size_ - 1);
   }
 

--- a/tachyon/math/polynomials/univariate/univariate_evaluation_domain_unittest.cc
+++ b/tachyon/math/polynomials/univariate/univariate_evaluation_domain_unittest.cc
@@ -197,7 +197,7 @@ TYPED_TEST(UnivariateEvaluationDomainTest, NonSystematicLagrangeCoefficients) {
       // evaluation
       F interpolated_eval = F::Zero();
       for (size_t i = 0; i < domain_size; ++i) {
-        interpolated_eval += lagrange_coeffs[i] * (*poly_evals[i]);
+        interpolated_eval += lagrange_coeffs[i] * poly_evals[i];
       }
       EXPECT_EQ(actual_eval, interpolated_eval);
     });
@@ -266,7 +266,7 @@ TYPED_TEST(UnivariateEvaluationDomainTest, FFTCorrectness) {
         domain_size, [domain_size, &rand_poly](const BaseDomain& d) {
           Evals poly_evals = d.FFT(rand_poly);
           for (size_t i = 0; i < domain_size; ++i) {
-            EXPECT_EQ(*poly_evals[i], rand_poly.Evaluate(d.GetElement(i)));
+            EXPECT_EQ(poly_evals[i], rand_poly.Evaluate(d.GetElement(i)));
           }
           EXPECT_EQ(rand_poly, d.IFFT(poly_evals));
         });
@@ -291,7 +291,7 @@ TYPED_TEST(UnivariateEvaluationDomainTest, DegreeAwareFFTCorrectness) {
                                     &rand_poly](const BaseDomain& d) {
       Evals deg_aware_fft_evals = d.FFT(rand_poly);
       for (size_t i = 0; i < domain_size; ++i) {
-        EXPECT_EQ(*deg_aware_fft_evals[i], rand_poly.Evaluate(d.GetElement(i)));
+        EXPECT_EQ(deg_aware_fft_evals[i], rand_poly.Evaluate(d.GetElement(i)));
       }
     });
   } else {

--- a/tachyon/math/polynomials/univariate/univariate_evaluations.h
+++ b/tachyon/math/polynomials/univariate/univariate_evaluations.h
@@ -44,6 +44,7 @@ class UnivariateEvaluations final
     : public Polynomial<UnivariateEvaluations<F, MaxDegree>> {
  public:
   constexpr static size_t kMaxDegree = MaxDegree;
+  constexpr static F kZero = F::Zero();
 
   using Field = F;
 
@@ -119,15 +120,24 @@ class UnivariateEvaluations final
     return !operator==(other);
   }
 
-  constexpr F* operator[](size_t i) {
-    return const_cast<F*>(std::as_const(*this)[i]);
+  // Returns a reference to the coefficient for the given |i| if it exists.
+  // Otherwise, it terminates the program.
+  constexpr F& at(size_t i) {
+    CHECK_LT(i, evaluations_.size());
+    return evaluations_[i];
   }
 
-  constexpr const F* operator[](size_t i) const {
+  // Returns a reference to the coefficient for the given |i| if it exists.
+  // Otherwise, returns a reference to the |F::Zero()|.
+  constexpr const F& at(size_t i) const { return (*this)[i]; }
+
+  // Returns a reference to the coefficient for the given |i| if it exists.
+  // Otherwise, returns a reference to the |F::Zero()|.
+  constexpr const F& operator[](size_t i) const {
     if (i < evaluations_.size()) {
-      return &evaluations_[i];
+      return evaluations_[i];
     }
-    return nullptr;
+    return kZero;
   }
 
   std::string ToString() const { return base::VectorToString(evaluations_); }

--- a/tachyon/math/polynomials/univariate/univariate_evaluations_unittest.cc
+++ b/tachyon/math/polynomials/univariate/univariate_evaluations_unittest.cc
@@ -82,9 +82,9 @@ TEST_F(UnivariateEvaluationsTest, IndexingOperator) {
   for (const auto& test : tests) {
     for (size_t i = 0; i < kMaxDegree; ++i) {
       if (i < test.evaluations.size()) {
-        EXPECT_EQ(*test.poly[i], GF7(test.evaluations[i]));
+        EXPECT_EQ(test.poly[i], GF7(test.evaluations[i]));
       } else {
-        EXPECT_EQ(test.poly[i], nullptr);
+        EXPECT_EQ(test.poly[i], GF7::Zero());
       }
     }
   }

--- a/tachyon/math/polynomials/univariate/univariate_polynomial.h
+++ b/tachyon/math/polynomials/univariate/univariate_polynomial.h
@@ -91,11 +91,21 @@ class UnivariatePolynomial final
     return !operator==(other);
   }
 
-  constexpr Field* operator[](size_t i) { return coefficients_[i]; }
+  // Returns a reference to the coefficient for the given |i| if it exists.
+  // Otherwise, it terminates the program.
+  constexpr Field& at(size_t i) { return coefficients_.at(i); }
 
-  constexpr const Field* operator[](size_t i) const { return coefficients_[i]; }
+  // Returns a reference to the coefficient for the given |i| if it exists.
+  // Otherwise, returns a reference to the |Field::Zero()|.
+  constexpr const Field& at(size_t i) const { return coefficients_.at(i); }
 
-  constexpr const Field* GetLeadingCoefficient() const {
+  // Returns a reference to the coefficient for the given |i| if it exists.
+  // Otherwise, returns a reference to the |Field::Zero()|.
+  constexpr const Field& operator[](size_t i) const { return coefficients_[i]; }
+
+  // Returns a reference to the leading coefficient if it exists.
+  // Otherwise, returns a reference to the |Field::Zero()|.
+  constexpr const Field& GetLeadingCoefficient() const {
     return coefficients_.GetLeadingCoefficient();
   }
 

--- a/tachyon/math/polynomials/univariate/univariate_polynomial_ops.h
+++ b/tachyon/math/polynomials/univariate/univariate_polynomial_ops.h
@@ -271,10 +271,10 @@ class UnivariatePolynomialOp<UnivariateDenseCoefficients<F, MaxDegree>> {
     // TODO(chokobole): What if this dense polynomial is really sparse..?
     terms.reserve(size);
     for (size_t i = 0; i < size; ++i) {
-      if (self[i] == nullptr || self[i]->IsZero()) {
+      if (self[i].IsZero()) {
         continue;
       }
-      terms.push_back({i, *self[i]});
+      terms.push_back({i, self[i]});
     }
     return UnivariatePolynomial<S>(S(std::move(terms)));
   }
@@ -313,7 +313,7 @@ class UnivariatePolynomialOp<UnivariateDenseCoefficients<F, MaxDegree>> {
         base::CreateVector(self.Degree() - other.Degree() + 1, F::Zero());
     UnivariatePolynomial<D> remainder = self.ToDense();
     std::vector<F>& r_coefficients = remainder.coefficients_.coefficients_;
-    F divisor_leading_inv = other.GetLeadingCoefficient()->Inverse();
+    F divisor_leading_inv = other.GetLeadingCoefficient().Inverse();
 
     while (!remainder.IsZero() && remainder.Degree() >= other.Degree()) {
       F q_coeff =
@@ -482,7 +482,7 @@ class UnivariatePolynomialOp<UnivariateSparseCoefficients<F, MaxDegree>> {
     size_t size = self.Degree() + 1;
     coefficients.reserve(size);
     for (size_t i = 0; i < size; ++i) {
-      coefficients.push_back(self[i] == nullptr ? F::Zero() : *self[i]);
+      coefficients.push_back(self[i]);
     }
     return UnivariatePolynomial<D>(D(std::move(coefficients)));
   }

--- a/tachyon/math/polynomials/univariate/univariate_sparse_coefficients.h
+++ b/tachyon/math/polynomials/univariate/univariate_sparse_coefficients.h
@@ -154,7 +154,7 @@ class UnivariateSparseCoefficients {
   }
 
   constexpr F* operator[](size_t i) {
-    return const_cast<F*>(std::as_const(*this).operator[](i));
+    return const_cast<F*>(std::as_const(*this)[i]);
   }
 
   constexpr const F* operator[](size_t i) const {

--- a/tachyon/math/polynomials/univariate/univariate_sparse_coefficients.h
+++ b/tachyon/math/polynomials/univariate/univariate_sparse_coefficients.h
@@ -93,6 +93,7 @@ template <typename F, size_t MaxDegree>
 class UnivariateSparseCoefficients {
  public:
   constexpr static size_t kMaxDegree = MaxDegree;
+  constexpr static F kZero = F::Zero();
 
   using Field = F;
   using Point = F;
@@ -153,22 +154,23 @@ class UnivariateSparseCoefficients {
     return !operator==(other);
   }
 
-  constexpr F* operator[](size_t i) {
-    return const_cast<F*>(std::as_const(*this)[i]);
+  constexpr F& at(size_t i) {
+    F* ptr = const_cast<F*>(std::as_const(*this).GetCoefficient(i));
+    CHECK(ptr);
+    return *ptr;
   }
 
-  constexpr const F* operator[](size_t i) const {
-    auto it = std::lower_bound(
-        terms_.begin(), terms_.end(), i,
-        [](const Term& term, size_t degree) { return term.degree < degree; });
-    if (it == terms_.end()) return nullptr;
-    if (it->degree != i) return nullptr;
-    return &it->coefficient;
+  constexpr const F& at(size_t i) const { return (*this)[i]; }
+
+  constexpr const F& operator[](size_t i) const {
+    const F* ptr = GetCoefficient(i);
+    if (ptr) return *ptr;
+    return kZero;
   }
 
-  constexpr const F* GetLeadingCoefficient() const {
-    if (IsZero()) return nullptr;
-    return &terms_.back().coefficient;
+  constexpr const F& GetLeadingCoefficient() const {
+    if (IsZero()) return kZero;
+    return terms_.back().coefficient;
   }
 
   constexpr bool IsZero() const { return terms_.empty(); }
@@ -272,6 +274,15 @@ class UnivariateSparseCoefficients {
   friend class internal::UnivariatePolynomialOp<
       UnivariateSparseCoefficients<F, MaxDegree>>;
   friend class base::Copyable<UnivariateSparseCoefficients<F, MaxDegree>>;
+
+  constexpr const F* GetCoefficient(size_t i) const {
+    auto it = std::lower_bound(
+        terms_.begin(), terms_.end(), i,
+        [](const Term& term, size_t degree) { return term.degree < degree; });
+    if (it == terms_.end()) return nullptr;
+    if (it->degree != i) return nullptr;
+    return &it->coefficient;
+  }
 
   void RemoveHighDegreeZeros() {  // Fix to RemoveZeros
     while (!IsZero()) {

--- a/tachyon/zk/base/blinder.h
+++ b/tachyon/zk/base/blinder.h
@@ -38,7 +38,8 @@ class Blinder {
     if (size < blinding_rows) return false;
     RowIndex start = size - blinding_rows;
     for (RowIndex i = start; i < size; ++i) {
-      *evals[i] = random_field_generator_->Generate();
+      // NOTE(chokobole): Boundary check is the responsibility of API callers.
+      evals.at(i) = random_field_generator_->Generate();
     }
     return true;
   }

--- a/tachyon/zk/base/blinder_unittest.cc
+++ b/tachyon/zk/base/blinder_unittest.cc
@@ -62,9 +62,9 @@ TEST(BlinderUnittest, Blind) {
     RowIndex not_blinded_rows = rows - blinded_rows;
     for (RowIndex i = 0; i < rows; ++i) {
       if (i < not_blinded_rows) {
-        EXPECT_EQ(*evals[i], values[i]);
+        EXPECT_EQ(evals[i], values[i]);
       } else {
-        EXPECT_EQ(*evals[i], blinding_values[i - not_blinded_rows]);
+        EXPECT_EQ(evals[i], blinding_values[i - not_blinded_rows]);
       }
     }
   }

--- a/tachyon/zk/expressions/evaluator/simple_evaluator.h
+++ b/tachyon/zk/expressions/evaluator/simple_evaluator.h
@@ -73,36 +73,21 @@ class SimpleEvaluator
         const FixedExpression<Field>* fixed_expr = input->ToFixed();
         const plonk::FixedQuery& query = fixed_expr->query();
         const Evals& evals = fixed_columns_[query.column().index()];
-        const Field* ret =
-            evals[query.rotation().GetIndex(idx_, rot_scale_, size_)];
-        if (ret == nullptr) {
-          return Field::Zero();
-        }
-        return *ret;
+        return evals[query.rotation().GetIndex(idx_, rot_scale_, size_)];
       }
 
       case ExpressionType::kAdvice: {
         const AdviceExpression<Field>* advice_expr = input->ToAdvice();
         const plonk::AdviceQuery& query = advice_expr->query();
         const Evals& evals = advice_columns_[query.column().index()];
-        const Field* ret =
-            evals[query.rotation().GetIndex(idx_, rot_scale_, size_)];
-        if (ret == nullptr) {
-          return Field::Zero();
-        }
-        return *ret;
+        return evals[query.rotation().GetIndex(idx_, rot_scale_, size_)];
       }
 
       case ExpressionType::kInstance: {
         const InstanceExpression<Field>* instance_expr = input->ToInstance();
         const plonk::InstanceQuery& query = instance_expr->query();
         const Evals& evals = instance_columns_[query.column().index()];
-        const Field* ret =
-            evals[query.rotation().GetIndex(idx_, rot_scale_, size_)];
-        if (ret == nullptr) {
-          return Field::Zero();
-        }
-        return *ret;
+        return evals[query.rotation().GetIndex(idx_, rot_scale_, size_)];
       }
       case ExpressionType::kChallenge:
         return challenges_[input->ToChallenge()->challenge().index()];

--- a/tachyon/zk/expressions/evaluator/simple_evaluator_unittest.cc
+++ b/tachyon/zk/expressions/evaluator/simple_evaluator_unittest.cc
@@ -70,10 +70,10 @@ TEST_F(SimpleEvaluatorTest, Fixed) {
                             plonk::FixedColumnKey(test.column_index));
     RowIndex row_index = query.rotation().GetIndex(idx, rot_scale, size);
 
-    const GF7* expected = fixed_columns_[test.column_index][row_index];
+    const GF7& expected = fixed_columns_[test.column_index][row_index];
     Expr expr = ExpressionFactory<GF7>::Fixed(query);
     GF7 evaluated = simple_evaluator_->Evaluate(expr.get());
-    EXPECT_EQ(evaluated, *expected);
+    EXPECT_EQ(evaluated, expected);
   }
 }
 
@@ -97,10 +97,10 @@ TEST_F(SimpleEvaluatorTest, Advice) {
         plonk::AdviceColumnKey(test.column_index, plonk::Phase(0)));
     RowIndex row_index = query.rotation().GetIndex(idx, rot_scale, size);
 
-    const GF7* expected = advice_columns_[test.column_index][row_index];
+    const GF7& expected = advice_columns_[test.column_index][row_index];
     Expr expr = ExpressionFactory<GF7>::Advice(query);
     GF7 evaluated = simple_evaluator_->Evaluate(expr.get());
-    EXPECT_EQ(evaluated, *expected);
+    EXPECT_EQ(evaluated, expected);
   }
 }
 
@@ -123,10 +123,10 @@ TEST_F(SimpleEvaluatorTest, Instance) {
                                plonk::InstanceColumnKey(test.column_index));
     RowIndex row_index = query.rotation().GetIndex(idx, rot_scale, size);
 
-    const GF7* expected = instance_columns_[test.column_index][row_index];
+    const GF7& expected = instance_columns_[test.column_index][row_index];
     Expr expr = ExpressionFactory<GF7>::Instance(query);
     GF7 evaluated = simple_evaluator_->Evaluate(expr.get());
-    EXPECT_EQ(evaluated, *expected);
+    EXPECT_EQ(evaluated, expected);
   }
 }
 

--- a/tachyon/zk/lookup/compress_expression.h
+++ b/tachyon/zk/lookup/compress_expression.h
@@ -20,8 +20,8 @@ Evals CompressExpressions(
     const Domain* domain,
     const std::vector<std::unique_ptr<Expression<F>>>& expressions,
     const F& theta, const SimpleEvaluator<Evals>& evaluator_tpl) {
-  Evals compressed_value = domain->template Empty<Evals>();
-  Evals values = domain->template Empty<Evals>();
+  Evals compressed_value = domain->template Zero<Evals>();
+  Evals values = domain->template Zero<Evals>();
 
   for (size_t expr_idx = 0; expr_idx < expressions.size(); ++expr_idx) {
     base::Parallelize(

--- a/tachyon/zk/lookup/lookup_argument_runner_impl.h
+++ b/tachyon/zk/lookup/lookup_argument_runner_impl.h
@@ -135,8 +135,8 @@ LookupArgumentRunner<Poly, Evals>::CreateNumeratorCallback(
                                     size_t chunk_size) {
     size_t i = chunk_index * chunk_size;
     for (F& value : chunk) {
-      value *= (*permuted.compressed_evals_pair().input()[i] + beta);
-      value *= (*permuted.compressed_evals_pair().table()[i] + gamma);
+      value *= (permuted.compressed_evals_pair().input()[i] + beta);
+      value *= (permuted.compressed_evals_pair().table()[i] + gamma);
       ++i;
     }
   };
@@ -152,8 +152,8 @@ LookupArgumentRunner<Poly, Evals>::CreateDenominatorCallback(
                                     size_t chunk_size) {
     size_t i = chunk_index * chunk_size;
     for (F& value : chunk) {
-      value = (*permuted.permuted_evals_pair().input()[i] + beta) *
-              (*permuted.permuted_evals_pair().table()[i] + gamma);
+      value = (permuted.permuted_evals_pair().input()[i] + beta) *
+              (permuted.permuted_evals_pair().table()[i] + gamma);
       ++i;
     }
   };

--- a/tachyon/zk/lookup/lookup_argument_runner_unittest.cc
+++ b/tachyon/zk/lookup/lookup_argument_runner_unittest.cc
@@ -66,12 +66,12 @@ TEST_F(LookupArgumentRunnerTest, ComputePermutationProduct) {
   for (RowIndex i = 0; i < prover_->GetUsableRows(); ++i) {
     F left = z[i + 1];
 
-    left *= (beta + *lookup_permuted.permuted_evals_pair().input()[i]);
-    left *= (gamma + *lookup_permuted.permuted_evals_pair().table()[i]);
+    left *= (beta + lookup_permuted.permuted_evals_pair().input()[i]);
+    left *= (gamma + lookup_permuted.permuted_evals_pair().table()[i]);
 
     F right = z[i];
-    F input_term = *lookup_permuted.compressed_evals_pair().input()[i];
-    F table_term = *lookup_permuted.compressed_evals_pair().table()[i];
+    F input_term = lookup_permuted.compressed_evals_pair().input()[i];
+    F table_term = lookup_permuted.compressed_evals_pair().table()[i];
 
     input_term += beta;
     table_term += gamma;

--- a/tachyon/zk/lookup/permute_expression_pair.h
+++ b/tachyon/zk/lookup/permute_expression_pair.h
@@ -42,7 +42,7 @@ template <typename PCS, typename Evals, typename F = typename Evals::Field>
   absl::btree_map<F, RowIndex> leftover_table_map;
 
   for (RowIndex i = 0; i < usable_rows; ++i) {
-    const F& coeff = *in.table()[i];
+    const F& coeff = in.table()[i];
     // if key doesn't exist, insert the key and value 1 for the key.
     auto it = leftover_table_map.try_emplace(coeff, RowIndex{1});
     // no inserted value, meaning the key exists.

--- a/tachyon/zk/lookup/permute_expression_pair_unittest.cc
+++ b/tachyon/zk/lookup/permute_expression_pair_unittest.cc
@@ -43,8 +43,8 @@ TEST_F(PermuteExpressionPairTest, PermuteExpressionPairTest) {
   // sanity check brought from halo2
   std::optional<F> last;
   for (size_t i = 0; i < usable_rows; ++i) {
-    const F& perm_input_expr = *output.input()[i];
-    const F& perm_table_coeff = *output.table()[i];
+    const F& perm_input_expr = output.input()[i];
+    const F& perm_table_coeff = output.table()[i];
 
     if (perm_input_expr != perm_table_coeff) {
       EXPECT_EQ(perm_input_expr, last.value());

--- a/tachyon/zk/plonk/examples/simple_circuit_test.cc
+++ b/tachyon/zk/plonk/examples/simple_circuit_test.cc
@@ -226,7 +226,8 @@ TEST_F(SimpleCircuitTest, Synthesize) {
 
   std::vector<RationalEvals> expected_fixed_columns;
   RationalEvals evals = domain->Zero<RationalEvals>();
-  *evals[0] = math::RationalField<F>(constant);
+  // NOTE(chokobole): It's safe to access since we created |n|-sized |evals_|.
+  evals.at(0) = math::RationalField<F>(constant);
   expected_fixed_columns.push_back(std::move(evals));
   EXPECT_EQ(assembly.fixed_columns(), expected_fixed_columns);
 

--- a/tachyon/zk/plonk/examples/simple_circuit_test.cc
+++ b/tachyon/zk/plonk/examples/simple_circuit_test.cc
@@ -225,7 +225,7 @@ TEST_F(SimpleCircuitTest, Synthesize) {
                            constraint_system.constants());
 
   std::vector<RationalEvals> expected_fixed_columns;
-  RationalEvals evals = domain->Empty<RationalEvals>();
+  RationalEvals evals = domain->Zero<RationalEvals>();
   *evals[0] = math::RationalField<F>(constant);
   expected_fixed_columns.push_back(std::move(evals));
   EXPECT_EQ(assembly.fixed_columns(), expected_fixed_columns);

--- a/tachyon/zk/plonk/examples/simple_v1_circuit_test.cc
+++ b/tachyon/zk/plonk/examples/simple_v1_circuit_test.cc
@@ -224,7 +224,7 @@ TEST_F(SimpleV1CircuitTest, Synthesize) {
                            constraint_system.constants());
 
   std::vector<RationalEvals> expected_fixed_columns;
-  RationalEvals evals = domain->Empty<RationalEvals>();
+  RationalEvals evals = domain->Zero<RationalEvals>();
   *evals[0] = math::RationalField<F>(constant);
   expected_fixed_columns.push_back(std::move(evals));
   EXPECT_EQ(assembly.fixed_columns(), expected_fixed_columns);

--- a/tachyon/zk/plonk/examples/simple_v1_circuit_test.cc
+++ b/tachyon/zk/plonk/examples/simple_v1_circuit_test.cc
@@ -225,7 +225,8 @@ TEST_F(SimpleV1CircuitTest, Synthesize) {
 
   std::vector<RationalEvals> expected_fixed_columns;
   RationalEvals evals = domain->Zero<RationalEvals>();
-  *evals[0] = math::RationalField<F>(constant);
+  // NOTE(chokobole): It's safe to access since we created |n|-sized |evals_|.
+  evals.at(0) = math::RationalField<F>(constant);
   expected_fixed_columns.push_back(std::move(evals));
   EXPECT_EQ(assembly.fixed_columns(), expected_fixed_columns);
 

--- a/tachyon/zk/plonk/halo2/witness_collection.h
+++ b/tachyon/zk/plonk/halo2/witness_collection.h
@@ -33,7 +33,7 @@ class WitnessCollection : public Assignment<typename Evals::Field> {
                     const absl::btree_map<size_t, F>& challenges,
                     const std::vector<Evals>& instance_columns)
       : advices_(base::CreateVector(num_advice_columns,
-                                    domain->template Empty<RationalEvals>())),
+                                    domain->template Zero<RationalEvals>())),
         usable_rows_(base::Range<RowIndex>::Until(usable_rows)),
         current_phase_(current_phase),
         challenges_(challenges),

--- a/tachyon/zk/plonk/halo2/witness_collection.h
+++ b/tachyon/zk/plonk/halo2/witness_collection.h
@@ -48,7 +48,7 @@ class WitnessCollection : public Assignment<typename Evals::Field> {
     CHECK(usable_rows_.Contains(row));
     CHECK_LT(column.index(), instance_columns_.size());
 
-    return Value<F>::Known(*instance_columns_[column.index()][row]);
+    return Value<F>::Known(instance_columns_[column.index()][row]);
   }
 
   void AssignAdvice(std::string_view, const AdviceColumnKey& column,
@@ -59,7 +59,8 @@ class WitnessCollection : public Assignment<typename Evals::Field> {
     CHECK(usable_rows_.Contains(row));
     CHECK_LT(column.index(), advices_.size());
 
-    *advices_[column.index()][row] = std::move(assign).Run().value();
+    // NOTE(chokobole): Boundary check is the responsibility of API callers.
+    advices_[column.index()].at(row) = std::move(assign).Run().value();
   }
 
   Value<F> GetChallenge(Challenge challenge) override {

--- a/tachyon/zk/plonk/halo2/witness_collection_unittest.cc
+++ b/tachyon/zk/plonk/halo2/witness_collection_unittest.cc
@@ -49,7 +49,7 @@ TEST_F(WitnessCollectionTest, QueryInstance) {
   Value<F> queried_value =
       witness_collection_.QueryInstance(InstanceColumnKey(col), row);
   EXPECT_EQ(queried_value,
-            Value<F>::Known(*expected_instance_columns_[col][row]));
+            Value<F>::Known(expected_instance_columns_[col][row]));
 }
 
 TEST_F(WitnessCollectionTest, AssignAdvice) {
@@ -66,7 +66,7 @@ TEST_F(WitnessCollectionTest, AssignAdvice) {
   std::vector<RationalEvals> rational_advice_columns =
       std::move(witness_collection_).TakeAdvices();
   const RationalEvals& rational_column = rational_advice_columns[col];
-  EXPECT_EQ(value_to_be_assign, *rational_column[row]);
+  EXPECT_EQ(value_to_be_assign, rational_column[row]);
 }
 
 TEST_F(WitnessCollectionTest, GetChallenge) {

--- a/tachyon/zk/plonk/keys/assembly.h
+++ b/tachyon/zk/plonk/keys/assembly.h
@@ -57,7 +57,8 @@ class Assembly : public Assignment<typename RationalEvals::Field::InnerField> {
   void AssignFixed(std::string_view, const FixedColumnKey& column, RowIndex row,
                    AssignCallback assign) override {
     CHECK(usable_rows_.Contains(row)) << "Not enough rows available";
-    *fixed_columns_[column.index()][row] = std::move(assign).Run().value();
+    // NOTE(chokobole): Boundary check is the responsibility of API callers.
+    fixed_columns_[column.index()].at(row) = std::move(assign).Run().value();
   }
 
   void Copy(const AnyColumnKey& left_column, RowIndex left_row,
@@ -73,7 +74,8 @@ class Assembly : public Assignment<typename RationalEvals::Field::InnerField> {
     base::Range<RowIndex> range(usable_rows_.from + from_row, usable_rows_.to);
     RationalEvals& fixed_column = fixed_columns_[column.index()];
     for (RowIndex row : range) {
-      *fixed_column[row] = value;
+      // NOTE(chokobole): Boundary check is the responsibility of API callers.
+      fixed_column.at(row) = value;
     }
   }
 

--- a/tachyon/zk/plonk/keys/key.h
+++ b/tachyon/zk/plonk/keys/key.h
@@ -39,7 +39,7 @@ class TACHYON_EXPORT Key {
     RowIndex n = static_cast<RowIndex>(domain->size());
     return {
         base::CreateVector(constraint_system.num_fixed_columns(),
-                           domain->template Empty<RationalEvals>()),
+                           domain->template Zero<RationalEvals>()),
         PermutationAssembly(constraint_system.permutation(), n),
         base::CreateVector(constraint_system.num_selectors(),
                            base::CreateVector(n, false)),

--- a/tachyon/zk/plonk/keys/proving_key.h
+++ b/tachyon/zk/plonk/keys/proving_key.h
@@ -108,7 +108,7 @@ class ProvingKey : public Key {
     // | 5 | 0          |
     // | 6 | 0          |
     // | 7 | 0          |
-    Evals evals = domain->template Empty<Evals>();
+    Evals evals = domain->template Zero<Evals>();
     *evals[0] = F::One();
     l_first_ = domain->IFFT(evals);
     *evals[0] = F::Zero();

--- a/tachyon/zk/plonk/keys/proving_key.h
+++ b/tachyon/zk/plonk/keys/proving_key.h
@@ -109,9 +109,11 @@ class ProvingKey : public Key {
     // | 6 | 0          |
     // | 7 | 0          |
     Evals evals = domain->template Zero<Evals>();
-    *evals[0] = F::One();
+    // NOTE(chokobole): It's safe to access since we created |domain->size()|
+    // |evals|.
+    evals.at(0) = F::One();
     l_first_ = domain->IFFT(evals);
-    *evals[0] = F::Zero();
+    evals.at(0) = F::Zero();
 
     // Compute l_last(X) which evaluates to 1 on the first inactive row (just
     // before the blinding factors) and 0 otherwise over the domain.
@@ -127,9 +129,11 @@ class ProvingKey : public Key {
     // | 6 | 0         |
     // | 7 | 0         |
     RowIndex usable_rows = prover->GetUsableRows();
-    *evals[usable_rows] = F::One();
+    // NOTE(chokobole): It's safe to access since we created |domain->size()|
+    // |evals|, which is greater than |usable_rows|.
+    evals.at(usable_rows) = F::One();
     l_last_ = domain->IFFT(evals);
-    *evals[usable_rows] = F::Zero();
+    evals.at(usable_rows) = F::Zero();
 
     // Compute l_active_row(X).
     //

--- a/tachyon/zk/plonk/permutation/permutation_argument_runner_impl.h
+++ b/tachyon/zk/plonk/permutation/permutation_argument_runner_impl.h
@@ -183,7 +183,7 @@ PermutationArgumentRunner<Poly, Evals>::CreateNumeratorCallback(
                absl::Span<F> chunk, size_t chunk_index, size_t chunk_size_in) {
       size_t i = chunk_index * chunk_size_in;
       for (F& result : chunk) {
-        result *= *values[i] + beta * *unpermuted_values[i] + gamma;
+        result *= values[i] + beta * unpermuted_values[i] + gamma;
         ++i;
       }
     };
@@ -205,7 +205,7 @@ PermutationArgumentRunner<Poly, Evals>::CreateDenominatorCallback(
                absl::Span<F> chunk, size_t chunk_index, size_t chunk_size_in) {
       size_t i = chunk_index * chunk_size_in;
       for (F& result : chunk) {
-        result *= *values[i] + beta * *permuted_values[i] + gamma;
+        result *= values[i] + beta * permuted_values[i] + gamma;
         ++i;
       }
     };

--- a/tachyon/zk/plonk/permutation/permutation_assembly.h
+++ b/tachyon/zk/plonk/permutation/permutation_assembly.h
@@ -120,17 +120,20 @@ class TACHYON_EXPORT PermutationAssembly {
         base::CreateVector(columns_.size(), domain->template Zero<Evals>());
 
     // Assign |unpermuted_table| to |permutations|.
-    base::Parallelize(permutations, [&unpermuted_table, this](
-                                        absl::Span<Evals> chunk, size_t c,
-                                        size_t chunk_size) {
-      size_t i = c * chunk_size;
-      for (Evals& evals : chunk) {
-        for (size_t j = 0; j < rows_; ++j) {
-          *evals[j] = unpermuted_table[cycle_store_.GetNextLabel(Label(i, j))];
-        }
-        ++i;
-      }
-    });
+    base::Parallelize(
+        permutations, [&unpermuted_table, this](absl::Span<Evals> chunk,
+                                                size_t c, size_t chunk_size) {
+          size_t i = c * chunk_size;
+          for (Evals& evals : chunk) {
+            for (size_t j = 0; j < rows_; ++j) {
+              // NOTE(chokobole): It's safe to access since we created |kDegree|
+              // |Zeros()|.
+              evals.at(j) =
+                  unpermuted_table[cycle_store_.GetNextLabel(Label(i, j))];
+            }
+            ++i;
+          }
+        });
     return permutations;
   }
 

--- a/tachyon/zk/plonk/permutation/permutation_assembly.h
+++ b/tachyon/zk/plonk/permutation/permutation_assembly.h
@@ -117,7 +117,7 @@ class TACHYON_EXPORT PermutationAssembly {
 
     // Init evaluation formed polynomials with all-zero coefficients.
     std::vector<Evals> permutations =
-        base::CreateVector(columns_.size(), domain->template Empty<Evals>());
+        base::CreateVector(columns_.size(), domain->template Zero<Evals>());
 
     // Assign |unpermuted_table| to |permutations|.
     base::Parallelize(permutations, [&unpermuted_table, this](

--- a/tachyon/zk/plonk/permutation/permutation_assembly_unittest.cc
+++ b/tachyon/zk/plonk/permutation/permutation_assembly_unittest.cc
@@ -42,7 +42,7 @@ TEST_F(PermutationAssemblyTest, GeneratePermutation) {
 
   for (size_t i = 0; i < columns_.size(); ++i) {
     for (size_t j = 0; j < n; ++j) {
-      EXPECT_EQ(*permutations[i][j], unpermuted_table[Label(i, j)]);
+      EXPECT_EQ(permutations[i][j], unpermuted_table[Label(i, j)]);
     }
   }
 }

--- a/tachyon/zk/plonk/permutation/unpermuted_table.h
+++ b/tachyon/zk/plonk/permutation/unpermuted_table.h
@@ -38,7 +38,7 @@ class UnpermutedTable {
   const Table& table() const& { return table_; }
 
   const F& operator[](const Label& label) const {
-    return *table_[label.col][label.row];
+    return table_[label.col][label.row];
   }
 
   base::Ref<const Evals> GetColumn(size_t i) const {
@@ -78,7 +78,7 @@ class UnpermutedTable {
       // TODO(dongchangYoo): Optimize this with
       // https://github.com/kroma-network/tachyon/pull/115.
       for (RowIndex j = 0; j < rows; ++j) {
-        col[j] = *unpermuted_table[i - 1][j] * delta;
+        col[j] = unpermuted_table[i - 1][j] * delta;
       }
       unpermuted_table.push_back(Evals(std::move(col)));
     }

--- a/tachyon/zk/plonk/permutation/unpermuted_table_unittest.cc
+++ b/tachyon/zk/plonk/permutation/unpermuted_table_unittest.cc
@@ -61,7 +61,7 @@ TEST_F(UnpermutedTableTest, GetColumns) {
 
   base::Ref<const Evals> column = unpermuted_table_.GetColumn(1);
   for (RowIndex i = 0; i < n; ++i) {
-    EXPECT_EQ(omega_powers[i], *(*column)[i]);
+    EXPECT_EQ(omega_powers[i], (*column)[i]);
   }
 
   std::vector<base::Ref<const Evals>> columns =
@@ -69,7 +69,7 @@ TEST_F(UnpermutedTableTest, GetColumns) {
   for (size_t i = 0; i < 2; ++i) {
     for (RowIndex j = 0; j < n; ++j) {
       omega_powers[j] *= delta;
-      EXPECT_EQ(omega_powers[j], *(*columns[i])[j]);
+      EXPECT_EQ(omega_powers[j], (*columns[i])[j]);
     }
   }
 }

--- a/tachyon/zk/plonk/vanishing/value_source.h
+++ b/tachyon/zk/plonk/vanishing/value_source.h
@@ -144,17 +144,17 @@ class TACHYON_EXPORT ValueSource {
       case Type::kChallenge:
         return data.challenges()[index_];
       case Type::kFixed:
-        return *data.table()
-                    .GetFixedColumns()[column_index_]
-                                      [data.rotations()[rotation_index_]];
+        return data.table()
+            .GetFixedColumns()[column_index_]
+                              [data.rotations()[rotation_index_]];
       case Type::kAdvice:
-        return *data.table()
-                    .GetAdviceColumns()[column_index_]
-                                       [data.rotations()[rotation_index_]];
+        return data.table()
+            .GetAdviceColumns()[column_index_]
+                               [data.rotations()[rotation_index_]];
       case Type::kInstance:
-        return *data.table()
-                    .GetInstanceColumns()[column_index_]
-                                         [data.rotations()[rotation_index_]];
+        return data.table()
+            .GetInstanceColumns()[column_index_]
+                                 [data.rotations()[rotation_index_]];
       case Type::kBeta:
         return data.beta();
       case Type::kGamma:


### PR DESCRIPTION
# Description

In order to access an element in a polynomial, you need to use the `[]` operator which in turn gives you a pointer of the field. It's likely we carelessly use the `[]` operator without a boundary check.

An error may show up where the result of the `[]` operator is dereferenced, since if there exists no element at a given index, the `[]` operator will return a nullptr. Here some more concrete examples of error-prone statements:
```c++
const F& value = *poly[idx];
*poly[idx] = F::One();
```

Thus, this commit has made 2 changes to fix this behavior.

1. The return type of the `[]` operator has been changed to a const reference. If there is no element at the given index, a const reference of the zero point of the field is returned.
2. The `at()` method has been added. Similar to STL, the `at()` method does a boundary check. See [at](https://en.cppreference.com/w/cpp/container/vector/at) and [operator[]](https://en.cppreference.com/w/cpp/container/vector/operator_at).

After this commit, we encourage developers to leave a comment noting whether accessing the given index is safe when using `at()`. Comments do not need to be added repetitively to `at()` methods in files that follow an overarching assumption. (like in univariate_evaluation_domain.h)