### PR TITLE
perf: optimize building circuit polynomial

### DIFF
--- a/tachyon/math/base/batch_inverse_benchmark.cc
+++ b/tachyon/math/base/batch_inverse_benchmark.cc
@@ -12,7 +12,7 @@ void BM_BatchInverse(benchmark::State& state) {
   std::vector<F> fields = base::CreateVector(
       state.range(0), [](size_t i) { return F::FromBigInt(BigInt(i)); });
   for (auto _ : state) {
-    F::BatchInverseInPlace(fields);
+    CHECK(F::BatchInverseInPlace(fields));
   }
   benchmark::DoNotOptimize(fields);
 }

--- a/tachyon/math/base/groups.h
+++ b/tachyon/math/base/groups.h
@@ -86,14 +86,14 @@ class MultiplicativeGroup : public MultiplicativeSemigroup<G> {
   }
 
   template <typename Container>
-  constexpr static bool BatchInverseInPlace(Container& groups,
-                                            const G& coeff = G::One()) {
+  [[nodiscard]] constexpr static bool BatchInverseInPlace(
+      Container& groups, const G& coeff = G::One()) {
     return BatchInverse(groups, &groups, coeff);
   }
 
   template <typename Container>
-  constexpr static bool BatchInverseInPlaceSerial(Container& groups,
-                                                  const G& coeff = G::One()) {
+  [[nodiscard]] constexpr static bool BatchInverseInPlaceSerial(
+      Container& groups, const G& coeff = G::One()) {
     return BatchInverseSerial(groups, &groups, coeff);
   }
 
@@ -101,9 +101,9 @@ class MultiplicativeGroup : public MultiplicativeSemigroup<G> {
   // https://github.com/arkworks-rs/algebra/blob/5dfeedf560da6937a5de0a2163b7958bd32cd551/ff/src/fields/mod.rs#L355-L418.
   // Batch inverse: [a₁, a₂, ..., aₙ] -> [a₁⁻¹, a₂⁻¹, ... , aₙ⁻¹]
   template <typename InputContainer, typename OutputContainer>
-  constexpr static bool BatchInverse(const InputContainer& groups,
-                                     OutputContainer* inverses,
-                                     const G& coeff = G::One()) {
+  [[nodiscard]] constexpr static bool BatchInverse(const InputContainer& groups,
+                                                   OutputContainer* inverses,
+                                                   const G& coeff = G::One()) {
     if (std::size(groups) != std::size(*inverses)) {
       LOG(ERROR) << "Size of |groups| and |inverses| do not match";
       return false;
@@ -140,9 +140,9 @@ class MultiplicativeGroup : public MultiplicativeSemigroup<G> {
   }
 
   template <typename InputContainer, typename OutputContainer>
-  constexpr static bool BatchInverseSerial(const InputContainer& groups,
-                                           OutputContainer* inverses,
-                                           const G& coeff = G::One()) {
+  [[nodiscard]] constexpr static bool BatchInverseSerial(
+      const InputContainer& groups, OutputContainer* inverses,
+      const G& coeff = G::One()) {
     if (std::size(groups) != std::size(*inverses)) {
       LOG(ERROR) << "Size of |groups| and |inverses| do not match";
       return false;

--- a/tachyon/math/base/rational_field.h
+++ b/tachyon/math/base/rational_field.h
@@ -56,7 +56,7 @@ class RationalField : public Field<RationalField<F>> {
     OPENMP_PARALLEL_FOR(size_t i = 0; i < size; ++i) {
       (*results)[i] = ration_fields[i].denominator_;
     }
-    F::BatchInverseInPlace(*results, coeff);
+    CHECK(F::BatchInverseInPlace(*results, coeff));
     OPENMP_PARALLEL_FOR(size_t i = 0; i < size; ++i) {
       (*results)[i] *= ration_fields[i].numerator_;
     }

--- a/tachyon/math/polynomials/univariate/lagrange_interpolation.h
+++ b/tachyon/math/polynomials/univariate/lagrange_interpolation.h
@@ -49,7 +49,7 @@ bool LagrangeInterpolate(
       }
       ++i;
     }
-    F::BatchInverseInPlaceSerial(chunk);
+    CHECK(F::BatchInverseInPlaceSerial(chunk));
   });
 
   std::vector<F> final_coeffs = base::CreateVector(points.size(), F::Zero());

--- a/tachyon/math/polynomials/univariate/univariate_evaluation_domain.h
+++ b/tachyon/math/polynomials/univariate/univariate_evaluation_domain.h
@@ -238,7 +238,7 @@ class UnivariateEvaluationDomain : public EvaluationDomain<F, MaxDegree> {
       // Invert |lagrange_coefficients_inverse| to get the actual coefficients,
       // and return these
       // Z_H(𝜏) * vᵢ / (𝜏 - h * gⁱ)
-      F::BatchInverseInPlace(lagrange_coefficients_inverse);
+      CHECK(F::BatchInverseInPlace(lagrange_coefficients_inverse));
       return lagrange_coefficients_inverse;
     }
   }

--- a/tachyon/zk/plonk/examples/shuffle_circuit.h
+++ b/tachyon/zk/plonk/examples/shuffle_circuit.h
@@ -268,7 +268,7 @@ class ShuffleCircuit : public Circuit<ShuffleCircuitConfig<F, W>> {
                   return compressed;
                 });
 
-            F::BatchInverseInPlace(product);
+            CHECK(F::BatchInverseInPlace(product));
 
             for (RowIndex i = 0; i < H; ++i) {
               F compressed = std::accumulate(

--- a/tachyon/zk/plonk/permutation/grand_product_argument.h
+++ b/tachyon/zk/plonk/permutation/grand_product_argument.h
@@ -69,7 +69,7 @@ class GrandProductArgument {
 
     base::Parallelize(grand_product, std::move(denominator_callback));
 
-    F::BatchInverseInPlace(grand_product);
+    CHECK(F::BatchInverseInPlace(grand_product));
 
     base::Parallelize(grand_product, std::move(numerator_callback));
 
@@ -89,7 +89,7 @@ class GrandProductArgument {
       base::Parallelize(grand_product, denominator_callback(i));
     }
 
-    F::BatchInverseInPlace(grand_product);
+    CHECK(F::BatchInverseInPlace(grand_product));
 
     for (size_t i = 0; i < num_cols; ++i) {
       base::Parallelize(grand_product, numerator_callback(i));

--- a/tachyon/zk/plonk/vanishing/circuit_polynomial_builder.h
+++ b/tachyon/zk/plonk/vanishing/circuit_polynomial_builder.h
@@ -123,8 +123,7 @@ class CircuitPolynomialBuilder {
       value_parts.push_back(std::move(value_part));
       UpdateCurrentExtendedOmega();
     }
-    std::vector<F> extended =
-        BuildExtendedColumnWithColumns(std::move(value_parts));
+    std::vector<F> extended = BuildExtendedColumnWithColumns(value_parts);
     return ExtendedEvals(std::move(extended));
   }
 

--- a/tachyon/zk/plonk/vanishing/circuit_polynomial_builder.h
+++ b/tachyon/zk/plonk/vanishing/circuit_polynomial_builder.h
@@ -97,12 +97,16 @@ class CircuitPolynomialBuilder {
     value_parts.reserve(num_parts_);
     // Calculate the quotient polynomial for each part
     for (size_t i = 0; i < num_parts_; ++i) {
+      VLOG(1) << "BuildExtendedCircuitColumn part: (" << i << " / "
+              << num_parts_ - 1 << ")";
       UpdateVanishingProvingKey();
 
       std::vector<F> value_part =
           base::CreateVector(static_cast<size_t>(n_), F::Zero());
       size_t circuit_num = poly_tables_->size();
       for (size_t j = 0; j < circuit_num; ++j) {
+        VLOG(1) << "BuildExtendedCircuitColumn part: " << i << " circuit: ("
+                << j << " / " << circuit_num - 1 << ")";
         UpdateVanishingTable(j);
         UpdateValuesByCustomGates(custom_gate_evaluator, value_part);
 

--- a/tachyon/zk/plonk/vanishing/evaluation_input.h
+++ b/tachyon/zk/plonk/vanishing/evaluation_input.h
@@ -36,7 +36,7 @@ class EvaluationInput {
         y_(y),
         n_(n) {}
 
-  const std::vector<F> intermediates() const { return intermediates_; }
+  const std::vector<F>& intermediates() const { return intermediates_; }
   std::vector<F>& intermediates() { return intermediates_; }
   const std::vector<int32_t>& rotations() const { return rotations_; }
   std::vector<int32_t>& rotations() { return rotations_; }

--- a/tachyon/zk/plonk/vanishing/value_source.h
+++ b/tachyon/zk/plonk/vanishing/value_source.h
@@ -134,8 +134,8 @@ class TACHYON_EXPORT ValueSource {
   }
 
   template <typename Evals, typename F>
-  F Get(const EvaluationInput<Evals>& data, const std::vector<F>& constants,
-        const F& previous_value) const {
+  const F& Get(const EvaluationInput<Evals>& data,
+               const std::vector<F>& constants, const F& previous_value) const {
     switch (type_) {
       case Type::kConstant:
         return constants[index_];
@@ -167,7 +167,7 @@ class TACHYON_EXPORT ValueSource {
         return previous_value;
     }
     NOTREACHED();
-    return F();
+    return previous_value;
   }
 
   std::string ToString() const;

--- a/tachyon/zk/plonk/vanishing/vanishing_utils.h
+++ b/tachyon/zk/plonk/vanishing/vanishing_utils.h
@@ -166,18 +166,14 @@ template <typename Domain, typename Poly, typename F,
 Evals CoeffToExtendedPart(const Domain* domain,
                           const BlindedPolynomial<Poly>& poly, const F& zeta,
                           const F& extended_omega_factor) {
-  Poly cloned = poly.poly();
-  Domain::DistributePowers(cloned, zeta * extended_omega_factor);
-  return domain->FFT(cloned);
+  return domain->GetCoset(zeta * extended_omega_factor)->FFT(poly.poly());
 }
 
 template <typename Domain, typename Poly, typename F,
           typename Evals = typename Domain::Evals>
 Evals CoeffToExtendedPart(const Domain* domain, const Poly& poly, const F& zeta,
                           const F& extended_omega_factor) {
-  Poly cloned = poly;
-  Domain::DistributePowers(cloned, zeta * extended_omega_factor);
-  return domain->FFT(cloned);
+  return domain->GetCoset(zeta * extended_omega_factor)->FFT(poly);
 }
 
 template <typename Domain, typename Poly, typename F,

--- a/tachyon/zk/plonk/vanishing/vanishing_utils.h
+++ b/tachyon/zk/plonk/vanishing/vanishing_utils.h
@@ -190,7 +190,7 @@ std::vector<Evals> CoeffsToExtendedPart(const Domain* domain,
 
 template <typename F>
 std::vector<F> BuildExtendedColumnWithColumns(
-    std::vector<std::vector<F>>&& columns) {
+    const std::vector<std::vector<F>>& columns) {
   CHECK(!columns.empty());
   size_t cols = columns.size();
   size_t rows = columns[0].size();

--- a/tachyon/zk/plonk/vanishing/vanishing_utils.h
+++ b/tachyon/zk/plonk/vanishing/vanishing_utils.h
@@ -21,11 +21,14 @@ namespace tachyon::zk::plonk {
 // Calculate ζ = g^((2ˢ * T) / 3).
 template <typename F>
 constexpr F GetZeta() {
-  CHECK_EQ(F::Config::kTrace % math::BigInt<F::kLimbNums>(3),
-           math::BigInt<F::kLimbNums>(0));
-  return F::FromMontgomery(F::Config::kSubgroupGenerator)
-      .Pow(F(2).Pow(F::Config::kTwoAdicity).ToBigInt() * F::Config::kTrace /
-           math::BigInt<F::kLimbNums>(3));
+  using BigInt = typename F::BigIntTy;
+  CHECK_EQ(F::Config::kTrace % BigInt(3), BigInt(0));
+  BigInt exp = F::Config::kTrace;
+  // NOTE(chokobole): The result of the exponential operation does not exceed
+  // the modulus of the scalar field.
+  exp.MulBy2ExpInPlace(F::Config::kTwoAdicity);
+  exp /= BigInt(3);
+  return F::FromMontgomery(F::Config::kSubgroupGenerator).Pow(exp);
 }
 
 // NOTE(TomTaehoonKim): The returning value of |GetZeta()| is different from the

--- a/tachyon/zk/plonk/vanishing/vanishing_utils.h
+++ b/tachyon/zk/plonk/vanishing/vanishing_utils.h
@@ -83,7 +83,7 @@ ExtendedEvals& DivideByVanishingPolyInPlace(
     }
   });
 
-  F::BatchInverseInPlace(t_evaluations);
+  CHECK(F::BatchInverseInPlace(t_evaluations));
 
   // Multiply the inverse to obtain the quotient polynomial in the coset
   // evaluation domain.

--- a/tachyon/zk/plonk/vanishing/vanishing_utils_unittest.cc
+++ b/tachyon/zk/plonk/vanishing/vanishing_utils_unittest.cc
@@ -65,9 +65,8 @@ TEST_F(VanishingUtilsTest, CoeffToExtendedPart) {
 }
 
 TEST_F(VanishingUtilsTest, BuildExtendedColumnWithColumns) {
-  base::Range<size_t> range = base::Range<size_t>::Until(4);
-  std::vector<std::vector<F>> columns =
-      base::Map(range, [](size_t i) { return base::CreateVector(N, F(i)); });
+  std::vector<std::vector<F>> columns = base::CreateVector(
+      4, [](size_t i) { return base::CreateVector(N, F(i)); });
 
   std::vector<F> extended = BuildExtendedColumnWithColumns(columns);
   EXPECT_EQ(extended.size(), 4 * N);

--- a/tachyon/zk/plonk/vanishing/vanishing_utils_unittest.cc
+++ b/tachyon/zk/plonk/vanishing/vanishing_utils_unittest.cc
@@ -69,7 +69,7 @@ TEST_F(VanishingUtilsTest, BuildExtendedColumnWithColumns) {
   std::vector<std::vector<F>> columns =
       base::Map(range, [](size_t i) { return base::CreateVector(N, F(i)); });
 
-  std::vector<F> extended = BuildExtendedColumnWithColumns(std::move(columns));
+  std::vector<F> extended = BuildExtendedColumnWithColumns(columns);
   EXPECT_EQ(extended.size(), 4 * N);
   for (size_t i = 0; i < extended.size(); ++i) {
     EXPECT_EQ(F(i % 4), extended[i]);


### PR DESCRIPTION
# Description

This PR optimizes building a circuit polynomial.

The main optimization parts are as follows:

- Avoid memory allocations if possible.
   - Change the value type to the reference type.
   - Use `OPENMP_PARALLEL_FOR` instead of `base::Parallelize()`
   - Use `BatchInverseInPlaceSerial()` within an existing parallel loop instead of `BatchInverseInPlace()`.
- Optimize algorithms
   - Use `MulBy2ExpInPlace()` when computing `a * 2ᵉˣᵖ`
   - Avoid calling `ToBigInt()` which incurs montgomery reduction
   - Use `GetCoset()`
   - Use a new feature of `GetSuccesivePowers()` in #221.