### PR TITLE
fix(zk): read commitments from proof in the correct order

### DIFF
--- a/tachyon/c/zk/plonk/halo2/prover_replay.cc
+++ b/tachyon/c/zk/plonk/halo2/prover_replay.cc
@@ -51,7 +51,7 @@ void CreateProof(tachyon_halo2_bn254_shplonk_prover* c_prover,
                  const std::vector<uint8_t>& transcript_state_bytes) {
   Prover* prover = reinterpret_cast<Prover*>(c_prover);
   std::cout << "deserializing proving key" << std::endl;
-  ProvingKey pk(absl::MakeConstSpan(pk_bytes));
+  ProvingKey pk(absl::MakeConstSpan(pk_bytes), /*read_only_vk=*/false);
   std::cout << "done deserializing proving key" << std::endl;
 
   uint32_t extended_k = pk.verifying_key().constraint_system().ComputeExtendedK(

--- a/tachyon/c/zk/plonk/halo2/verifier_replay.cc
+++ b/tachyon/c/zk/plonk/halo2/verifier_replay.cc
@@ -36,7 +36,7 @@ bool VerifyProof(tachyon_halo2_bn254_shplonk_verifier* c_verifier,
                  const std::vector<uint8_t>& pk_bytes) {
   Verifier* verifier = reinterpret_cast<Verifier*>(c_verifier);
   std::cout << "deserializing proving key" << std::endl;
-  ProvingKey pk(absl::MakeConstSpan(pk_bytes));
+  ProvingKey pk(absl::MakeConstSpan(pk_bytes), /*read_only_vk=*/true);
   std::cout << "done deserializing proving key" << std::endl;
 
   uint32_t extended_k = pk.verifying_key().constraint_system().ComputeExtendedK(

--- a/tachyon/c/zk/plonk/keys/bn254_plonk_proving_key.cc
+++ b/tachyon/c/zk/plonk/keys/bn254_plonk_proving_key.cc
@@ -14,7 +14,8 @@ using PKeyImpl = c::zk::plonk::bn254::ProvingKeyImpl;
 tachyon_bn254_plonk_proving_key*
 tachyon_bn254_plonk_proving_key_create_from_state(const uint8_t* state,
                                                   size_t state_len) {
-  PKeyImpl* pkey = new PKeyImpl(absl::Span<const uint8_t>(state, state_len));
+  PKeyImpl* pkey = new PKeyImpl(absl::Span<const uint8_t>(state, state_len),
+                                /*read_only_vk=*/false);
   return reinterpret_cast<tachyon_bn254_plonk_proving_key*>(pkey);
 }
 

--- a/tachyon/c/zk/plonk/keys/bn254_plonk_proving_key_impl.h
+++ b/tachyon/c/zk/plonk/keys/bn254_plonk_proving_key_impl.h
@@ -20,9 +20,8 @@ class ProvingKeyImpl
     : public ProvingKeyImplBase<Poly, Evals,
                                 tachyon::math::bn254::G1AffinePoint> {
  public:
-  explicit ProvingKeyImpl(absl::Span<const uint8_t> state)
-      : ProvingKeyImplBase<Poly, Evals, tachyon::math::bn254::G1AffinePoint>(
-            state) {}
+  using ProvingKeyImplBase<
+      Poly, Evals, tachyon::math::bn254::G1AffinePoint>::ProvingKeyImplBase;
 };
 
 using PKeyImpl = ProvingKeyImpl;

--- a/tachyon/c/zk/plonk/keys/proving_key_impl_base.h
+++ b/tachyon/c/zk/plonk/keys/proving_key_impl_base.h
@@ -24,7 +24,8 @@ class ProvingKeyImplBase
  public:
   using F = typename Poly::Field;
 
-  explicit ProvingKeyImplBase(absl::Span<const uint8_t> state) {
+  ProvingKeyImplBase(absl::Span<const uint8_t> state, bool read_only_vk)
+      : read_only_vk_(read_only_vk) {
     std::string_view pk_str;
     if (base::Environment::Get("TACHYON_PK_LOG_PATH", &pk_str)) {
       VLOG(1) << "Save pk to: " << pk_str;
@@ -53,6 +54,7 @@ class ProvingKeyImplBase
  private:
   void ReadProvingKey(const base::ReadOnlyBuffer& buffer) {
     ReadVerifyingKey(buffer, this->verifying_key_);
+    if (read_only_vk_) return;
     ReadBuffer(buffer, this->l_first_);
     ReadBuffer(buffer, this->l_last_);
     ReadBuffer(buffer, this->l_active_row_);
@@ -104,6 +106,9 @@ class ProvingKeyImplBase
     ReadBuffer(buffer, cs.lookups_);
     ReadBuffer(buffer, cs.constants_);
   }
+
+ private:
+  bool read_only_vk_ = false;
 };
 
 }  // namespace tachyon::c::zk::plonk

--- a/tachyon/zk/plonk/halo2/proof_reader.h
+++ b/tachyon/zk/plonk/halo2/proof_reader.h
@@ -53,16 +53,18 @@ class ProofReader {
     const ConstraintSystem<F>& constraint_system =
         verifying_key_.constraint_system();
     proof_.advices_commitments_vec.resize(num_circuits_);
+    size_t num_advice_columns = constraint_system.num_advice_columns();
     for (size_t i = 0; i < num_circuits_; ++i) {
-      proof_.advices_commitments_vec[i].reserve(
-          constraint_system.num_advice_columns());
+      proof_.advices_commitments_vec[i].resize(num_advice_columns);
     }
     proof_.challenges.reserve(constraint_system.challenge_phases().size());
     for (Phase current_phase : constraint_system.GetPhases()) {
       for (size_t i = 0; i < num_circuits_; ++i) {
-        for (Phase phase : constraint_system.advice_column_phases()) {
-          if (current_phase == phase) {
-            proof_.advices_commitments_vec[i].push_back(Read<C>());
+        const std::vector<Phase>& advice_column_phases =
+            constraint_system.advice_column_phases();
+        for (size_t j = 0; j < num_advice_columns; ++j) {
+          if (current_phase == advice_column_phases[j]) {
+            proof_.advices_commitments_vec[i][j] = Read<C>();
           }
         }
       }


### PR DESCRIPTION
# Description

Unlike other columns, the advice columns have their own phases. The phase iterates from 0, and the advice columns are committed when the current phase is equal to the phases of the advice columns. Therefore, commitments are created in the order of phase. However, commitments should be written to the proof in the order of column. For example, if there are commitments {C₀, C₁, C₂} corresponding to columns 0, 1, 2 and phases {0, 1, 0}, previously, the proof was read in the order of C₀, C₂, C₁, even though the correct order should have been C₀, C₁, C₂. In this commit, the order to read the columns has been corrected.