### PR TITLE
refac: remove unnecessary `CreateVector` call type

### DIFF
--- a/tachyon/base/containers/container_util.h
+++ b/tachyon/base/containers/container_util.h
@@ -66,14 +66,6 @@ std::vector<ReturnType> CreateVector(size_t size, Generator&& generator) {
   return ret;
 }
 
-template <typename T,
-          std::enable_if_t<!internal::IsCallableObject<T>::value>* = nullptr>
-std::vector<T> CreateVector(size_t size, const T& initial_value) {
-  std::vector<T> ret;
-  ret.resize(size, initial_value);
-  return ret;
-}
-
 template <typename Iterator, typename UnaryOp,
           typename FunctorTraits = internal::MakeFunctorTraits<UnaryOp>,
           typename RunType = typename FunctorTraits::RunType,

--- a/tachyon/base/containers/container_util_unittest.cc
+++ b/tachyon/base/containers/container_util_unittest.cc
@@ -34,11 +34,6 @@ TEST(ContainerUtilTest, CreateVectorWithGenerator) {
               testing::ContainerEq(std::vector<int>{1, 2, 3, 4, 5}));
 }
 
-TEST(ContainerUtilTest, CreateVectorWithInitialValue) {
-  EXPECT_THAT(CreateVector(5, 1),
-              testing::ContainerEq(std::vector<int>{1, 1, 1, 1, 1}));
-}
-
 TEST(ContainerUtilTest, Map) {
   std::vector<int> arr({1, 2, 3});
   EXPECT_THAT(Map(arr.begin(), arr.end(),

--- a/tachyon/base/parallelize_unittest.cc
+++ b/tachyon/base/parallelize_unittest.cc
@@ -5,8 +5,6 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-#include "tachyon/base/containers/container_util.h"
-
 namespace tachyon::base {
 
 namespace {
@@ -40,8 +38,7 @@ TEST(ParallelizeTest, ParallelizeByChunks) {
   EXPECT_EQ(expected, test_in);
 
   expected = {2, 3, 4, 5, 6, 7};
-  std::vector<size_t> chunk_indices =
-      base::CreateVector(test_in.size() / chunk_size, size_t{0});
+  std::vector<size_t> chunk_indices(test_in.size() / chunk_size, size_t{0});
   ParallelizeByChunkSize(
       test_in, chunk_size,
       [chunk_size, &chunk_indices](absl::Span<int> chunk, size_t chunk_offset) {
@@ -53,9 +50,8 @@ TEST(ParallelizeTest, ParallelizeByChunks) {
   EXPECT_THAT(chunk_indices, testing::UnorderedElementsAreArray({0, 1, 2}));
 
   expected = {3, 4, 5, 6, 7, 8};
-  chunk_indices = base::CreateVector(test_in.size() / chunk_size, size_t{0});
-  std::vector<size_t> chunk_sizes =
-      base::CreateVector(test_in.size() / chunk_size, size_t{0});
+  chunk_indices = std::vector<size_t>(test_in.size() / chunk_size, size_t{0});
+  std::vector<size_t> chunk_sizes(test_in.size() / chunk_size, size_t{0});
   ParallelizeByChunkSize(
       test_in, chunk_size,
       [chunk_size, &chunk_indices, &chunk_sizes](

--- a/tachyon/crypto/hashes/sponge/BUILD.bazel
+++ b/tachyon/crypto/hashes/sponge/BUILD.bazel
@@ -8,7 +8,6 @@ tachyon_cc_library(
     deps = [
         "//tachyon/base:logging",
         "//tachyon/base/buffer:copyable",
-        "//tachyon/base/containers:container_util",
         "//tachyon/math/finite_fields:finite_field_traits",
     ],
 )

--- a/tachyon/crypto/hashes/sponge/poseidon/poseidon.h
+++ b/tachyon/crypto/hashes/sponge/poseidon/poseidon.h
@@ -12,7 +12,6 @@
 #include <vector>
 
 #include "tachyon/base/buffer/copyable.h"
-#include "tachyon/base/containers/container_util.h"
 #include "tachyon/base/logging.h"
 #include "tachyon/crypto/hashes/prime_field_serializable.h"
 #include "tachyon/crypto/hashes/sponge/poseidon/poseidon_config.h"
@@ -274,8 +273,8 @@ struct PoseidonSponge final
     if constexpr (std::is_same_v<F, F2>) {
       return SqueezeNativeFieldElements(num_elements);
     } else {
-      return SqueezeFieldElementsWithSizes<F2>(base::CreateVector(
-          num_elements, []() { return FieldElementSize::Full(); }));
+      return SqueezeFieldElementsWithSizes<F2>(std::vector<FieldElementSize>(
+          num_elements, FieldElementSize::Full()));
     }
   }
 
@@ -283,8 +282,7 @@ struct PoseidonSponge final
   // NOTE(TomTaehoonKim): If you ever update this, please update
   // |Halo2PoseidonSponge| for consistency.
   std::vector<F> SqueezeNativeFieldElements(size_t num_elements) {
-    std::vector<F> ret =
-        base::CreateVector(num_elements, []() { return F::Zero(); });
+    std::vector<F> ret(num_elements);
     switch (state.mode.type) {
       case DuplexSpongeMode::Type::kAbsorbing: {
         Permute();

--- a/tachyon/crypto/hashes/sponge/sponge.h
+++ b/tachyon/crypto/hashes/sponge/sponge.h
@@ -10,7 +10,6 @@
 #include <vector>
 
 #include "tachyon/base/buffer/copyable.h"
-#include "tachyon/base/containers/container_util.h"
 #include "tachyon/base/logging.h"
 #include "tachyon/math/finite_fields/finite_field_traits.h"
 
@@ -75,8 +74,8 @@ class CryptographicSponge {
   // Squeeze |num_elements| nonnative field elements from the sponge.
   std::vector<F> SqueezeFieldElements(size_t num_elements) {
     Derived* derived = static_cast<Derived*>(this);
-    return derived->SqueezeFieldElementsWithSizes(base::CreateVector(
-        num_elements, []() { return FieldElementSize::Full(); }));
+    return derived->SqueezeFieldElementsWithSizes(
+        std::vector<FieldElementSize>(num_elements, FieldElementSize::Full()));
   }
 
   // Creates a new sponge with applied domain separation.

--- a/tachyon/math/elliptic_curves/msm/algorithms/pippenger/BUILD.bazel
+++ b/tachyon/math/elliptic_curves/msm/algorithms/pippenger/BUILD.bazel
@@ -13,7 +13,6 @@ tachyon_cc_library(
     deps = [
         ":pippenger_base",
         "//tachyon/base:openmp_util",
-        "//tachyon/base/containers:container_util",
         "//tachyon/math/elliptic_curves/msm:msm_ctx",
         "//tachyon/math/elliptic_curves/msm:msm_util",
     ],

--- a/tachyon/math/elliptic_curves/msm/algorithms/pippenger/pippenger.h
+++ b/tachyon/math/elliptic_curves/msm/algorithms/pippenger/pippenger.h
@@ -12,7 +12,6 @@
 #include <utility>
 #include <vector>
 
-#include "tachyon/base/containers/container_util.h"
 #include "tachyon/base/openmp_util.h"
 #include "tachyon/math/base/big_int.h"
 #include "tachyon/math/elliptic_curves/msm/algorithms/pippenger/pippenger_base.h"
@@ -94,8 +93,7 @@ class Pippenger : public PippengerBase<Point> {
       scalars[i] = scalars_it->ToBigInt();
     }
 
-    std::vector<Bucket> window_sums =
-        base::CreateVector(ctx_.window_count, Bucket::Zero());
+    std::vector<Bucket> window_sums(ctx_.window_count);
 
     if (use_msm_window_naf_) {
       AccumulateWindowNAFSums(std::move(bases_first), scalars, &window_sums);
@@ -120,8 +118,7 @@ class Pippenger : public PippengerBase<Point> {
     } else {
       bucket_size = 1 << (ctx_.window_bits - 1);
     }
-    std::vector<Bucket> buckets =
-        base::CreateVector(bucket_size, Bucket::Zero());
+    std::vector<Bucket> buckets(bucket_size);
     for (size_t j = 0; j < scalar_digits.size(); ++j, ++bases_it) {
       const Point& base = *bases_it;
       int64_t scalar = scalar_digits[j][i];
@@ -169,8 +166,7 @@ class Pippenger : public PippengerBase<Point> {
     Bucket window_sum = Bucket::Zero();
     // We don't need the "zero" bucket, so we only have 2^{window_bits} - 1
     // buckets.
-    std::vector<Bucket> buckets =
-        base::CreateVector((1 << ctx_.window_bits) - 1, Bucket::Zero());
+    std::vector<Bucket> buckets((1 << ctx_.window_bits) - 1);
     auto bases_it = bases_first;
     for (size_t j = 0; j < scalars.size(); ++j, ++bases_it) {
       const BigInt<N>& scalar = scalars[j];

--- a/tachyon/math/elliptic_curves/msm/fixed_base_msm.h
+++ b/tachyon/math/elliptic_curves/msm/fixed_base_msm.h
@@ -200,7 +200,7 @@ class FixedBaseMSM {
     // -------+-----------+-----------+-------+------------+------------+
 
     base_multiples_ = base::CreateVector(window_count, [window_size]() {
-      return base::CreateVector(window_size, AddResult::Zero());
+      return std::vector<AddResult>(window_size);
     });
     OPENMP_PARALLEL_FOR(size_t i = 0; i < window_count; ++i) {
       size_t cur_window_size =

--- a/tachyon/math/elliptic_curves/msm/fixed_base_msm.h
+++ b/tachyon/math/elliptic_curves/msm/fixed_base_msm.h
@@ -199,9 +199,8 @@ class FixedBaseMSM {
     //    31  |  31 * 2⁰G |  31 * 2⁵G |  ...  | 31 * 2²⁴⁵G |     0G     |
     // -------+-----------+-----------+-------+------------+------------+
 
-    base_multiples_ = base::CreateVector(window_count, [window_size]() {
-      return std::vector<AddResult>(window_size);
-    });
+    base_multiples_ = std::vector<std::vector<AddResult>>(
+        window_count, std::vector<AddResult>(window_size));
     OPENMP_PARALLEL_FOR(size_t i = 0; i < window_count; ++i) {
       size_t cur_window_size =
           i == window_count - 1 ? last_window_size : window_size;

--- a/tachyon/math/polynomials/multivariate/linear_combination_unittest.cc
+++ b/tachyon/math/polynomials/multivariate/linear_combination_unittest.cc
@@ -36,7 +36,8 @@ TEST_F(LinearCombinationTest, AddTermAndSumOfProducts) {
       });
   linear_combination.AddTerm(coefficient1, evals1);
 
-  Point evaluation_point = base::CreateVector(kMaxDegree, F::Random());
+  Point evaluation_point =
+      base::CreateVector(kMaxDegree, []() { return F::Random(); });
 
   // Set up the expected evaluation result for this 1 term
   F expected_evaluation =
@@ -52,8 +53,8 @@ TEST_F(LinearCombinationTest, AddTermAndSumOfProducts) {
 
   // Test |AddTerm()| and |SumOfProducts| on 2 terms
   F coefficient2 = F::Random();
-  std::vector<PolyPtr> evals2 =
-      base::CreateVector(5, std::make_shared<Poly>(Poly::Random(kMaxDegree)));
+  std::vector<PolyPtr> evals2 = base::CreateVector(
+      5, []() { return std::make_shared<Poly>(Poly::Random(kMaxDegree)); });
   linear_combination.AddTerm(coefficient2, evals2);
   expected_evaluation +=
       coefficient2 *

--- a/tachyon/math/polynomials/multivariate/multilinear_dense_evaluations.h
+++ b/tachyon/math/polynomials/multivariate/multilinear_dense_evaluations.h
@@ -53,7 +53,7 @@ class MultilinearDenseEvaluations {
 
   constexpr static MultilinearDenseEvaluations One(size_t degree) {
     return MultilinearDenseEvaluations(
-        base::CreateVector(size_t{1} << degree, F::One()));
+        std::vector<F>(size_t{1} << degree, F::One()));
   }
 
   constexpr static MultilinearDenseEvaluations Random(size_t degree) {
@@ -175,7 +175,7 @@ class MultilinearDenseEvaluations {
   // |degree| + 1.
   constexpr static MultilinearDenseEvaluations Zero(size_t degree) {
     MultilinearDenseEvaluations ret;
-    ret.evaluations_ = base::CreateVector(size_t{1} << degree, F::Zero());
+    ret.evaluations_ = std::vector<F>(size_t{1} << degree);
     return ret;
   }
 

--- a/tachyon/math/polynomials/multivariate/multilinear_dense_evaluations_unittest.cc
+++ b/tachyon/math/polynomials/multivariate/multilinear_dense_evaluations_unittest.cc
@@ -209,11 +209,11 @@ TEST_F(MultilinearDenseEvaluationsTest, MultiplicativeOperators) {
 }
 
 TEST_F(MultilinearDenseEvaluationsTest, Hash) {
-  EXPECT_TRUE(absl::VerifyTypeImplementsAbslHashCorrectly(std::make_tuple(
-      Poly(), Poly::Zero(),
-      Poly(Evals(base::CreateVector(size_t{1} << kMaxDegree, GF7::Zero()))),
-      Poly::One(kMaxDegree), Poly::Random(kMaxDegree),
-      Poly::Random(kMaxDegree))));
+  EXPECT_TRUE(absl::VerifyTypeImplementsAbslHashCorrectly(
+      std::make_tuple(Poly(), Poly::Zero(),
+                      Poly(Evals(std::vector<GF7>(size_t{1} << kMaxDegree))),
+                      Poly::One(kMaxDegree), Poly::Random(kMaxDegree),
+                      Poly::Random(kMaxDegree))));
 }
 
 }  // namespace tachyon::math

--- a/tachyon/math/polynomials/univariate/BUILD.bazel
+++ b/tachyon/math/polynomials/univariate/BUILD.bazel
@@ -9,7 +9,6 @@ tachyon_cc_library(
         ":univariate_polynomial",
         "//tachyon/base:parallelize",
         "//tachyon/base:template_util",
-        "//tachyon/base/containers:container_util",
     ],
 )
 

--- a/tachyon/math/polynomials/univariate/lagrange_interpolation.h
+++ b/tachyon/math/polynomials/univariate/lagrange_interpolation.h
@@ -10,7 +10,6 @@
 #include <utility>
 #include <vector>
 
-#include "tachyon/base/containers/container_util.h"
 #include "tachyon/base/parallelize.h"
 #include "tachyon/base/template_util.h"
 #include "tachyon/math/polynomials/univariate/univariate_polynomial.h"
@@ -38,7 +37,7 @@ bool LagrangeInterpolate(
 
   // points = [x₀, x₁, ..., xₙ₋₁]
   // |denoms[i]| = Dᵢ = 1 / (xᵢ - x₀)(xᵢ - x₁)...(xᵢ - xₙ₋₁)
-  std::vector<F> denoms = base::CreateVector(points.size(), F::One());
+  std::vector<F> denoms(points.size(), F::One());
   base::Parallelize(denoms, [&points](absl::Span<F> chunk, size_t chunk_offset,
                                       size_t chunk_size) {
     size_t i = chunk_offset * chunk_size;

--- a/tachyon/math/polynomials/univariate/mixed_radix_evaluation_domain.h
+++ b/tachyon/math/polynomials/univariate/mixed_radix_evaluation_domain.h
@@ -303,8 +303,7 @@ class MixedRadixEvaluationDomain
     // |num_cosets|}, etc.) the second coset is (g, g^{1 + |num_cosets|}, g^{1 +
     // 2 * |num_cosets|}, etc.) These are cosets with generator
     // g^{|num_cosets|}, and varying shifts.
-    std::vector<PolyOrEvals> tmp =
-        base::CreateVector(num_cosets, PolyOrEvals::Zero(coset_size - 1));
+    std::vector<PolyOrEvals> tmp(num_cosets, PolyOrEvals::Zero(coset_size - 1));
     F new_omega = omega.Pow(num_cosets);
     uint32_t new_two_adicity =
         ComputeAdicity(2, gmp::FromUnsignedInt(coset_size));

--- a/tachyon/math/polynomials/univariate/univariate_dense_coefficients.h
+++ b/tachyon/math/polynomials/univariate/univariate_dense_coefficients.h
@@ -101,8 +101,7 @@ class UnivariateDenseCoefficients {
     // i = 3 | x₀x₁x₂x₃ | -(x₀x₁x₂ + x₀x₁x₃ + x₀x₂x₃ + x₁x₂x₃) | x₀x₁ + x₀x₂ + x₀x₃ + x₁x₂ + x₁x₃ + x₂x₃ | -(x₀ + x₁ + x₂ + x₃) |    1 |
     // clang-format on
 
-    std::vector<F> coefficients =
-        base::CreateVector(std::size(roots) + 1, F::Zero());
+    std::vector<F> coefficients(std::size(roots) + 1);
     coefficients[0] = F::One();
     for (size_t i = 0; i < std::size(roots); ++i) {
       for (size_t j = i + 1; j > 0; --j) {
@@ -171,8 +170,7 @@ class UnivariateDenseCoefficients {
   template <bool MulRandomWithEvens>
   constexpr UnivariateDenseCoefficients Fold(const Field& r) const {
     size_t size = coefficients_.size();
-    std::vector<F> coefficients =
-        base::CreateVector((size + 1) >> 1, F::Zero());
+    std::vector<F> coefficients((size + 1) >> 1);
     OPENMP_PARALLEL_FOR(size_t i = 0; i < size; i += 2) {
       if constexpr (MulRandomWithEvens) {
         coefficients[i >> 1] = coefficients_[i];
@@ -232,7 +230,7 @@ class UnivariateDenseCoefficients {
   // with |IsZero()|, it returns false. So please use it carefully!
   constexpr static UnivariateDenseCoefficients Zero(size_t degree) {
     UnivariateDenseCoefficients ret;
-    ret.coefficients_ = base::CreateVector(degree + 1, F::Zero());
+    ret.coefficients_ = std::vector<F>(degree + 1);
     return ret;
   }
 

--- a/tachyon/math/polynomials/univariate/univariate_evaluations.h
+++ b/tachyon/math/polynomials/univariate/univariate_evaluations.h
@@ -71,7 +71,7 @@ class UnivariateEvaluations final
 
   constexpr static UnivariateEvaluations One(size_t degree) {
     UnivariateEvaluations ret;
-    ret.evaluations_ = base::CreateVector(degree + 1, F::One());
+    ret.evaluations_ = std::vector<F>(degree + 1, F::One());
     return ret;
   }
 
@@ -214,7 +214,7 @@ class UnivariateEvaluations final
   // |degree| + 1.
   constexpr static UnivariateEvaluations Zero(size_t degree) {
     UnivariateEvaluations ret;
-    ret.evaluations_ = base::CreateVector(degree + 1, F::Zero());
+    ret.evaluations_ = std::vector<F>(degree + 1);
     return ret;
   }
 

--- a/tachyon/math/polynomials/univariate/univariate_evaluations_unittest.cc
+++ b/tachyon/math/polynomials/univariate/univariate_evaluations_unittest.cc
@@ -271,11 +271,10 @@ TEST_F(UnivariateEvaluationsTest, Copyable) {
 }
 
 TEST_F(UnivariateEvaluationsTest, Hash) {
-  EXPECT_TRUE(absl::VerifyTypeImplementsAbslHashCorrectly(
-      std::make_tuple(Poly(), Poly::Zero(),
-                      Poly({base::CreateVector(kMaxDegree + 1, GF7::Zero())}),
-                      Poly::One(kMaxDegree), Poly::Random(kMaxDegree),
-                      Poly::Random(kMaxDegree))));
+  EXPECT_TRUE(absl::VerifyTypeImplementsAbslHashCorrectly(std::make_tuple(
+      Poly(), Poly::Zero(), Poly({std::vector<GF7>(kMaxDegree + 1)}),
+      Poly::One(kMaxDegree), Poly::Random(kMaxDegree),
+      Poly::Random(kMaxDegree))));
 }
 
 TEST_F(UnivariateEvaluationsTest, JsonValueConverter) {

--- a/tachyon/math/polynomials/univariate/univariate_polynomial_ops.h
+++ b/tachyon/math/polynomials/univariate/univariate_polynomial_ops.h
@@ -59,7 +59,7 @@ class UnivariatePolynomialOp<UnivariateDenseCoefficients<F, MaxDegree>> {
     size_t other_degree = other.Degree();
     std::vector<F> upper_coeffs;
     if (degree < other_degree) {
-      upper_coeffs = base::CreateVector(other_degree - degree, F::Zero());
+      upper_coeffs = std::vector<F>(other_degree - degree);
     }
 
     std::vector<F>& l_coefficients = self.coefficients_.coefficients_;
@@ -114,7 +114,7 @@ class UnivariatePolynomialOp<UnivariateDenseCoefficients<F, MaxDegree>> {
     size_t other_degree = other.Degree();
     std::vector<F> upper_coeffs;
     if (degree < other_degree) {
-      upper_coeffs = base::CreateVector(other_degree - degree, F::Zero());
+      upper_coeffs = std::vector<F>(other_degree - degree);
     }
 
     std::vector<F>& l_coefficients = self.coefficients_.coefficients_;
@@ -171,8 +171,7 @@ class UnivariatePolynomialOp<UnivariateDenseCoefficients<F, MaxDegree>> {
 
     size_t degree = self.Degree();
     size_t other_degree = other.Degree();
-    std::vector<F> coefficients =
-        base::CreateVector(degree + other_degree + 1, F::Zero());
+    std::vector<F> coefficients(degree + other_degree + 1);
     for (size_t i = 0; i < r_coefficients.size(); ++i) {
       const F& r = r_coefficients[i];
       if (r.IsZero()) {
@@ -203,8 +202,7 @@ class UnivariatePolynomialOp<UnivariateDenseCoefficients<F, MaxDegree>> {
 
     size_t degree = self.Degree();
     size_t other_degree = other.Degree();
-    std::vector<F> coefficients =
-        base::CreateVector(degree + other_degree + 1, F::Zero());
+    std::vector<F> coefficients(degree + other_degree + 1);
 
     const std::vector<Term>& r_terms = other.coefficients().terms_;
     for (size_t i = 0; i < r_terms.size(); ++i) {
@@ -284,7 +282,7 @@ class UnivariatePolynomialOp<UnivariateDenseCoefficients<F, MaxDegree>> {
   static UnivariatePolynomial<D>& Copy(UnivariatePolynomial<D>& self,
                                        const UnivariatePolynomial<S>& other) {
     std::vector<F>& l_coefficients = self.coefficients_.coefficients_;
-    l_coefficients = base::CreateVector(other.Degree() + 1, F::Zero());
+    l_coefficients = std::vector<F>(other.Degree() + 1);
 
     const std::vector<Term>& r_terms = other.coefficients().terms_;
     OPENMP_PARALLEL_FOR(const Term& r_term : r_terms) {
@@ -309,8 +307,7 @@ class UnivariatePolynomialOp<UnivariateDenseCoefficients<F, MaxDegree>> {
     } else if (self.Degree() < other.Degree()) {
       return {UnivariatePolynomial<D>::Zero(), self.ToDense()};
     }
-    std::vector<F> quotient =
-        base::CreateVector(self.Degree() - other.Degree() + 1, F::Zero());
+    std::vector<F> quotient(self.Degree() - other.Degree() + 1);
     UnivariatePolynomial<D> remainder = self.ToDense();
     std::vector<F>& r_coefficients = remainder.coefficients_.coefficients_;
     F divisor_leading_inv = other.GetLeadingCoefficient().Inverse();

--- a/tachyon/zk/lookup/halo2/BUILD.bazel
+++ b/tachyon/zk/lookup/halo2/BUILD.bazel
@@ -21,7 +21,6 @@ tachyon_cc_library(
     name = "permute_expression_pair",
     hdrs = ["permute_expression_pair.h"],
     deps = [
-        "//tachyon/base/containers:container_util",
         "//tachyon/zk/base/entities:prover_base",
         "//tachyon/zk/lookup:lookup_pair",
         "@com_google_absl//absl/container:btree",

--- a/tachyon/zk/lookup/halo2/compress_expression_unittest.cc
+++ b/tachyon/zk/lookup/halo2/compress_expression_unittest.cc
@@ -26,7 +26,7 @@ TEST_F(CompressExpressionTest, CompressExpressions) {
 
   size_t n = prover_->pcs().N();
   SimpleEvaluator<Evals> evaluator = evaluator_;
-  std::vector<F> expected = base::CreateVector(n, F::Zero());
+  std::vector<F> expected(n);
   for (size_t i = 0; i < expressions.size(); ++i) {
     F value = evaluator.Evaluate(expressions[i].get());
     for (size_t j = 0; j < n; ++j) {

--- a/tachyon/zk/lookup/halo2/permute_expression_pair.h
+++ b/tachyon/zk/lookup/halo2/permute_expression_pair.h
@@ -13,7 +13,6 @@
 
 #include "absl/container/btree_map.h"
 
-#include "tachyon/base/containers/container_util.h"
 #include "tachyon/zk/base/entities/prover_base.h"
 #include "tachyon/zk/lookup/lookup_pair.h"
 
@@ -52,8 +51,7 @@ template <typename PCS, typename Evals, typename F = typename Evals::Field>
     }
   }
 
-  std::vector<F> permuted_table_expressions =
-      base::CreateVector(domain_size, F::Zero());
+  std::vector<F> permuted_table_expressions(domain_size);
 
   std::vector<RowIndex> repeated_input_rows;
   repeated_input_rows.reserve(usable_rows - 1);

--- a/tachyon/zk/plonk/constraint_system/constraint_system.h
+++ b/tachyon/zk/plonk/constraint_system/constraint_system.h
@@ -296,8 +296,7 @@ class ConstraintSystem {
     // expressions in gates, as lookup arguments cannot support simple
     // selectors. Selectors that are complex or do not appear in any gates
     // will have degree zero.
-    std::vector<size_t> degrees =
-        base::CreateVector(selectors.size(), size_t{0});
+    std::vector<size_t> degrees(selectors.size(), size_t{0});
     for (const Gate<F>& gate : gates_) {
       for (const std::unique_ptr<Expression<F>>& expression : gate.polys()) {
         std::optional<Selector> selector = expression->ExtractSimpleSelector();
@@ -323,9 +322,9 @@ class ConstraintSystem {
 
     std::vector<FixedColumnKey> selector_map;
     selector_map.resize(selector_compressor.selector_assignments().size());
-    std::vector<base::Ref<const Expression<F>>> selector_replacements =
-        base::CreateVector(selector_compressor.selector_assignments().size(),
-                           base::Ref<const Expression<F>>());
+    std::vector<base::Ref<const Expression<F>>> selector_replacements(
+        selector_compressor.selector_assignments().size(),
+        base::Ref<const Expression<F>>());
     for (const SelectorAssignment<F>& assignment :
          selector_compressor.selector_assignments()) {
       selector_replacements[assignment.selector_index()] =

--- a/tachyon/zk/plonk/constraint_system/selector_compressor.h
+++ b/tachyon/zk/plonk/constraint_system/selector_compressor.h
@@ -174,7 +174,7 @@ class SelectorCompressor {
   void CombineSimpleSelectors(size_t n, const ExclusionMatrix& exclusion_matrix,
                               size_t max_degree) {
     // Simple selectors that we've added to combinations already.
-    std::vector<bool> added = base::CreateVector(selectors_.size(), false);
+    std::vector<bool> added(selectors_.size(), false);
     // For example in the first iteration, it adds:
     //   s₀: SelectorDescription(0, [1, 0, 0, 0, 0, 0, 0, 0, 1], 3)
     //   s₃: SelectorDescription(3, [0, 1, 0, 0, 0, 1, 1, 1, 0], 3)
@@ -237,7 +237,7 @@ class SelectorCompressor {
   void ConstructCombinedSelector(
       size_t n, const std::vector<SelectorDescription>& combination) {
     // Now, compute the selector and combination assignments.
-    std::vector<F> combination_assignment = base::CreateVector(n, F::Zero());
+    std::vector<F> combination_assignment(n);
     size_t combination_len = combination.size();
     size_t combination_index = combination_assignments_.size();
     std::unique_ptr<Expression<F>> query = callback_.Run();

--- a/tachyon/zk/plonk/examples/shuffle_circuit.h
+++ b/tachyon/zk/plonk/examples/shuffle_circuit.h
@@ -196,10 +196,8 @@ class ShuffleCircuit : public Circuit<ShuffleCircuitConfig<F, W>> {
 
   std::unique_ptr<Circuit<ShuffleCircuitConfig<F, W>>> WithoutWitness()
       const override {
-    std::vector<std::vector<F>> dummy_original_table =
-        base::CreateVector(W, []() { return std::vector<F>(H); });
-    std::vector<std::vector<F>> dummy_shuffled_table =
-        base::CreateVector(W, []() { return std::vector<F>(H); });
+    std::vector<std::vector<F>> dummy_original_table(W, std::vector<F>(H));
+    std::vector<std::vector<F>> dummy_shuffled_table(W, std::vector<F>(H));
     ShuffleCircuit dummy_circuit(std::move(dummy_original_table),
                                  std::move(dummy_shuffled_table));
     return std::make_unique<ShuffleCircuit>(std::move(dummy_circuit));

--- a/tachyon/zk/plonk/examples/shuffle_circuit.h
+++ b/tachyon/zk/plonk/examples/shuffle_circuit.h
@@ -196,10 +196,10 @@ class ShuffleCircuit : public Circuit<ShuffleCircuitConfig<F, W>> {
 
   std::unique_ptr<Circuit<ShuffleCircuitConfig<F, W>>> WithoutWitness()
       const override {
-    std::vector<std::vector<F>> dummy_original_table = base::CreateVector(
-        W, []() { return base::CreateVector(H, F::Zero()); });
-    std::vector<std::vector<F>> dummy_shuffled_table = base::CreateVector(
-        W, []() { return base::CreateVector(H, F::Zero()); });
+    std::vector<std::vector<F>> dummy_original_table =
+        base::CreateVector(W, []() { return std::vector<F>(H); });
+    std::vector<std::vector<F>> dummy_shuffled_table =
+        base::CreateVector(W, []() { return std::vector<F>(H); });
     ShuffleCircuit dummy_circuit(std::move(dummy_original_table),
                                  std::move(dummy_shuffled_table));
     return std::make_unique<ShuffleCircuit>(std::move(dummy_circuit));
@@ -285,7 +285,7 @@ class ShuffleCircuit : public Circuit<ShuffleCircuitConfig<F, W>> {
               z[i + 1] = z[i] * Value<F>::Known(product[i]);
             }
           } else {
-            z = base::CreateVector(H + 1, Value<F>::Unknown());
+            z = std::vector<Value<F>>(H + 1);
           }
 
           for (RowIndex i = 0; i < H + 1; ++i) {

--- a/tachyon/zk/plonk/halo2/BUILD.bazel
+++ b/tachyon/zk/plonk/halo2/BUILD.bazel
@@ -216,7 +216,6 @@ tachyon_cc_library(
     hdrs = ["synthesizer.h"],
     deps = [
         ":witness_collection",
-        "//tachyon/base/containers:container_util",
         "//tachyon/zk/base/entities:prover_base",
         "//tachyon/zk/plonk/constraint_system",
     ],

--- a/tachyon/zk/plonk/halo2/proof_unittest.cc
+++ b/tachyon/zk/plonk/halo2/proof_unittest.cc
@@ -21,8 +21,9 @@ using Commitment = math::bn254::G1AffinePoint;
 template <typename T>
 std::vector<std::vector<T>> CreateRandomElementsVec(RowIndex rows,
                                                     size_t cols) {
-  return base::CreateVector(
-      rows, [cols]() { return base::CreateVector(cols, T::Random()); });
+  return base::CreateVector(rows, [cols]() {
+    return base::CreateVector(cols, []() { return T::Random(); });
+  });
 }
 
 std::vector<std::vector<zk::LookupPair<Commitment>>> CreateRandomLookupPairsVec(
@@ -46,7 +47,8 @@ TEST(ProofTest, JsonValueConverter) {
   Proof<F, Commitment> expected_proof;
   expected_proof.advices_commitments_vec =
       CreateRandomElementsVec<Commitment>(num_circuits_, num_elements_);
-  expected_proof.challenges = base::CreateVector(num_circuits_, F::Random());
+  expected_proof.challenges =
+      base::CreateVector(num_circuits_, []() { return F::Random(); });
   expected_proof.theta = F::Random();
   expected_proof.lookup_permuted_commitments_vec =
       CreateRandomLookupPairsVec(num_circuits_, num_elements_);
@@ -59,23 +61,30 @@ TEST(ProofTest, JsonValueConverter) {
   expected_proof.vanishing_random_poly_commitment = Commitment::Random();
   expected_proof.y = F::Random();
   expected_proof.vanishing_h_poly_commitments =
-      base::CreateVector(5, Commitment::Random());
+      base::CreateVector(5, []() { return Commitment::Random(); });
   expected_proof.x = F::Random();
   expected_proof.instance_evals_vec =
       CreateRandomElementsVec<F>(num_circuits_, num_elements_);
   expected_proof.advice_evals_vec =
       CreateRandomElementsVec<F>(num_circuits_, num_elements_);
-  expected_proof.fixed_evals = base::CreateVector(num_circuits_, F::Random());
+  expected_proof.fixed_evals =
+      base::CreateVector(num_circuits_, []() { return F::Random(); });
   expected_proof.vanishing_random_eval = F::Random();
   expected_proof.common_permutation_evals =
-      base::CreateVector(num_circuits_, F::Random());
+      base::CreateVector(num_circuits_, []() { return F::Random(); });
   expected_proof.permutation_product_evals_vec =
       CreateRandomElementsVec<F>(num_circuits_, num_elements_);
   expected_proof.permutation_product_next_evals_vec =
       CreateRandomElementsVec<F>(num_circuits_, num_elements_);
-  expected_proof.permutation_product_last_evals_vec = {
-      base::CreateVector(5, std::optional<F>(F::Random())),
-      base::CreateVector(5, std::optional<F>())};
+  expected_proof.permutation_product_last_evals_vec =
+      std::vector<std::vector<std::optional<F>>>(
+          num_circuits_, base::CreateVector(num_elements_, [](size_t i) {
+            if (i % 2 == 0) {
+              return std::optional<F>(F::Random());
+            } else {
+              return std::optional<F>();
+            }
+          }));
   expected_proof.lookup_product_evals_vec =
       CreateRandomElementsVec<F>(num_circuits_, num_elements_);
   expected_proof.lookup_product_next_evals_vec =

--- a/tachyon/zk/plonk/halo2/synthesizer.h
+++ b/tachyon/zk/plonk/halo2/synthesizer.h
@@ -29,10 +29,10 @@ class Synthesizer {
     advice_blinds_vec_.resize(num_circuits_);
     for (size_t i = 0; i < num_circuits_; ++i) {
       // And these may be assigned with random order.
-      advice_columns_vec_[i] = base::CreateVector(
-          constraint_system->num_advice_columns(), Evals::Zero());
-      advice_blinds_vec_[i] = base::CreateVector(
-          constraint_system->num_advice_columns(), F::Zero());
+      advice_columns_vec_[i] =
+          std::vector<Evals>(constraint_system->num_advice_columns());
+      advice_blinds_vec_[i] =
+          std::vector<F>(constraint_system->num_advice_columns());
     }
   }
 

--- a/tachyon/zk/plonk/halo2/witness_collection.h
+++ b/tachyon/zk/plonk/halo2/witness_collection.h
@@ -13,7 +13,6 @@
 
 #include "absl/container/btree_map.h"
 
-#include "tachyon/base/containers/container_util.h"
 #include "tachyon/base/range.h"
 #include "tachyon/zk/plonk/base/phase.h"
 #include "tachyon/zk/plonk/layout/assignment.h"
@@ -32,8 +31,8 @@ class WitnessCollection : public Assignment<typename Evals::Field> {
                     RowIndex usable_rows, Phase current_phase,
                     const absl::btree_map<size_t, F>& challenges,
                     const std::vector<Evals>& instance_columns)
-      : advices_(base::CreateVector(num_advice_columns,
-                                    domain->template Zero<RationalEvals>())),
+      : advices_(std::vector<RationalEvals>(
+            num_advice_columns, domain->template Zero<RationalEvals>())),
         usable_rows_(base::Range<RowIndex>::Until(usable_rows)),
         current_phase_(current_phase),
         challenges_(challenges),

--- a/tachyon/zk/plonk/keys/key.h
+++ b/tachyon/zk/plonk/keys/key.h
@@ -38,11 +38,11 @@ class TACHYON_EXPORT Key {
     // NOTE(chokobole): It's safe to downcast because domain is already checked.
     RowIndex n = static_cast<RowIndex>(domain->size());
     return {
-        base::CreateVector(constraint_system.num_fixed_columns(),
-                           domain->template Zero<RationalEvals>()),
+        std::vector<RationalEvals>(constraint_system.num_fixed_columns(),
+                                   domain->template Zero<RationalEvals>()),
         PermutationAssembly(constraint_system.permutation(), n),
-        base::CreateVector(constraint_system.num_selectors(),
-                           base::CreateVector(n, false)),
+        std::vector<std::vector<bool>>(constraint_system.num_selectors(),
+                                       std::vector<bool>(n, false)),
         // NOTE(chokobole): Considering that this is called from a verifier,
         // then you can't load this number through |prover->GetUsableRows()|.
         base::Range<RowIndex>::Until(
@@ -81,8 +81,7 @@ class TACHYON_EXPORT Key {
 
     result->fixed_columns =
         base::Map(assembly.fixed_columns(), [](const RationalEvals& evals) {
-          std::vector<F> result =
-              base::CreateVector(evals.evaluations().size(), F::Zero());
+          std::vector<F> result(evals.evaluations().size());
           CHECK(math::RationalField<F>::BatchEvaluate(evals.evaluations(),
                                                       &result));
           return Evals(std::move(result));

--- a/tachyon/zk/plonk/permutation/BUILD.bazel
+++ b/tachyon/zk/plonk/permutation/BUILD.bazel
@@ -17,7 +17,6 @@ tachyon_cc_library(
     hdrs = ["grand_product_argument.h"],
     deps = [
         "//tachyon/base:parallelize",
-        "//tachyon/base/containers:container_util",
         "//tachyon/zk/base/entities:prover_base",
     ],
 )

--- a/tachyon/zk/plonk/permutation/cycle_store.h
+++ b/tachyon/zk/plonk/permutation/cycle_store.h
@@ -95,8 +95,8 @@ class TACHYON_EXPORT CycleStore {
           rows, [col](RowIndex row) { return Label(col, row); });
     }));
     aux_ = mapping_;
-    sizes_ =
-        Table(base::CreateVector(cols, base::CreateVector(rows, size_t{1})));
+    sizes_ = Table(std::vector<std::vector<size_t>>(
+        cols, std::vector<size_t>(rows, size_t{1})));
   }
 
   const Table<Label>& mapping() const { return mapping_; }

--- a/tachyon/zk/plonk/permutation/grand_product_argument.h
+++ b/tachyon/zk/plonk/permutation/grand_product_argument.h
@@ -4,7 +4,6 @@
 #include <utility>
 #include <vector>
 
-#include "tachyon/base/containers/container_util.h"
 #include "tachyon/base/parallelize.h"
 #include "tachyon/zk/base/entities/prover_base.h"
 
@@ -23,7 +22,7 @@ class GrandProductArgument {
 
     // NOTE(chokobole): It's safe to downcast because domain is already checked.
     RowIndex size = static_cast<RowIndex>(prover->pcs().N());
-    std::vector<F> z = base::CreateVector(size + 1, F::Zero());
+    std::vector<F> z(size + 1);
     absl::Span<F> grand_product = absl::MakeSpan(z).subspan(1);
 
     base::Parallelize(grand_product, std::move(denominator_callback));
@@ -45,7 +44,7 @@ class GrandProductArgument {
 
     // NOTE(chokobole): It's safe to downcast because domain is already checked.
     RowIndex size = static_cast<RowIndex>(prover->pcs().N());
-    std::vector<F> z = base::CreateVector(size + 1, F::Zero());
+    std::vector<F> z(size + 1);
     absl::Span<F> grand_product = absl::MakeSpan(z).subspan(1);
 
     for (RowIndex i = 0; i < size; ++i) {
@@ -75,7 +74,7 @@ class GrandProductArgument {
                                    size_t num_cols, F& last_z) {
     // NOTE(chokobole): It's safe to downcast because domain is already checked.
     RowIndex size = static_cast<RowIndex>(prover->pcs().N());
-    std::vector<F> z = base::CreateVector(size + 1, F::One());
+    std::vector<F> z(size + 1, F::One());
     absl::Span<F> grand_product = absl::MakeSpan(z).subspan(1);
 
     size_t chunk_size = base::GetNumElementsPerThread(grand_product);

--- a/tachyon/zk/plonk/permutation/permutation_assembly.h
+++ b/tachyon/zk/plonk/permutation/permutation_assembly.h
@@ -116,8 +116,8 @@ class TACHYON_EXPORT PermutationAssembly {
         UnpermutedTable<Evals>::Construct(columns_.size(), rows_, domain);
 
     // Init evaluation formed polynomials with all-zero coefficients.
-    std::vector<Evals> permutations =
-        base::CreateVector(columns_.size(), domain->template Zero<Evals>());
+    std::vector<Evals> permutations(columns_.size(),
+                                    domain->template Zero<Evals>());
 
     // Assign |unpermuted_table| to |permutations|.
     OPENMP_PARALLEL_NESTED_FOR(size_t i = 0; i < permutations.size(); ++i) {

--- a/tachyon/zk/plonk/permutation/unpermuted_table.h
+++ b/tachyon/zk/plonk/permutation/unpermuted_table.h
@@ -69,7 +69,7 @@ class UnpermutedTable {
 
     // Assign [δⁱω⁰, δⁱω¹, δⁱω², ..., δⁱωⁿ⁻¹] to each col.
     for (size_t i = 1; i < cols; ++i) {
-      std::vector<F> col = base::CreateVector(rows, F::Zero());
+      std::vector<F> col(rows);
       OPENMP_PARALLEL_FOR(RowIndex j = 0; j < rows; ++j) {
         col[j] = unpermuted_table[i - 1][j] * delta;
       }

--- a/tachyon/zk/plonk/vanishing/BUILD.bazel
+++ b/tachyon/zk/plonk/vanishing/BUILD.bazel
@@ -22,7 +22,6 @@ tachyon_cc_library(
         ":vanishing_utils",
         "//tachyon/base:parallelize",
         "//tachyon/base/containers:adapters",
-        "//tachyon/base/containers:container_util",
         "//tachyon/base/numerics:checked_math",
         "//tachyon/zk/base:rotation",
         "//tachyon/zk/lookup/halo2:prover",

--- a/tachyon/zk/plonk/vanishing/circuit_polynomial_builder.h
+++ b/tachyon/zk/plonk/vanishing/circuit_polynomial_builder.h
@@ -13,7 +13,6 @@
 #include "absl/types/span.h"
 
 #include "tachyon/base/containers/adapters.h"
-#include "tachyon/base/containers/container_util.h"
 #include "tachyon/base/numerics/checked_math.h"
 #include "tachyon/base/parallelize.h"
 #include "tachyon/zk/base/rotation.h"
@@ -105,8 +104,7 @@ class CircuitPolynomialBuilder {
 
       UpdateVanishingProvingKey(coset.get());
 
-      std::vector<F> value_part =
-          base::CreateVector(static_cast<size_t>(n_), F::Zero());
+      std::vector<F> value_part(static_cast<size_t>(n_));
       size_t circuit_num = poly_tables_->size();
       for (size_t j = 0; j < circuit_num; ++j) {
         VLOG(1) << "BuildExtendedCircuitColumn part: " << i << " circuit: ("

--- a/tachyon/zk/plonk/vanishing/graph_evaluator.h
+++ b/tachyon/zk/plonk/vanishing/graph_evaluator.h
@@ -12,7 +12,6 @@
 
 #include "absl/strings/substitute.h"
 
-#include "tachyon/base/containers/container_util.h"
 #include "tachyon/zk/expressions/advice_expression.h"
 #include "tachyon/zk/expressions/challenge_expression.h"
 #include "tachyon/zk/expressions/constant_expression.h"
@@ -210,10 +209,10 @@ class GraphEvaluator : public Evaluator<F, ValueSource> {
   }
 
   std::vector<F> CreateInitialIntermediates() const {
-    return base::CreateVector(num_intermediates_, F::Zero());
+    return std::vector<F>(num_intermediates_);
   }
   std::vector<int32_t> CreateEmptyRotations() const {
-    return base::CreateVector(rotations_.size(), 0);
+    return std::vector<int32_t>(rotations_.size(), 0);
   }
 
   // Currently does the simplest thing possible: just stores the

--- a/tachyon/zk/plonk/vanishing/vanishing_utils_unittest.cc
+++ b/tachyon/zk/plonk/vanishing/vanishing_utils_unittest.cc
@@ -40,8 +40,8 @@ TEST_F(VanishingUtilsTest, GetZeta) {
 }
 
 TEST_F(VanishingUtilsTest, BuildExtendedColumnWithColumns) {
-  std::vector<std::vector<F>> columns = base::CreateVector(
-      4, [](size_t i) { return base::CreateVector(N, F(i)); });
+  std::vector<std::vector<F>> columns =
+      base::CreateVector(4, [](size_t i) { return std::vector<F>(N, F(i)); });
 
   std::vector<F> extended = BuildExtendedColumnWithColumns(columns);
   EXPECT_EQ(extended.size(), 4 * N);


### PR DESCRIPTION
# Description

`base::CreateVector` was originally created to allow for easy population of vectors with a lambda function. A form of `base::CreateVector(size, value)` was also created to fill a vector of size `size` with `value`; however, this is redundant with a constructor in `std`. Therefore, the function form `base::CreateVector(size, value)` has been removed and all pertaining calls have been changed.