### PR TITLE
refac: remove redundant calls to `absl::MakeSpan()` and `absl::MakeConstSpan()`

### DIFF
--- a/tachyon/c/math/elliptic_curves/msm/msm_gpu.h
+++ b/tachyon/c/math/elliptic_curves/msm/msm_gpu.h
@@ -132,7 +132,7 @@ CRetPoint* DoMSMGpu(MSMGpuApi<GpuCurve>& msm_api, const CPoint* bases,
       base::WriteFile(
           base::FilePath(absl::Substitute(
               "$0/bases$1.txt", msm_api.msm_gpu_input_dir, msm_api.idx - 1)),
-          absl::MakeConstSpan(buffer.owned_buffer()));
+          buffer.owned_buffer());
     }
     {
       buffer.set_buffer_offset(0);
@@ -141,7 +141,7 @@ CRetPoint* DoMSMGpu(MSMGpuApi<GpuCurve>& msm_api, const CPoint* bases,
       base::WriteFile(
           base::FilePath(absl::Substitute(
               "$0/scalars$1.txt", msm_api.msm_gpu_input_dir, msm_api.idx - 1)),
-          absl::MakeConstSpan(buffer.owned_buffer()));
+          buffer.owned_buffer());
     }
   }
 

--- a/tachyon/c/math/elliptic_curves/msm/msm_input_provider.h
+++ b/tachyon/c/math/elliptic_curves/msm/msm_input_provider.h
@@ -52,7 +52,7 @@ class MSMInputProvider {
       bases_owned_[i] =
           AffinePoint(points[i], points[i].x.IsZero() && points[i].y.IsZero());
     }
