### PR TITLE
fix(zk): fix number of affine points to be normalized

### DIFF
--- a/tachyon/zk/r1cs/groth16/verifying_key.h
+++ b/tachyon/zk/r1cs/groth16/verifying_key.h
@@ -105,7 +105,7 @@ class VerifyingKey : public Key {
     gamma_g2_ = std::move(beta_gamma_delta[1]);
     delta_g2_ = std::move(beta_gamma_delta[2]);
 
-    l_g1_query_.resize(2);
+    l_g1_query_.resize(l_g1_query_jacobian.size());
     return G1JacobianPoint::BatchNormalize(l_g1_query_jacobian, &l_g1_query_);
   }
 


### PR DESCRIPTION
# Description

The number should have been `l_g1_query_jacobian.size()`, which represents the number of affine points to be normalized. However, occasionally it was set to 2, this PR fixes the bug.