### PR TITLE
fix(math): correct parallel IFFT

### DIFF
--- a/tachyon/math/polynomials/univariate/radix2_evaluation_domain.h
+++ b/tachyon/math/polynomials/univariate/radix2_evaluation_domain.h
@@ -255,10 +255,18 @@ class Radix2EvaluationDomain : public UnivariateEvaluationDomain<F, MaxDegree> {
       if (should_compact) {
         if (!first) {
           size_t size = roots.size() / (step * 2);
+#if defined(TACHYON_HAS_OPENMP)
+          std::vector<F> new_roots(size);
           OPENMP_PARALLEL_FOR(size_t i = 0; i < size; ++i) {
+            new_roots[i] = roots[i * (step * 2)];
+          }
+          roots = std::move(new_roots);
+#else
+          for (size_t i = 0; i < size; ++i) {
             roots[i] = roots[i * (step * 2)];
           }
           roots.erase(roots.begin() + size, roots.end());
+#endif
         }
         step = 1;
       } else {


### PR DESCRIPTION
# Description

When compacting roots in place, there is a potential for collisions. Our code originally relied on the assumption that the assignments of the new compacted roots ran in order from smallest to largest index, but parallelization faults this assumption.

For example, we expect moves to occur in our roots vector in the order of indexes 0, 1, 2 like so:

0: [0] <- [0]
1: [1] <- [2]
2: [2] <- [4]

However, if the order changes to assign indexes 0, 2, 1 instead due to parallelization, we get this:

0: [0] <- [0]
1: [2] <- [4]
2: [1] <- [2] = [4]

This issue is resolved by compacting roots separately first instead of in place.