### PR TITLE
perf(crypto): avoid copying twice when returning a polynomial

### DIFF
--- a/tachyon/crypto/commitments/kzg/shplonk.h
+++ b/tachyon/crypto/commitments/kzg/shplonk.h
@@ -188,7 +188,7 @@ class SHPlonk final : public UnivariatePolynomialCommitmentScheme<
           // clang-format on
           Poly& l = Poly::template LinearCombinationInPlace</*forward=*/false>(
               polys, y);
-          return l *= z_diff;
+          return l * z_diff;
         });
 
     // Create a linear combination of polynomials [L₀(X), L₁(X), L₂(X)] with

--- a/tachyon/crypto/commitments/polynomial_openings.h
+++ b/tachyon/crypto/commitments/polynomial_openings.h
@@ -167,7 +167,7 @@ struct GroupedPolynomialOpenings {
     // Divide combined polynomial by vanishing polynomial of evaluation points.
     // H(X) = N(X) / (X - x₀)(X - x₁)(X - x₂)
     Poly vanishing_poly = Poly::FromRoots(points);
-    return n /= vanishing_poly;
+    return n / vanishing_poly;
   }
 };
 


### PR DESCRIPTION
# Description

The need for this optimization stems from the internal copying that occurs during multiplication and division between the polynomials. With `Poly& * operand`, copying occurs twice, so we use `Poly * operand` instead so that copying occurs just once.

```c++
Poly Func() {
  Poly& poly;
  Poly operand;
  return poly *= operand; // copying twice
}
```

```c++
Poly Func() {
  Poly& poly;
  Poly operand;
  return poly * operand; // copying once
}
```