### PR TITLE
perf: optimize FFT and IFFT

### DIFF
--- a/tachyon/math/polynomials/univariate/mixed_radix_evaluation_domain.h
+++ b/tachyon/math/polynomials/univariate/mixed_radix_evaluation_domain.h
@@ -84,52 +84,17 @@ class MixedRadixEvaluationDomain
     return absl::WrapUnique(new MixedRadixEvaluationDomain(*this));
   }
 
-  [[nodiscard]] constexpr Evals FFT(const DensePoly& poly) const override {
-    if (poly.IsZero()) return {};
-
-    Evals evals;
-    evals.evaluations_ = poly.coefficients_.coefficients_;
-    return DoFFT(std::move(evals));
-  }
-
-  [[nodiscard]] constexpr Evals FFT(DensePoly&& poly) const override {
-    if (poly.IsZero()) return {};
-
-    Evals evals;
-    evals.evaluations_ = std::move(poly.coefficients_.coefficients_);
-    return DoFFT(std::move(evals));
-  }
-
-  [[nodiscard]] constexpr Evals DoFFT(Evals&& evals) const {
+  // UnivariateEvaluationDomain methods
+  constexpr void DoFFT(Evals& evals) const override {
     if (!this->offset_.IsOne()) {
       Base::DistributePowers(evals, this->offset_);
     }
     evals.evaluations_.resize(this->size_, F::Zero());
     BestFFT(evals, this->group_gen_);
-    return evals;
   }
 
-  [[nodiscard]] constexpr DensePoly IFFT(const Evals& evals) const override {
-    // NOTE(chokobole): This is not a faster check any more since
-    // https://github.com/kroma-network/tachyon/pull/104.
-    if (evals.IsZero()) return {};
-
-    DensePoly poly;
-    poly.coefficients_.coefficients_ = evals.evaluations_;
-    return DoIFFT(std::move(poly));
-  }
-
-  [[nodiscard]] constexpr DensePoly IFFT(Evals&& evals) const override {
-    // NOTE(chokobole): This is not a faster check any more since
-    // https://github.com/kroma-network/tachyon/pull/104.
-    if (evals.IsZero()) return {};
-
-    DensePoly poly;
-    poly.coefficients_.coefficients_ = std::move(evals.evaluations_);
-    return DoIFFT(std::move(poly));
-  }
-
-  [[nodiscard]] constexpr DensePoly DoIFFT(DensePoly&& poly) const {
+  // UnivariateEvaluationDomain methods
+  constexpr void DoIFFT(DensePoly& poly) const override {
     poly.coefficients_.coefficients_.resize(this->size_, F::Zero());
     BestFFT(poly, this->group_gen_inv_);
     if (this->offset_.IsOne()) {
@@ -143,7 +108,6 @@ class MixedRadixEvaluationDomain
                                           this->size_inv_);
     }
     poly.coefficients_.RemoveHighDegreeZeros();
-    return poly;
   }
 
   constexpr static bool ComputeSizeAndFactors(size_t num_coeffs,

--- a/tachyon/math/polynomials/univariate/radix2_evaluation_domain.h
+++ b/tachyon/math/polynomials/univariate/radix2_evaluation_domain.h
@@ -92,23 +92,8 @@ class Radix2EvaluationDomain : public UnivariateEvaluationDomain<F, MaxDegree> {
     return absl::WrapUnique(new Radix2EvaluationDomain(*this));
   }
 
-  [[nodiscard]] constexpr Evals FFT(const DensePoly& poly) const override {
-    if (poly.IsZero()) return {};
-
-    Evals evals;
-    evals.evaluations_ = poly.coefficients_.coefficients_;
-    return DoFFT(std::move(evals));
-  }
-
-  [[nodiscard]] constexpr Evals FFT(DensePoly&& poly) const override {
-    if (poly.IsZero()) return {};
-
-    Evals evals;
-    evals.evaluations_ = std::move(poly.coefficients_.coefficients_);
-    return DoFFT(std::move(evals));
-  }
-
-  [[nodiscard]] constexpr Evals DoFFT(Evals&& evals) const {
+  // UnivariateEvaluationDomain methods
+  constexpr void DoFFT(Evals& evals) const {
     if (evals.evaluations_.size() * kDegreeAwareFFTThresholdFactor <=
         this->size_) {
       DegreeAwareFFTInPlace(evals);
@@ -116,34 +101,13 @@ class Radix2EvaluationDomain : public UnivariateEvaluationDomain<F, MaxDegree> {
       evals.evaluations_.resize(this->size_, F::Zero());
       InOrderFFTInPlace(evals);
     }
-    return evals;
   }
 
-  [[nodiscard]] constexpr DensePoly IFFT(const Evals& evals) const override {
-    // NOTE(chokobole): This is not a faster check any more since
-    // https://github.com/kroma-network/tachyon/pull/104.
-    if (evals.IsZero()) return {};
-
-    DensePoly poly;
-    poly.coefficients_.coefficients_ = evals.evaluations_;
-    return DoIFFT(std::move(poly));
-  }
-
-  [[nodiscard]] constexpr DensePoly IFFT(Evals&& evals) const override {
-    // NOTE(chokobole): This is not a faster check any more since
-    // https://github.com/kroma-network/tachyon/pull/104.
-    if (evals.IsZero()) return {};
-
-    DensePoly poly;
-    poly.coefficients_.coefficients_ = std::move(evals.evaluations_);
-    return DoIFFT(std::move(poly));
-  }
-
-  [[nodiscard]] constexpr DensePoly DoIFFT(DensePoly&& poly) const {
+  // UnivariateEvaluationDomain methods
+  constexpr void DoIFFT(DensePoly& poly) const {
     poly.coefficients_.coefficients_.resize(this->size_, F::Zero());
     InOrderIFFTInPlace(poly);
     poly.coefficients_.RemoveHighDegreeZeros();
-    return poly;
   }
 
   // Degree aware FFT that runs in O(n log d) instead of O(n log n).

--- a/tachyon/math/polynomials/univariate/univariate_dense_coefficients.h
+++ b/tachyon/math/polynomials/univariate/univariate_dense_coefficients.h
@@ -222,6 +222,7 @@ class UnivariateDenseCoefficients {
   friend class internal::UnivariatePolynomialOp<
       UnivariateSparseCoefficients<F, MaxDegree>>;
   friend class UnivariatePolynomial<UnivariateDenseCoefficients<F, MaxDegree>>;
+  friend class UnivariateEvaluationDomain<F, MaxDegree>;
   friend class Radix2EvaluationDomain<F, MaxDegree>;
   friend class MixedRadixEvaluationDomain<F, MaxDegree>;
   friend class base::Copyable<UnivariateDenseCoefficients<F, MaxDegree>>;

--- a/tachyon/math/polynomials/univariate/univariate_evaluation_domain_unittest.cc
+++ b/tachyon/math/polynomials/univariate/univariate_evaluation_domain_unittest.cc
@@ -261,12 +261,6 @@ TYPED_TEST(UnivariateEvaluationDomainTest, FFTCorrectness) {
   // |Radix2EvaluationDomain::kDefaultMinNumChunksForCompaction| - 1.
   size_t log_degree = 5;
   size_t degree = (size_t{1} << log_degree) - 1;
-#if defined(TACHYON_HAS_OPENMP)
-  if constexpr (std::is_same_v<F, bls12_381::Fr>) {
-    degree = Domain::kDefaultMinNumChunksForCompaction - 1;
-    log_degree = base::bits::SafeLog2Ceiling(degree);
-  }
-#endif
   DensePoly rand_poly = DensePoly::Random(degree);
   for (size_t log_domain_size = log_degree; log_domain_size < log_degree + 2;
        ++log_domain_size) {

--- a/tachyon/zk/plonk/vanishing/vanishing_utils.h
+++ b/tachyon/zk/plonk/vanishing/vanishing_utils.h
@@ -127,31 +127,6 @@ ExtendedPoly ExtendedToCoeff(ExtendedEvals&& evals,
   return poly;
 }
 
-template <typename Domain, typename Poly, typename F, typename Evals>
-Evals CoeffToExtendedPart(const Domain* domain,
-                          const BlindedPolynomial<Poly, Evals>& poly,
-                          const F& zeta, const F& extended_omega_factor) {
-  return domain->GetCoset(zeta * extended_omega_factor)->FFT(poly.poly());
-}
-
-template <typename Domain, typename Poly, typename F,
-          typename Evals = typename Domain::Evals>
-Evals CoeffToExtendedPart(const Domain* domain, const Poly& poly, const F& zeta,
-                          const F& extended_omega_factor) {
-  return domain->GetCoset(zeta * extended_omega_factor)->FFT(poly);
-}
-
-template <typename Domain, typename Poly, typename F,
-          typename Evals = typename Domain::Evals>
-std::vector<Evals> CoeffsToExtendedParts(const Domain* domain,
-                                         absl::Span<Poly> polys, const F& zeta,
-                                         const F& extended_omega_factor) {
-  return base::Map(
-      polys, [domain, &zeta, &extended_omega_factor](const Poly& poly) {
-        return CoeffToExtendedPart(domain, poly, zeta, extended_omega_factor);
-      });
-}
-
 template <typename F>
 std::vector<F> BuildExtendedColumnWithColumns(
     const std::vector<std::vector<F>>& columns) {

--- a/tachyon/zk/plonk/vanishing/vanishing_utils_unittest.cc
+++ b/tachyon/zk/plonk/vanishing/vanishing_utils_unittest.cc
@@ -6,8 +6,6 @@
 
 #include "tachyon/zk/plonk/vanishing/vanishing_utils.h"
 
-#include <memory>
-#include <utility>
 #include <vector>
 
 #include "gtest/gtest.h"
@@ -39,29 +37,6 @@ TEST_F(VanishingUtilsTest, GetZeta) {
   F halo2_zeta = GetHalo2Zeta<F>();
   EXPECT_EQ(halo2_zeta.Pow(3), F::One());
   EXPECT_EQ(zeta * halo2_zeta, F::One());
-}
-
-TEST_F(VanishingUtilsTest, CoeffToExtendedPart) {
-  std::unique_ptr<Domain> domain = Domain::Create(N);
-
-  F zeta = GetHalo2Zeta<F>();
-  F extended_omega_factor = F::Random();
-  Poly poly = domain->Random<Poly>();
-
-  Evals extended_part =
-      CoeffToExtendedPart(domain.get(), poly, zeta, extended_omega_factor);
-
-  F offset = zeta * extended_omega_factor;
-  F base = F::One();
-  std::vector<F> expected = base::Map(poly.coefficients().coefficients(),
-                                      [&offset, &base](const F& coeff) {
-                                        F ret = coeff * base;
-                                        base *= offset;
-                                        return ret;
-                                      });
-
-  Poly expected_poly(Coeffs(std::move(expected)));
-  EXPECT_EQ(extended_part, domain->FFT(std::move(expected_poly)));
 }
 
 TEST_F(VanishingUtilsTest, BuildExtendedColumnWithColumns) {


### PR DESCRIPTION
In this PR, FFT and IFFT was improved by removing redundant calculations.
1. `InOutHelper` and `OutInHelper` were modified so that `GetRootsOfUnity` is no longer called upon their invocation. Instead, the domain is precomputed and stored at the time of creation.
2. `CoeffToExtendedPart` redundantly created the coset domain every time it was called. To fix this, the coset domain is now created only once by its caller.