### PR TITLE
feat: support generating circom witness

### DIFF
--- a/tachyon/math/finite_fields/generator/prime_field_generator/build_defs.bzl
+++ b/tachyon/math/finite_fields/generator/prime_field_generator/build_defs.bzl
@@ -1,5 +1,5 @@
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
-load("@iden3_ffiasm//:build_defs.bzl", "generate_asm")
+load("@iden3_ffiasm//:build_defs.bzl", generate_ffiasm_prime_field = "generate_prime_field")
 load("//bazel:tachyon_cc.bzl", "tachyon_cc_library")
 
 SMALL_SUBGROUP_ADICITY = "small_subgroup_adicity"
@@ -139,9 +139,9 @@ def _do_generate_prime_fields(
         modulus,
         **kwargs):
     prefix = namespace.replace("::", "_") + "_" + name
-    generate_asm(
+    generate_ffiasm_prime_field(
         name = prefix,
-        out = "{}.asm".format(name),
+        asm_out = "{}.asm".format(name),
         modulus = modulus,
     )
 

--- a/third_party/ffiasm/workspace.bzl
+++ b/third_party/ffiasm/workspace.bzl
@@ -5,7 +5,7 @@ load("//third_party:repo.bzl", "tachyon_http_archive", "tf_mirror_urls")
 def repo():
     tachyon_http_archive(
         name = "iden3_ffiasm",
-        urls = tf_mirror_urls("https://github.com/kroma-network/ffiasm/archive/fd362c583c577c15b512e96d2683eeefc658f7f2.tar.gz"),
-        sha256 = "50e147f50a9ffd84b9806158bca1d4428e4fc67ee56a78bcd1bdbf87934c3eb0",
-        strip_prefix = "ffiasm-fd362c583c577c15b512e96d2683eeefc658f7f2",
+        urls = tf_mirror_urls("https://github.com/kroma-network/ffiasm/archive/3ea01c80d3e1709ba554d4d6d1b24bec101520c7.tar.gz"),
+        sha256 = "9b570f5177e28793f9e96cb951bdb419f16d10787fe5f3af63cabfb89f376800",
+        strip_prefix = "ffiasm-3ea01c80d3e1709ba554d4d6d1b24bec101520c7",
     )

--- a/vendors/circom/build_defs.bzl
+++ b/vendors/circom/build_defs.bzl
@@ -1,7 +1,18 @@
-def _generate_r1cs_impl(ctx):
-    arguments = [
-        "--r1cs",
-    ]
+def _cpp_dir(name):
+    return name + "_cpp/"
+
+def _c_srcs(name):
+    return [_cpp_dir(name) + file for file in [
+        name + ".cpp",
+    ]]
+
+def _c_data(name):
+    return [_cpp_dir(name) + file for file in [
+        name + ".dat",
+    ]]
+
+def _compile_circuit_impl(ctx):
+    arguments = ["--r1cs", "--c"]
 
     if ctx.attr.O0:
         arguments.append("--O0")
@@ -25,24 +36,26 @@ def _generate_r1cs_impl(ctx):
     src = ctx.attr.main.files.to_list()[0]
     arguments.append(src.path)
 
-    dst = src.basename[:-len(".circom")] + ".r1cs"
-    out = ctx.actions.declare_file(dst)
-
-    arguments.append("--output=" + out.dirname)
+    name = src.basename[:-len(".circom")]
+    outputs = [
+        name + ".r1cs",
+    ] + _c_srcs(name) + _c_data(name)
+    outputs = [ctx.actions.declare_file(out) for out in outputs]
+    arguments.append("--output=" + outputs[0].dirname)
 
     ctx.actions.run(
         inputs = ctx.files.srcs + ctx.files.main,
         tools = [ctx.executable._tool],
         executable = ctx.executable._tool,
-        progress_message = "Generating %s" % (out.short_path),
-        outputs = [out],
+        progress_message = "Compiling for " + name,
+        outputs = outputs,
         arguments = arguments,
     )
 
-    return [DefaultInfo(files = depset([out]))]
+    return [DefaultInfo(files = depset(outputs))]
 
-generate_r1cs = rule(
-    implementation = _generate_r1cs_impl,
+compile_circuit = rule(
+    implementation = _compile_circuit_impl,
     attrs = {
         "srcs": attr.label_list(allow_files = True),
         "main": attr.label(mandatory = True, allow_single_file = True),
@@ -72,3 +85,21 @@ generate_r1cs = rule(
         ),
     },
 )
+
+def witness_gen_library(
+        name,
+        gendep,
+        prime = "bn128"):
+    native.cc_library(
+        name = name,
+        srcs = [
+            gendep,
+            "//circomlib/generated/common:common_srcs",
+        ],
+        data = [gendep],
+        deps = [
+            "//circomlib/generated/common:common_hdrs",
+            "//circomlib/generated/{}:fr".format(prime),
+            "@com_google_absl//absl/container:flat_hash_map",
+        ],
+    )

--- a/vendors/circom/build_defs.bzl
+++ b/vendors/circom/build_defs.bzl
@@ -31,7 +31,7 @@ def _generate_r1cs_impl(ctx):
     arguments.append("--output=" + out.dirname)
 
     ctx.actions.run(
-        inputs = ctx.files.srcs,
+        inputs = ctx.files.srcs + ctx.files.main,
         tools = [ctx.executable._tool],
         executable = ctx.executable._tool,
         progress_message = "Generating %s" % (out.short_path),

--- a/vendors/circom/circomlib/CPPLINT.cfg
+++ b/vendors/circom/circomlib/CPPLINT.cfg
@@ -1,0 +1,1 @@
+exclude_files=generated

--- a/vendors/circom/circomlib/generated/.clang-format
+++ b/vendors/circom/circomlib/generated/.clang-format
@@ -1,0 +1,1 @@
+DisableFormat: true

--- a/vendors/circom/circomlib/generated/README.md
+++ b/vendors/circom/circomlib/generated/README.md
@@ -1,0 +1,15 @@
+# Generated
+
+This is taken and modified from [iden3/circom/code_producers/src/c_elements](https://github.com/iden3/circom/tree/v2.1.8/code_producers/src/c_elements).
+
+## Modifications
+
+- Modified to remove errors from compilation.
+- `loadCircuit` and `writeBinWitness` are moved to [common/calcwit.hpp](/vendors/circom//circomlib/generated/common/calcwit.hpp) and [common/calcwit.hpp](/vendors/circom//circomlib/generated/common/calcwit.cpp).
+- `loadWitness` is created instead of `loadJson`, which loads the witness from the `absl::flat_hash_map<>`.
+
+See the following files for more details on the modifications.
+
+- [calcwit.cpp.diff](/vendors/circom/circomlib/generated/common/calcwit.cpp.diff)
+- [calcwit.hpp.diff](/vendors/circom/circomlib/generated/common/calcwit.hpp.diff)
+- [circom.hpp.diff](/vendors/circom/circomlib/generated/common/circom.hpp.diff)

--- a/vendors/circom/circomlib/generated/bls12381/BUILD.bazel
+++ b/vendors/circom/circomlib/generated/bls12381/BUILD.bazel
@@ -1,0 +1,5 @@
+load("//circomlib/generated:build_defs.bzl", "fr_library")
+
+package(default_visibility = ["//visibility:public"])
+
+fr_library(modulus = "52435875175126190479447740508185965837690552500527637822603658699938581184513")

--- a/vendors/circom/circomlib/generated/bn128/BUILD.bazel
+++ b/vendors/circom/circomlib/generated/bn128/BUILD.bazel
@@ -1,0 +1,5 @@
+load("//circomlib/generated:build_defs.bzl", "fr_library")
+
+package(default_visibility = ["//visibility:public"])
+
+fr_library(modulus = "21888242871839275222246405745257275088548364400416034343698204186575808495617")

--- a/vendors/circom/circomlib/generated/build_defs.bzl
+++ b/vendors/circom/circomlib/generated/build_defs.bzl
@@ -1,0 +1,75 @@
+load("@iden3_ffiasm//:build_defs.bzl", "generate_prime_field")
+
+def fr_library(modulus):
+    generate_prime_field(
+        name = "Fr",
+        asm_out = "fr.asm",
+        h_out = "fr.hpp",
+        c_out = "fr.cpp",
+        element_h_out = "fr_element.hpp",
+        generic_c_out = "fr_generic.cpp",
+        raw_generic_c_out = "fr_raw_generic.cpp",
+        arm64_s_out = "fr_raw_arm64.s",
+        modulus = modulus,
+    )
+
+    cmd_linux_x86 = "\n".join([
+        "for out in $(OUTS); do",
+        "$(location @nasm//:nasm) -f elf64 -o $$out $$(dirname $(location fr.asm))/$$(basename $${out%.o}.asm)",
+        "done",
+    ])
+
+    cmd_macos_x86 = "\n".join([
+        "for out in $(OUTS); do",
+        "$(location @nasm//:nasm) -f macho64 --prefix _ -o $$out $$(dirname $(location fr.asm))/$$(basename $${out%.o}.asm)",
+        "done",
+    ])
+
+    native.genrule(
+        name = "fr_asm",
+        srcs = ["fr.asm"],
+        outs = ["fr.o"],
+        cmd = select({
+            "@kroma_network_tachyon//:linux_x86_64": cmd_linux_x86,
+            "@kroma_network_tachyon//:macos_x86_64": cmd_macos_x86,
+            "//conditions:default": "touch $@",
+        }),
+        tools = ["@nasm"],
+    )
+
+    native.cc_library(
+        name = "fr_object",
+        srcs = select({
+            "@kroma_network_tachyon//:linux_x86_64": ["fr.o"],
+            "@kroma_network_tachyon//:macos_x86_64": ["fr.o"],
+            "//conditions:default": [],
+        }),
+        linkstatic = True,
+    )
+
+    native.cc_library(
+        name = "fr",
+        srcs = ["fr.cpp"] + select({
+            "@kroma_network_tachyon//:linux_x86_64": [],
+            "@kroma_network_tachyon//:macos_x86_64": [],
+            "//conditions:default": [
+                "fr_generic.cpp",
+                "fr_raw_generic.cpp",
+            ],
+        }),
+        defines = select({
+            "@kroma_network_tachyon//:linux_x86_64": ["USE_ASM", "ARCH_X86_64"],
+            "@kroma_network_tachyon//:macos_x86_64": ["USE_ASM", "ARCH_X86_64"],
+            "//conditions:default": [],
+        }),
+        hdrs = [
+            "fr.hpp",
+            "fr_element.hpp",
+        ],
+        includes = ["."],
+        deps = ["@local_config_gmp//:gmp"] + select({
+            "@kroma_network_tachyon//:linux_x86_64": [":fr_object"],
+            "@kroma_network_tachyon//:macos_x86_64": [":fr_object"],
+            "//conditions:default": [],
+        }),
+    )

--- a/vendors/circom/circomlib/generated/common/BUILD.bazel
+++ b/vendors/circom/circomlib/generated/common/BUILD.bazel
@@ -1,0 +1,15 @@
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "common_hdrs",
+    hdrs = [
+        "calcwit.hpp",
+        "circom.hpp",
+    ],
+    includes = ["."],
+)
+
+filegroup(
+    name = "common_srcs",
+    srcs = ["calcwit.cpp"],
+)

--- a/vendors/circom/circomlib/generated/common/calcwit.cpp
+++ b/vendors/circom/circomlib/generated/common/calcwit.cpp
@@ -1,0 +1,298 @@
+#include <iomanip>
+#include <sstream>
+#include <assert.h>
+#include <iostream>
+#include <fstream>
+#include <sstream>
+#include <iomanip>
+#include <sys/stat.h>
+#include <sys/mman.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <vector>
+#include <chrono>
+#include "calcwit.hpp"
+
+extern void run(Circom_CalcWit* ctx);
+
+std::string int_to_hex( u64 i )
+{
+  std::stringstream stream;
+  stream << "0x"
+         << std::setfill ('0') << std::setw(16)
+         << std::hex << i;
+  return stream.str();
+}
+
+u64 fnv1a(std::string s) {
+  u64 hash = 0xCBF29CE484222325LL;
+  for(char& c : s) {
+    hash ^= u64(c);
+    hash *= 0x100000001B3LL;
+  }
+  return hash;
+}
+
+Circom_CalcWit::Circom_CalcWit (Circom_Circuit *aCircuit, uint maxTh) {
+  circuit = aCircuit;
+  inputSignalAssignedCounter = get_main_input_signal_no();
+  inputSignalAssigned = new bool[inputSignalAssignedCounter];
+  for (uint i = 0; i< inputSignalAssignedCounter; i++) {
+    inputSignalAssigned[i] = false;
+  }
+  signalValues = new FrElement[get_total_signal_no()];
+  Fr_str2element(&signalValues[0], "1", 10);
+  componentMemory = new Circom_Component[get_number_of_components()];
+  circuitConstants = circuit ->circuitConstants;
+  templateInsId2IOSignalInfo = circuit -> templateInsId2IOSignalInfo;
+
+  maxThread = maxTh;
+
+  // parallelism
+  numThread = 0;
+
+}
+
+Circom_CalcWit::~Circom_CalcWit() {
+  // ...
+}
+
+uint Circom_CalcWit::getInputSignalHashPosition(u64 h) {
+  uint n = get_size_of_input_hashmap();
+  uint pos = (uint)(h % (u64)n);
+  if (circuit->InputHashMap[pos].hash!=h){
+    uint inipos = pos;
+    pos++;
+    while (pos != inipos) {
+      if (circuit->InputHashMap[pos].hash==h) return pos;
+      if (circuit->InputHashMap[pos].hash==0) {
+	fprintf(stderr, "Signal not found\n");
+	assert(false);
+      }
+      pos = (pos+1)%n;
+    }
+    fprintf(stderr, "Signals not found\n");
+    assert(false);
+  }
+  return pos;
+}
+
+void Circom_CalcWit::tryRunCircuit(){
+  if (inputSignalAssignedCounter == 0) {
+    run(this);
+  }
+}
+
+void Circom_CalcWit::setInputSignal(u64 h, uint i,  FrElement const & val){
+  if (inputSignalAssignedCounter == 0) {
+    fprintf(stderr, "No more signals to be assigned\n");
+    assert(false);
+  }
+  uint pos = getInputSignalHashPosition(h);
+  if (i >= circuit->InputHashMap[pos].signalsize) {
+    fprintf(stderr, "Input signal array access exceeds the size\n");
+    assert(false);
+  }
+
+  uint si = circuit->InputHashMap[pos].signalid+i;
+  if (inputSignalAssigned[si-get_main_input_signal_start()]) {
+    fprintf(stderr, "Signal assigned twice: %d\n", si);
+    assert(false);
+  }
+  signalValues[si] = val;
+  inputSignalAssigned[si-get_main_input_signal_start()] = true;
+  inputSignalAssignedCounter--;
+  tryRunCircuit();
+}
+
+u64 Circom_CalcWit::getInputSignalSize(u64 h) {
+  uint pos = getInputSignalHashPosition(h);
+  return circuit->InputHashMap[pos].signalsize;
+}
+
+std::string Circom_CalcWit::getTrace(u64 id_cmp){
+  if (id_cmp == 0) return componentMemory[id_cmp].componentName;
+  else{
+    u64 id_father = componentMemory[id_cmp].idFather;
+    std::string my_name = componentMemory[id_cmp].componentName;
+
+    return Circom_CalcWit::getTrace(id_father) + "." + my_name;
+  }
+
+
+}
+
+std::string Circom_CalcWit::generate_position_array(uint* dimensions, uint size_dimensions, uint index){
+  std::string positions = "";
+
+  for (uint i = 0 ; i < size_dimensions; i++){
+    uint last_pos = index % dimensions[size_dimensions -1 - i];
+    index = index / dimensions[size_dimensions -1 - i];
+    std::string new_pos = "[" + std::to_string(last_pos) + "]";
+    positions =  new_pos + positions;
+  }
+  return positions;
+}
+
+#define handle_error(msg) \
+           do { perror(msg); exit(EXIT_FAILURE); } while (0)
+
+Circom_Circuit* loadCircuit(std::string const &datFileName) {
+  Circom_Circuit *circuit = new Circom_Circuit;
+
+  int fd;
+  struct stat sb;
+
+  fd = open(datFileName.c_str(), O_RDONLY);
+  if (fd == -1) {
+    std::cout << ".dat file not found: " << datFileName << "\n";
+    throw std::system_error(errno, std::generic_category(), "open");
+  }
+
+  if (fstat(fd, &sb) == -1) {          /* To obtain file size */
+    throw std::system_error(errno, std::generic_category(), "fstat");
+  }
+
+  u8* bdata = (u8*)mmap(NULL, sb.st_size, PROT_READ , MAP_PRIVATE, fd, 0);
+  close(fd);
+
+  circuit->InputHashMap = new HashSignalInfo[get_size_of_input_hashmap()];
+  uint dsize = get_size_of_input_hashmap()*sizeof(HashSignalInfo);
+  memcpy((void *)(circuit->InputHashMap), (void *)bdata, dsize);
+
+  circuit->witness2SignalList = new u64[get_size_of_witness()];
+  uint inisize = dsize;
+  dsize = get_size_of_witness()*sizeof(u64);
+  memcpy((void *)(circuit->witness2SignalList), (void *)(bdata+inisize), dsize);
+
+  circuit->circuitConstants = new FrElement[get_size_of_constants()];
+  if (get_size_of_constants()>0) {
+    inisize += dsize;
+    dsize = get_size_of_constants()*sizeof(FrElement);
+    memcpy((void *)(circuit->circuitConstants), (void *)(bdata+inisize), dsize);
+  }
+
+  std::map<u32,IODefPair> templateInsId2IOSignalInfo1;
+  if (get_size_of_io_map()>0) {
+    u32 index[get_size_of_io_map()];
+    inisize += dsize;
+    dsize = get_size_of_io_map()*sizeof(u32);
+    memcpy((void *)index, (void *)(bdata+inisize), dsize);
+    inisize += dsize;
+    assert(inisize % sizeof(u32) == 0);
+    assert(sb.st_size % sizeof(u32) == 0);
+    u32 dataiomap[(sb.st_size-inisize)/sizeof(u32)];
+    memcpy((void *)dataiomap, (void *)(bdata+inisize), sb.st_size-inisize);
+    u32* pu32 = dataiomap;
+
+    for (uint i = 0; i < get_size_of_io_map(); i++) {
+      u32 n = *pu32;
+      IODefPair p;
+      p.len = n;
+      IODef defs[n];
+      pu32 += 1;
+      for (u32 j = 0; j <n; j++){
+        defs[j].offset=*pu32;
+        u32 len = *(pu32+1);
+        defs[j].len = len;
+        defs[j].lengths = new u32[len];
+        memcpy((void *)defs[j].lengths,(void *)(pu32+2),len*sizeof(u32));
+        pu32 += len + 2;
+      }
+      p.defs = (IODef*)calloc(10, sizeof(IODef));
+      for (u32 j = 0; j < p.len; j++){
+        p.defs[j] = defs[j];
+      }
+	    templateInsId2IOSignalInfo1[index[i]] = p;
+    }
+  }
+  circuit->templateInsId2IOSignalInfo = std::move(templateInsId2IOSignalInfo1);
+
+  munmap(bdata, sb.st_size);
+
+  return circuit;
+}
+
+void loadWitness(Circom_CalcWit *ctx, const absl::flat_hash_map<std::string, std::vector<FrElement>>& witness) {
+  size_t nItems = witness.size();
+  // printf("Items : %llu\n",nItems);
+  if (nItems == 0){
+    ctx->tryRunCircuit();
+  }
+  for (const auto& [key, value] : witness) {
+    u64 h = fnv1a(key);
+    uint signalSize = ctx->getInputSignalSize(h);
+    if (value.size() < signalSize) {
+	    std::ostringstream errStrStream;
+	    errStrStream << "Error loading signal " << key << ": Not enough values\n";
+	    throw std::runtime_error(errStrStream.str() );
+    }
+    if (value.size() > signalSize) {
+	    std::ostringstream errStrStream;
+	    errStrStream << "Error loading signal " << key << ": Too many values\n";
+	    throw std::runtime_error(errStrStream.str() );
+    }
+    for (uint i = 0; i<value.size(); i++){
+      try {
+	      // std::cout << key << "," << i << " => " << Fr_element2str(&(value[i])) << '\n';
+	      ctx->setInputSignal(h,i,value[i]);
+      } catch (std::runtime_error e) {
+	      std::ostringstream errStrStream;
+	      errStrStream << "Error setting signal: " << key << "\n" << e.what();
+	      throw std::runtime_error(errStrStream.str() );
+      }
+    }
+  }
+  if (ctx->getRemaingInputsToBeSet()!=0) {
+    std::cerr << "Not all inputs have been set. Only " << get_main_input_signal_no()-ctx->getRemaingInputsToBeSet() << " out of " << get_main_input_signal_no() << std::endl;
+    assert(false);
+  }
+}
+
+void writeBinWitness(Circom_CalcWit *ctx, std::string const &wtnsFileName) {
+  FILE *write_ptr;
+
+  write_ptr = fopen(wtnsFileName.c_str(),"wb");
+
+  fwrite("wtns", 4, 1, write_ptr);
+
+  u32 version = 2;
+  fwrite(&version, 4, 1, write_ptr);
+
+  u32 nSections = 2;
+  fwrite(&nSections, 4, 1, write_ptr);
+
+  // Header
+  u32 idSection1 = 1;
+  fwrite(&idSection1, 4, 1, write_ptr);
+
+  u32 n8 = Fr_N64*8;
+
+  u64 idSection1length = 8 + n8;
+  fwrite(&idSection1length, 8, 1, write_ptr);
+
+  fwrite(&n8, 4, 1, write_ptr);
+
+  fwrite(Fr_q.longVal, Fr_N64*8, 1, write_ptr);
+
+  uint Nwtns = get_size_of_witness();
+
+  u32 nVars = (u32)Nwtns;
+  fwrite(&nVars, 4, 1, write_ptr);
+
+  // Data
+  u32 idSection2 = 2;
+  fwrite(&idSection2, 4, 1, write_ptr);
+
+  u64 idSection2length = (u64)n8*(u64)Nwtns;
+  fwrite(&idSection2length, 8, 1, write_ptr);
+
+  FrElement v;
+
+  for (int i=0;i<Nwtns;i++) {
+    ctx->getWitness(i, &v);
+    Fr_toLongNormal(&v, &v);
+    fwrite(v.longVal, Fr_N64*8, 1, write_ptr);
+  }
+  fclose(write_ptr);
+}

--- a/vendors/circom/circomlib/generated/common/calcwit.cpp.diff
+++ b/vendors/circom/circomlib/generated/common/calcwit.cpp.diff
@@ -1,0 +1,194 @@
+4,13d3
+< #include <iostream>
+< #include <fstream>
+< #include <sstream>
+< #include <iomanip>
+< #include <sys/stat.h>
+< #include <sys/mman.h>
+< #include <fcntl.h>
+< #include <unistd.h>
+< #include <vector>
+< #include <chrono>
+40c30
+<   for (uint i = 0; i< inputSignalAssignedCounter; i++) {
+---
+>   for (int i = 0; i< inputSignalAssignedCounter; i++) {
+72c62
+<       pos = (pos+1)%n;
+---
+>       pos = (pos+1)%n; 
+80c70
+< void Circom_CalcWit::tryRunCircuit(){
+---
+> void Circom_CalcWit::tryRunCircuit(){ 
+86c76
+< void Circom_CalcWit::setInputSignal(u64 h, uint i,  FrElement const & val){
+---
+> void Circom_CalcWit::setInputSignal(u64 h, uint i,  FrElement & val){
+96c86
+< 
+---
+>   
+137,298d126
+< #define handle_error(msg) \
+<            do { perror(msg); exit(EXIT_FAILURE); } while (0)
+< 
+< Circom_Circuit* loadCircuit(std::string const &datFileName) {
+<   Circom_Circuit *circuit = new Circom_Circuit;
+< 
+<   int fd;
+<   struct stat sb;
+< 
+<   fd = open(datFileName.c_str(), O_RDONLY);
+<   if (fd == -1) {
+<     std::cout << ".dat file not found: " << datFileName << "\n";
+<     throw std::system_error(errno, std::generic_category(), "open");
+<   }
+< 
+<   if (fstat(fd, &sb) == -1) {          /* To obtain file size */
+<     throw std::system_error(errno, std::generic_category(), "fstat");
+<   }
+< 
+<   u8* bdata = (u8*)mmap(NULL, sb.st_size, PROT_READ , MAP_PRIVATE, fd, 0);
+<   close(fd);
+< 
+<   circuit->InputHashMap = new HashSignalInfo[get_size_of_input_hashmap()];
+<   uint dsize = get_size_of_input_hashmap()*sizeof(HashSignalInfo);
+<   memcpy((void *)(circuit->InputHashMap), (void *)bdata, dsize);
+< 
+<   circuit->witness2SignalList = new u64[get_size_of_witness()];
+<   uint inisize = dsize;
+<   dsize = get_size_of_witness()*sizeof(u64);
+<   memcpy((void *)(circuit->witness2SignalList), (void *)(bdata+inisize), dsize);
+< 
+<   circuit->circuitConstants = new FrElement[get_size_of_constants()];
+<   if (get_size_of_constants()>0) {
+<     inisize += dsize;
+<     dsize = get_size_of_constants()*sizeof(FrElement);
+<     memcpy((void *)(circuit->circuitConstants), (void *)(bdata+inisize), dsize);
+<   }
+< 
+<   std::map<u32,IODefPair> templateInsId2IOSignalInfo1;
+<   if (get_size_of_io_map()>0) {
+<     u32 index[get_size_of_io_map()];
+<     inisize += dsize;
+<     dsize = get_size_of_io_map()*sizeof(u32);
+<     memcpy((void *)index, (void *)(bdata+inisize), dsize);
+<     inisize += dsize;
+<     assert(inisize % sizeof(u32) == 0);
+<     assert(sb.st_size % sizeof(u32) == 0);
+<     u32 dataiomap[(sb.st_size-inisize)/sizeof(u32)];
+<     memcpy((void *)dataiomap, (void *)(bdata+inisize), sb.st_size-inisize);
+<     u32* pu32 = dataiomap;
+< 
+<     for (uint i = 0; i < get_size_of_io_map(); i++) {
+<       u32 n = *pu32;
+<       IODefPair p;
+<       p.len = n;
+<       IODef defs[n];
+<       pu32 += 1;
+<       for (u32 j = 0; j <n; j++){
+<         defs[j].offset=*pu32;
+<         u32 len = *(pu32+1);
+<         defs[j].len = len;
+<         defs[j].lengths = new u32[len];
+<         memcpy((void *)defs[j].lengths,(void *)(pu32+2),len*sizeof(u32));
+<         pu32 += len + 2;
+<       }
+<       p.defs = (IODef*)calloc(10, sizeof(IODef));
+<       for (u32 j = 0; j < p.len; j++){
+<         p.defs[j] = defs[j];
+<       }
+< 	    templateInsId2IOSignalInfo1[index[i]] = p;
+<     }
+<   }
+<   circuit->templateInsId2IOSignalInfo = std::move(templateInsId2IOSignalInfo1);
+< 
+<   munmap(bdata, sb.st_size);
+< 
+<   return circuit;
+< }
+< 
+< void loadWitness(Circom_CalcWit *ctx, const absl::flat_hash_map<std::string, std::vector<FrElement>>& witness) {
+<   size_t nItems = witness.size();
+<   // printf("Items : %llu\n",nItems);
+<   if (nItems == 0){
+<     ctx->tryRunCircuit();
+<   }
+<   for (const auto& [key, value] : witness) {
+<     u64 h = fnv1a(key);
+<     uint signalSize = ctx->getInputSignalSize(h);
+<     if (value.size() < signalSize) {
+< 	    std::ostringstream errStrStream;
+< 	    errStrStream << "Error loading signal " << key << ": Not enough values\n";
+< 	    throw std::runtime_error(errStrStream.str() );
+<     }
+<     if (value.size() > signalSize) {
+< 	    std::ostringstream errStrStream;
+< 	    errStrStream << "Error loading signal " << key << ": Too many values\n";
+< 	    throw std::runtime_error(errStrStream.str() );
+<     }
+<     for (uint i = 0; i<value.size(); i++){
+<       try {
+< 	      // std::cout << key << "," << i << " => " << Fr_element2str(&(value[i])) << '\n';
+< 	      ctx->setInputSignal(h,i,value[i]);
+<       } catch (std::runtime_error e) {
+< 	      std::ostringstream errStrStream;
+< 	      errStrStream << "Error setting signal: " << key << "\n" << e.what();
+< 	      throw std::runtime_error(errStrStream.str() );
+<       }
+<     }
+<   }
+<   if (ctx->getRemaingInputsToBeSet()!=0) {
+<     std::cerr << "Not all inputs have been set. Only " << get_main_input_signal_no()-ctx->getRemaingInputsToBeSet() << " out of " << get_main_input_signal_no() << std::endl;
+<     assert(false);
+<   }
+< }
+< 
+< void writeBinWitness(Circom_CalcWit *ctx, std::string const &wtnsFileName) {
+<   FILE *write_ptr;
+< 
+<   write_ptr = fopen(wtnsFileName.c_str(),"wb");
+< 
+<   fwrite("wtns", 4, 1, write_ptr);
+< 
+<   u32 version = 2;
+<   fwrite(&version, 4, 1, write_ptr);
+< 
+<   u32 nSections = 2;
+<   fwrite(&nSections, 4, 1, write_ptr);
+< 
+<   // Header
+<   u32 idSection1 = 1;
+<   fwrite(&idSection1, 4, 1, write_ptr);
+< 
+<   u32 n8 = Fr_N64*8;
+< 
+<   u64 idSection1length = 8 + n8;
+<   fwrite(&idSection1length, 8, 1, write_ptr);
+< 
+<   fwrite(&n8, 4, 1, write_ptr);
+< 
+<   fwrite(Fr_q.longVal, Fr_N64*8, 1, write_ptr);
+< 
+<   uint Nwtns = get_size_of_witness();
+< 
+<   u32 nVars = (u32)Nwtns;
+<   fwrite(&nVars, 4, 1, write_ptr);
+< 
+<   // Data
+<   u32 idSection2 = 2;
+<   fwrite(&idSection2, 4, 1, write_ptr);
+< 
+<   u64 idSection2length = (u64)n8*(u64)Nwtns;
+<   fwrite(&idSection2length, 8, 1, write_ptr);
+< 
+<   FrElement v;
+< 
+<   for (int i=0;i<Nwtns;i++) {
+<     ctx->getWitness(i, &v);
+<     Fr_toLongNormal(&v, &v);
+<     fwrite(v.longVal, Fr_N64*8, 1, write_ptr);
+<   }
+<   fclose(write_ptr);
+< }

--- a/vendors/circom/circomlib/generated/common/calcwit.hpp
+++ b/vendors/circom/circomlib/generated/common/calcwit.hpp
@@ -1,0 +1,78 @@
+#ifndef CIRCOM_CALCWIT_H
+#define CIRCOM_CALCWIT_H
+
+#include <mutex>
+#include <condition_variable>
+#include <functional>
+#include <atomic>
+#include <memory>
+#include <vector>
+
+#include "absl/container/flat_hash_map.h"
+
+#include "circom.hpp"
+#include "fr.hpp"
+
+#define NMUTEXES 32 //512
+
+u64 fnv1a(std::string s);
+
+class Circom_CalcWit {
+
+  bool *inputSignalAssigned;
+  uint inputSignalAssignedCounter;
+
+  Circom_Circuit *circuit;
+
+public:
+
+  FrElement *signalValues;
+  Circom_Component* componentMemory;
+  FrElement* circuitConstants;
+  std::map<u32,IODefPair> templateInsId2IOSignalInfo;
+  std::string* listOfTemplateMessages;
+
+  // parallelism
+  std::mutex numThreadMutex;
+  std::condition_variable ntcvs;
+  int numThread;
+
+  int maxThread;
+
+  // Functions called by the circuit
+  Circom_CalcWit(Circom_Circuit *aCircuit, uint numTh = NMUTEXES);
+  ~Circom_CalcWit();
+
+  // Public functions
+  void setInputSignal(u64 h, uint i, FrElement const &val);
+  void tryRunCircuit();
+
+  u64 getInputSignalSize(u64 h);
+
+  inline uint getRemaingInputsToBeSet() {
+    return inputSignalAssignedCounter;
+  }
+
+  inline void getWitness(uint idx, PFrElement val) {
+    Fr_copy(val, &signalValues[circuit->witness2SignalList[idx]]);
+  }
+
+  std::string getTrace(u64 id_cmp);
+
+  std::string generate_position_array(uint* dimensions, uint size_dimensions, uint index);
+
+private:
+
+  uint getInputSignalHashPosition(u64 h);
+
+};
+
+typedef void (*Circom_TemplateFunction)(uint __cIdx, Circom_CalcWit* __ctx);
+
+Circom_Circuit* loadCircuit(std::string const &datFileName);
+
+void loadWitness(Circom_CalcWit *ctx, absl::flat_hash_map<std::string, std::vector<FrElement>> const &witness);
+
+void writeBinWitness(Circom_CalcWit *ctx, std::string const &wtnsFileName);
+
+#endif // CIRCOM_CALCWIT_H

--- a/vendors/circom/circomlib/generated/common/calcwit.hpp.diff
+++ b/vendors/circom/circomlib/generated/common/calcwit.hpp.diff
@@ -1,0 +1,40 @@
+9d8
+< #include <vector>
+11,12d9
+< #include "absl/container/flat_hash_map.h"
+< 
+31,33c28,30
+<   FrElement* circuitConstants;
+<   std::map<u32,IODefPair> templateInsId2IOSignalInfo;
+<   std::string* listOfTemplateMessages;
+---
+>   FrElement* circuitConstants; 
+>   std::map<u32,IODefPair> templateInsId2IOSignalInfo; 
+>   std::string* listOfTemplateMessages; 
+47c44
+<   void setInputSignal(u64 h, uint i, FrElement const &val);
+---
+>   void setInputSignal(u64 h, uint i, FrElement &val);
+49c46
+< 
+---
+>   
+55c52
+< 
+---
+>   
+65c62
+< 
+---
+>   
+70c67
+< typedef void (*Circom_TemplateFunction)(uint __cIdx, Circom_CalcWit* __ctx);
+---
+> typedef void (*Circom_TemplateFunction)(uint __cIdx, Circom_CalcWit* __ctx); 
+72,77d68
+< Circom_Circuit* loadCircuit(std::string const &datFileName);
+< 
+< void loadWitness(Circom_CalcWit *ctx, absl::flat_hash_map<std::string, std::vector<FrElement>> const &witness);
+< 
+< void writeBinWitness(Circom_CalcWit *ctx, std::string const &wtnsFileName);
+< 

--- a/vendors/circom/circomlib/generated/common/circom.hpp
+++ b/vendors/circom/circomlib/generated/common/circom.hpp
@@ -1,0 +1,85 @@
+#ifndef __CIRCOM_H
+#define __CIRCOM_H
+
+#include <map>
+#include <gmp.h>
+#include <mutex>
+#include <condition_variable>
+#include <thread>
+
+#include "fr.hpp"
+
+typedef unsigned long long u64;
+typedef uint32_t u32;
+typedef uint8_t u8;
+
+//only for the main inputs
+struct __attribute__((__packed__)) HashSignalInfo {
+    u64 hash;
+    u64 signalid;
+    u64 signalsize;
+};
+
+struct IODef {
+    u32 offset;
+    u32 len;
+    u32 *lengths;
+};
+
+struct IODefPair {
+    u32 len;
+    IODef* defs;
+};
+
+struct Circom_Circuit {
+  //  const char *P;
+  HashSignalInfo* InputHashMap;
+  u64* witness2SignalList;
+  FrElement* circuitConstants;
+  std::map<u32,IODefPair> templateInsId2IOSignalInfo;
+};
+
+
+struct Circom_Component {
+  u32 templateId;
+  u64 signalStart;
+  u32 inputCounter;
+  std::string templateName;
+  std::string componentName;
+  u64 idFather;
+  u32* subcomponents = NULL;
+  bool* subcomponentsParallel = NULL;
+  bool *outputIsSet = NULL;  //one for each output
+  std::mutex *mutexes = NULL;  //one for each output
+  std::condition_variable *cvs = NULL;
+  std::thread *sbct = NULL;//subcomponent threads
+};
+
+/*
+For every template instantiation create two functions:
+- name_create
+- name_run
+
+//PFrElement: pointer to FrElement
+
+Every name_run or circom_function has:
+=====================================
+
+//array of PFrElements for auxiliars in expression computation (known size);
+PFrElements expaux[];
+
+//array of PFrElements for local vars (known size)
+PFrElements lvar[];
+
+*/
+
+uint get_main_input_signal_start();
+uint get_main_input_signal_no();
+uint get_total_signal_no();
+uint get_number_of_components();
+uint get_size_of_input_hashmap();
+uint get_size_of_witness();
+uint get_size_of_constants();
+uint get_size_of_io_map();
+
+#endif  // __CIRCOM_H

--- a/vendors/circom/circomlib/generated/common/circom.hpp.diff
+++ b/vendors/circom/circomlib/generated/common/circom.hpp.diff
@@ -1,0 +1,22 @@
+19,20c19,20
+<     u64 signalid;
+<     u64 signalsize;
+---
+>     u64 signalid; 
+>     u64 signalsize; 
+23c23
+< struct IODef {
+---
+> struct IODef { 
+29c29
+< struct IODefPair {
+---
+> struct IODefPair { 
+38c38
+<   FrElement* circuitConstants;
+---
+>   FrElement* circuitConstants;  
+49c49
+<   u64 idFather;
+---
+>   u64 idFather; 

--- a/vendors/circom/circomlib/generated/goldilocks/BUILD.bazel
+++ b/vendors/circom/circomlib/generated/goldilocks/BUILD.bazel
@@ -1,0 +1,5 @@
+load("//circomlib/generated:build_defs.bzl", "fr_library")
+
+package(default_visibility = ["//visibility:public"])
+
+fr_library(modulus = "18446744069414584321")

--- a/vendors/circom/circomlib/generated/grumpkin/BUILD.bazel
+++ b/vendors/circom/circomlib/generated/grumpkin/BUILD.bazel
@@ -1,0 +1,5 @@
+load("//circomlib/generated:build_defs.bzl", "fr_library")
+
+package(default_visibility = ["//visibility:public"])
+
+fr_library(modulus = "21888242871839275222246405745257275088696311157297823662689037894645226208583")

--- a/vendors/circom/circomlib/generated/pallas/BUILD.bazel
+++ b/vendors/circom/circomlib/generated/pallas/BUILD.bazel
@@ -1,0 +1,5 @@
+load("//circomlib/generated:build_defs.bzl", "fr_library")
+
+package(default_visibility = ["//visibility:public"])
+
+fr_library(modulus = "28948022309329048855892746252171976963363056481941647379679742748393362948097")

--- a/vendors/circom/circomlib/generated/secq256r1/BUILD.bazel
+++ b/vendors/circom/circomlib/generated/secq256r1/BUILD.bazel
@@ -1,0 +1,5 @@
+load("//circomlib/generated:build_defs.bzl", "fr_library")
+
+package(default_visibility = ["//visibility:public"])
+
+fr_library(modulus = "115792089237316195423570985008687907852837564279074904382605163141518161494337")

--- a/vendors/circom/circomlib/generated/vesta/BUILD.bazel
+++ b/vendors/circom/circomlib/generated/vesta/BUILD.bazel
@@ -1,0 +1,5 @@
+load("//circomlib/generated:build_defs.bzl", "fr_library")
+
+package(default_visibility = ["//visibility:public"])
+
+fr_library(modulus = "28948022309329048855892746252171976963363056481941560715954676764349967630337")

--- a/vendors/circom/circomlib/r1cs/BUILD.bazel
+++ b/vendors/circom/circomlib/r1cs/BUILD.bazel
@@ -30,7 +30,7 @@ tachyon_cc_library(
 tachyon_cc_unittest(
     name = "r1cs_unittests",
     srcs = ["r1cs_parser_unittest.cc"],
-    data = ["//examples:multiplier_n_r1cs"],
+    data = ["//examples:multiplier_3_r1cs"],
     deps = [
         ":r1cs_parser",
         "@kroma_network_tachyon//tachyon/math/elliptic_curves/bn/bn254:fr",

--- a/vendors/circom/circomlib/r1cs/BUILD.bazel
+++ b/vendors/circom/circomlib/r1cs/BUILD.bazel
@@ -30,7 +30,7 @@ tachyon_cc_library(
 tachyon_cc_unittest(
     name = "r1cs_unittests",
     srcs = ["r1cs_parser_unittest.cc"],
-    data = ["//examples:multiplier_3_r1cs"],
+    data = ["//examples:compile_multiplier_3"],
     deps = [
         ":r1cs_parser",
         "@kroma_network_tachyon//tachyon/math/elliptic_curves/bn/bn254:fr",

--- a/vendors/circom/circomlib/r1cs/r1cs_parser_unittest.cc
+++ b/vendors/circom/circomlib/r1cs/r1cs_parser_unittest.cc
@@ -11,7 +11,7 @@ namespace tachyon::circom {
 TEST(R1CSParser, Parse) {
   R1CSParser parser;
   std::unique_ptr<R1CS> r1cs =
-      parser.Parse(base::FilePath("examples/multiplier_n.r1cs"));
+      parser.Parse(base::FilePath("examples/multiplier_3.r1cs"));
   ASSERT_TRUE(r1cs);
   ASSERT_EQ(r1cs->GetVersion(), 1);
 

--- a/vendors/circom/examples/BUILD.bazel
+++ b/vendors/circom/examples/BUILD.bazel
@@ -1,14 +1,30 @@
-load("//:build_defs.bzl", "generate_r1cs")
+load("@kroma_network_tachyon//bazel:tachyon_cc.bzl", "tachyon_cc_binary")
+load("//:build_defs.bzl", "compile_circuit", "witness_gen_library")
 
 package(default_visibility = ["//visibility:public"])
 
 exports_files(["multiplier_3.zkey"])
 
-generate_r1cs(
-    name = "multiplier_3_r1cs",
+PRIME = "bn128"
+
+compile_circuit(
+    name = "compile_multiplier_3",
     srcs = [
         "multiplier_2.circom",
         "multiplier_n.circom",
     ],
     main = "multiplier_3.circom",
+    prime = PRIME,
+)
+
+witness_gen_library(
+    name = "gen_witness_multiplier_3",
+    gendep = ":compile_multiplier_3",
+    prime = PRIME,
+)
+
+tachyon_cc_binary(
+    name = "compute_witness_multiplier_3",
+    srcs = ["compute_witness_multiplier_3.cc"],
+    deps = [":gen_witness_multiplier_3"],
 )

--- a/vendors/circom/examples/BUILD.bazel
+++ b/vendors/circom/examples/BUILD.bazel
@@ -6,9 +6,6 @@ exports_files(["multiplier_3.zkey"])
 
 generate_r1cs(
     name = "multiplier_n_r1cs",
-    srcs = [
-        "multiplier_2.circom",
-        "multiplier_n.circom",
-    ],
+    srcs = ["multiplier_2.circom"],
     main = "multiplier_n.circom",
 )

--- a/vendors/circom/examples/BUILD.bazel
+++ b/vendors/circom/examples/BUILD.bazel
@@ -5,7 +5,10 @@ package(default_visibility = ["//visibility:public"])
 exports_files(["multiplier_3.zkey"])
 
 generate_r1cs(
-    name = "multiplier_n_r1cs",
-    srcs = ["multiplier_2.circom"],
-    main = "multiplier_n.circom",
+    name = "multiplier_3_r1cs",
+    srcs = [
+        "multiplier_2.circom",
+        "multiplier_n.circom",
+    ],
+    main = "multiplier_3.circom",
 )

--- a/vendors/circom/examples/compute_witness_multiplier_3.cc
+++ b/vendors/circom/examples/compute_witness_multiplier_3.cc
@@ -1,0 +1,24 @@
+#include <memory>
+
+#include "circomlib/generated/common/calcwit.hpp"
+
+namespace tachyon {
+
+int RealMain(int argc, char **argv) {
+  std::unique_ptr<Circom_Circuit> circuit(
+      loadCircuit("examples/multiplier_3_cpp/multiplier_3.dat"));
+  std::unique_ptr<Circom_CalcWit> ctx(new Circom_CalcWit(circuit.get()));
+  absl::flat_hash_map<std::string, std::vector<FrElement>> witness;
+  std::vector<FrElement> in(3);
+  Fr_str2element(&in[0], "3", 10);
+  Fr_str2element(&in[1], "4", 10);
+  Fr_str2element(&in[2], "5", 10);
+  witness["in"] = std::move(in);
+  loadWitness(ctx.get(), witness);
+  writeBinWitness(ctx.get(), "multiplier_3.wtns");
+  return 0;
+}
+
+}  // namespace tachyon
+
+int main(int argc, char **argv) { return tachyon::RealMain(argc, argv); }

--- a/vendors/circom/examples/multiplier_3.circom
+++ b/vendors/circom/examples/multiplier_3.circom
@@ -1,0 +1,5 @@
+pragma circom 2.0.0;
+
+include "multiplier_n.circom";
+
+component main = MultiplierN(3);

--- a/vendors/circom/examples/multiplier_n.circom
+++ b/vendors/circom/examples/multiplier_n.circom
@@ -18,5 +18,3 @@ template MultiplierN(N) {
   }
   out <== comp[N-2].out;
 }
-
-component main = MultiplierN(3);


### PR DESCRIPTION
# Description

This PR enables generating circom witness.

Please test this by running this command!

```shell
cd vendors/circom
bazel run //examples:compute_witness_multiplier_3
```

You can find `multiplier_3.wtns` in `bazel-bin/examples/compute_witness_multiplier_3.runfiles/kroma_network_circom`.

See also https://docs.circom.io/getting-started/computing-the-witness/.