### PR TITLE
chore(halo2): add links for history tracking

### DIFF
--- a/vendors/halo2/src/bn254.rs
+++ b/vendors/halo2/src/bn254.rs
@@ -304,7 +304,8 @@ impl<W: Write, C: CurveAffine> TranscriptWriterBuffer<W, C, Challenge255<C>>
     }
 
     fn finalize(self) -> W {
-        // TODO: handle outstanding scalars? see issue #138
+        // TODO: handle outstanding scalars?
+        // See https://github.com/zcash/halo2/issues/138.
         self.writer
     }
 }
@@ -413,7 +414,8 @@ impl<W: Write, C: CurveAffine, E: EncodedChallenge<C>> PoseidonWrite<W, C, E> {
 
     /// Conclude the interaction and return the output buffer (writer).
     pub fn finalize(self) -> W {
-        // TODO: handle outstanding scalars? see issue #138
+        // TODO: handle outstanding scalars?
+        // See https://github.com/zcash/halo2/issues/138.
         self.writer
     }
 }
@@ -535,7 +537,8 @@ impl<W: Write, C: CurveAffine, E: EncodedChallenge<C>> Sha256Write<W, C, E> {
 
     /// Conclude the interaction and return the output buffer (writer).
     pub fn finalize(self) -> W {
-        // TODO: handle outstanding scalars? see issue #138
+        // TODO: handle outstanding scalars?
+        // See https://github.com/zcash/halo2/issues/138.
         self.writer
     }
 }


### PR DESCRIPTION
# Description

The issue doesn't belong to our repository, so this commit leaves a link for history tracking. This is actually raised by @TomTaehoonKim  in https://github.com/kroma-network/tachyon/pull/304#discussion_r1495159792, and I definitely made the changes, but somehow I missed during rebase... :(


