### PR TITLE
build: add missing header to tachyon hdrs

### DIFF
--- a/tachyon/c/BUILD.bazel
+++ b/tachyon/c/BUILD.bazel
@@ -80,6 +80,7 @@ collect_hdrs(
         "api.h",
         "export.h",
         "version.h",
+        ":version_generated",
     ],
     deps = [
         "//tachyon/c/crypto:crypto_hdrs",

--- a/tachyon/cc/BUILD.bazel
+++ b/tachyon/cc/BUILD.bazel
@@ -71,6 +71,8 @@ collect_hdrs(
     hdrs = [
         "api.h",
         "export.h",
+        "version.h",
+        ":version_generated",
     ],
     deps = [
         "//tachyon/cc/math:math_hdrs",


### PR DESCRIPTION
# Description

This PR addresses the issue where `//tachyon/c:tachyon_hdrs` was missing `tachyon/c/version_generated.h`, and `//tachyon/cc:tachyon_hdrs` was missing `tachyon/cc/version.h` and `tachyon/cc/version_generated.h`. These changes ensure that the headers are properly included.