-    bases_ = absl::MakeConstSpan(bases_owned_);
+    bases_ = bases_owned_;
 
     if (needs_align_) {
       scalars_owned_.resize(aligned_size);
@@ -62,7 +62,7 @@ class MSMInputProvider {
       for (size_t i = size; i < aligned_size; ++i) {
         scalars_owned_[i] = ScalarField::Zero();
       }
-      scalars_ = absl::MakeConstSpan(scalars_owned_);
+      scalars_ = scalars_owned_;
     } else {
       scalars_ = absl::MakeConstSpan(
           reinterpret_cast<const ScalarField*>(scalars_in), size);
@@ -87,8 +87,8 @@ class MSMInputProvider {
       for (size_t i = size; i < aligned_size; ++i) {
         scalars_owned_[i] = ScalarField::Zero();
       }
-      bases_ = absl::MakeConstSpan(bases_owned_);
-      scalars_ = absl::MakeConstSpan(scalars_owned_);
+      bases_ = bases_owned_;
+      scalars_ = scalars_owned_;
     } else {
       bases_ = absl::MakeConstSpan(
           reinterpret_cast<const AffinePoint*>(bases_in), size);

--- a/tachyon/c/zk/plonk/halo2/prover_impl_base.h
+++ b/tachyon/c/zk/plonk/halo2/prover_impl_base.h
@@ -32,9 +32,8 @@ class ProverImplBase : public tachyon::zk::plonk::halo2::Prover<PCS> {
       tachyon::base::Uint8VectorBuffer buffer;
       CHECK(buffer.Grow(tachyon::base::EstimateSize(this->pcs_)));
       CHECK(buffer.Write(this->pcs_));
-      CHECK(
-          tachyon::base::WriteFile(tachyon::base::FilePath(pcs_params_str),
-                                   absl::MakeConstSpan(buffer.owned_buffer())));
+      CHECK(tachyon::base::WriteFile(tachyon::base::FilePath(pcs_params_str),
+                                     buffer.owned_buffer()));
     }
   }
 
@@ -80,9 +79,8 @@ class ProverImplBase : public tachyon::zk::plonk::halo2::Prover<PCS> {
       tachyon::base::Uint8VectorBuffer buffer;
       CHECK(buffer.Grow(tachyon::base::EstimateSize(*argument_data)));
       CHECK(buffer.Write(*argument_data));
-      CHECK(tachyon::base::WriteLargeFile(
-          tachyon::base::FilePath(arg_data_str),
-          absl::MakeConstSpan(buffer.owned_buffer())));
+      CHECK(tachyon::base::WriteLargeFile(tachyon::base::FilePath(arg_data_str),
+                                          buffer.owned_buffer()));
     }
 
     Base::CreateProof(proving_key, argument_data);

--- a/tachyon/c/zk/plonk/halo2/prover_replay.cc
+++ b/tachyon/c/zk/plonk/halo2/prover_replay.cc
@@ -51,8 +51,7 @@ void WriteParams(CProver* c_prover,
   CHECK(buffer.Grow(tachyon::base::EstimateSize(prover->pcs())));
   CHECK(buffer.Write(prover->pcs()));
   CHECK(buffer.Done());
-  CHECK(tachyon::base::WriteLargeFile(
-      params_path, absl::MakeConstSpan(buffer.owned_buffer())));
+  CHECK(tachyon::base::WriteLargeFile(params_path, buffer.owned_buffer()));
 }
 
 template <typename CProver>
@@ -64,7 +63,7 @@ void CreateProof(CProver* c_prover, const std::vector<uint8_t>& pk_bytes,
 
   NativeProver* prover = base::native_cast(c_prover);
   std::cout << "deserializing proving key" << std::endl;
-  ProvingKey pk(absl::MakeConstSpan(pk_bytes), /*read_only_vk=*/false);
+  ProvingKey pk(pk_bytes, /*read_only_vk=*/false);
   std::cout << "done deserializing proving key" << std::endl;
 
   uint32_t extended_k = pk.verifying_key().constraint_system().ComputeExtendedK(

--- a/tachyon/c/zk/plonk/halo2/verifier_replay.cc
+++ b/tachyon/c/zk/plonk/halo2/verifier_replay.cc
@@ -43,7 +43,7 @@ bool VerifyProof(CVerifier* c_verifier, const std::vector<uint8_t>& pk_bytes) {
 
   NativeVerifier* verifier = base::native_cast(c_verifier);
   std::cout << "deserializing proving key" << std::endl;
-  ProvingKey pk(absl::MakeConstSpan(pk_bytes), /*read_only_vk=*/true);
+  ProvingKey pk(pk_bytes, /*read_only_vk=*/true);
   std::cout << "done deserializing proving key" << std::endl;
 
   uint32_t extended_k = pk.verifying_key().constraint_system().ComputeExtendedK(

--- a/tachyon/crypto/hashes/prime_field_serializable.h
+++ b/tachyon/crypto/hashes/prime_field_serializable.h
@@ -66,8 +66,7 @@ class PrimeFieldSerializable<std::vector<T>> {
   template <typename PrimeField>
   constexpr static bool ToPrimeField(const std::vector<T>& values,
                                      std::vector<PrimeField>* fields) {
-    return PrimeFieldSerializable<T>::BatchToPrimeField(
-        absl::MakeConstSpan(values), fields);
+    return PrimeFieldSerializable<T>::BatchToPrimeField(values, fields);
   }
 };
 
@@ -77,8 +76,7 @@ class PrimeFieldSerializable<absl::InlinedVector<T, N>> {
   template <typename PrimeField>
   constexpr static bool ToPrimeField(const absl::InlinedVector<T, N>& values,
                                      std::vector<PrimeField>* fields) {
-    return PrimeFieldSerializable<T>::BatchToPrimeField(
-        absl::MakeConstSpan(values), fields);
+    return PrimeFieldSerializable<T>::BatchToPrimeField(values, fields);
   }
 };
 
@@ -89,7 +87,7 @@ class PrimeFieldSerializable<absl::Span<T>> {
   constexpr static bool ToPrimeField(absl::Span<T> values,
                                      std::vector<PrimeField>* fields) {
     return PrimeFieldSerializable<std::remove_const_t<T>>::BatchToPrimeField(
-        absl::MakeConstSpan(values), fields);
+        values, fields);
   }
 };
 
@@ -99,8 +97,7 @@ class PrimeFieldSerializable<std::array<T, N>> {
   template <typename PrimeField>
   constexpr static bool ToPrimeField(const std::array<T, N>& values,
                                      std::vector<PrimeField>* fields) {
-    return PrimeFieldSerializable<T>::BatchToPrimeField(
-        absl::MakeConstSpan(values), fields);
+    return PrimeFieldSerializable<T>::BatchToPrimeField(values, fields);
   }
 };
 

--- a/tachyon/crypto/hashes/sponge/poseidon/poseidon_config.h
+++ b/tachyon/crypto/hashes/sponge/poseidon/poseidon_config.h
@@ -165,9 +165,8 @@ struct PoseidonConfig {
 
   static PoseidonConfig CreateDefault(size_t rate, bool optimized_for_weights) {
     absl::Span<const PoseidonConfigEntry> param_set =
-        optimized_for_weights
-            ? absl::MakeConstSpan(kOptimizedWeightsDefaultParams)
-            : absl::MakeConstSpan(kOptimizedConstraintsDefaultParams);
+        optimized_for_weights ? kOptimizedWeightsDefaultParams
+                              : kOptimizedConstraintsDefaultParams;
 
     auto it = base::ranges::find_if(param_set.begin(), param_set.end(),
                                     [rate](const PoseidonConfigEntry& param) {

--- a/tachyon/device/gpu/gpu_memory_unittest.cc
+++ b/tachyon/device/gpu/gpu_memory_unittest.cc
@@ -98,7 +98,7 @@ TEST(GpuMemoryTest, CopyFrom) {
 
     GPU_MUST_SUCCESS(gpuDeviceSynchronize(), "");
     for (size_t i = 0; i < memories.size(); ++i) {
-      EXPECT_EQ(absl::MakeConstSpan(results[i]), unified_memory_view);
+      EXPECT_EQ(results[i], unified_memory_view);
     }
   }
 #endif  // TACHYON_CUDA

--- a/tachyon/math/base/groups.h
+++ b/tachyon/math/base/groups.h
@@ -130,8 +130,7 @@ class MultiplicativeGroup : public MultiplicativeSemigroup<G> {
       return true;
     }
 #endif
-    DoBatchInverse(absl::MakeConstSpan(groups), absl::MakeSpan(*inverses),
-                   coeff);
+    DoBatchInverse(groups, absl::MakeSpan(*inverses), coeff);
     return true;
   }
 
@@ -143,8 +142,7 @@ class MultiplicativeGroup : public MultiplicativeSemigroup<G> {
       LOG(ERROR) << "Size of |groups| and |inverses| do not match";
       return false;
     }
-    DoBatchInverse(absl::MakeConstSpan(groups), absl::MakeSpan(*inverses),
-                   coeff);
+    DoBatchInverse(groups, absl::MakeSpan(*inverses), coeff);
     return true;
   }
 

--- a/tachyon/math/base/semigroups_unittest.cc
+++ b/tachyon/math/base/semigroups_unittest.cc
@@ -155,8 +155,8 @@ TEST_F(MultiScalarMulTest, SingleScalarMultiBases) {
   {
     std::vector<test::JacobianPoint> actual;
     actual.resize(test_set_.bases.size());
-    ASSERT_TRUE(test::AffinePoint::MultiScalarMul(
-        test_set_.scalars[0], absl::MakeConstSpan(test_set_.bases), &actual));
+    ASSERT_TRUE(test::AffinePoint::MultiScalarMul(test_set_.scalars[0],
+                                                  test_set_.bases, &actual));
     EXPECT_EQ(actual, expected);
   }
 }
@@ -178,8 +178,8 @@ TEST_F(MultiScalarMulTest, MultiScalarsSingleBase) {
   {
     std::vector<test::JacobianPoint> actual;
     actual.resize(test_set_.bases.size());
-    ASSERT_TRUE(test::AffinePoint::MultiScalarMul(
-        absl::MakeConstSpan(test_set_.scalars), test_set_.bases[0], &actual));
+    ASSERT_TRUE(test::AffinePoint::MultiScalarMul(test_set_.scalars,
+                                                  test_set_.bases[0], &actual));
     EXPECT_EQ(actual, expected);
   }
 }
@@ -201,9 +201,8 @@ TEST_F(MultiScalarMulTest, MultiScalarsMultiBases) {
   {
     std::vector<test::JacobianPoint> actual;
     actual.resize(test_set_.bases.size());
-    ASSERT_TRUE(test::AffinePoint::MultiScalarMul(
-        absl::MakeConstSpan(test_set_.scalars),
-        absl::MakeConstSpan(test_set_.bases), &actual));
+    ASSERT_TRUE(test::AffinePoint::MultiScalarMul(test_set_.scalars,
+                                                  test_set_.bases, &actual));
     EXPECT_EQ(actual, expected);
   }
 }

--- a/tachyon/math/elliptic_curves/bn/generator/generator.cc
+++ b/tachyon/math/elliptic_curves/bn/generator/generator.cc
@@ -125,12 +125,12 @@ int GenerationConfig::GenerateConfigHdr() const {
   x_mpz = math::gmp::GetAbs(x_mpz);
   size_t x_size = math::gmp::GetLimbSize(x_mpz);
 
-  std::string twist_mul_by_q_x_init = math::GenerateInitExtField(
-      "kTwistMulByQX", "Fq2", absl::MakeConstSpan(twist_mul_by_q_x),
-      /*is_prime_field=*/true);
-  std::string twist_mul_by_q_y_init = math::GenerateInitExtField(
-      "kTwistMulByQY", "Fq2", absl::MakeConstSpan(twist_mul_by_q_y),
-      /*is_prime_field=*/true);
+  std::string twist_mul_by_q_x_init =
+      math::GenerateInitExtField("kTwistMulByQX", "Fq2", twist_mul_by_q_x,
+                                 /*is_prime_field=*/true);
+  std::string twist_mul_by_q_y_init =
+      math::GenerateInitExtField("kTwistMulByQY", "Fq2", twist_mul_by_q_y,
+                                 /*is_prime_field=*/true);
 
   std::string content = absl::StrReplaceAll(
       tpl_content,

--- a/tachyon/math/elliptic_curves/msm/algorithms/pippenger/pippenger.h
+++ b/tachyon/math/elliptic_curves/msm/algorithms/pippenger/pippenger.h
@@ -103,8 +103,8 @@ class Pippenger : public PippengerBase<Point> {
       AccumulateWindowSums(std::move(bases_first), scalars, &window_sums);
     }
 
-    *ret = PippengerBase<Point>::AccumulateWindowSums(
-        absl::MakeConstSpan(window_sums), ctx_.window_bits);
+    *ret = PippengerBase<Point>::AccumulateWindowSums(window_sums,
+                                                      ctx_.window_bits);
     return true;
   }
 
@@ -131,8 +131,7 @@ class Pippenger : public PippengerBase<Point> {
         buckets[static_cast<uint64_t>(-scalar - 1)] -= base;
       }
     }
-    *window_sum =
-        PippengerBase<Point>::AccumulateBuckets(absl::MakeConstSpan(buckets));
+    *window_sum = PippengerBase<Point>::AccumulateBuckets(buckets);
   }
 
   template <typename BaseInputIterator>
@@ -200,8 +199,7 @@ class Pippenger : public PippengerBase<Point> {
         }
       }
     }
-    *out = PippengerBase<Point>::AccumulateBuckets(absl::MakeConstSpan(buckets),
-                                                   window_sum);
+    *out = PippengerBase<Point>::AccumulateBuckets(buckets, window_sum);
   }
 
   template <typename BaseInputIterator>

--- a/tachyon/math/elliptic_curves/short_weierstrass/generator/generator.cc
+++ b/tachyon/math/elliptic_curves/short_weierstrass/generator/generator.cc
@@ -172,15 +172,13 @@ int GenerationConfig::GenerateConfigHdr() const {
           return math::gmp::FromDecString(a) == mpz_class(0);
         });
 
-    a_init = math::GenerateInitExtField(
-        "kA", "BaseField", absl::MakeConstSpan(a), /*is_prime_field=*/true);
-    b_init = math::GenerateInitExtField(
-        "kB", "BaseField", absl::MakeConstSpan(b), /*is_prime_field=*/true);
-    x_init = math::GenerateInitExtField("kGenerator.x", "BaseField",
-                                        absl::MakeConstSpan(x),
+    a_init = math::GenerateInitExtField("kA", "BaseField", a,
                                         /*is_prime_field=*/true);
-    y_init = math::GenerateInitExtField("kGenerator.y", "BaseField",
-                                        absl::MakeConstSpan(y),
+    b_init = math::GenerateInitExtField("kB", "BaseField", b,
+                                        /*is_prime_field=*/true);
+    x_init = math::GenerateInitExtField("kGenerator.x", "BaseField", x,
+                                        /*is_prime_field=*/true);
+    y_init = math::GenerateInitExtField("kGenerator.y", "BaseField", y,
                                         /*is_prime_field=*/true);
   }
 
@@ -228,8 +226,7 @@ int GenerationConfig::GenerateConfigHdr() const {
           "kEndomorphismCoefficient", "BaseField", endomorphism_coefficient[0]);
     } else {
       endomorphism_coefficient_init = math::GenerateInitExtField(
-          "kEndomorphismCoefficient", "BaseField",
-          absl::MakeConstSpan(endomorphism_coefficient),
+          "kEndomorphismCoefficient", "BaseField", endomorphism_coefficient,
           /*is_prime_field=*/true);
     }
     lambda_init = math::GenerateInitField("kLambda", "ScalarField", lambda);

--- a/tachyon/math/finite_fields/generator/ext_prime_field_generator/ext_prime_field_generator.cc
+++ b/tachyon/math/finite_fields/generator/ext_prime_field_generator/ext_prime_field_generator.cc
@@ -107,8 +107,7 @@ int GenerationConfig::GenerateConfigHdr() const {
         std::all_of(non_residue.begin() + 1, non_residue.end(),
                     [](const std::string& e) { return e == "0"; });
 
-    init = math::GenerateInitExtField("kNonResidue", "BaseField",
-                                      absl::MakeConstSpan(non_residue),
+    init = math::GenerateInitExtField("kNonResidue", "BaseField", non_residue,
                                       /*is_prime_field=*/degree != 12);
   }
 

--- a/tachyon/math/polynomials/univariate/univariate_dense_coefficients.h
+++ b/tachyon/math/polynomials/univariate/univariate_dense_coefficients.h
@@ -256,7 +256,7 @@ class UnivariateDenseCoefficients {
     return std::accumulate(results.begin(), results.end(), F::Zero(),
                            std::plus<>());
 #else
-    return HornerEvaluate(absl::MakeConstSpan(coefficients_), point);
+    return HornerEvaluate(coefficients_, point);
 #endif
   }
 

--- a/tachyon/math/polynomials/univariate/univariate_sparse_coefficients.h
+++ b/tachyon/math/polynomials/univariate/univariate_sparse_coefficients.h
@@ -205,8 +205,7 @@ class UnivariateSparseCoefficients {
 
     F sum = F::Zero();
     for (const Term& term : terms_) {
-      sum += F::PowWithTable(absl::MakeConstSpan(powers_of_2),
-                             F(term.degree).ToBigInt()) *
+      sum += F::PowWithTable(powers_of_2, F(term.degree).ToBigInt()) *
              term.coefficient;
     }
     return sum;

--- a/tachyon/zk/expressions/evaluator/simple_evaluator_unittest.cc
+++ b/tachyon/zk/expressions/evaluator/simple_evaluator_unittest.cc
@@ -26,11 +26,10 @@ class SimpleEvaluatorTest : public EvaluatorTest {
       challenges_.push_back(GF7::Random());
     }
 
-    plonk::RefTable<Evals> columns(absl::MakeConstSpan(fixed_columns_),
-                                   absl::MakeConstSpan(advice_columns_),
-                                   absl::MakeConstSpan(instance_columns_));
-    simple_evaluator_ = std::make_unique<SimpleEvaluator<Evals>>(
-        3, 4, 1, columns, absl::MakeConstSpan(challenges_));
+    plonk::RefTable<Evals> columns(fixed_columns_, advice_columns_,
+                                   instance_columns_);
+    simple_evaluator_ =
+        std::make_unique<SimpleEvaluator<Evals>>(3, 4, 1, columns, challenges_);
   }
 
  protected:

--- a/tachyon/zk/lookup/halo2/test/compress_expression_test.h
+++ b/tachyon/zk/lookup/halo2/test/compress_expression_test.h
@@ -14,11 +14,10 @@ class CompressExpressionTest : public plonk::halo2::BN254SHPlonkProverTest {
   void SetUp() override {
     plonk::halo2::BN254SHPlonkProverTest::SetUp();
 
-    plonk::RefTable<Evals> columns(absl::MakeConstSpan(fixed_columns_),
-                                   absl::MakeConstSpan(advice_columns_),
-                                   absl::MakeConstSpan(instance_columns_));
+    plonk::RefTable<Evals> columns(fixed_columns_, advice_columns_,
+                                   instance_columns_);
     evaluator_ = {0, static_cast<int32_t>(prover_->domain()->size()), 1,
-                  columns, absl::MakeConstSpan(challenges_)};
+                  columns, challenges_};
     theta_ = F(2);
   }
 

--- a/tachyon/zk/plonk/base/ref_table_unittest.cc
+++ b/tachyon/zk/plonk/base/ref_table_unittest.cc
@@ -48,9 +48,8 @@ TYPED_TEST(RefTableTest, GetColumns) {
       FixedColumnKey(2), AdviceColumnKey(2, kFirstPhase), InstanceColumnKey(2),
   };
 
-  RefTable<Evals> table(absl::MakeConstSpan(this->fixed_columns_),
-                        absl::MakeConstSpan(this->advice_columns_),
-                        absl::MakeConstSpan(this->instance_columns_));
+  RefTable<Evals> table(this->fixed_columns_, this->advice_columns_,
+                        this->instance_columns_);
 
   std::vector<base::Ref<const Evals>> evals_refs = table.GetColumns(targets);
 

--- a/tachyon/zk/plonk/halo2/argument_data.h
+++ b/tachyon/zk/plonk/halo2/argument_data.h
@@ -97,12 +97,10 @@ class ArgumentData {
 
   absl::Span<const F> GetAdviceBlinds(size_t circuit_idx) const {
     CHECK_LT(circuit_idx, GetNumCircuits());
-    return absl::MakeConstSpan(advice_blinds_vec_[circuit_idx]);
+    return advice_blinds_vec_[circuit_idx];
   }
 
-  absl::Span<const F> GetChallenges() const {
-    return absl::MakeConstSpan(challenges_);
-  }
+  absl::Span<const F> GetChallenges() const { return challenges_; }
 
   // Generate a vector of advice coefficient-formed polynomials with a vector
   // of advice evaluation-formed columns. (a.k.a. Batch IFFT)
@@ -130,14 +128,11 @@ class ArgumentData {
   std::vector<RefTable<Evals>> ExportColumnTables(
       absl::Span<const Evals> fixed_columns) const {
     CHECK(!advice_transformed_);
-    return base::CreateVector(GetNumCircuits(), [fixed_columns,
-                                                 this](size_t i) {
-      absl::Span<const Evals> advice_columns =
-          absl::MakeConstSpan(advice_columns_vec_[i]);
-      absl::Span<const Evals> instance_columns =
-          absl::MakeConstSpan(instance_columns_vec_[i]);
-      return RefTable<Evals>(fixed_columns, advice_columns, instance_columns);
-    });
+    return base::CreateVector(
+        GetNumCircuits(), [fixed_columns, this](size_t i) {
+          return RefTable<Evals>(fixed_columns, advice_columns_vec_[i],
+                                 instance_columns_vec_[i]);
+        });
   }
 
   // Return a table including every type of columns in coefficient form.
@@ -145,11 +140,8 @@ class ArgumentData {
       absl::Span<const Poly> fixed_polys) const {
     CHECK(advice_transformed_);
     return base::CreateVector(GetNumCircuits(), [fixed_polys, this](size_t i) {
-      absl::Span<const Poly> advice_polys =
-          absl::MakeConstSpan(advice_polys_vec_[i]);
-      absl::Span<const Poly> instance_polys =
-          absl::MakeConstSpan(instance_polys_vec_[i]);
-      return RefTable<Poly>(fixed_polys, advice_polys, instance_polys);
+      return RefTable<Poly>(fixed_polys, advice_polys_vec_[i],
+                            instance_polys_vec_[i]);
     });
   }
 

--- a/tachyon/zk/plonk/halo2/proof.h
+++ b/tachyon/zk/plonk/halo2/proof.h
@@ -91,28 +91,25 @@ struct Proof {
 
   VanishingVerificationData<F> ToVanishingVerificationData(size_t i) const {
     VanishingVerificationData<F> ret;
-    ret.fixed_evals = absl::MakeConstSpan(fixed_evals);
-    ret.advice_evals = absl::MakeConstSpan(advice_evals_vec[i]);
-    ret.instance_evals = absl::MakeConstSpan(instance_evals_vec[i]);
-    ret.challenges = absl::MakeConstSpan(challenges);
+    ret.fixed_evals = fixed_evals;
+    ret.advice_evals = advice_evals_vec[i];
+    ret.instance_evals = instance_evals_vec[i];
+    ret.challenges = challenges;
     return ret;
   }
 
   PermutationVerificationData<F, C> ToPermutationVerificationData(
       size_t i) const {
     PermutationVerificationData<F, C> ret;
-    ret.fixed_evals = absl::MakeConstSpan(fixed_evals);
-    ret.advice_evals = absl::MakeConstSpan(advice_evals_vec[i]);
-    ret.instance_evals = absl::MakeConstSpan(instance_evals_vec[i]);
-    ret.challenges = absl::MakeConstSpan(challenges);
-    ret.product_commitments =
-        absl::MakeConstSpan(permutation_product_commitments_vec[i]);
-    ret.common_evals = absl::MakeConstSpan(common_permutation_evals);
-    ret.product_evals = absl::MakeConstSpan(permutation_product_evals_vec[i]);
-    ret.product_next_evals =
-        absl::MakeConstSpan(permutation_product_next_evals_vec[i]);
-    ret.product_last_evals =
-        absl::MakeConstSpan(permutation_product_last_evals_vec[i]);
+    ret.fixed_evals = fixed_evals;
+    ret.advice_evals = advice_evals_vec[i];
+    ret.instance_evals = instance_evals_vec[i];
+    ret.challenges = challenges;
+    ret.product_commitments = permutation_product_commitments_vec[i];
+    ret.common_evals = common_permutation_evals;
+    ret.product_evals = permutation_product_evals_vec[i];
+    ret.product_next_evals = permutation_product_next_evals_vec[i];
+    ret.product_last_evals = permutation_product_last_evals_vec[i];
     ret.beta = &beta;
     ret.gamma = &gamma;
     ret.x = &x;
@@ -127,10 +124,10 @@ struct Proof {
   LookupVerificationData<F, C> ToLookupVerificationData(size_t i,
                                                         size_t j) const {
     LookupVerificationData<F, C> ret;
-    ret.fixed_evals = absl::MakeConstSpan(fixed_evals);
-    ret.advice_evals = absl::MakeConstSpan(advice_evals_vec[i]);
-    ret.instance_evals = absl::MakeConstSpan(instance_evals_vec[i]);
-    ret.challenges = absl::MakeConstSpan(challenges);
+    ret.fixed_evals = fixed_evals;
+    ret.advice_evals = advice_evals_vec[i];
+    ret.instance_evals = instance_evals_vec[i];
+    ret.challenges = challenges;
     ret.permuted_commitment = &lookup_permuted_commitments_vec[i][j];
     ret.product_commitment = &lookup_product_commitments_vec[i][j];
     ret.product_eval = &lookup_product_evals_vec[i][j];

--- a/tachyon/zk/plonk/halo2/verifier.h
+++ b/tachyon/zk/plonk/halo2/verifier.h
@@ -222,8 +222,7 @@ class Verifier : public VerifierBase<PCS> {
     const std::vector<F>& instances =
         instance_columns[instance_query.column().index()].evaluations();
     size_t offset = max_rotation - instance_query.rotation().value();
-    absl::Span<const F> sub_partial_lagrange_coeffs =
-        absl::MakeConstSpan(partial_lagrange_coeffs);
+    absl::Span<const F> sub_partial_lagrange_coeffs(partial_lagrange_coeffs);
     sub_partial_lagrange_coeffs =
         sub_partial_lagrange_coeffs.subspan(offset, instances.size());
     return F::SumOfProductsSerial(instances, sub_partial_lagrange_coeffs);

--- a/tachyon/zk/plonk/permutation/grand_product_argument.h
+++ b/tachyon/zk/plonk/permutation/grand_product_argument.h
@@ -109,7 +109,7 @@ class GrandProductArgument {
                             std::vector<F>&& grand_product) {
     RowIndex usable_rows = prover->GetUsableRows();
 
-    absl::Span<F> z = absl::MakeSpan(grand_product);
+    absl::Span<F> z(grand_product);
     z[0] = last_z;
     for (RowIndex i = 0; i < usable_rows; ++i) {
       z[i + 1] = z[i] * grand_product[i + 1];

--- a/tachyon/zk/plonk/permutation/permutation_table_store_unittest.cc
+++ b/tachyon/zk/plonk/permutation/permutation_table_store_unittest.cc
@@ -35,9 +35,8 @@ class PermutationTableStoreTest : public math::FiniteFieldTest<F> {
     instance_columns_ = base::CreateVector(
         3, [domain_ptr]() { return domain_ptr->Random<Evals>(); });
 
-    table_ = RefTable<Evals>(absl::MakeConstSpan(fixed_columns_),
-                             absl::MakeConstSpan(advice_columns_),
-                             absl::MakeConstSpan(instance_columns_));
+    table_ =
+        RefTable<Evals>(fixed_columns_, advice_columns_, instance_columns_);
 
     column_keys_ = {
         FixedColumnKey(0),  InstanceColumnKey(0), AdviceColumnKey(0),


### PR DESCRIPTION
# Description

Since `absl::Span<T>` can be constructed if the type `EnableIfConvertibleFrom<T>`  is true, we can convert the container to `absl::Span<T>` without explicit conversion! Therefore, this PR removes these redundant calls.

```c++
  // Explicit reference constructor for a mutable `Span<T>` type. Can be
  // replaced with MakeSpan() to infer the type parameter.
  template <typename V, typename = EnableIfConvertibleFrom<V>,
            typename = EnableIfValueIsMutable<V>,
            typename = span_internal::EnableIfNotIsView<V>>
  explicit Span(
      V& v
          ABSL_ATTRIBUTE_LIFETIME_BOUND) noexcept  // NOLINT(runtime/references)
      : Span(span_internal::GetData(v), v.size()) {}

  // Implicit reference constructor for a read-only `Span<const T>` type
  template <typename V, typename = EnableIfConvertibleFrom<V>,
            typename = EnableIfValueIsConst<V>,
            typename = span_internal::EnableIfNotIsView<V>>
  constexpr Span(
      const V& v
          ABSL_ATTRIBUTE_LIFETIME_BOUND) noexcept  // NOLINT(runtime/explicit)
      : Span(span_internal::GetData(v), v.size()) {}

  // Overloads of the above two functions that are only enabled for view types.
  // This is so we can drop the ABSL_ATTRIBUTE_LIFETIME_BOUND annotation. These
  // overloads must be made unique by using a different template parameter list
  // (hence the = 0 for the IsView enabler).
  template <typename V, typename = EnableIfConvertibleFrom<V>,
            typename = EnableIfValueIsMutable<V>,
            span_internal::EnableIfIsView<V> = 0>
  explicit Span(V& v) noexcept  // NOLINT(runtime/references)
      : Span(span_internal::GetData(v), v.size()) {}
  template <typename V, typename = EnableIfConvertibleFrom<V>,
            typename = EnableIfValueIsConst<V>,
            span_internal::EnableIfIsView<V> = 0>
  constexpr Span(const V& v) noexcept  // NOLINT(runtime/explicit)
      : Span(span_internal::GetData(v), v.size()) {}
```