### PR TITLE
feat: implement multilinear sumcheck

### DIFF
--- a/tachyon/base/BUILD.bazel
+++ b/tachyon/base/BUILD.bazel
@@ -94,6 +94,7 @@ tachyon_cc_library(
     srcs = ["random.cc"],
     hdrs = ["random.h"],
     deps = [
+        ":logging",
         ":range",
         "//tachyon:export",
         "@com_google_absl//absl/algorithm:container",

--- a/tachyon/base/openmp_util.h
+++ b/tachyon/base/openmp_util.h
@@ -12,9 +12,11 @@
 #define OPENMP_PARALLEL_FOR(expr) _Pragma("omp parallel for") for (expr)
 #define OPENMP_PARALLEL_NESTED_FOR(expr) \
   _Pragma("omp parallel for collapse(2)") for (expr)
+#define OPENMP_FOR(expr) _Pragma("omp for") for (expr)
 #else
 #define OPENMP_PARALLEL_FOR(expr) for (expr)
 #define OPENMP_PARALLEL_NESTED_FOR(expr) for (expr)
+#define OPENMP_FOR(expr) for (expr)
 #endif  // defined(TACHYON_HAS_OPENMP)
 
 namespace tachyon::base {

--- a/tachyon/base/random.h
+++ b/tachyon/base/random.h
@@ -5,6 +5,7 @@
 
 #include "absl/random/random.h"
 
+#include "tachyon/base/logging.h"
 #include "tachyon/base/range.h"
 #include "tachyon/export.h"
 
@@ -14,6 +15,7 @@ TACHYON_EXPORT absl::BitGen& GetAbslBitGen();
 
 template <typename T, bool IsStartInclusive, bool IsEndInclusive>
 T Uniform(const Range<T, IsStartInclusive, IsEndInclusive>& range) {
+  CHECK(!range.IsEmpty());
   if constexpr (IsStartInclusive && IsEndInclusive) {
     return absl::Uniform(absl::IntervalClosedClosed, GetAbslBitGen(),
                          range.from, range.to);

--- a/tachyon/crypto/sumcheck/multilinear/BUILD.bazel
+++ b/tachyon/crypto/sumcheck/multilinear/BUILD.bazel
@@ -22,7 +22,7 @@ tachyon_cc_library(
 )
 
 tachyon_cc_unittest(
-    name = "sumcheck_unittests",
+    name = "multilinear_unittests",
     srcs = [
         "sumcheck_proving_key_unittest.cc",
         "sumcheck_verifying_key_unittest.cc",

--- a/tachyon/crypto/sumcheck/multilinear/BUILD.bazel
+++ b/tachyon/crypto/sumcheck/multilinear/BUILD.bazel
@@ -21,6 +21,12 @@ tachyon_cc_library(
 )
 
 tachyon_cc_library(
+    name = "sumcheck_verifier_msg",
+    hdrs = ["sumcheck_verifier_msg.h"],
+    deps = ["//tachyon/base/buffer:copyable"],
+)
+
+tachyon_cc_library(
     name = "sumcheck_verifying_key",
     hdrs = ["sumcheck_verifying_key.h"],
     deps = [
@@ -35,11 +41,13 @@ tachyon_cc_unittest(
     srcs = [
         "sumcheck_prover_msg_unittest.cc",
         "sumcheck_proving_key_unittest.cc",
+        "sumcheck_verifier_msg_unittest.cc",
         "sumcheck_verifying_key_unittest.cc",
     ],
     deps = [
         ":sumcheck_prover_msg",
         ":sumcheck_proving_key",
+        ":sumcheck_verifier_msg",
         "//tachyon/base/buffer:vector_buffer",
         "//tachyon/math/finite_fields/test:finite_field_test",
         "//tachyon/math/finite_fields/test:gf7",

--- a/tachyon/crypto/sumcheck/multilinear/BUILD.bazel
+++ b/tachyon/crypto/sumcheck/multilinear/BUILD.bazel
@@ -3,6 +3,15 @@ load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_unittest")
 package(default_visibility = ["//visibility:public"])
 
 tachyon_cc_library(
+    name = "multilinear_sumcheck",
+    hdrs = ["multilinear_sumcheck.h"],
+    deps = [
+        ":sumcheck_prover",
+        ":sumcheck_verifier",
+    ],
+)
+
+tachyon_cc_library(
     name = "sumcheck_prover",
     hdrs = ["sumcheck_prover.h"],
     deps = [
@@ -61,15 +70,18 @@ tachyon_cc_library(
 tachyon_cc_unittest(
     name = "multilinear_unittests",
     srcs = [
+        "multilinear_sumcheck_unittest.cc",
         "sumcheck_prover_msg_unittest.cc",
         "sumcheck_proving_key_unittest.cc",
         "sumcheck_verifier_msg_unittest.cc",
         "sumcheck_verifying_key_unittest.cc",
     ],
     deps = [
+        ":multilinear_sumcheck",
         ":sumcheck_prover_msg",
         ":sumcheck_proving_key",
         ":sumcheck_verifier_msg",
+        "//tachyon/base:range",
         "//tachyon/base/buffer:vector_buffer",
         "//tachyon/math/finite_fields/test:finite_field_test",
         "//tachyon/math/finite_fields/test:gf7",

--- a/tachyon/crypto/sumcheck/multilinear/BUILD.bazel
+++ b/tachyon/crypto/sumcheck/multilinear/BUILD.bazel
@@ -3,6 +3,15 @@ load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_unittest")
 package(default_visibility = ["//visibility:public"])
 
 tachyon_cc_library(
+    name = "sumcheck_prover_msg",
+    hdrs = ["sumcheck_prover_msg.h"],
+    deps = [
+        "//tachyon/base/buffer:copyable",
+        "//tachyon/math/polynomials/univariate:univariate_evaluations",
+    ],
+)
+
+tachyon_cc_library(
     name = "sumcheck_proving_key",
     hdrs = ["sumcheck_proving_key.h"],
     deps = [
@@ -24,14 +33,17 @@ tachyon_cc_library(
 tachyon_cc_unittest(
     name = "multilinear_unittests",
     srcs = [
+        "sumcheck_prover_msg_unittest.cc",
         "sumcheck_proving_key_unittest.cc",
         "sumcheck_verifying_key_unittest.cc",
     ],
     deps = [
+        ":sumcheck_prover_msg",
         ":sumcheck_proving_key",
         "//tachyon/base/buffer:vector_buffer",
         "//tachyon/math/finite_fields/test:finite_field_test",
         "//tachyon/math/finite_fields/test:gf7",
         "//tachyon/math/polynomials/multivariate:multilinear_extension",
+        "//tachyon/math/polynomials/univariate:univariate_evaluations",
     ],
 )

--- a/tachyon/crypto/sumcheck/multilinear/BUILD.bazel
+++ b/tachyon/crypto/sumcheck/multilinear/BUILD.bazel
@@ -33,6 +33,16 @@ tachyon_cc_library(
 )
 
 tachyon_cc_library(
+    name = "sumcheck_verifier",
+    hdrs = ["sumcheck_verifier.h"],
+    deps = [
+        ":sumcheck_prover_msg",
+        ":sumcheck_verifier_msg",
+        ":sumcheck_verifying_key",
+    ],
+)
+
+tachyon_cc_library(
     name = "sumcheck_verifier_msg",
     hdrs = ["sumcheck_verifier_msg.h"],
     deps = ["//tachyon/base/buffer:copyable"],

--- a/tachyon/crypto/sumcheck/multilinear/BUILD.bazel
+++ b/tachyon/crypto/sumcheck/multilinear/BUILD.bazel
@@ -3,6 +3,18 @@ load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_unittest")
 package(default_visibility = ["//visibility:public"])
 
 tachyon_cc_library(
+    name = "sumcheck_prover",
+    hdrs = ["sumcheck_prover.h"],
+    deps = [
+        ":sumcheck_prover_msg",
+        ":sumcheck_proving_key",
+        ":sumcheck_verifier_msg",
+        "//tachyon/math/polynomials/multivariate:linear_combination",
+        "//tachyon/math/polynomials/univariate:univariate_evaluations",
+    ],
+)
+
+tachyon_cc_library(
     name = "sumcheck_prover_msg",
     hdrs = ["sumcheck_prover_msg.h"],
     deps = [

--- a/tachyon/crypto/sumcheck/multilinear/multilinear_sumcheck.h
+++ b/tachyon/crypto/sumcheck/multilinear/multilinear_sumcheck.h
@@ -1,0 +1,53 @@
+// Copyright 2022 arkworks contributors
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.arkworks and the LICENCE-APACHE.arkworks
+// file.
+
+#ifndef TACHYON_CRYPTO_SUMCHECK_MULTILINEAR_MULTILINEAR_SUMCHECK_H_
+#define TACHYON_CRYPTO_SUMCHECK_MULTILINEAR_MULTILINEAR_SUMCHECK_H_
+
+#include <utility>
+
+#include "gtest/gtest.h"
+
+#include "tachyon/crypto/sumcheck/multilinear/sumcheck_prover.h"
+#include "tachyon/crypto/sumcheck/multilinear/sumcheck_verifier.h"
+
+namespace tachyon::crypto {
+
+template <typename MLE>
+class MultilinearSumcheck {
+ public:
+  template <size_t MaxDegree>
+  [[nodiscard]] static bool RunInteractiveProtocol(
+      const math::LinearCombination<MLE>& linear_combination,
+      size_t num_variables) {
+    using F = typename MLE::Field;
+
+    const SumcheckProvingKey<MLE> proving_key =
+        SumcheckProvingKey<MLE>::Build(linear_combination);
+    const SumcheckVerifyingKey verifying_key =
+        SumcheckVerifyingKey::Build(linear_combination);
+    SumcheckProver<MLE, MaxDegree> prover(std::move(proving_key));
+    SumcheckVerifier<MLE> verifier(std::move(verifying_key));
+    SumcheckProverMsg<F, MaxDegree> prover_msg = prover.Round();
+    SumcheckVerifierMsg<F> verifier_msg = verifier.Round(std::move(prover_msg));
+
+    for (size_t i = 1; i < num_variables; ++i) {
+      prover_msg = prover.Round(std::move(verifier_msg));
+      verifier_msg = verifier.Round(std::move(prover_msg));
+    }
+    const F asserted_sum = linear_combination.Combine();
+    Subclaim<F> subclaim;
+    if (!verifier.CheckAndGenerateSubclaim(asserted_sum, &subclaim)) {
+      return false;
+    }
+    F expected_sum = linear_combination.Evaluate(subclaim.point);
+
+    return expected_sum == subclaim.expected_evaluation;
+  }
+};
+
+}  // namespace tachyon::crypto
+
+#endif  // TACHYON_CRYPTO_SUMCHECK_MULTILINEAR_MULTILINEAR_SUMCHECK_H_

--- a/tachyon/crypto/sumcheck/multilinear/multilinear_sumcheck_unittest.cc
+++ b/tachyon/crypto/sumcheck/multilinear/multilinear_sumcheck_unittest.cc
@@ -1,0 +1,57 @@
+// Copyright 2022 arkworks contributors
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.arkworks and the LICENCE-APACHE.arkworks
+// file.
+
+#include "tachyon/crypto/sumcheck/multilinear/multilinear_sumcheck.h"
+
+#include "gtest/gtest.h"
+
+#include "tachyon/base/range.h"
+#include "tachyon/math/finite_fields/test/finite_field_test.h"
+#include "tachyon/math/finite_fields/test/gf7.h"
+#include "tachyon/math/polynomials/multivariate/linear_combination.h"
+#include "tachyon/math/polynomials/multivariate/multilinear_dense_evaluations.h"
+
+namespace tachyon::crypto {
+namespace {
+
+using F = math::GF7;
+
+class MultilinearSumcheckTest : public math::FiniteFieldTest<F> {};
+
+}  // namespace
+
+TEST_F(MultilinearSumcheckTest, TestInteractiveProtocolSmall) {
+  // |SumcheckVerifier| runs in-depth logic in |InterpolateUniPoly()|
+  constexpr size_t kNumVariables = 2;
+  const base::Range<size_t> kMaxEvaluationsInTermRange(2, 3);
+  constexpr size_t kMaxPossibleEvaluations = 3;
+  size_t kNumTerms = 2;
+  using MLE = math::MultilinearDenseEvaluations<F, kNumVariables>;
+  const math::LinearCombination<MLE> linear_combination =
+      math::LinearCombination<MLE>::Random(
+          kNumVariables, kMaxEvaluationsInTermRange, kNumTerms);
+
+  EXPECT_TRUE(
+      MultilinearSumcheck<MLE>::RunInteractiveProtocol<kMaxPossibleEvaluations>(
+          linear_combination, kNumVariables));
+}
+
+TEST_F(MultilinearSumcheckTest, TestInteractiveProtocolBig) {
+  // |SumcheckVerifier| returns early for |InterpolateUniPoly()|
+  constexpr size_t kNumVariables = 10;
+  const base::Range<size_t> kMaxEvaluationsInTermRange(6, 30);
+  constexpr size_t kMaxPossibleEvaluations = 30;
+  size_t kNumTerms = 20;
+  using MLE = math::MultilinearDenseEvaluations<F, kNumVariables>;
+  const math::LinearCombination<MLE> linear_combination =
+      math::LinearCombination<MLE>::Random(
+          kNumVariables, kMaxEvaluationsInTermRange, kNumTerms);
+
+  EXPECT_TRUE(
+      MultilinearSumcheck<MLE>::RunInteractiveProtocol<kMaxPossibleEvaluations>(
+          linear_combination, kNumVariables));
+}
+
+}  // namespace tachyon::crypto

--- a/tachyon/crypto/sumcheck/multilinear/sumcheck_prover.h
+++ b/tachyon/crypto/sumcheck/multilinear/sumcheck_prover.h
@@ -1,0 +1,181 @@
+// Copyright 2022 arkworks contributors
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.arkworks and the LICENCE-APACHE.arkworks
+// file.
+
+#ifndef TACHYON_CRYPTO_SUMCHECK_MULTILINEAR_SUMCHECK_PROVER_H_
+#define TACHYON_CRYPTO_SUMCHECK_MULTILINEAR_SUMCHECK_PROVER_H_
+
+#include <utility>
+#include <vector>
+
+#include "tachyon/crypto/sumcheck/multilinear/sumcheck_prover_msg.h"
+#include "tachyon/crypto/sumcheck/multilinear/sumcheck_proving_key.h"
+#include "tachyon/crypto/sumcheck/multilinear/sumcheck_verifier_msg.h"
+#include "tachyon/math/polynomials/multivariate/linear_combination.h"
+#include "tachyon/math/polynomials/univariate/univariate_evaluations.h"
+
+namespace tachyon::crypto {
+
+// The prover argues for the sum of the polynomial over {0,1}^|num_variables_|.
+//
+// The polynomial is represented by a list of terms each containing a
+// coefficient and a list of |MultilinearDenseEvaluations|. Refer to
+// "tachyon/math/polynomials/multivariate/linear_combination.h" for more info.
+template <typename MLE, size_t MaxDegree>
+class SumcheckProver {
+ public:
+  constexpr static size_t kParallelFactor = 16;
+
+  using F = typename MLE::Field;
+  using Point = typename MLE::Point;
+  using Term = math::LinearCombinationTerm<F>;
+
+  SumcheckProver() = default;
+  explicit SumcheckProver(const SumcheckProvingKey<MLE>& key)
+      : num_variables_(key.verifying_key.num_variables),
+        max_evaluations_(key.verifying_key.max_evaluations),
+        terms_(key.terms),
+        flattened_ml_evaluations_(key.flattened_ml_evaluations) {
+    // Constants are not accepted.
+    CHECK_NE(num_variables_, size_t{0});
+    randomness_.reserve(num_variables_);
+  }
+  explicit SumcheckProver(SumcheckProvingKey<MLE>&& key)
+      : num_variables_(key.verifying_key.num_variables),
+        max_evaluations_(key.verifying_key.max_evaluations),
+        terms_(std::move(key.terms)),
+        flattened_ml_evaluations_(std::move(key.flattened_ml_evaluations)) {
+    // Constants are not accepted.
+    CHECK_NE(num_variables_, size_t{0});
+    randomness_.reserve(num_variables_);
+  }
+
+  // Generate prover message, and proceed to next round.
+  //
+  // Main algorithm used is from section 3.2 of
+  // [XZZPS19](https://eprint.iacr.org/2019/317.pdf#subsection.3.2).
+  //
+  // Referencing https://people.cs.georgetown.edu/jthaler/sumcheck.pdf
+  // v = the number of variables
+  // For the first round, the Prover creates and sends:
+  //   g₁(X₁) := ∑ g(X₁,x₂,...,xᵥ), (x₂,...,xᵥ)∈{0,1}ᵛ⁻¹
+  // For the consequent round i, the Prover creates and sends:
+  //   gᵢ(Xᵢ) = ∑ g(r₁,...,rᵢ₋₁,Xᵢ,xᵢ₊₁,...,xᵥ), (xᵢ₊₁ ,...,xᵥ)∈{0,1}ᵛ⁻¹
+  // More specifically, |Prover(VerifierMsg)| fixes the front variables with
+  // r₁,...,rᵢ₋₁, and |Prover()| creates the total gᵢ(Xᵢ).
+  SumcheckProverMsg<F, MaxDegree> Round() {
+    // Max number of prover rounds should be |num_variables_|.
+    CHECK_LE(++round_, num_variables_);
+
+    // Generate sum
+    // clang-format off
+    // g(x₁, x₂) = 1(1 - x₁)(1 - x₂) + 2x₁(1 - x₂) + 3(1 - x₁)x₂ + 4x₁x₂
+    //
+    // Creating the univariate polynomial:
+    // g₁(X₁) = ∑ 1(1 - X₁)(1 - x₂) + 2X₁(1 - x₂) + 3(1 - X₁)x₂ + 4X₁x₂, x₂∈{0,1}
+    //        = 1(1 - X₁) + 2X₁ + 3(1 - X₁) + 4X₁
+    //        = start₀ + step₀X₁ + start₁ + step₁X₁
+    //         (where start₀ = 1, step₀ = 1 = 2 - 1, start₁ = 3 and step₁ = 1 = 4 - 3)
+    //        = start₀ + start₁ + (step₀ + step₁)X₁
+    //
+    // g₁(0) = start₀ + start₁
+    // g₁(1) = start₀ + start₁ + step₀ + step₁
+    // g₁(2) = start₀ + start₁ + 2step₀ + 2step₁
+    // g₁(3) = start₀ + start₁ + 3step₀ + 3step₁
+    //         where product_sum₀ = start₀ + start₁ and product_sumᵢ = product_sum₀ + (i - 1) * (step₀ + step₁)
+    // clang-format on
+#if defined(TACHYON_HAS_OPENMP)
+    size_t thread_nums = static_cast<size_t>(omp_get_max_threads());
+#else
+    size_t thread_nums = 1;
+#endif
+    size_t size = size_t{1} << (num_variables_ - round_);
+    thread_nums = (thread_nums * kParallelFactor) <= size ? thread_nums : 1;
+
+    size_t chunk_size = (size + thread_nums - 1) / thread_nums;
+    size_t num_chunks = (size + chunk_size - 1) / chunk_size;
+
+    std::vector<std::vector<F>> finished_evaluations(
+        num_chunks, std::vector<F>(max_evaluations_ + 1, F::Zero()));
+
+    OPENMP_PARALLEL_FOR(size_t i = 0; i < num_chunks; ++i) {
+      size_t begin = i * chunk_size;
+      size_t len = (i == num_chunks - 1) ? size - begin : chunk_size;
+      std::vector<F> intermediate_evaluations(max_evaluations_ + 1, F::Zero());
+      for (size_t j = begin; j < begin + len; ++j) {
+        for (const Term& term : terms_) {
+          std::fill(intermediate_evaluations.begin(),
+                    intermediate_evaluations.end(), term.coefficient);
+          EvaluateTermPerVariable(j, intermediate_evaluations, term);
+          for (size_t k = 0; k < max_evaluations_ + 1; ++k) {
+            finished_evaluations[i][k] += intermediate_evaluations[k];
+          }
+        }
+      }
+    }
+    for (size_t i = 1; i < num_chunks; ++i) {
+      for (size_t j = 0; j < max_evaluations_ + 1; ++j) {
+        finished_evaluations[0][j] += finished_evaluations[i][j];
+      }
+    }
+    return {math::UnivariateEvaluations<F, MaxDegree>(
+        std::move(finished_evaluations[0]))};
+  }
+
+  // Receive message from verifier and run a prover round.
+  //
+  // Referencing https://people.cs.georgetown.edu/jthaler/sumcheck.pdf
+  // v = the number of variables
+  // For each round i, the Prover creates and sends:
+  //   gᵢ(Xᵢ) = ∑ g(r₁,...,rᵢ₋₁,Xᵢ,xᵢ₊₁,...,xᵥ), (xᵢ₊₁,...,xᵥ)∈{0,1}ᵛ⁻¹
+  //
+  // The first section of |Round(SumcheckVerifierMsg)| fixes r₁,...,rᵢ₋₁.
+  // |Round()| subsequently creates gᵢ(Xᵢ).
+  //
+  // Note that the Prover's last round v will create:
+  //   gᵥ(Xᵥ) = g(r₁,...,rᵥ₋₁,Xᵥ)
+  SumcheckProverMsg<F, MaxDegree> Round(SumcheckVerifierMsg<F>&& v_msg) {
+    // First round should be prover
+    CHECK_GT(round_, size_t{0});
+    randomness_.push_back(v_msg.random_value);
+    Point point({std::move(v_msg.random_value)});
+    for (MLE& evaluations : flattened_ml_evaluations_) {
+      evaluations.FixVariablesInPlace(point);
+    }
+    return Round();
+  }
+
+ private:
+  void EvaluateTermPerVariable(size_t j, std::vector<F>& products,
+                               const Term& term) const {
+    for (size_t index : term.indexes) {
+      const MLE& table = flattened_ml_evaluations_[index];
+      F start = table[j << 1];
+      const F step = table[(j << 1) + 1] - start;
+      // start, (start + step), (start + 2 * step), (start + 3 * step),...
+      for (F& p : products) {
+        p *= start;
+        start += step;
+      }
+    }
+  }
+
+  // The current round number.
+  size_t round_ = 0;
+  // Number of variables.
+  size_t num_variables_ = 0;
+  // Max number of evaluations in a term.
+  size_t max_evaluations_ = 0;
+  // Sampled set of random values given by the verifier.
+  std::vector<F> randomness_;
+  // Stores the list of terms that is meant to be added together. Each
+  // evaluation is represented by the index in |flattened_ml_evaluations_|.
+  std::vector<Term> terms_;
+  // Stores a list of multilinear evaluations in which |terms_| points to.
+  std::vector<MLE> flattened_ml_evaluations_;
+};
+
+}  // namespace tachyon::crypto
+
+#endif  // TACHYON_CRYPTO_SUMCHECK_MULTILINEAR_SUMCHECK_PROVER_H_

--- a/tachyon/crypto/sumcheck/multilinear/sumcheck_prover_msg.h
+++ b/tachyon/crypto/sumcheck/multilinear/sumcheck_prover_msg.h
@@ -1,0 +1,60 @@
+// Copyright 2022 arkworks contributors
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.arkworks and the LICENCE-APACHE.arkworks
+// file.
+
+#ifndef TACHYON_CRYPTO_SUMCHECK_MULTILINEAR_SUMCHECK_PROVER_MSG_H_
+#define TACHYON_CRYPTO_SUMCHECK_MULTILINEAR_SUMCHECK_PROVER_MSG_H_
+
+#include <utility>
+#include <vector>
+
+#include "tachyon/base/buffer/copyable.h"
+#include "tachyon/math/polynomials/univariate/univariate_evaluations.h"
+
+namespace tachyon {
+namespace crypto {
+
+template <typename F, size_t MaxDegree>
+struct SumcheckProverMsg {
+  // Evaluations on P(0), P(1), P(2), ...
+  math::UnivariateEvaluations<F, MaxDegree> evaluations;
+
+  bool operator==(const SumcheckProverMsg& other) const {
+    return evaluations == other.evaluations;
+  }
+  bool operator!=(const SumcheckProverMsg& other) const {
+    return !operator==(other);
+  }
+};
+
+}  // namespace crypto
+
+namespace base {
+
+template <typename F, size_t MaxDegree>
+class Copyable<crypto::SumcheckProverMsg<F, MaxDegree>> {
+ public:
+  static bool WriteTo(const crypto::SumcheckProverMsg<F, MaxDegree>& msg,
+                      Buffer* buffer) {
+    return buffer->Write(msg.evaluations);
+  }
+
+  static bool ReadFrom(const ReadOnlyBuffer& buffer,
+                       crypto::SumcheckProverMsg<F, MaxDegree>* msg) {
+    math::UnivariateEvaluations<F, MaxDegree> evaluations;
+    if (!buffer.Read(&evaluations)) return false;
+    *msg = {std::move(evaluations)};
+    return true;
+  }
+
+  static size_t EstimateSize(
+      const crypto::SumcheckProverMsg<F, MaxDegree>& msg) {
+    return base::EstimateSize(msg.evaluations);
+  }
+};
+
+}  // namespace base
+}  // namespace tachyon
+
+#endif  // TACHYON_CRYPTO_SUMCHECK_MULTILINEAR_SUMCHECK_PROVER_MSG_H_

--- a/tachyon/crypto/sumcheck/multilinear/sumcheck_prover_msg_unittest.cc
+++ b/tachyon/crypto/sumcheck/multilinear/sumcheck_prover_msg_unittest.cc
@@ -1,0 +1,38 @@
+#include "tachyon/crypto/sumcheck/multilinear/sumcheck_prover_msg.h"
+
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "tachyon/base/buffer/vector_buffer.h"
+#include "tachyon/base/containers/container_util.h"
+#include "tachyon/math/finite_fields/test/finite_field_test.h"
+#include "tachyon/math/finite_fields/test/gf7.h"
+#include "tachyon/math/polynomials/univariate/univariate_evaluations.h"
+
+namespace tachyon::crypto {
+namespace {
+
+using F = math::GF7;
+
+class SumcheckProverMsgTest : public math::FiniteFieldTest<math::GF7> {};
+
+}  // namespace
+
+TEST_F(SumcheckProverMsgTest, Copyable) {
+  SumcheckProverMsg<F, 5> expected = {
+      math::UnivariateEvaluations<F, 5>::Random(5)};
+
+  base::Uint8VectorBuffer write_buf;
+  ASSERT_TRUE(write_buf.Grow(base::EstimateSize(expected)));
+  ASSERT_TRUE(write_buf.Write(expected));
+  ASSERT_TRUE(write_buf.Done());
+
+  write_buf.set_buffer_offset(0);
+
+  SumcheckProverMsg<F, 5> value;
+  ASSERT_TRUE(write_buf.Read(&value));
+  EXPECT_EQ(expected, value);
+}
+
+}  // namespace tachyon::crypto

--- a/tachyon/crypto/sumcheck/multilinear/sumcheck_proving_key.h
+++ b/tachyon/crypto/sumcheck/multilinear/sumcheck_proving_key.h
@@ -13,25 +13,27 @@ namespace tachyon {
 namespace crypto {
 
 template <typename MLE>
-struct ProvingKey {
-  VerifyingKey verifying_key;
+struct SumcheckProvingKey {
+  SumcheckVerifyingKey verifying_key;
   std::vector<math::LinearCombinationTerm<typename MLE::Field>> terms;
   std::vector<MLE> flattened_ml_evaluations;
 
-  static ProvingKey Build(
+  static SumcheckProvingKey Build(
       const math::LinearCombination<MLE>& linear_combination) {
     std::vector<MLE> flattened_ml_evaluations =
         base::Map(linear_combination.flattened_ml_evaluations(),
                   [](const std::shared_ptr<MLE> ptr) { return *ptr.get(); });
-    return {VerifyingKey::Build(linear_combination), linear_combination.terms(),
-            std::move(flattened_ml_evaluations)};
+    return {SumcheckVerifyingKey::Build(linear_combination),
+            linear_combination.terms(), std::move(flattened_ml_evaluations)};
   }
 
-  bool operator==(const ProvingKey& other) const {
+  bool operator==(const SumcheckProvingKey& other) const {
     return verifying_key == other.verifying_key && terms == other.terms &&
            flattened_ml_evaluations == flattened_ml_evaluations;
   }
-  bool operator!=(const ProvingKey& other) const { return !operator==(other); }
+  bool operator!=(const SumcheckProvingKey& other) const {
+    return !operator==(other);
+  }
 };
 
 }  // namespace crypto
@@ -39,17 +41,17 @@ struct ProvingKey {
 namespace base {
 
 template <typename MLE>
-class Copyable<crypto::ProvingKey<MLE>> {
+class Copyable<crypto::SumcheckProvingKey<MLE>> {
  public:
-  static bool WriteTo(const crypto::ProvingKey<MLE>& proving_key,
+  static bool WriteTo(const crypto::SumcheckProvingKey<MLE>& proving_key,
                       Buffer* buffer) {
     return buffer->WriteMany(proving_key.verifying_key, proving_key.terms,
                              proving_key.flattened_ml_evaluations);
   }
 
   static bool ReadFrom(const ReadOnlyBuffer& buffer,
-                       crypto::ProvingKey<MLE>* proving_key) {
-    crypto::VerifyingKey verifying_key;
+                       crypto::SumcheckProvingKey<MLE>* proving_key) {
+    crypto::SumcheckVerifyingKey verifying_key;
     std::vector<math::LinearCombinationTerm<typename MLE::Field>> terms;
     std::vector<MLE> flattened_ml_evaluations;
     if (!buffer.ReadMany(&verifying_key, &terms, &flattened_ml_evaluations))
@@ -59,7 +61,8 @@ class Copyable<crypto::ProvingKey<MLE>> {
     return true;
   }
 
-  static size_t EstimateSize(const crypto::ProvingKey<MLE>& proving_key) {
+  static size_t EstimateSize(
+      const crypto::SumcheckProvingKey<MLE>& proving_key) {
     return base::EstimateSize(proving_key.verifying_key, proving_key.terms,
                               proving_key.flattened_ml_evaluations);
   }

--- a/tachyon/crypto/sumcheck/multilinear/sumcheck_proving_key.h
+++ b/tachyon/crypto/sumcheck/multilinear/sumcheck_proving_key.h
@@ -1,5 +1,5 @@
-#ifndef TACHYON_CRYPTO_SUMCHECK_SUMCHECK_PROVING_KEY_H_
-#define TACHYON_CRYPTO_SUMCHECK_SUMCHECK_PROVING_KEY_H_
+#ifndef TACHYON_CRYPTO_SUMCHECK_MULTILINEAR_SUMCHECK_PROVING_KEY_H_
+#define TACHYON_CRYPTO_SUMCHECK_MULTILINEAR_SUMCHECK_PROVING_KEY_H_
 
 #include <memory>
 #include <utility>
@@ -7,7 +7,7 @@
 
 #include "tachyon/base/buffer/copyable.h"
 #include "tachyon/base/containers/container_util.h"
-#include "tachyon/crypto/sumcheck/sumcheck_verifying_key.h"
+#include "tachyon/crypto/sumcheck/multilinear/sumcheck_verifying_key.h"
 
 namespace tachyon {
 namespace crypto {
@@ -68,4 +68,4 @@ class Copyable<crypto::ProvingKey<MLE>> {
 }  // namespace base
 }  // namespace tachyon
 
-#endif  // TACHYON_CRYPTO_SUMCHECK_SUMCHECK_PROVING_KEY_H_
+#endif  // TACHYON_CRYPTO_SUMCHECK_MULTILINEAR_SUMCHECK_PROVING_KEY_H_

--- a/tachyon/crypto/sumcheck/multilinear/sumcheck_proving_key_unittest.cc
+++ b/tachyon/crypto/sumcheck/multilinear/sumcheck_proving_key_unittest.cc
@@ -1,4 +1,4 @@
-#include "tachyon/crypto/sumcheck/sumcheck_proving_key.h"
+#include "tachyon/crypto/sumcheck/multilinear/sumcheck_proving_key.h"
 
 #include "gtest/gtest.h"
 

--- a/tachyon/crypto/sumcheck/multilinear/sumcheck_proving_key_unittest.cc
+++ b/tachyon/crypto/sumcheck/multilinear/sumcheck_proving_key_unittest.cc
@@ -15,16 +15,16 @@ const size_t kMaxDegree = 4;
 
 using Poly = math::MultilinearDenseEvaluations<math::GF7, kMaxDegree>;
 
-class ProvingKeyTest : public math::FiniteFieldTest<math::GF7> {};
+class SumcheckProvingKeyTest : public math::FiniteFieldTest<math::GF7> {};
 
 }  // namespace
 
-TEST_F(ProvingKeyTest, Copyable) {
+TEST_F(SumcheckProvingKeyTest, Copyable) {
   math::LinearCombination<Poly> random_linear_combination =
       math::LinearCombination<Poly>::Random(kMaxDegree,
                                             base::Range<size_t>(6, 12), 7);
-  ProvingKey<Poly> expected =
-      ProvingKey<Poly>::Build(random_linear_combination);
+  SumcheckProvingKey<Poly> expected =
+      SumcheckProvingKey<Poly>::Build(random_linear_combination);
 
   base::Uint8VectorBuffer write_buf;
   ASSERT_TRUE(write_buf.Grow(base::EstimateSize(expected)));
@@ -33,7 +33,7 @@ TEST_F(ProvingKeyTest, Copyable) {
 
   write_buf.set_buffer_offset(0);
 
-  ProvingKey<Poly> value;
+  SumcheckProvingKey<Poly> value;
   ASSERT_TRUE(write_buf.Read(&value));
   EXPECT_EQ(expected, value);
 }

--- a/tachyon/crypto/sumcheck/multilinear/sumcheck_verifier.h
+++ b/tachyon/crypto/sumcheck/multilinear/sumcheck_verifier.h
@@ -1,0 +1,262 @@
+// Copyright 2022 arkworks contributors
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.arkworks and the LICENCE-APACHE.arkworks
+// file.
+
+#ifndef TACHYON_CRYPTO_SUMCHECK_MULTILINEAR_SUMCHECK_VERIFIER_H_
+#define TACHYON_CRYPTO_SUMCHECK_MULTILINEAR_SUMCHECK_VERIFIER_H_
+
+#include <utility>
+#include <vector>
+
+#include "tachyon/crypto/sumcheck/multilinear/sumcheck_prover_msg.h"
+#include "tachyon/crypto/sumcheck/multilinear/sumcheck_verifier_msg.h"
+#include "tachyon/crypto/sumcheck/multilinear/sumcheck_verifying_key.h"
+
+namespace tachyon::crypto {
+
+template <typename F>
+F InterpolateUniPoly(const std::vector<F>& poly, const F& evaluation_point);
+
+// Subclaim created when verifier is convinced.
+template <typename F>
+struct Subclaim {
+  // The multi-dimensional point this multilinear evaluation is evaluated at.
+  std::vector<F> point;
+  // The expected evaluation.
+  F expected_evaluation;
+};
+
+template <typename MLE>
+class SumcheckVerifier {
+ public:
+  using F = typename MLE::Field;
+
+  SumcheckVerifier() = default;
+  explicit SumcheckVerifier(const SumcheckVerifyingKey& key)
+      : num_variables_(key.num_variables),
+        max_evaluations_(key.max_evaluations) {
+    randomness_.reserve(key.num_variables);
+    polynomials_received_.reserve(key.num_variables);
+  }
+  explicit SumcheckVerifier(SumcheckVerifyingKey&& key)
+      : num_variables_(key.num_variables),
+        max_evaluations_(key.max_evaluations) {
+    randomness_.reserve(key.num_variables);
+    polynomials_received_.reserve(key.num_variables);
+  }
+
+  // Runs a "round" given a |SumcheckProverMsg|, sampling and storing a random
+  // value.
+  //
+  // While a true verifier round should perform actual verification, |Round()|
+  // merely samples and stores random values. Verifications will be performed
+  // altogether in |CheckAndGenerateSubclaim| after all prover and verifier
+  // sub-rounds are subsequently finished.
+  //
+  // Referencing https://people.cs.georgetown.edu/jthaler/sumcheck.pdf
+  // |random_value| is the challenge that will given from the Verifier
+  // to the Prover aka rᵢ.
+  template <size_t MaxDegree>
+  SumcheckVerifierMsg<F> Round(SumcheckProverMsg<F, MaxDegree>&& prover_msg) {
+    CHECK_LT(polynomials_received_.size(), num_variables_);
+
+    const F random_value = F::Random();
+    randomness_.push_back(random_value);
+    polynomials_received_.push_back(
+        std::move(prover_msg.evaluations.evaluations()));
+
+    return {std::move(random_value)};
+  }
+
+  // Verifies the sumcheck phases' validity and generates a subclaim.
+  //
+  // If the asserted sum is correct, then the multilinear polynomial evaluated
+  // at |subclaim.point| is |subclaim.expected_evaluation|. Otherwise, it is
+  // highly unlikely that these two will be equal. A larger field size
+  // guarantees a smaller soundness error.
+  //
+  // Referencing https://people.cs.georgetown.edu/jthaler/sumcheck.pdf
+  // |CheckAndGenerateSubclaim()| verifies for each round i:
+  //   gᵢ(0) + gᵢ(1) =  gᵢ₋₁(rᵢ₋₁)
+  // Note: For the first round, gᵢ₋₁(rᵢ₋₁) = H = |LinearCombination.Combine()|
+  //   Meanwhile, for the last round, gᵢ₋₁(rᵢ₋₁) = the |LinearCombination|
+  //   evaluated on the multivariate point of Verifier's challenges.
+  bool CheckAndGenerateSubclaim(const F& asserted_sum, Subclaim<F>* subclaim) {
+    // Insufficient rounds.
+    CHECK_EQ(polynomials_received_.size(), num_variables_);
+    F expected = asserted_sum;
+
+    for (size_t i = 0; i < num_variables_; ++i) {
+      const std::vector<F>& evaluations = polynomials_received_[i];
+      // Incorrect number of evaluations.
+      CHECK_EQ(evaluations.size(), max_evaluations_ + 1);
+
+      const F& p0 = evaluations[0];
+      const F& p1 = evaluations[1];
+
+      F sum = p0 + p1;
+
+      // Check that prover message is consistent with the claim.
+      if (sum != expected) {
+        return false;
+      }
+      expected = InterpolateUniPoly(evaluations, randomness_[i]);
+    }
+    *subclaim = {std::move(randomness_), std::move(expected)};
+    return true;
+  }
+
+ private:
+  size_t num_variables_ = 0;
+  size_t max_evaluations_ = 0;
+  // A list storing the randomness sampled by the verifier at each round.
+  std::vector<F> randomness_;
+  // A list storing the univariate polynomial in evaluation form sent by the
+  // prover at each round.
+  std::vector<std::vector<F>> polynomials_received_;
+};
+
+// Interpolates the unique univariate polynomial |poly| of degree at most
+// |poly.size()| - 1 = |poly_size| passing through the y-values in |poly| at
+// x = 0,..., |poly[i].size()| - 1 and evaluates this polynomial at
+// |evaluation_point|:
+//   ∑ poly[i] * ∏ⱼ≠ᵢ(|evaluation_point| - j)/(i - j), (i = 0,1,...,|poly_size|)
+template <typename F>
+F InterpolateUniPoly(const std::vector<F>& poly, const F& evaluation_point) {
+  constexpr size_t kParallelFactor = 16;
+
+  using BigInt = typename F::BigIntTy;
+
+  // clang-format off
+  // Calculating iteration i on X = |evaluation_point| is done like so:
+  //
+  //                             (|product| / |evals[i]|)
+  //                                        |
+  //                          |‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾|
+  // iteration i =  poly[i] * ∏ⱼ≠ᵢ(|evaluation_point| - j)/(i - j), (i = 0,1,...,|poly_size|)
+  //                         |___|------------------------|______|
+  //                                                         |
+  //                                                     denom[i]
+  //
+  // More specifically...
+  //
+  //                                       |product|
+  //                                           |
+  //                         |‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾|
+  //                         (X - 0)(X - 1)(X - 2)...(X - poly_size)
+  // iteration i = poly[i] * ―――――――――――――――――――――――――――――――――――――――
+  //                                   (X - i) * denom[i]
+  //                                  |______|
+  //                                     |
+  //                                |evals[i]|
+  //
+  // Where...
+  //                                                  |denom_up|
+  //                                                      |
+  //             |‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾|
+  //            (|poly_size| - 1)! * ∏ -|offset_up|, (|offset_up| = 1,2,...,|poly_size| - i - 1)
+  // denom[i] = ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――
+  //                     ∏ |offset_down|, (|offset_down| = |poly_size| - 1,...,i + 1)
+  //                    |___________________________________________________________|
+  //                                                  |
+  //                                            |denom_down|
+  //
+  // More information on denom is given later.
+  // clang-format on
+
+  // Return early if 0 ≤ |evaluation_point| < |poly_size|, i.e. if the desired
+  // value is already calculated (in |poly|)
+  size_t poly_size = poly.size();
+  CHECK_NE(poly_size, size_t{0});
+
+  const BigInt test = evaluation_point.ToBigInt();
+  if (test < BigInt(poly_size)) {
+    return poly[test.smallest_limb()];
+  }
+
+  // |product| = ∏ⱼ(|evaluation_point| - j)
+#if defined(TACHYON_HAS_OPENMP)
+  size_t thread_nums = static_cast<size_t>(omp_get_max_threads());
+#else
+  size_t thread_nums = 1;
+#endif
+  thread_nums =
+      ((thread_nums * kParallelFactor) <= poly_size) ? thread_nums : 1;
+
+  size_t chunk_size = (poly_size + thread_nums - 1) / thread_nums;
+  size_t num_chunks = (poly_size + chunk_size - 1) / chunk_size;
+
+  std::vector<F> products(num_chunks, F::One());
+  std::vector<F> denom_ups(num_chunks, F::One());
+  std::vector<std::vector<F>> list_of_evals(num_chunks);
+  OPENMP_PARALLEL_FOR(size_t i = 0; i < num_chunks; ++i) {
+    size_t begin = i * chunk_size;
+    size_t len = (i == num_chunks - 1) ? poly_size - begin : chunk_size;
+    list_of_evals[i].reserve(len);
+    F check = F(begin);
+    for (size_t j = begin; j < begin + len; ++j) {
+      const F difference = evaluation_point - check;
+      list_of_evals[i].push_back(difference);
+      products[i] *= difference;
+      if (j > 1) {
+        denom_ups[i] *= check;
+      }
+      check += F::One();
+    }
+  }
+  F product = products[0];
+  F denom_up = denom_ups[0];
+  std::vector<F> evals = list_of_evals[0];
+  for (size_t i = 1; i < num_chunks; ++i) {
+    evals.insert(evals.end(), list_of_evals[i].begin(), list_of_evals[i].end());
+    product *= products[i];
+    denom_up *= denom_ups[i];
+  }
+
+  // Computing denom[i] = ∏ⱼ≠ᵢ(i - j) for a given i:
+  //
+  // clang-format off
+  // Start from the last step:
+  //  denom[poly_size - 1] = (poly_size - 1) * (poly_size - 2) *... * 2 * 1
+  //  aka:
+  //   denom[poly_size - 1] = (poly_size - 1)!
+  // The step before that is
+  //  denom[poly_size - 2] = (poly_size - 2) * (poly_size - 3) * ... * 2 * 1 * -1
+  // and the step before that is
+  //  denom[poly_size - 3] = (poly_size - 3) * (poly_size - 4) * ... * 2 * 1 * -1 *-2
+  // clang-format on
+  //
+  // i.e., for any i, the one before this will be derived from
+  //  denom[i - 1] = - denom[i] * (|poly_size| - i) / i
+  // aka:
+  //  denom[i] = (|poly_size| - 1)! * ∏ -|offset_up|, (|offset_up| =
+  //  1,2,...,|poly_size| - i - 1)
+  //
+  // denom is stored as a fraction number to reduce field divisions.
+  F res = F::Zero();
+  F offset_up = F::One();
+
+  for (size_t i = poly_size - 1; i < SIZE_MAX; --i) {
+    evals[i] *= denom_up;
+    if (i != 0) {
+      denom_up *= -offset_up;
+      offset_up += F::One();
+    }
+  }
+  CHECK(F::BatchInverseInPlace(evals));
+  F denom_down = F::One();
+  F offset_down = F(poly_size - 1);
+  for (size_t i = poly_size - 1; i < SIZE_MAX; --i) {
+    res += poly[i] * product * denom_down * evals[i];
+    if (i != 0) {
+      denom_down *= offset_down;
+      offset_down -= F::One();
+    }
+  }
+  return res;
+}
+
+}  // namespace tachyon::crypto
+
+#endif  // TACHYON_CRYPTO_SUMCHECK_MULTILINEAR_SUMCHECK_VERIFIER_H_

--- a/tachyon/crypto/sumcheck/multilinear/sumcheck_verifier_msg.h
+++ b/tachyon/crypto/sumcheck/multilinear/sumcheck_verifier_msg.h
@@ -1,0 +1,57 @@
+// Copyright 2022 arkworks contributors
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.arkworks and the LICENCE-APACHE.arkworks
+// file.
+
+#ifndef TACHYON_CRYPTO_SUMCHECK_MULTILINEAR_SUMCHECK_VERIFIER_MSG_H_
+#define TACHYON_CRYPTO_SUMCHECK_MULTILINEAR_SUMCHECK_VERIFIER_MSG_H_
+
+#include <utility>
+
+#include "tachyon/base/buffer/copyable.h"
+
+namespace tachyon {
+namespace crypto {
+
+template <typename F>
+struct SumcheckVerifierMsg {
+  // Random value sampled by verifier.
+  F random_value;
+
+  bool operator==(const SumcheckVerifierMsg& other) const {
+    return random_value == other.random_value;
+  }
+  bool operator!=(const SumcheckVerifierMsg& other) const {
+    return !operator==(other);
+  }
+};
+
+}  // namespace crypto
+
+namespace base {
+
+template <typename F>
+class Copyable<crypto::SumcheckVerifierMsg<F>> {
+ public:
+  static bool WriteTo(const crypto::SumcheckVerifierMsg<F>& msg,
+                      Buffer* buffer) {
+    return buffer->Write(msg.random_value);
+  }
+
+  static bool ReadFrom(const ReadOnlyBuffer& buffer,
+                       crypto::SumcheckVerifierMsg<F>* msg) {
+    F random_value;
+    if (!buffer.Read(&random_value)) return false;
+    *msg = {std::move(random_value)};
+    return true;
+  }
+
+  static size_t EstimateSize(const crypto::SumcheckVerifierMsg<F>& msg) {
+    return base::EstimateSize(msg.random_value);
+  }
+};
+
+}  // namespace base
+}  // namespace tachyon
+
+#endif  // TACHYON_CRYPTO_SUMCHECK_MULTILINEAR_SUMCHECK_VERIFIER_MSG_H_

--- a/tachyon/crypto/sumcheck/multilinear/sumcheck_verifier_msg_unittest.cc
+++ b/tachyon/crypto/sumcheck/multilinear/sumcheck_verifier_msg_unittest.cc
@@ -1,0 +1,33 @@
+#include "tachyon/crypto/sumcheck/multilinear/sumcheck_verifier_msg.h"
+
+#include "gtest/gtest.h"
+
+#include "tachyon/base/buffer/vector_buffer.h"
+#include "tachyon/math/finite_fields/test/finite_field_test.h"
+#include "tachyon/math/finite_fields/test/gf7.h"
+
+namespace tachyon::crypto {
+namespace {
+
+using F = math::GF7;
+
+class SumcheckVerifierMsgTest : public math::FiniteFieldTest<math::GF7> {};
+
+}  // namespace
+
+TEST_F(SumcheckVerifierMsgTest, Copyable) {
+  SumcheckVerifierMsg<F> expected = {F::Random()};
+
+  base::Uint8VectorBuffer write_buf;
+  ASSERT_TRUE(write_buf.Grow(base::EstimateSize(expected)));
+  ASSERT_TRUE(write_buf.Write(expected));
+  ASSERT_TRUE(write_buf.Done());
+
+  write_buf.set_buffer_offset(0);
+
+  SumcheckVerifierMsg<F> value;
+  ASSERT_TRUE(write_buf.Read(&value));
+  EXPECT_EQ(expected, value);
+}
+
+}  // namespace tachyon::crypto

--- a/tachyon/crypto/sumcheck/multilinear/sumcheck_verifying_key.h
+++ b/tachyon/crypto/sumcheck/multilinear/sumcheck_verifying_key.h
@@ -3,8 +3,8 @@
 // can be found in the LICENSE-MIT.arkworks and the LICENCE-APACHE.arkworks
 // file.
 
-#ifndef TACHYON_CRYPTO_SUMCHECK_SUMCHECK_VERIFYING_KEY_H_
-#define TACHYON_CRYPTO_SUMCHECK_SUMCHECK_VERIFYING_KEY_H_
+#ifndef TACHYON_CRYPTO_SUMCHECK_MULTILINEAR_SUMCHECK_VERIFYING_KEY_H_
+#define TACHYON_CRYPTO_SUMCHECK_MULTILINEAR_SUMCHECK_VERIFYING_KEY_H_
 
 #include "tachyon/base/buffer/copyable.h"
 #include "tachyon/base/random.h"
@@ -69,4 +69,4 @@ class Copyable<crypto::VerifyingKey> {
 }  // namespace base
 }  // namespace tachyon
 
-#endif  // TACHYON_CRYPTO_SUMCHECK_SUMCHECK_VERIFYING_KEY_H_
+#endif  // TACHYON_CRYPTO_SUMCHECK_MULTILINEAR_SUMCHECK_VERIFYING_KEY_H_

--- a/tachyon/crypto/sumcheck/multilinear/sumcheck_verifying_key.h
+++ b/tachyon/crypto/sumcheck/multilinear/sumcheck_verifying_key.h
@@ -13,26 +13,26 @@
 namespace tachyon {
 namespace crypto {
 
-struct TACHYON_EXPORT VerifyingKey {
+struct TACHYON_EXPORT SumcheckVerifyingKey {
   size_t max_evaluations;
   size_t num_variables;
 
   template <typename MLE>
-  static VerifyingKey Build(
+  static SumcheckVerifyingKey Build(
       const math::LinearCombination<MLE>& linear_combination) {
     return {linear_combination.max_evaluations(),
             linear_combination.num_variables()};
   }
 
-  bool operator==(const VerifyingKey& other) const {
+  bool operator==(const SumcheckVerifyingKey& other) const {
     return max_evaluations == other.max_evaluations &&
            num_variables == other.num_variables;
   }
-  bool operator!=(const VerifyingKey& other) const {
+  bool operator!=(const SumcheckVerifyingKey& other) const {
     return !operator==(other);
   }
 
-  static VerifyingKey Random() {
+  static SumcheckVerifyingKey Random() {
     return {base::Uniform(base::Range<size_t>()),
             base::Uniform(base::Range<size_t>())};
   }
@@ -43,16 +43,16 @@ struct TACHYON_EXPORT VerifyingKey {
 namespace base {
 
 template <>
-class Copyable<crypto::VerifyingKey> {
+class Copyable<crypto::SumcheckVerifyingKey> {
  public:
-  static bool WriteTo(const crypto::VerifyingKey& verifying_key,
+  static bool WriteTo(const crypto::SumcheckVerifyingKey& verifying_key,
                       Buffer* buffer) {
     return buffer->WriteMany(verifying_key.max_evaluations,
                              verifying_key.num_variables);
   }
 
   static bool ReadFrom(const ReadOnlyBuffer& buffer,
-                       crypto::VerifyingKey* verifying_key) {
+                       crypto::SumcheckVerifyingKey* verifying_key) {
     size_t max_evaluations;
     size_t num_variables;
     if (!buffer.ReadMany(&max_evaluations, &num_variables)) return false;
@@ -60,7 +60,8 @@ class Copyable<crypto::VerifyingKey> {
     return true;
   }
 
-  static size_t EstimateSize(const crypto::VerifyingKey& verifying_key) {
+  static size_t EstimateSize(
+      const crypto::SumcheckVerifyingKey& verifying_key) {
     return base::EstimateSize(verifying_key.max_evaluations,
                               verifying_key.num_variables);
   }

--- a/tachyon/crypto/sumcheck/multilinear/sumcheck_verifying_key_unittest.cc
+++ b/tachyon/crypto/sumcheck/multilinear/sumcheck_verifying_key_unittest.cc
@@ -6,8 +6,8 @@
 
 namespace tachyon::crypto {
 
-TEST(VerifyingKeyTest, Copyable) {
-  VerifyingKey expected = VerifyingKey::Random();
+TEST(SumcheckVerifyingKeyTest, Copyable) {
+  SumcheckVerifyingKey expected = SumcheckVerifyingKey::Random();
 
   base::Uint8VectorBuffer write_buf;
   ASSERT_TRUE(write_buf.Grow(base::EstimateSize(expected)));
@@ -16,7 +16,7 @@ TEST(VerifyingKeyTest, Copyable) {
 
   write_buf.set_buffer_offset(0);
 
-  VerifyingKey value;
+  SumcheckVerifyingKey value;
   ASSERT_TRUE(write_buf.Read(&value));
   EXPECT_EQ(expected, value);
 }

--- a/tachyon/crypto/sumcheck/multilinear/sumcheck_verifying_key_unittest.cc
+++ b/tachyon/crypto/sumcheck/multilinear/sumcheck_verifying_key_unittest.cc
@@ -1,4 +1,4 @@
-#include "tachyon/crypto/sumcheck/sumcheck_verifying_key.h"
+#include "tachyon/crypto/sumcheck/multilinear/sumcheck_verifying_key.h"
 
 #include "gtest/gtest.h"
 

--- a/tachyon/crypto/sumcheck/sumcheck_proving_key_unittest.cc
+++ b/tachyon/crypto/sumcheck/sumcheck_proving_key_unittest.cc
@@ -5,7 +5,7 @@
 #include "tachyon/base/buffer/vector_buffer.h"
 #include "tachyon/math/finite_fields/test/finite_field_test.h"
 #include "tachyon/math/finite_fields/test/gf7.h"
-#include "tachyon/math/polynomials/multivariate/multilinear_extension.h"
+#include "tachyon/math/polynomials/multivariate/multilinear_dense_evaluations.h"
 
 namespace tachyon::crypto {
 
@@ -13,8 +13,7 @@ namespace {
 
 const size_t kMaxDegree = 4;
 
-using Poly = math::MultilinearExtension<
-    math::MultilinearDenseEvaluations<math::GF7, kMaxDegree>>;
+using Poly = math::MultilinearDenseEvaluations<math::GF7, kMaxDegree>;
 
 class ProvingKeyTest : public math::FiniteFieldTest<math::GF7> {};
 

--- a/tachyon/crypto/sumcheck/sumcheck_verifying_key.h
+++ b/tachyon/crypto/sumcheck/sumcheck_verifying_key.h
@@ -1,3 +1,8 @@
+// Copyright 2022 arkworks contributors
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.arkworks and the LICENCE-APACHE.arkworks
+// file.
+
 #ifndef TACHYON_CRYPTO_SUMCHECK_SUMCHECK_VERIFYING_KEY_H_
 #define TACHYON_CRYPTO_SUMCHECK_SUMCHECK_VERIFYING_KEY_H_
 

--- a/tachyon/math/polynomials/multivariate/BUILD.bazel
+++ b/tachyon/math/polynomials/multivariate/BUILD.bazel
@@ -7,6 +7,8 @@ tachyon_cc_library(
     hdrs = ["linear_combination.h"],
     deps = [
         ":linear_combination_term",
+        "//tachyon/base:parallelize",
+        "//tachyon/base:random",
         "//tachyon/base/containers:container_util",
         "@com_google_absl//absl/container:node_hash_map",
     ],

--- a/tachyon/math/polynomials/multivariate/BUILD.bazel
+++ b/tachyon/math/polynomials/multivariate/BUILD.bazel
@@ -10,7 +10,7 @@ tachyon_cc_library(
         "//tachyon/base:parallelize",
         "//tachyon/base:random",
         "//tachyon/base/containers:container_util",
-        "@com_google_absl//absl/container:node_hash_map",
+        "@com_google_absl//absl/container:flat_hash_map",
     ],
 )
 

--- a/tachyon/math/polynomials/multivariate/linear_combination.h
+++ b/tachyon/math/polynomials/multivariate/linear_combination.h
@@ -98,6 +98,18 @@ class LinearCombination {
   }
 
  private:
+  static F EvaluateSerial(
+      const Point& point,
+      const std::vector<std::shared_ptr<MLE>>& flattened_ml_evaluations,
+      absl::Span<const LinearCombinationTerm<F>> terms) {
+    return std::accumulate(terms.begin(), terms.end(), F::Zero(),
+                           [&point, &flattened_ml_evaluations](
+                               F& acc, const LinearCombinationTerm<F>& term) {
+                             return acc += term.Evaluate(
+                                        point, flattened_ml_evaluations);
+                           });
+  }
+
   // max number of evaluations for each term
   size_t max_evaluations_ = 0;
   // number of variables of the polynomial
@@ -111,18 +123,6 @@ class LinearCombination {
   // corresponding index in |flattened_ml_evaluations_|
   // not owned
   absl::flat_hash_map<const MLE*, size_t> lookup_table_;
-
-  static F EvaluateSerial(
-      const Point& point,
-      const std::vector<std::shared_ptr<MLE>>& flattened_ml_evaluations,
-      absl::Span<const LinearCombinationTerm<F>> terms) {
-    return std::accumulate(terms.begin(), terms.end(), F::Zero(),
-                           [&point, &flattened_ml_evaluations](
-                               F& acc, const LinearCombinationTerm<F>& term) {
-                             return acc += term.Evaluate(
-                                        point, flattened_ml_evaluations);
-                           });
-  }
 };
 
 }  // namespace tachyon::math

--- a/tachyon/math/polynomials/multivariate/linear_combination.h
+++ b/tachyon/math/polynomials/multivariate/linear_combination.h
@@ -84,7 +84,6 @@ class LinearCombination {
   // where n = total terms, m = number of evaluations per term
   F SumOfProducts(const Point& point) const {
     CHECK_EQ(point.size(), num_variables_);
-#if defined(TACHYON_HAS_OPENMP)
     std::vector<F> results = base::ParallelizeMap(
         terms_,
         [this, &point](absl::Span<const LinearCombinationTerm<F>> chunk) {
@@ -92,9 +91,6 @@ class LinearCombination {
         });
     return std::accumulate(results.begin(), results.end(), F::Zero(),
                            std::plus<>());
-#else
-    return EvaluateSerial(point, flattened_ml_evaluations_, terms_);
-#endif
   }
 
  private:

--- a/tachyon/math/polynomials/multivariate/linear_combination.h
+++ b/tachyon/math/polynomials/multivariate/linear_combination.h
@@ -82,7 +82,7 @@ class LinearCombination {
   // Evaluates all terms together on an evaluation point for each variable:
   // ∑ᵢ₌₀..ₙ(coefficientᵢ⋅∏ⱼ₌₀..ₘevaluationᵢⱼ)
   // where n = total terms, m = number of evaluations per term
-  F SumOfProducts(const Point& point) const {
+  F Evaluate(const Point& point) const {
     CHECK_EQ(point.size(), num_variables_);
     std::vector<F> results = base::ParallelizeMap(
         terms_,

--- a/tachyon/math/polynomials/multivariate/linear_combination.h
+++ b/tachyon/math/polynomials/multivariate/linear_combination.h
@@ -1,3 +1,8 @@
+// Copyright 2022 arkworks contributors
+// Use of this source code is governed by a MIT/Apache-2.0 style license that
+// can be found in the LICENSE-MIT.arkworks and the LICENCE-APACHE.arkworks
+// file.
+
 #ifndef TACHYON_MATH_POLYNOMIALS_MULTIVARIATE_LINEAR_COMBINATION_H_
 #define TACHYON_MATH_POLYNOMIALS_MULTIVARIATE_LINEAR_COMBINATION_H_
 

--- a/tachyon/math/polynomials/multivariate/linear_combination.h
+++ b/tachyon/math/polynomials/multivariate/linear_combination.h
@@ -13,7 +13,7 @@
 #include <utility>
 #include <vector>
 
-#include "absl/container/node_hash_map.h"
+#include "absl/container/flat_hash_map.h"
 
 #include "tachyon/base/containers/container_util.h"
 #include "tachyon/base/parallelize.h"
@@ -110,7 +110,7 @@ class LinearCombination {
   // holds all unique dense multilinear evaluations currently used & their
   // corresponding index in |flattened_ml_evaluations_|
   // not owned
-  absl::node_hash_map<const MLE*, size_t> lookup_table_;
+  absl::flat_hash_map<const MLE*, size_t> lookup_table_;
 
   static F EvaluateSerial(
       const Point& point,

--- a/tachyon/math/polynomials/multivariate/linear_combination.h
+++ b/tachyon/math/polynomials/multivariate/linear_combination.h
@@ -46,9 +46,9 @@ class LinearCombination {
                                   size_t num_terms) {
     LinearCombination linear_combination(num_variables);
 
-    size_t max_evaluations = base::Uniform(max_evaluations_range);
     for (size_t i = 0; i < num_terms; ++i) {
       F coefficient = F::Random();
+      size_t max_evaluations = base::Uniform(max_evaluations_range);
       std::vector<std::shared_ptr<MLE>> evaluations =
           base::CreateVector(max_evaluations, [num_variables]() {
             return std::make_shared<MLE>(MLE::Random(num_variables));

--- a/tachyon/math/polynomials/multivariate/linear_combination_term.h
+++ b/tachyon/math/polynomials/multivariate/linear_combination_term.h
@@ -23,7 +23,6 @@ struct LinearCombinationTerm {
   F Evaluate(
       const Container& point,
       const std::vector<std::shared_ptr<MLE>>& flattened_ml_evaluations) const {
-#if defined(TACHYON_HAS_OPENMP)
     std::vector<F> results = base::ParallelizeMap(
         indexes,
         [&flattened_ml_evaluations, &point](absl::Span<const size_t> chunk) {
@@ -31,10 +30,6 @@ struct LinearCombinationTerm {
         });
     return coefficient * std::accumulate(results.begin(), results.end(),
                                          F::One(), std::multiplies<>());
-#else
-    return coefficient *
-           EvaluateSerial(point, flattened_ml_evaluations, indexes);
-#endif
   }
 
   bool operator==(const LinearCombinationTerm& other) const {

--- a/tachyon/math/polynomials/multivariate/linear_combination_unittest.cc
+++ b/tachyon/math/polynomials/multivariate/linear_combination_unittest.cc
@@ -5,7 +5,7 @@
 #include "tachyon/base/containers/container_util.h"
 #include "tachyon/math/finite_fields/test/finite_field_test.h"
 #include "tachyon/math/finite_fields/test/gf7.h"
-#include "tachyon/math/polynomials/multivariate/multilinear_extension.h"
+#include "tachyon/math/polynomials/multivariate/multilinear_dense_evaluations.h"
 
 namespace tachyon::math {
 namespace {
@@ -13,7 +13,7 @@ namespace {
 const size_t kMaxDegree = 4;
 
 using F = GF7;
-using Poly = MultilinearExtension<MultilinearDenseEvaluations<F, kMaxDegree>>;
+using Poly = MultilinearDenseEvaluations<F, kMaxDegree>;
 using Point = Poly::Point;
 using PolyPtr = std::shared_ptr<Poly>;
 

--- a/tachyon/math/polynomials/multivariate/linear_combination_unittest.cc
+++ b/tachyon/math/polynomials/multivariate/linear_combination_unittest.cc
@@ -21,8 +21,8 @@ class LinearCombinationTest : public FiniteFieldTest<F> {};
 
 }  // namespace
 
-// Tests |AddTerm()| and |SumOfProducts()|
-TEST_F(LinearCombinationTest, AddTermAndSumOfProducts) {
+// Tests |AddTerm()| and |Evaluate()|
+TEST_F(LinearCombinationTest, AddTermAndEvaluate) {
   LinearCombination<Poly> linear_combination(kMaxDegree);
   F coefficient1 = F::Random();
 
@@ -47,11 +47,10 @@ TEST_F(LinearCombinationTest, AddTermAndSumOfProducts) {
                         return acc *= eval->Evaluate(evaluation_point);
                       });
 
-  // Test validity of |AddTerm()| and |SumOfProducts()| on 1 term
-  EXPECT_EQ(linear_combination.SumOfProducts(evaluation_point),
-            expected_evaluation);
+  // Test validity of |AddTerm()| and |Evaluate()| on 1 term
+  EXPECT_EQ(linear_combination.Evaluate(evaluation_point), expected_evaluation);
 
-  // Test |AddTerm()| and |SumOfProducts| on 2 terms
+  // Test |AddTerm()| and |Evaluate()| on 2 terms
   F coefficient2 = F::Random();
   std::vector<PolyPtr> evals2 = base::CreateVector(
       5, []() { return std::make_shared<Poly>(Poly::Random(kMaxDegree)); });
@@ -62,8 +61,7 @@ TEST_F(LinearCombinationTest, AddTermAndSumOfProducts) {
                       [&evaluation_point](F& acc, const PolyPtr eval) {
                         return acc *= eval->Evaluate(evaluation_point);
                       });
-  EXPECT_EQ(linear_combination.SumOfProducts(evaluation_point),
-            expected_evaluation);
+  EXPECT_EQ(linear_combination.Evaluate(evaluation_point), expected_evaluation);
 }
 
 }  // namespace tachyon::math

--- a/tachyon/math/polynomials/multivariate/multilinear_dense_evaluations.h
+++ b/tachyon/math/polynomials/multivariate/multilinear_dense_evaluations.h
@@ -124,13 +124,13 @@ class MultilinearDenseEvaluations {
     //           = (1(1 - s₀) + 2s₀)(1 - x₁) + (3(1 - s₀) + 4s₀)x₁
     //           = (left₀(1 - s₀) + right₀s₀)(1 - x₁) + (left₁(1 - s₀) + right₁s₀)x₁
     //             (where left₀ = 1, right₀ = 2, left₁ = 3 and right₁ = 4)
-    //           = (right₀ + s₀(right₀ - left₀))(1 - x₁) + (right₁ + s₀(right₁ - left₁))x₁
+    //           = (left₀ + s₀(right₀ - left₀))(1 - x₁) + (left₁ + s₀(right₁ - left₁))x₁
     //
     // Fixing s₁:
     // P(s₀, s₁) = (1 + (2 - 1)s₀)(1 - s₁) + (3 + (4 - 1)4s₀)s₁
     //           = (left₀(1 - s₀) + right₀s₀)(1 - x₁) + (left₁(1 - s₀) + right₁s₀)x₁
     //             (where left₀ = 1 + (2 - 1)s₀ and right₀ = (3 + (4 - 1)4s₀)
-    //           = right₀ + s₁(right₀ - left₀)
+    //           = left₀ + s₁(right₀ - left₀)
     // clang-format on
     for (size_t i = 1; i <= k; ++i) {
       const F& r = partial_point[i - 1];

--- a/tachyon/math/polynomials/multivariate/multivariate_sparse_coefficients.h
+++ b/tachyon/math/polynomials/multivariate/multivariate_sparse_coefficients.h
@@ -104,16 +104,12 @@ class MultivariateSparseCoefficients {
     }
 
     F Evaluate(const Point& points) const {
-#if defined(TACHYON_HAS_OPENMP)
       std::vector<F> results = base::ParallelizeMap(
           elements, [&points](absl::Span<const Element> chunk) {
             return EvaluateSerial(chunk, points);
           });
       return std::accumulate(results.begin(), results.end(), F::One(),
                              std::multiplies<>());
-#else
-      return EvaluateSerial(elements, points);
-#endif
     }
 
     std::string ToString() const {
@@ -276,16 +272,12 @@ class MultivariateSparseCoefficients {
     if (IsZero()) {
       return F::Zero();
     }
-#if defined(TACHYON_HAS_OPENMP)
     std::vector<F> results =
         base::ParallelizeMap(terms_, [&points](absl::Span<const Term> chunk) {
           return EvaluateSerial(chunk, points);
         });
     return std::accumulate(results.begin(), results.end(), F::Zero(),
                            std::plus<>());
-#else
-    return EvaluateSerial(terms_, points);
-#endif
   }
 
   std::string ToString() const {

--- a/tachyon/math/polynomials/univariate/univariate_dense_coefficients.h
+++ b/tachyon/math/polynomials/univariate/univariate_dense_coefficients.h
@@ -235,7 +235,6 @@ class UnivariateDenseCoefficients {
   }
 
   constexpr F DoEvaluate(const Point& point) const {
-#if defined(TACHYON_HAS_OPENMP)
     // Horner's method - parallel method
     // run Horner's method on each thread as follows:
     // 1) Split up the coefficients across each thread evenly.
@@ -253,9 +252,6 @@ class UnivariateDenseCoefficients {
         });
     return std::accumulate(results.begin(), results.end(), F::Zero(),
                            std::plus<>());
-#else
-    return HornerEvaluate(coefficients_, point);
-#endif
   }
 
   constexpr static F HornerEvaluate(absl::Span<const F> coefficients,


### PR DESCRIPTION
Implements and tests an interactive multilinear sumcheck protocol involving a prover and a verifier.

Uses [arkwork's sumcheck](https://github.com/arkworks-rs/sumcheck/tree/master/src/ml_sumcheck) as a coding reference and uses [this file](https://people.cs.georgetown.edu/jthaler/sumcheck.pdf) as a reference for the sumcheck  protocol.