### PR TITLE
perf(math): optimize usage of is one

### DIFF
--- a/tachyon/math/base/groups.h
+++ b/tachyon/math/base/groups.h
@@ -176,7 +176,7 @@ class MultiplicativeGroup : public MultiplicativeSemigroup<G> {
     // Multiply |product_inv| by |coeff|, so all inverses will be scaled by
     // |coeff|.
     // c * (a₁ * a₂ * ... *  aₙ)⁻¹
-    product_inv *= coeff;
+    if (!coeff.IsOne()) product_inv *= coeff;
 
     // Second pass: iterate backwards to compute inverses.
     //              [c * a₁⁻¹, c * a₂,⁻¹ ..., c * aₙ⁻¹]

--- a/tachyon/math/base/semigroups.h
+++ b/tachyon/math/base/semigroups.h
@@ -172,7 +172,8 @@ class MultiplicativeSemigroup {
     size_t num_elems_per_thread =
         base::GetNumElementsPerThread(ret, kDefaultParallelThreshold);
     OPENMP_PARALLEL_FOR(size_t i = 0; i < size; i += num_elems_per_thread) {
-      MulResult pow = c * generator.Pow(i);
+      MulResult pow = generator.Pow(i);
+      if (!c.IsOne()) pow *= c;
       for (size_t j = i; j < i + num_elems_per_thread && j < size; ++j) {
         ret[j] = pow;
         pow *= generator;

--- a/tachyon/math/elliptic_curves/bn/bn254/prime_field_fq.h
+++ b/tachyon/math/elliptic_curves/bn/bn254/prime_field_fq.h
@@ -103,7 +103,9 @@ class PrimeField<_Config, std::enable_if_t<_Config::kIsBn254Fq>> final
 
   constexpr bool IsZero() const { return Fq_rawIsZero(value_.limbs); }
 
-  constexpr bool IsOne() const { return ToBigInt().IsOne(); }
+  constexpr bool IsOne() const {
+    return Fq_rawIsEq(value_.limbs, Config::kOne.limbs);
+  }
 
   std::string ToString() const { return ToBigInt().ToString(); }
   std::string ToHexString(bool pad_zero = false) const {

--- a/tachyon/math/elliptic_curves/bn/bn254/prime_field_fr.h
+++ b/tachyon/math/elliptic_curves/bn/bn254/prime_field_fr.h
@@ -103,7 +103,9 @@ class PrimeField<_Config, std::enable_if_t<_Config::kIsBn254Fr>> final
 
   constexpr bool IsZero() const { return Fr_rawIsZero(value_.limbs); }
 
-  constexpr bool IsOne() const { return ToBigInt().IsOne(); }
+  constexpr bool IsOne() const {
+    return Fr_rawIsEq(value_.limbs, Config::kOne.limbs);
+  }
 
   std::string ToString() const { return ToBigInt().ToString(); }
   std::string ToHexString(bool pad_zero = false) const {

--- a/tachyon/math/elliptic_curves/secp/secp256k1/prime_field_fq.h
+++ b/tachyon/math/elliptic_curves/secp/secp256k1/prime_field_fq.h
@@ -103,7 +103,9 @@ class PrimeField<_Config, std::enable_if_t<_Config::kIsSecp256k1Fq>> final
 
   constexpr bool IsZero() const { return Fec_rawIsZero(value_.limbs); }
 
-  constexpr bool IsOne() const { return ToBigInt().IsOne(); }
+  constexpr bool IsOne() const {
+    return Fec_rawIsEq(value_.limbs, Config::kOne.limbs);
+  }
 
   std::string ToString() const { return ToBigInt().ToString(); }
   std::string ToHexString(bool pad_zero = false) const {

--- a/tachyon/math/elliptic_curves/secp/secp256k1/prime_field_fr.h
+++ b/tachyon/math/elliptic_curves/secp/secp256k1/prime_field_fr.h
@@ -103,7 +103,9 @@ class PrimeField<_Config, std::enable_if_t<_Config::kIsSecp256k1Fr>> final
 
   constexpr bool IsZero() const { return Fnec_rawIsZero(value_.limbs); }
 
-  constexpr bool IsOne() const { return ToBigInt().IsOne(); }
+  constexpr bool IsOne() const {
+    return Fnec_rawIsEq(value_.limbs, Config::kOne.limbs);
+  }
 
   std::string ToString() const { return ToBigInt().ToString(); }
   std::string ToHexString(bool pad_zero = false) const {

--- a/tachyon/math/finite_fields/prime_field.h
+++ b/tachyon/math/finite_fields/prime_field.h
@@ -99,7 +99,12 @@ class PrimeField<_Config, std::enable_if_t<!_Config::kIsSpecialPrime>> final
 
   constexpr bool IsZero() const { return value_.IsZero(); }
 
-  constexpr bool IsOne() const { return ToBigInt().IsOne(); }
+  constexpr bool IsOne() const {
+    for (size_t i = 0; i < N; ++i) {
+      if (value_[i] != Config::kOne[i]) return false;
+    }
+    return true;
+  }
 
   std::string ToString() const { return ToBigInt().ToString(); }
   std::string ToHexString(bool pad_zero = false) const {

--- a/tachyon/math/finite_fields/prime_field_gpu.h
+++ b/tachyon/math/finite_fields/prime_field_gpu.h
@@ -108,16 +108,21 @@ class PrimeFieldGpu final : public PrimeFieldBase<PrimeFieldGpu<_Config>> {
   }
 
   __device__ constexpr bool IsOne() const {
-    BigInt<N> value = ToBigInt();
-    const uint64_t* x = value.limbs;
-    uint64_t limbs_or = 0;
-    for (size_t i = 1; i < N; ++i) limbs_or |= x[i];
-    return x[0] == 1 && limbs_or == 0;
+    BigInt<N> one = GetOne();
+    for (size_t i = 0; i < N; ++i) {
+      if (value_[i] != one[i]) return false;
+    }
+    return true;
   }
 
   constexpr bool IsZeroHost() const { return value_.IsZero(); }
 
-  constexpr bool IsOneHost() const { return ToBigIntHost().IsOne(); }
+  constexpr bool IsOneHost() const {
+    for (size_t i = 0; i < N; ++i) {
+      if (value_[i] != Config::kOne[i]) return false;
+    }
+    return true;
+  }
 
   constexpr bool IsEven() const { return value_.IsEven(); }
 

--- a/tachyon/math/finite_fields/prime_field_gpu_debug.h
+++ b/tachyon/math/finite_fields/prime_field_gpu_debug.h
@@ -99,7 +99,12 @@ class PrimeFieldGpuDebug final
 
   constexpr bool IsZero() const { return ToBigInt().IsZero(); }
 
-  constexpr bool IsOne() const { return ToBigInt().IsOne(); }
+  constexpr bool IsOne() const {
+    for (size_t i = 0; i < N; ++i) {
+      if (value_[i] != Config::kOne[i]) return false;
+    }
+    return true;
+  }
 
   constexpr bool IsEven() const { return value_.IsEven(); }
 


### PR DESCRIPTION
# Description

This PR optimizes `IsOne()` by avoiding montgomery reduction and optimizes some functions by not multiplying the operand if it is one.