### PR TITLE
build: fix cargo lock files

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,13 +1,13 @@
 {
-  "checksum": "5791399243842816bd68e0e8c42ba598d5cb39f11b464311369ed9df218b416c",
+  "checksum": "368163de53c48039587e674924f6ce958b624eaf4d57f46e9e5cec6ae698a28a",
   "crates": {
-    "ahash 0.8.8": {
+    "ahash 0.8.3": {
       "name": "ahash",
-      "version": "0.8.8",
+      "version": "0.8.3",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/ahash/0.8.8/download",
-          "sha256": "42cd52102d3df161c77a887b608d7a4897d7cc112886a9537b738a887a03aaff"
+          "url": "https://crates.io/api/v1/crates/ahash/0.8.3/download",
+          "sha256": "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
         }
       },
       "targets": [
@@ -38,29 +38,25 @@
         "deps": {
           "common": [
             {
-              "id": "ahash 0.8.8",
+              "id": "ahash 0.8.3",
               "target": "build_script_build"
             },
             {
               "id": "cfg-if 1.0.0",
               "target": "cfg_if"
-            },
-            {
-              "id": "zerocopy 0.7.32",
-              "target": "zerocopy"
             }
           ],
           "selects": {
             "cfg(not(all(target_arch = \"arm\", target_os = \"none\")))": [
               {
-                "id": "once_cell 1.19.0",
+                "id": "once_cell 1.18.0",
                 "target": "once_cell"
               }
             ]
           }
         },
         "edition": "2018",
-        "version": "0.8.8"
+        "version": "0.8.3"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -194,15 +190,15 @@
               "target": "itertools"
             },
             {
-              "id": "num-traits 0.2.18",
+              "id": "num-traits 0.2.16",
               "target": "num_traits"
             },
             {
-              "id": "rayon 1.8.1",
+              "id": "rayon 1.7.0",
               "target": "rayon"
             },
             {
-              "id": "zeroize 1.7.0",
+              "id": "zeroize 1.6.0",
               "target": "zeroize"
             }
           ],
@@ -272,15 +268,15 @@
               "target": "itertools"
             },
             {
-              "id": "num-bigint 0.4.4",
+              "id": "num-bigint 0.4.3",
               "target": "num_bigint"
             },
             {
-              "id": "num-traits 0.2.18",
+              "id": "num-traits 0.2.16",
               "target": "num_traits"
             },
             {
-              "id": "zeroize 1.7.0",
+              "id": "zeroize 1.6.0",
               "target": "zeroize"
             }
           ],
@@ -340,7 +336,7 @@
         "deps": {
           "common": [
             {
-              "id": "quote 1.0.35",
+              "id": "quote 1.0.32",
               "target": "quote"
             },
             {
@@ -383,19 +379,19 @@
         "deps": {
           "common": [
             {
-              "id": "num-bigint 0.4.4",
+              "id": "num-bigint 0.4.3",
               "target": "num_bigint"
             },
             {
-              "id": "num-traits 0.2.18",
+              "id": "num-traits 0.2.16",
               "target": "num_traits"
             },
             {
-              "id": "proc-macro2 1.0.78",
+              "id": "proc-macro2 1.0.66",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.35",
+              "id": "quote 1.0.32",
               "target": "quote"
             },
             {
@@ -514,7 +510,7 @@
               "target": "digest"
             },
             {
-              "id": "num-bigint 0.4.4",
+              "id": "num-bigint 0.4.3",
               "target": "num_bigint"
             }
           ],
@@ -562,11 +558,11 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.78",
+              "id": "proc-macro2 1.0.66",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.35",
+              "id": "quote 1.0.32",
               "target": "quote"
             },
             {
@@ -616,7 +612,7 @@
         "deps": {
           "common": [
             {
-              "id": "num-traits 0.2.18",
+              "id": "num-traits 0.2.16",
               "target": "num_traits"
             },
             {
@@ -668,7 +664,7 @@
         "deps": {
           "common": [
             {
-              "id": "num-traits 0.2.18",
+              "id": "num-traits 0.2.16",
               "target": "num_traits"
             },
             {
@@ -676,7 +672,7 @@
               "target": "rand"
             },
             {
-              "id": "rayon 1.8.1",
+              "id": "rayon 1.7.0",
               "target": "rayon"
             }
           ],
@@ -897,7 +893,7 @@
               "target": "bit_vec"
             },
             {
-              "id": "byteorder 1.5.0",
+              "id": "byteorder 1.4.3",
               "target": "byteorder"
             },
             {
@@ -1018,13 +1014,13 @@
       },
       "license": "MIT"
     },
-    "blake2b_simd 1.0.2": {
+    "blake2b_simd 1.0.1": {
       "name": "blake2b_simd",
-      "version": "1.0.2",
+      "version": "1.0.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/blake2b_simd/1.0.2/download",
-          "sha256": "23285ad32269793932e830392f2fe2f83e26488fd3ec778883a93c8323735780"
+          "url": "https://crates.io/api/v1/crates/blake2b_simd/1.0.1/download",
+          "sha256": "3c2f0dc9a68c6317d884f97cc36cf5a3d20ba14ce404227df55e1af708ab04bc"
         }
       },
       "targets": [
@@ -1061,14 +1057,14 @@
               "target": "arrayvec"
             },
             {
-              "id": "constant_time_eq 0.3.0",
+              "id": "constant_time_eq 0.2.6",
               "target": "constant_time_eq"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.2"
+        "version": "1.0.1"
       },
       "license": "MIT"
     },
@@ -1190,13 +1186,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "byteorder 1.5.0": {
+    "byteorder 1.4.3": {
       "name": "byteorder",
-      "version": "1.5.0",
+      "version": "1.4.3",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/byteorder/1.5.0/download",
-          "sha256": "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+          "url": "https://crates.io/api/v1/crates/byteorder/1.4.3/download",
+          "sha256": "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
         }
       },
       "targets": [
@@ -1222,18 +1218,18 @@
           ],
           "selects": {}
         },
-        "edition": "2021",
-        "version": "1.5.0"
+        "edition": "2018",
+        "version": "1.4.3"
       },
       "license": "Unlicense OR MIT"
     },
-    "cc 1.0.85": {
+    "cc 1.0.83": {
       "name": "cc",
-      "version": "1.0.85",
+      "version": "1.0.83",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/cc/1.0.85/download",
-          "sha256": "9b918671670962b48bc23753aef0c51d072dca6f52f01f800854ada6ddb7f7d3"
+          "url": "https://crates.io/api/v1/crates/cc/1.0.83/download",
+          "sha256": "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
         }
       },
       "targets": [
@@ -1252,8 +1248,19 @@
         "compile_data_glob": [
           "**"
         ],
+        "deps": {
+          "common": [],
+          "selects": {
+            "cfg(unix)": [
+              {
+                "id": "libc 0.2.147",
+                "target": "libc"
+              }
+            ]
+          }
+        },
         "edition": "2018",
-        "version": "1.0.85"
+        "version": "1.0.83"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -1317,13 +1324,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "constant_time_eq 0.3.0": {
+    "constant_time_eq 0.2.6": {
       "name": "constant_time_eq",
-      "version": "0.3.0",
+      "version": "0.2.6",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/constant_time_eq/0.3.0/download",
-          "sha256": "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
+          "url": "https://crates.io/api/v1/crates/constant_time_eq/0.2.6/download",
+          "sha256": "21a53c0a4d288377e7415b53dcfc3c04da5cdc2cc95c8d5ac178b58f0b861ad6"
         }
       },
       "targets": [
@@ -1343,17 +1350,17 @@
           "**"
         ],
         "edition": "2021",
-        "version": "0.3.0"
+        "version": "0.2.6"
       },
       "license": "CC0-1.0 OR MIT-0 OR Apache-2.0"
     },
-    "cpufeatures 0.2.12": {
+    "cpufeatures 0.2.9": {
       "name": "cpufeatures",
-      "version": "0.2.12",
+      "version": "0.2.9",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/cpufeatures/0.2.12/download",
-          "sha256": "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+          "url": "https://crates.io/api/v1/crates/cpufeatures/0.2.9/download",
+          "sha256": "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
         }
       },
       "targets": [
@@ -1377,32 +1384,26 @@
           "selects": {
             "aarch64-linux-android": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.147",
                 "target": "libc"
               }
             ],
             "cfg(all(target_arch = \"aarch64\", target_os = \"linux\"))": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.147",
                 "target": "libc"
               }
             ],
             "cfg(all(target_arch = \"aarch64\", target_vendor = \"apple\"))": [
               {
-                "id": "libc 0.2.153",
-                "target": "libc"
-              }
-            ],
-            "cfg(all(target_arch = \"loongarch64\", target_os = \"linux\"))": [
-              {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.147",
                 "target": "libc"
               }
             ]
           }
         },
         "edition": "2018",
