### PR TITLE
perf: optimize `KZG::UnsafeSetup`

### DIFF
--- a/tachyon/crypto/commitments/kzg/kzg.h
+++ b/tachyon/crypto/commitments/kzg/kzg.h
@@ -73,13 +73,11 @@ class KZG {
   }
 
   [[nodiscard]] bool UnsafeSetup(size_t size, const Field& tau) {
-    using G1JacobianPoint = math::JacobianPoint<typename G1Point::Curve>;
     using Domain = math::UnivariateEvaluationDomain<Field, kMaxDegree>;
 
     // |g1_powers_of_tau_| = [𝜏⁰g₁, 𝜏¹g₁, ... , 𝜏ⁿ⁻¹g₁]
     G1Point g1 = G1Point::Generator();
     std::vector<Field> powers_of_tau = Field::GetSuccessivePowers(size, tau);
-    std::vector<G1JacobianPoint> g1_powers_of_tau_jacobian;
 
     g1_powers_of_tau_.resize(size);
     if (!G1Point::BatchMapScalarFieldToPoint(g1, powers_of_tau,
@@ -91,7 +89,6 @@ class KZG {
     std::unique_ptr<Domain> domain = Domain::Create(size);
     std::vector<Field> lagrange_coeffs =
         domain->EvaluateAllLagrangeCoefficients(tau);
-    std::vector<G1JacobianPoint> g1_powers_of_tau_lagrange_jacobian;
 
     g1_powers_of_tau_lagrange_.resize(size);
     return G1Point::BatchMapScalarFieldToPoint(g1, lagrange_coeffs,

--- a/tachyon/math/elliptic_curves/short_weierstrass/BUILD.bazel
+++ b/tachyon/math/elliptic_curves/short_weierstrass/BUILD.bazel
@@ -21,6 +21,7 @@ tachyon_cc_library(
         "projective_point_impl.h",
     ],
     deps = [
+        "//tachyon/base:parallelize",
         "//tachyon/base/buffer:copyable",
         "//tachyon/base/containers:container_util",
         "//tachyon/base/json",

--- a/tachyon/math/elliptic_curves/short_weierstrass/affine_point_unittest.cc
+++ b/tachyon/math/elliptic_curves/short_weierstrass/affine_point_unittest.cc
@@ -113,10 +113,13 @@ TEST_F(AffinePointTest, ToPointXYZZ) {
   EXPECT_EQ(p.ToXYZZ(), test::PointXYZZ(GF7(3), GF7(2), GF7(1), GF7(1)));
 }
 
-#if defined(TACHYON_HAS_OPENMP)
 TEST_F(AffinePointTest, BatchMapScalarFieldToPoint) {
+#if defined(TACHYON_HAS_OPENMP)
   size_t size = size_t{1} << (static_cast<size_t>(omp_get_max_threads()) /
                               GF7::kParallelBatchInverseDivisorThreshold);
+#else
+  size_t size = 7;
+#endif  // defined(TACHYON_HAS_OPENMP)
   std::vector<GF7> scalar_fields =
       base::CreateVector(size, [](int i) { return GF7(i % 7); });
   test::AffinePoint point = test::AffinePoint::Generator();
@@ -128,28 +131,6 @@ TEST_F(AffinePointTest, BatchMapScalarFieldToPoint) {
 
   affine_points.resize(scalar_fields.size());
   ASSERT_TRUE(test::AffinePoint::BatchMapScalarFieldToPoint(
-      point, scalar_fields, &affine_points));
-
-  std::vector<test::AffinePoint> expected_affine_points =
-      base::Map(scalar_fields, [&point](const GF7& scalar_field) {
-        return (scalar_field * point).ToAffine();
-      });
-  EXPECT_EQ(affine_points, expected_affine_points);
-}
-#endif  // defined(TACHYON_HAS_OPENMP)
-
-TEST_F(AffinePointTest, BatchMapScalarFieldToPointSerial) {
-  std::vector<GF7> scalar_fields =
-      base::CreateVector(7, [](int i) { return GF7(i); });
-  test::AffinePoint point = test::AffinePoint::Generator();
-
-  std::vector<test::AffinePoint> affine_points;
-  affine_points.resize(6);
-  ASSERT_FALSE(test::AffinePoint::BatchMapScalarFieldToPointSerial(
-      point, scalar_fields, &affine_points));
-
-  affine_points.resize(7);
-  ASSERT_TRUE(test::AffinePoint::BatchMapScalarFieldToPointSerial(
       point, scalar_fields, &affine_points));
 
   std::vector<test::AffinePoint> expected_affine_points =


### PR DESCRIPTION
# Description

This PR optimizes `KZG::UnsafeSetup` by parallelizing `AffinePoint::DoBatchMapScalarFieldToPoint`.

Note that there is a side effect; `BatchMapScalarFieldToPointSerial` method is removed since `BatchNormalizeSerial` is called inside `base::Parallelize`.

Tachyon's `UnsafeSetup` is now 40% faster than halo2's.
