### PR TITLE
fix(zk): add `CHECK` for `LookupAny` as well

### DIFF
--- a/tachyon/zk/expressions/evaluator/BUILD.bazel
+++ b/tachyon/zk/expressions/evaluator/BUILD.bazel
@@ -6,6 +6,7 @@ tachyon_cc_library(
     name = "selector_replacer",
     hdrs = ["selector_replacer.h"],
     deps = [
+        "//tachyon/base:logging",
         "//tachyon/zk/expressions:evaluator",
         "//tachyon/zk/expressions:negated_expression",
         "//tachyon/zk/expressions:product_expression",

--- a/tachyon/zk/expressions/evaluator/selector_replacer.h
+++ b/tachyon/zk/expressions/evaluator/selector_replacer.h
@@ -10,6 +10,7 @@
 #include <memory>
 #include <vector>
 
+#include "tachyon/base/logging.h"
 #include "tachyon/zk/expressions/evaluator.h"
 #include "tachyon/zk/expressions/negated_expression.h"
 #include "tachyon/zk/expressions/product_expression.h"

--- a/tachyon/zk/expressions/evaluator/selector_replacer.h
+++ b/tachyon/zk/expressions/evaluator/selector_replacer.h
@@ -41,7 +41,9 @@ class SelectorsReplacer : public Evaluator<F, std::unique_ptr<Expression<F>>> {
         if (must_be_non_simple_) {
           // Simple selectors are prohibited from appearing in
           // expressions in the lookup argument by |ConstraintSystem|.
-          CHECK(!selector.is_simple());
+          if (selector.is_simple()) {
+            LOG(DFATAL) << "Simple selector found in lookup argument";
+          }
         }
         return replacements_[selector.index()]->Clone();
       }

--- a/tachyon/zk/plonk/constraint_system/BUILD.bazel
+++ b/tachyon/zk/plonk/constraint_system/BUILD.bazel
@@ -30,6 +30,7 @@ tachyon_cc_library(
     name = "constraint_system",
     hdrs = ["constraint_system.h"],
     deps = [
+        "//tachyon/base:logging",
         "//tachyon/base/containers:container_util",
         "//tachyon/base/containers:contains",
         "//tachyon/base/functional:callback",

--- a/tachyon/zk/plonk/constraint_system/constraint_system.h
+++ b/tachyon/zk/plonk/constraint_system/constraint_system.h
@@ -163,6 +163,12 @@ class ConstraintSystem {
     LookupPairs<std::unique_ptr<Expression<F>>> pairs =
         std::move(callback).Run(cells);
 
+    for (const LookupPair<std::unique_ptr<Expression<F>>>& pair : pairs) {
+      CHECK(!pair.input()->ContainsSimpleSelector())
+          << "expression containing simple selector "
+             "supplied to lookup argument";
+    }
+
     lookups_.emplace_back(name, std::move(pairs));
     return lookups_.size() - 1;
   }

--- a/tachyon/zk/plonk/constraint_system/constraint_system.h
+++ b/tachyon/zk/plonk/constraint_system/constraint_system.h
@@ -23,6 +23,7 @@
 #include "tachyon/base/containers/container_util.h"
 #include "tachyon/base/containers/contains.h"
 #include "tachyon/base/functional/callback.h"
+#include "tachyon/base/logging.h"
 #include "tachyon/base/strings/string_util.h"
 #include "tachyon/zk/base/row_index.h"
 #include "tachyon/zk/expressions/evaluator/simple_selector_finder.h"


### PR DESCRIPTION
# Description
While it's not implemented in rust halo2 code, simple selectors are prohibited from appearing in expressions in the lookup argument by `ConstraintSystem`. So, `CHECK` is added to `LookupAny` as well, like `Lookup`.

See https://github.com/kroma-network/tachyon/blob/92f3550bc62dc5d10cfd295c0996b6620f9d46f5/tachyon/zk/expressions/evaluator/selector_replacer.h#L42-L43 and
https://github.com/kroma-network/halo2/blob/7d0a36990452c8e7ebd600de258420781a9b7917/halo2_proofs/src/plonk/circuit.rs#L1563-L1580