-        "version": "0.2.12"
+        "version": "0.2.9"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -1518,6 +1519,57 @@
       },
       "license": "MIT OR Apache-2.0"
     },
+    "crossbeam-channel 0.5.8": {
+      "name": "crossbeam-channel",
+      "version": "0.5.8",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/crossbeam-channel/0.5.8/download",
+          "sha256": "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "crossbeam_channel",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "crossbeam_channel",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "crossbeam-utils",
+            "default",
+            "std"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "cfg-if 1.0.0",
+              "target": "cfg_if"
+            },
+            {
+              "id": "crossbeam-utils 0.8.16",
+              "target": "crossbeam_utils"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.5.8"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
     "crossbeam-deque 0.7.4": {
       "name": "crossbeam-deque",
       "version": "0.7.4",
@@ -1565,13 +1617,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "crossbeam-deque 0.8.5": {
+    "crossbeam-deque 0.8.3": {
       "name": "crossbeam-deque",
-      "version": "0.8.5",
+      "version": "0.8.3",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/crossbeam-deque/0.8.5/download",
-          "sha256": "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+          "url": "https://crates.io/api/v1/crates/crossbeam-deque/0.8.3/download",
+          "sha256": "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
         }
       },
       "targets": [
@@ -1592,6 +1644,8 @@
         ],
         "crate_features": {
           "common": [
+            "crossbeam-epoch",
+            "crossbeam-utils",
             "default",
             "std"
           ],
@@ -1600,18 +1654,22 @@
         "deps": {
           "common": [
             {
-              "id": "crossbeam-epoch 0.9.18",
+              "id": "cfg-if 1.0.0",
+              "target": "cfg_if"
+            },
+            {
+              "id": "crossbeam-epoch 0.9.15",
               "target": "crossbeam_epoch"
             },
             {
-              "id": "crossbeam-utils 0.8.19",
+              "id": "crossbeam-utils 0.8.16",
               "target": "crossbeam_utils"
             }
           ],
           "selects": {}
         },
-        "edition": "2021",
-        "version": "0.8.5"
+        "edition": "2018",
+        "version": "0.8.3"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -1709,13 +1767,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "crossbeam-epoch 0.9.18": {
+    "crossbeam-epoch 0.9.15": {
       "name": "crossbeam-epoch",
-      "version": "0.9.18",
+      "version": "0.9.15",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/crossbeam-epoch/0.9.18/download",
-          "sha256": "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+          "url": "https://crates.io/api/v1/crates/crossbeam-epoch/0.9.15/download",
+          "sha256": "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
         }
       },
       "targets": [
@@ -1723,6 +1781,15 @@
           "Library": {
             "crate_name": "crossbeam_epoch",
             "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
             "srcs": [
               "**/*.rs"
             ]
@@ -1744,14 +1811,44 @@
         "deps": {
           "common": [
             {
-              "id": "crossbeam-utils 0.8.19",
+              "id": "cfg-if 1.0.0",
+              "target": "cfg_if"
+            },
+            {
+              "id": "crossbeam-epoch 0.9.15",
+              "target": "build_script_build"
+            },
+            {
+              "id": "crossbeam-utils 0.8.16",
               "target": "crossbeam_utils"
+            },
+            {
+              "id": "memoffset 0.9.0",
+              "target": "memoffset"
+            },
+            {
+              "id": "scopeguard 1.2.0",
+              "target": "scopeguard"
             }
           ],
           "selects": {}
         },
-        "edition": "2021",
-        "version": "0.9.18"
+        "edition": "2018",
+        "version": "0.9.15"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "autocfg 1.1.0",
+              "target": "autocfg"
+            }
+          ],
+          "selects": {}
+        }
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -1887,13 +1984,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "crossbeam-utils 0.8.19": {
+    "crossbeam-utils 0.8.16": {
       "name": "crossbeam-utils",
-      "version": "0.8.19",
+      "version": "0.8.16",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/crossbeam-utils/0.8.19/download",
-          "sha256": "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+          "url": "https://crates.io/api/v1/crates/crossbeam-utils/0.8.16/download",
+          "sha256": "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
         }
       },
       "targets": [
@@ -1931,14 +2028,18 @@
         "deps": {
           "common": [
             {
-              "id": "crossbeam-utils 0.8.19",
+              "id": "cfg-if 1.0.0",
+              "target": "cfg_if"
+            },
+            {
+              "id": "crossbeam-utils 0.8.16",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
-        "edition": "2021",
-        "version": "0.8.19"
+        "edition": "2018",
+        "version": "0.8.16"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -1985,7 +2086,7 @@
               "target": "generic_array"
             },
             {
-              "id": "typenum 1.17.0",
+              "id": "typenum 1.16.0",
               "target": "typenum"
             }
           ],
@@ -1996,13 +2097,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "cxx 1.0.116": {
+    "cxx 1.0.112": {
       "name": "cxx",
-      "version": "1.0.116",
+      "version": "1.0.112",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/cxx/1.0.116/download",
-          "sha256": "8aff472b83efd22bfc0176aa8ba34617dd5c17364670eb201a5f06d339b8abf7"
+          "url": "https://crates.io/api/v1/crates/cxx/1.0.112/download",
+          "sha256": "58ab30434ea0ff6aa640a08dda5284026a366d47565496fd40b6cbfbdd7e31a2"
         }
       },
       "targets": [
@@ -2041,7 +2142,7 @@
         "deps": {
           "common": [
             {
-              "id": "cxx 1.0.116",
+              "id": "cxx 1.0.112",
               "target": "build_script_build"
             },
             {
@@ -2055,13 +2156,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "cxxbridge-macro 1.0.116",
+              "id": "cxxbridge-macro 1.0.112",
               "target": "cxxbridge_macro"
             }
           ],
           "selects": {}
         },
-        "version": "1.0.116"
+        "version": "1.0.112"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -2070,11 +2171,11 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.0.85",
+              "id": "cc 1.0.83",
               "target": "cc"
             },
             {
-              "id": "cxxbridge-flags 1.0.116",
+              "id": "cxxbridge-flags 1.0.112",
               "target": "cxxbridge_flags"
             }
           ],
@@ -2093,13 +2194,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "cxxbridge-flags 1.0.116": {
+    "cxxbridge-flags 1.0.112": {
       "name": "cxxbridge-flags",
-      "version": "1.0.116",
+      "version": "1.0.112",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/cxxbridge-flags/1.0.116/download",
-          "sha256": "589e83d02fc1d4fb78f5ad56ca08835341e23499d086d2821315869426d618dc"
+          "url": "https://crates.io/api/v1/crates/cxxbridge-flags/1.0.112/download",
+          "sha256": "42281b20eba5218c539295c667c18e2f50211bb11902419194c6ed1ae808e547"
         }
       },
       "targets": [
@@ -2125,17 +2226,17 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.0.116"
+        "version": "1.0.112"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "cxxbridge-macro 1.0.116": {
+    "cxxbridge-macro 1.0.112": {
       "name": "cxxbridge-macro",
-      "version": "1.0.116",
+      "version": "1.0.112",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/cxxbridge-macro/1.0.116/download",
-          "sha256": "e2cb1fd8ffae4230c7cfbbaf3698dbeaf750fa8c5dadf7ed897df581b9b572a5"
+          "url": "https://crates.io/api/v1/crates/cxxbridge-macro/1.0.112/download",
+          "sha256": "b45506e3c66512b0a65d291a6b452128b7b1dd9841e20d1e151addbd2c00ea50"
         }
       },
       "targets": [
@@ -2157,22 +2258,22 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.78",
+              "id": "proc-macro2 1.0.66",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.35",
+              "id": "quote 1.0.32",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.48",
+              "id": "syn 2.0.28",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.0.116"
+        "version": "1.0.112"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -2210,11 +2311,11 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.78",
+              "id": "proc-macro2 1.0.66",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.35",
+              "id": "quote 1.0.32",
               "target": "quote"
             },
             {
@@ -2362,13 +2463,13 @@
       },
       "license": null
     },
-    "either 1.10.0": {
+    "either 1.9.0": {
       "name": "either",
-      "version": "1.10.0",
+      "version": "1.9.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/either/1.10.0/download",
-          "sha256": "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+          "url": "https://crates.io/api/v1/crates/either/1.9.0/download",
+          "sha256": "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
         }
       },
       "targets": [
@@ -2394,7 +2495,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.10.0"
+        "version": "1.9.0"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -2491,7 +2592,7 @@
         "deps": {
           "common": [
             {
-              "id": "byteorder 1.5.0",
+              "id": "byteorder 1.4.3",
               "target": "byteorder"
             },
             {
@@ -2557,23 +2658,23 @@
         "deps": {
           "common": [
             {
-              "id": "num-bigint 0.4.4",
+              "id": "num-bigint 0.4.3",
               "target": "num_bigint"
             },
             {
-              "id": "num-integer 0.1.46",
+              "id": "num-integer 0.1.45",
               "target": "num_integer"
             },
             {
-              "id": "num-traits 0.2.18",
+              "id": "num-traits 0.2.16",
               "target": "num_traits"
             },
             {
-              "id": "proc-macro2 1.0.78",
+              "id": "proc-macro2 1.0.66",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.35",
+              "id": "quote 1.0.32",
               "target": "quote"
             },
             {
@@ -2787,7 +2888,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "typenum 1.17.0",
+              "id": "typenum 1.16.0",
               "target": "typenum"
             }
           ],
@@ -2812,13 +2913,13 @@
       },
       "license": "MIT"
     },
-    "getrandom 0.2.12": {
+    "getrandom 0.2.10": {
       "name": "getrandom",
-      "version": "0.2.12",
+      "version": "0.2.10",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/getrandom/0.2.12/download",
-          "sha256": "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+          "url": "https://crates.io/api/v1/crates/getrandom/0.2.10/download",
+          "sha256": "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
         }
       },
       "targets": [
@@ -2859,14 +2960,14 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.147",
                 "target": "libc"
               }
             ]
           }
         },
         "edition": "2018",
-        "version": "0.2.12"
+        "version": "0.2.10"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -3035,7 +3136,7 @@
               "target": "ark_std"
             },
             {
-              "id": "blake2b_simd 1.0.2",
+              "id": "blake2b_simd 1.0.1",
               "target": "blake2b_simd"
             },
             {
@@ -3059,11 +3160,11 @@
               "target": "log"
             },
             {
-              "id": "num-bigint 0.4.4",
+              "id": "num-bigint 0.4.3",
               "target": "num_bigint"
             },
             {
-              "id": "num-integer 0.1.46",
+              "id": "num-integer 0.1.45",
               "target": "num_integer"
             },
             {
@@ -3075,7 +3176,7 @@
               "target": "rand_core"
             },
             {
-              "id": "rayon 1.8.1",
+              "id": "rayon 1.7.0",
               "target": "rayon"
             },
             {
@@ -3087,7 +3188,7 @@
               "target": "subtle"
             },
             {
-              "id": "tracing 0.1.40",
+              "id": "tracing 0.1.37",
               "target": "tracing"
             }
           ],
@@ -3159,11 +3260,11 @@
               "target": "lazy_static"
             },
             {
-              "id": "num-bigint 0.4.4",
+              "id": "num-bigint 0.4.3",
               "target": "num_bigint"
             },
             {
-              "id": "num-traits 0.2.18",
+              "id": "num-traits 0.2.16",
               "target": "num_traits"
             },
             {
@@ -3248,7 +3349,7 @@
         "deps": {
           "common": [
             {
-              "id": "ahash 0.8.8",
+              "id": "ahash 0.8.3",
               "target": "ahash"
             }
           ],
@@ -3259,13 +3360,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "hermit-abi 0.3.5": {
+    "hermit-abi 0.3.2": {
       "name": "hermit-abi",
-      "version": "0.3.5",
+      "version": "0.3.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/hermit-abi/0.3.5/download",
-          "sha256": "d0c62115964e08cb8039170eb33c1d0e2388a256930279edca206fff675f82c3"
+          "url": "https://crates.io/api/v1/crates/hermit-abi/0.3.2/download",
+          "sha256": "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
         }
       },
       "targets": [
@@ -3285,7 +3386,7 @@
           "**"
         ],
         "edition": "2021",
-        "version": "0.3.5"
+        "version": "0.3.2"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -3362,7 +3463,7 @@
         "deps": {
           "common": [
             {
-              "id": "either 1.10.0",
+              "id": "either 1.9.0",
               "target": "either"
             }
           ],
@@ -3373,13 +3474,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "keccak 0.1.5": {
+    "keccak 0.1.4": {
       "name": "keccak",
-      "version": "0.1.5",
+      "version": "0.1.4",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/keccak/0.1.5/download",
-          "sha256": "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+          "url": "https://crates.io/api/v1/crates/keccak/0.1.4/download",
+          "sha256": "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
         }
       },
       "targets": [
@@ -3403,14 +3504,14 @@
           "selects": {
             "cfg(target_arch = \"aarch64\")": [
               {
-                "id": "cpufeatures 0.2.12",
+                "id": "cpufeatures 0.2.9",
                 "target": "cpufeatures"
               }
             ]
           }
         },
         "edition": "2018",
-        "version": "0.1.5"
+        "version": "0.1.4"
       },
       "license": "Apache-2.0 OR MIT"
     },
@@ -3444,13 +3545,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "libc 0.2.153": {
+    "libc 0.2.147": {
       "name": "libc",
-      "version": "0.2.153",
+      "version": "0.2.147",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/libc/0.2.153/download",
-          "sha256": "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+          "url": "https://crates.io/api/v1/crates/libc/0.2.147/download",
+          "sha256": "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
         }
       },
       "targets": [
@@ -3488,14 +3589,14 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.153",
+              "id": "libc 0.2.147",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "0.2.153"
+        "version": "0.2.147"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -3563,7 +3664,7 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.0.85",
+              "id": "cc 1.0.83",
               "target": "cc"
             }
           ],
