### PR TITLE
perf(halo2): avoid copying when returning `s_g2()`

### DIFF
--- a/vendors/halo2/include/bn254_gwc_prover.h
+++ b/vendors/halo2/include/bn254_gwc_prover.h
@@ -34,8 +34,7 @@ class GWCProver {
 
   uint32_t k() const;
   uint64_t n() const;
-  // TODO(dongchangYoo): avoid copying through the use of |rust::Box|.
-  rust::Box<G2AffinePoint> s_g2() const;
+  const G2AffinePoint& s_g2() const;
   rust::Box<G1JacobianPoint> commit(const Poly& poly) const;
   rust::Box<G1JacobianPoint> commit_lagrange(const Evals& evals) const;
   std::unique_ptr<Evals> empty_evals() const;

--- a/vendors/halo2/include/bn254_shplonk_prover.h
+++ b/vendors/halo2/include/bn254_shplonk_prover.h
@@ -34,8 +34,7 @@ class SHPlonkProver {
 
   uint32_t k() const;
   uint64_t n() const;
-  // TODO(dongchangYoo): avoid copying through the use of |rust::Box|.
-  rust::Box<G2AffinePoint> s_g2() const;
+  const G2AffinePoint& s_g2() const;
   rust::Box<G1JacobianPoint> commit(const Poly& poly) const;
   rust::Box<G1JacobianPoint> commit_lagrange(const Evals& evals) const;
   std::unique_ptr<Evals> empty_evals() const;

--- a/vendors/halo2/src/bn254.rs
+++ b/vendors/halo2/src/bn254.rs
@@ -171,7 +171,7 @@ pub mod ffi {
         ) -> UniquePtr<GWCProver>;
         fn k(&self) -> u32;
         fn n(&self) -> u64;
-        fn s_g2(&self) -> Box<G2AffinePoint>;
+        fn s_g2(&self) -> &G2AffinePoint;
         fn commit(&self, poly: &Poly) -> Box<G1JacobianPoint>;
         fn commit_lagrange(&self, evals: &Evals) -> Box<G1JacobianPoint>;
         fn empty_evals(&self) -> UniquePtr<Evals>;
@@ -208,7 +208,7 @@ pub mod ffi {
         ) -> UniquePtr<SHPlonkProver>;
         fn k(&self) -> u32;
         fn n(&self) -> u64;
-        fn s_g2(&self) -> Box<G2AffinePoint>;
+        fn s_g2(&self) -> &G2AffinePoint;
         fn commit(&self, poly: &Poly) -> Box<G1JacobianPoint>;
         fn commit_lagrange(&self, evals: &Evals) -> Box<G1JacobianPoint>;
         fn empty_evals(&self) -> UniquePtr<Evals>;
@@ -743,7 +743,7 @@ pub trait TachyonProver<Scheme: CommitmentScheme> {
 
     fn n(&self) -> u64;
 
-    fn s_g2(&self) -> G2Affine;
+    fn s_g2(&self) -> &G2Affine;
 
     fn commit(&self, poly: &Poly) -> <Scheme::Curve as CurveAffine>::CurveExt;
 
@@ -809,8 +809,8 @@ impl<Scheme: CommitmentScheme> TachyonProver<Scheme> for GWCProver<Scheme> {
         self.inner.n()
     }
 
-    fn s_g2(&self) -> G2Affine {
-        *unsafe { std::mem::transmute::<_, Box<G2Affine>>(self.inner.s_g2()) }
+    fn s_g2(&self) -> &G2Affine {
+        unsafe { std::mem::transmute::<_, &G2Affine>(self.inner.s_g2()) }
     }
 
     fn commit(&self, poly: &Poly) -> <Scheme::Curve as CurveAffine>::CurveExt {
@@ -922,8 +922,8 @@ impl<Scheme: CommitmentScheme> TachyonProver<Scheme> for SHPlonkProver<Scheme> {
         self.inner.n()
     }
 
-    fn s_g2(&self) -> G2Affine {
-        *unsafe { std::mem::transmute::<_, Box<G2Affine>>(self.inner.s_g2()) }
+    fn s_g2(&self) -> &G2Affine {
+        unsafe { std::mem::transmute::<_, &G2Affine>(self.inner.s_g2()) }
     }
 
     fn commit(&self, poly: &Poly) -> <Scheme::Curve as CurveAffine>::CurveExt {

--- a/vendors/halo2/src/bn254_gwc_prover.cc
+++ b/vendors/halo2/src/bn254_gwc_prover.cc
@@ -26,10 +26,9 @@ uint64_t GWCProver::n() const {
   return static_cast<uint64_t>(tachyon_halo2_bn254_gwc_prover_get_n(prover_));
 }
 
-rust::Box<G2AffinePoint> GWCProver::s_g2() const {
-  return rust::Box<G2AffinePoint>::from_raw(
-      reinterpret_cast<G2AffinePoint*>(new tachyon_bn254_g2_affine(
-          *tachyon_halo2_bn254_gwc_prover_get_s_g2(prover_))));
+const G2AffinePoint& GWCProver::s_g2() const {
+  return reinterpret_cast<const G2AffinePoint&>(
+      *tachyon_halo2_bn254_gwc_prover_get_s_g2(prover_));
 }
 
 rust::Box<G1JacobianPoint> GWCProver::commit(const Poly& poly) const {

--- a/vendors/halo2/src/bn254_shplonk_prover.cc
+++ b/vendors/halo2/src/bn254_shplonk_prover.cc
@@ -29,10 +29,9 @@ uint64_t SHPlonkProver::n() const {
       tachyon_halo2_bn254_shplonk_prover_get_n(prover_));
 }
 
-rust::Box<G2AffinePoint> SHPlonkProver::s_g2() const {
-  return rust::Box<G2AffinePoint>::from_raw(
-      reinterpret_cast<G2AffinePoint*>(new tachyon_bn254_g2_affine(
-          *tachyon_halo2_bn254_shplonk_prover_get_s_g2(prover_))));
+const G2AffinePoint& SHPlonkProver::s_g2() const {
+  return reinterpret_cast<const G2AffinePoint&>(
+      *tachyon_halo2_bn254_shplonk_prover_get_s_g2(prover_));
 }
 
 rust::Box<G1JacobianPoint> SHPlonkProver::commit(const Poly& poly) const {

--- a/vendors/halo2/src/prover.rs
+++ b/vendors/halo2/src/prover.rs
@@ -482,8 +482,8 @@ mod test {
         assert_eq!(prover_from_params.n(), N);
 
         let expected_s_g2 = params.s_g2();
-        assert_eq!(prover_from_s.s_g2(), expected_s_g2);
-        assert_eq!(prover_from_params.s_g2(), expected_s_g2);
+        assert_eq!(prover_from_s.s_g2(), &expected_s_g2);
+        assert_eq!(prover_from_params.s_g2(), &expected_s_g2);
 
         let domain = EvaluationDomain::new(1, k);
         let scalars = (0..N).map(|_| Fr::random(OsRng)).collect::<Vec<_>>();


### PR DESCRIPTION
# Description

This PR eliminates the need to copy a structure with potentially large memory when returning `s_g2()`.