### PR TITLE
perf(halo2): drop `pk` immediately right after it is used

### DIFF
--- a/vendors/halo2/src/circuits/shuffle_circuit.rs
+++ b/vendors/halo2/src/circuits/shuffle_circuit.rs
@@ -310,6 +310,7 @@ mod test {
                 let mut pk_bytes: Vec<u8> = vec![];
                 pk.write(&mut pk_bytes, halo2_proofs::SerdeFormat::RawBytesUnchecked)
                     .unwrap();
+                drop(pk);
                 TachyonProvingKey::from(pk_bytes.as_slice())
             };
             let mut transcript = TachyonBlake2bWrite::init(vec![]);

--- a/vendors/halo2/src/circuits/simple_circuit.rs
+++ b/vendors/halo2/src/circuits/simple_circuit.rs
@@ -393,6 +393,7 @@ mod test {
                 let mut pk_bytes: Vec<u8> = vec![];
                 pk.write(&mut pk_bytes, halo2_proofs::SerdeFormat::RawBytesUnchecked)
                     .unwrap();
+                drop(pk);
                 TachyonProvingKey::from(pk_bytes.as_slice())
             };
             let mut transcript = TachyonBlake2bWrite::init(vec![]);

--- a/vendors/halo2/src/circuits/simple_lookup_circuit.rs
+++ b/vendors/halo2/src/circuits/simple_lookup_circuit.rs
@@ -166,6 +166,7 @@ mod test {
                 let mut pk_bytes: Vec<u8> = vec![];
                 pk.write(&mut pk_bytes, halo2_proofs::SerdeFormat::RawBytesUnchecked)
                     .unwrap();
+                drop(pk);
                 TachyonProvingKey::from(pk_bytes.as_slice())
             };
             let mut transcript = TachyonBlake2bWrite::init(vec![]);


### PR DESCRIPTION
# Description

To reduce memory usage in Halo2, this PR drops `pk` immediately after its usage.