@@ -3724,13 +3825,81 @@
       },
       "license": "MIT"
     },
-    "num-bigint 0.4.4": {
-      "name": "num-bigint",
-      "version": "0.4.4",
+    "memoffset 0.9.0": {
+      "name": "memoffset",
+      "version": "0.9.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/num-bigint/0.4.4/download",
-          "sha256": "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+          "url": "https://crates.io/api/v1/crates/memoffset/0.9.0/download",
+          "sha256": "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "memoffset",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "memoffset",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "memoffset 0.9.0",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2015",
+        "version": "0.9.0"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "autocfg 1.1.0",
+              "target": "autocfg"
+            }
+          ],
+          "selects": {}
+        }
+      },
+      "license": "MIT"
+    },
+    "num-bigint 0.4.3": {
+      "name": "num-bigint",
+      "version": "0.4.3",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/num-bigint/0.4.3/download",
+          "sha256": "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
         }
       },
       "targets": [
@@ -3769,15 +3938,15 @@
         "deps": {
           "common": [
             {
-              "id": "num-bigint 0.4.4",
+              "id": "num-bigint 0.4.3",
               "target": "build_script_build"
             },
             {
-              "id": "num-integer 0.1.46",
+              "id": "num-integer 0.1.45",
               "target": "num_integer"
             },
             {
-              "id": "num-traits 0.2.18",
+              "id": "num-traits 0.2.16",
               "target": "num_traits"
             },
             {
@@ -3788,7 +3957,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.4.4"
+        "version": "0.4.3"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -3806,13 +3975,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "num-integer 0.1.46": {
+    "num-integer 0.1.45": {
       "name": "num-integer",
-      "version": "0.1.46",
+      "version": "0.1.45",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/num-integer/0.1.46/download",
-          "sha256": "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+          "url": "https://crates.io/api/v1/crates/num-integer/0.1.45/download",
+          "sha256": "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
         }
       },
       "targets": [
@@ -3820,6 +3989,15 @@
           "Library": {
             "crate_name": "num_integer",
             "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
             "srcs": [
               "**/*.rs"
             ]
@@ -3842,24 +4020,42 @@
         "deps": {
           "common": [
             {
-              "id": "num-traits 0.2.18",
+              "id": "num-integer 0.1.45",
+              "target": "build_script_build"
+            },
+            {
+              "id": "num-traits 0.2.16",
               "target": "num_traits"
             }
           ],
           "selects": {}
         },
-        "edition": "2018",
-        "version": "0.1.46"
+        "edition": "2015",
+        "version": "0.1.45"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "autocfg 1.1.0",
+              "target": "autocfg"
+            }
+          ],
+          "selects": {}
+        }
       },
       "license": "MIT OR Apache-2.0"
     },
-    "num-traits 0.2.18": {
+    "num-traits 0.2.16": {
       "name": "num-traits",
-      "version": "0.2.18",
+      "version": "0.2.16",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/num-traits/0.2.18/download",
-          "sha256": "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+          "url": "https://crates.io/api/v1/crates/num-traits/0.2.16/download",
+          "sha256": "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
         }
       },
       "targets": [
@@ -3898,14 +4094,14 @@
         "deps": {
           "common": [
             {
-              "id": "num-traits 0.2.18",
+              "id": "num-traits 0.2.16",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.2.18"
+        "version": "0.2.16"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -3953,13 +4149,13 @@
           "selects": {
             "cfg(not(windows))": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.147",
                 "target": "libc"
               }
             ],
             "cfg(target_os = \"hermit\")": [
               {
-                "id": "hermit-abi 0.3.5",
+                "id": "hermit-abi 0.3.2",
                 "target": "hermit_abi"
               }
             ]
@@ -3970,13 +4166,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "once_cell 1.19.0": {
+    "once_cell 1.18.0": {
       "name": "once_cell",
-      "version": "1.19.0",
+      "version": "1.18.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/once_cell/1.19.0/download",
-          "sha256": "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+          "url": "https://crates.io/api/v1/crates/once_cell/1.18.0/download",
+          "sha256": "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
         }
       },
       "targets": [
@@ -4000,12 +4196,13 @@
             "alloc",
             "default",
             "race",
-            "std"
+            "std",
+            "unstable"
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.19.0"
+        "version": "1.18.0"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -4073,7 +4270,7 @@
         "deps": {
           "common": [
             {
-              "id": "byteorder 1.5.0",
+              "id": "byteorder 1.4.3",
               "target": "byteorder"
             },
             {
@@ -4140,7 +4337,7 @@
         "deps": {
           "common": [
             {
-              "id": "blake2b_simd 1.0.2",
+              "id": "blake2b_simd 1.0.1",
               "target": "blake2b_simd"
             },
             {
@@ -4228,13 +4425,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "pin-project-lite 0.2.13": {
+    "pin-project-lite 0.2.12": {
       "name": "pin-project-lite",
-      "version": "0.2.13",
+      "version": "0.2.12",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/pin-project-lite/0.2.13/download",
-          "sha256": "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+          "url": "https://crates.io/api/v1/crates/pin-project-lite/0.2.12/download",
+          "sha256": "12cc1b0bf1727a77a54b6654e7b5f1af8604923edc8b81885f8ec92f9e3f0a05"
         }
       },
       "targets": [
@@ -4254,7 +4451,7 @@
           "**"
         ],
         "edition": "2018",
-        "version": "0.2.13"
+        "version": "0.2.12"
       },
       "license": "Apache-2.0 OR MIT"
     },
@@ -4344,13 +4541,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "proc-macro2 1.0.78": {
+    "proc-macro2 1.0.66": {
       "name": "proc-macro2",
-      "version": "1.0.78",
+      "version": "1.0.66",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/proc-macro2/1.0.78/download",
-          "sha256": "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+          "url": "https://crates.io/api/v1/crates/proc-macro2/1.0.66/download",
+          "sha256": "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
         }
       },
       "targets": [
@@ -4388,18 +4585,18 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.78",
+              "id": "proc-macro2 1.0.66",
               "target": "build_script_build"
             },
             {
-              "id": "unicode-ident 1.0.12",
+              "id": "unicode-ident 1.0.11",
               "target": "unicode_ident"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.0.78"
+        "version": "1.0.66"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -4408,13 +4605,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "quote 1.0.35": {
+    "quote 1.0.32": {
       "name": "quote",
-      "version": "1.0.35",
+      "version": "1.0.32",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/quote/1.0.35/download",
-          "sha256": "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+          "url": "https://crates.io/api/v1/crates/quote/1.0.32/download",
+          "sha256": "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
         }
       },
       "targets": [
@@ -4443,14 +4640,14 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.78",
+              "id": "proc-macro2 1.0.66",
               "target": "proc_macro2"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.35"
+        "version": "1.0.32"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -4561,7 +4758,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.147",
                 "target": "libc"
               }
             ],
@@ -4629,7 +4826,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.147",
                 "target": "libc"
               }
             ]
@@ -4794,7 +4991,7 @@
         "deps": {
           "common": [
             {
-              "id": "getrandom 0.2.12",
+              "id": "getrandom 0.2.10",
               "target": "getrandom"
             }
           ],
@@ -4844,13 +5041,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "rayon 1.8.1": {
+    "rayon 1.7.0": {
       "name": "rayon",
-      "version": "1.8.1",
+      "version": "1.7.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/rayon/1.8.1/download",
-          "sha256": "fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051"
+          "url": "https://crates.io/api/v1/crates/rayon/1.7.0/download",
+          "sha256": "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
         }
       },
       "targets": [
@@ -4872,28 +5069,28 @@
         "deps": {
           "common": [
             {
-              "id": "either 1.10.0",
+              "id": "either 1.9.0",
               "target": "either"
             },
             {
-              "id": "rayon-core 1.12.1",
+              "id": "rayon-core 1.11.0",
               "target": "rayon_core"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.8.1"
+        "version": "1.7.0"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "rayon-core 1.12.1": {
+    "rayon-core 1.11.0": {
       "name": "rayon-core",
-      "version": "1.12.1",
+      "version": "1.11.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/rayon-core/1.12.1/download",
-          "sha256": "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+          "url": "https://crates.io/api/v1/crates/rayon-core/1.11.0/download",
+          "sha256": "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
         }
       },
       "targets": [
@@ -4924,22 +5121,30 @@
         "deps": {
           "common": [
             {
-              "id": "crossbeam-deque 0.8.5",
+              "id": "crossbeam-channel 0.5.8",
+              "target": "crossbeam_channel"
+            },
+            {
+              "id": "crossbeam-deque 0.8.3",
               "target": "crossbeam_deque"
             },
             {
-              "id": "crossbeam-utils 0.8.19",
+              "id": "crossbeam-utils 0.8.16",
               "target": "crossbeam_utils"
             },
             {
-              "id": "rayon-core 1.12.1",
+              "id": "num_cpus 1.16.0",
+              "target": "num_cpus"
+            },
+            {
+              "id": "rayon-core 1.11.0",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.12.1"
+        "version": "1.11.0"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -5016,7 +5221,7 @@
         "deps": {
           "common": [
             {
-              "id": "semver 1.0.21",
+              "id": "semver 1.0.18",
               "target": "semver"
             }
           ],
@@ -5057,13 +5262,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "semver 1.0.21": {
+    "semver 1.0.18": {
       "name": "semver",
-      "version": "1.0.21",
+      "version": "1.0.18",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/semver/1.0.21/download",
-          "sha256": "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
+          "url": "https://crates.io/api/v1/crates/semver/1.0.18/download",
+          "sha256": "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
         }
       },
       "targets": [
@@ -5101,14 +5306,14 @@
         "deps": {
           "common": [
             {
-              "id": "semver 1.0.21",
+              "id": "semver 1.0.18",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.21"
+        "version": "1.0.18"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -5222,15 +5427,15 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.78",
+              "id": "proc-macro2 1.0.66",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.35",
+              "id": "quote 1.0.32",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.48",
+              "id": "syn 2.0.28",
               "target": "syn"
             }
           ],
@@ -5287,7 +5492,7 @@
           "selects": {
             "cfg(any(target_arch = \"aarch64\", target_arch = \"x86_64\", target_arch = \"x86\"))": [
               {
-                "id": "cpufeatures 0.2.12",
+                "id": "cpufeatures 0.2.9",
                 "target": "cpufeatures"
               }
             ]
@@ -5341,7 +5546,7 @@
               "target": "digest"
             },
             {
-              "id": "keccak 0.1.5",
+              "id": "keccak 0.1.4",
               "target": "keccak"
             },
             {
@@ -5476,11 +5681,11 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.78",
+              "id": "proc-macro2 1.0.66",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.35",
+              "id": "quote 1.0.32",
               "target": "quote"
             },
             {
@@ -5488,7 +5693,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "unicode-ident 1.0.12",
+              "id": "unicode-ident 1.0.11",
               "target": "unicode_ident"
             }
           ],
@@ -5504,13 +5709,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "syn 2.0.48": {
+    "syn 2.0.28": {
       "name": "syn",
-      "version": "2.0.48",
+      "version": "2.0.28",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/syn/2.0.48/download",
-          "sha256": "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+          "url": "https://crates.io/api/v1/crates/syn/2.0.28/download",
+          "sha256": "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
         }
       },
       "targets": [
@@ -5548,22 +5753,22 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.78",
+              "id": "proc-macro2 1.0.66",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.35",
+              "id": "quote 1.0.32",
               "target": "quote"
             },
             {
-              "id": "unicode-ident 1.0.12",
+              "id": "unicode-ident 1.0.11",
               "target": "unicode_ident"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "2.0.48"
+        "version": "2.0.28"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -5596,7 +5801,7 @@
         "deps": {
           "common": [
             {
-              "id": "cxx 1.0.116",
+              "id": "cxx 1.0.112",
               "target": "cxx"
             },
             {
@@ -5616,7 +5821,7 @@
               "target": "halo2curves"
             },
             {
-              "id": "num-bigint 0.4.4",
+              "id": "num-bigint 0.4.3",
               "target": "num_bigint"
             },
             {
@@ -5667,7 +5872,7 @@
         "deps": {
           "common": [
             {
-              "id": "zeroize 1.7.0",
+              "id": "zeroize 1.6.0",
               "target": "zeroize"
             }
           ],
@@ -5708,13 +5913,13 @@
       },
       "license": "MIT"
     },
-    "tracing 0.1.40": {
+    "tracing 0.1.37": {
       "name": "tracing",
-      "version": "0.1.40",
+      "version": "0.1.37",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tracing/0.1.40/download",
-          "sha256": "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+          "url": "https://crates.io/api/v1/crates/tracing/0.1.37/download",
+          "sha256": "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
         }
       },
       "targets": [
@@ -5745,11 +5950,15 @@
         "deps": {
           "common": [
             {
-              "id": "pin-project-lite 0.2.13",
+              "id": "cfg-if 1.0.0",
+              "target": "cfg_if"
+            },
+            {
+              "id": "pin-project-lite 0.2.12",
               "target": "pin_project_lite"
             },
             {
-              "id": "tracing-core 0.1.32",
+              "id": "tracing-core 0.1.31",
               "target": "tracing_core"
             }
           ],
@@ -5759,23 +5968,23 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "tracing-attributes 0.1.27",
+              "id": "tracing-attributes 0.1.26",
               "target": "tracing_attributes"
             }
           ],
           "selects": {}
         },
-        "version": "0.1.40"
+        "version": "0.1.37"
       },
       "license": "MIT"
     },
-    "tracing-attributes 0.1.27": {
+    "tracing-attributes 0.1.26": {
       "name": "tracing-attributes",
-      "version": "0.1.27",
+      "version": "0.1.26",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tracing-attributes/0.1.27/download",
-          "sha256": "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+          "url": "https://crates.io/api/v1/crates/tracing-attributes/0.1.26/download",
+          "sha256": "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
         }
       },
       "targets": [
@@ -5797,32 +6006,32 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.78",
+              "id": "proc-macro2 1.0.66",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.35",
+              "id": "quote 1.0.32",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.48",
+              "id": "syn 2.0.28",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.1.27"
+        "version": "0.1.26"
       },
       "license": "MIT"
     },
-    "tracing-core 0.1.32": {
+    "tracing-core 0.1.31": {
       "name": "tracing-core",
-      "version": "0.1.32",
+      "version": "0.1.31",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tracing-core/0.1.32/download",
-          "sha256": "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+          "url": "https://crates.io/api/v1/crates/tracing-core/0.1.31/download",
+          "sha256": "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
         }
       },
       "targets": [
@@ -5851,24 +6060,24 @@
         "deps": {
           "common": [
             {
-              "id": "once_cell 1.19.0",
+              "id": "once_cell 1.18.0",
               "target": "once_cell"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.1.32"
+        "version": "0.1.31"
       },
       "license": "MIT"
     },
-    "typenum 1.17.0": {
+    "typenum 1.16.0": {
       "name": "typenum",
-      "version": "1.17.0",
+      "version": "1.16.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/typenum/1.17.0/download",
-          "sha256": "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+          "url": "https://crates.io/api/v1/crates/typenum/1.16.0/download",
+          "sha256": "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
         }
       },
       "targets": [
@@ -5899,14 +6108,14 @@
         "deps": {
           "common": [
             {
-              "id": "typenum 1.17.0",
+              "id": "typenum 1.16.0",
               "target": "build_script_main"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.17.0"
+        "version": "1.16.0"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -5915,13 +6124,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "unicode-ident 1.0.12": {
+    "unicode-ident 1.0.11": {
       "name": "unicode-ident",
-      "version": "1.0.12",
+      "version": "1.0.11",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/unicode-ident/1.0.12/download",
-          "sha256": "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+          "url": "https://crates.io/api/v1/crates/unicode-ident/1.0.11/download",
+          "sha256": "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
         }
       },
       "targets": [
@@ -5941,7 +6150,7 @@
           "**"
         ],
         "edition": "2018",
-        "version": "1.0.12"
+        "version": "1.0.11"
       },
       "license": "(MIT OR Apache-2.0) AND Unicode-DFS-2016"
     },
@@ -6225,107 +6434,13 @@
       },
       "license": "MIT"
     },
-    "zerocopy 0.7.32": {
-      "name": "zerocopy",
-      "version": "0.7.32",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/zerocopy/0.7.32/download",
-          "sha256": "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "zerocopy",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "zerocopy",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "simd"
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "proc_macro_deps": {
-          "common": [],
-          "selects": {
-            "cfg(any())": [
-              {
-                "id": "zerocopy-derive 0.7.32",
-                "target": "zerocopy_derive"
-              }
-            ]
-          }
-        },
-        "version": "0.7.32"
-      },
-      "license": "BSD-2-Clause OR Apache-2.0 OR MIT"
-    },
-    "zerocopy-derive 0.7.32": {
-      "name": "zerocopy-derive",
-      "version": "0.7.32",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/zerocopy-derive/0.7.32/download",
-          "sha256": "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "zerocopy_derive",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "zerocopy_derive",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "proc-macro2 1.0.78",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.35",
-              "target": "quote"
-            },
-            {
-              "id": "syn 2.0.48",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.7.32"
-      },
-      "license": "BSD-2-Clause OR Apache-2.0 OR MIT"
-    },
-    "zeroize 1.7.0": {
+    "zeroize 1.6.0": {
       "name": "zeroize",
-      "version": "1.7.0",
+      "version": "1.6.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/zeroize/1.7.0/download",
-          "sha256": "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+          "url": "https://crates.io/api/v1/crates/zeroize/1.6.0/download",
+          "sha256": "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
         }
       },
       "targets": [
@@ -6360,7 +6475,7 @@
           ],
           "selects": {}
         },
-        "version": "1.7.0"
+        "version": "1.6.0"
       },
       "license": "Apache-2.0 OR MIT"
     },
@@ -6392,15 +6507,15 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.78",
+              "id": "proc-macro2 1.0.66",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.35",
+              "id": "quote 1.0.32",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.48",
+              "id": "syn 2.0.28",
               "target": "syn"
             }
           ],
@@ -6434,8 +6549,6 @@
       "aarch64-apple-ios",
       "aarch64-apple-ios-sim"
     ],
-    "cfg(all(target_arch = \"loongarch64\", target_os = \"linux\"))": [],
-    "cfg(any())": [],
     "cfg(any(target_arch = \"aarch64\", target_arch = \"x86_64\", target_arch = \"x86\"))": [
       "aarch64-apple-darwin",
       "aarch64-apple-ios",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,14 +4,13 @@ version = 3
 
 [[package]]
 name = "ahash"
-version = "0.8.8"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cd52102d3df161c77a887b608d7a4897d7cc112886a9537b738a887a03aaff"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
  "cfg-if 1.0.0",
  "once_cell",
  "version_check",
- "zerocopy",
 ]
 
 [[package]]
@@ -215,9 +214,9 @@ dependencies = [
 
 [[package]]
 name = "blake2b_simd"
-version = "1.0.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23285ad32269793932e830392f2fe2f83e26488fd3ec778883a93c8323735780"
+checksum = "3c2f0dc9a68c6317d884f97cc36cf5a3d20ba14ce404227df55e1af708ab04bc"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -251,15 +250,18 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "byteorder"
-version = "1.5.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cc"
-version = "1.0.85"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b918671670962b48bc23753aef0c51d072dca6f52f01f800854ada6ddb7f7d3"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cfg-if"
@@ -275,15 +277,15 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "constant_time_eq"
-version = "0.3.0"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
+checksum = "21a53c0a4d288377e7415b53dcfc3c04da5cdc2cc95c8d5ac178b58f0b861ad6"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.12"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
 dependencies = [
  "libc",
 ]
@@ -295,7 +297,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69323bff1fb41c635347b8ead484a5ca6c3f11914d784170b158d8449ab07f8e"
 dependencies = [
  "cfg-if 0.1.10",
- "crossbeam-channel",
+ "crossbeam-channel 0.4.4",
  "crossbeam-deque 0.7.4",
  "crossbeam-epoch 0.8.2",
  "crossbeam-queue",
@@ -313,6 +315,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils 0.8.16",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,12 +337,13 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.5"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
 dependencies = [
- "crossbeam-epoch 0.9.18",
- "crossbeam-utils 0.8.19",
+ "cfg-if 1.0.0",
+ "crossbeam-epoch 0.9.15",
+ "crossbeam-utils 0.8.16",
 ]
 
 [[package]]
@@ -344,17 +357,21 @@ dependencies = [
  "crossbeam-utils 0.7.2",
  "lazy_static",
  "maybe-uninit",
- "memoffset",
+ "memoffset 0.5.6",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
 dependencies = [
- "crossbeam-utils 0.8.19",
+ "autocfg",
+ "cfg-if 1.0.0",
+ "crossbeam-utils 0.8.16",
+ "memoffset 0.9.0",
+ "scopeguard",
 ]
 
 [[package]]
@@ -381,9 +398,12 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.19"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
+dependencies = [
+ "cfg-if 1.0.0",
+]
 
 [[package]]
 name = "crypto-common"
@@ -397,9 +417,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.116"
+version = "1.0.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aff472b83efd22bfc0176aa8ba34617dd5c17364670eb201a5f06d339b8abf7"
+checksum = "58ab30434ea0ff6aa640a08dda5284026a366d47565496fd40b6cbfbdd7e31a2"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -409,19 +429,19 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.116"
+version = "1.0.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589e83d02fc1d4fb78f5ad56ca08835341e23499d086d2821315869426d618dc"
+checksum = "42281b20eba5218c539295c667c18e2f50211bb11902419194c6ed1ae808e547"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.116"
+version = "1.0.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2cb1fd8ffae4230c7cfbbaf3698dbeaf750fa8c5dadf7ed897df581b9b572a5"
+checksum = "b45506e3c66512b0a65d291a6b452128b7b1dd9841e20d1e151addbd2c00ea50"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -455,10 +475,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "direct-cargo-bazel-deps"
+version = "0.0.1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "either"
-version = "1.10.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "ff"
@@ -539,9 +566,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -627,9 +654,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.5"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c62115964e08cb8039170eb33c1d0e2388a256930279edca206fff675f82c3"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "hex"
@@ -648,9 +675,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.5"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
 dependencies = [
  "cpufeatures",
 ]
@@ -663,9 +690,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "link-cplusplus"
@@ -698,10 +725,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint"
-version = "0.4.4"
+name = "memoffset"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -711,18 +747,19 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
+ "autocfg",
  "num-traits",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.18"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
 ]
@@ -739,9 +776,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "opaque-debug"
@@ -785,9 +822,9 @@ checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.13"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+checksum = "12cc1b0bf1727a77a54b6654e7b5f1af8604923edc8b81885f8ec92f9e3f0a05"
 
 [[package]]
 name = "poseidon"
@@ -807,18 +844,18 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
 dependencies = [
  "proc-macro2",
 ]
@@ -898,9 +935,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.8.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051"
+checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
 dependencies = [
  "either",
  "rayon-core",
@@ -908,12 +945,14 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
 dependencies = [
- "crossbeam-deque 0.8.5",
- "crossbeam-utils 0.8.19",
+ "crossbeam-channel 0.5.8",
+ "crossbeam-deque 0.8.3",
+ "crossbeam-utils 0.8.16",
+ "num_cpus",
 ]
 
 [[package]]
@@ -942,9 +981,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.21"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
+checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
@@ -963,7 +1002,7 @@ checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -1014,9 +1053,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1054,10 +1093,11 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
+ "cfg-if 1.0.0",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -1065,35 +1105,35 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.28",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "version_check"
@@ -1139,30 +1179,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerocopy"
-version = "0.7.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
-]
-
-[[package]]
 name = "zeroize"
-version = "1.7.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
 dependencies = [
  "zeroize_derive",
 ]
@@ -1175,5 +1195,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.28",
 ]


### PR DESCRIPTION
# Description
In 88e4660, cargo lock files were updated wrong, causing ci failure with the error message below. This PR fixes it.

```
ERROR: /private/var/tmp/_bazel_takim9999/3a7efe9626017559f78ec48c055ca385/external/crate_index__ahash-0.8.8/BUILD.bazel:22:13: Compiling Rust rlib ahash v0.8.8 (14 files) failed: (Exit 1): process_wrapper failed: error executing command (from target @crate_index__ahash-0.8.8//:ahash) bazel-out/darwin_arm64-opt-exec-2B5CBBC6/bin/external/rules_rust/util/process_wrapper/process_wrapper --env-file bazel-out/darwin_arm64-dbg/bin/external/crate_index__ahash-0.8.8/ahash_build_script.env ... (remaining 33 arguments skipped) error[E0658]: use of unstable library feature 'stdsimd'
   --> external/crate_index__ahash-0.8.8/src/operations.rs:124:24
    |
124 |     let res = unsafe { vaesmcq_u8(vaeseq_u8(transmute!(value), transmute!(0u128))) };
    |                        ^^^^^^^^^^
    |
    = note: see issue #48556 <https://github.com/rust-lang/rust/issues/48556> for more information
```