### PR TITLE
perf: avoid in place operator where ineffective

### DIFF
--- a/tachyon/device/tracking_allocator.cc
+++ b/tachyon/device/tracking_allocator.cc
@@ -57,7 +57,7 @@ void* TrackingAllocator::AllocateRaw(
     size_t allocated_bytes = allocator_->AllocatedSizeSlow(ptr);
     allocated_bytes = std::max(num_bytes, allocated_bytes);
     absl::MutexLock lock(&mu_);
-    next_allocation_id_ += 1;
+    ++next_allocation_id_;
     Chunk chunk = {num_bytes, allocated_bytes, next_allocation_id_};
     in_use_.emplace(std::make_pair(ptr, chunk));
     allocated_ += allocated_bytes;

--- a/tachyon/math/elliptic_curves/bn/bn_curve.h
+++ b/tachyon/math/elliptic_curves/bn/bn_curve.h
@@ -82,9 +82,8 @@ class BNCurve : public PairingFriendlyCurve<Config> {
     // Follows, e.g., Beuchat et al page 9, by computing result as follows:
     //   f^((q⁶ - 1) * (q² + 1)) = (conj(f) * f⁻¹)^(q² + 1)
 
-    // f1 = f.CyclotomicInverseInPlace() = f^(q⁶)
-    Fp12 f1 = f;
-    f1.CyclotomicInverseInPlace();
+    // f1 = f.CyclotomicInverse() = f^(q⁶)
+    Fp12 f1 = f.CyclotomicInverse();
 
     // f2 = f⁻¹
     Fp12 f2 = f.Inverse();

--- a/tachyon/math/elliptic_curves/msm/algorithms/cuzk/cuzk.h
+++ b/tachyon/math/elliptic_curves/msm/algorithms/cuzk/cuzk.h
@@ -300,7 +300,7 @@ class CUZK : public PippengerBase<AffinePoint<GpuCurve>>,
       unsigned int start = row_ptrs[i];
       unsigned int end = row_ptrs[i + 1];
       if ((end - start > gz) || (end - start < z)) continue;
-      n_other_total += 1;
+      ++n_other_total;
     }
     if (n_other_total == 0) {
       return true;
@@ -322,7 +322,7 @@ class CUZK : public PippengerBase<AffinePoint<GpuCurve>>,
       unsigned int n = (end - start) / z;
       row_ptrs2[n_other_total_idx + 1] = row_ptrs2[n_other_total_idx] + n;
 
-      n_other_total_idx += 1;
+      ++n_other_total_idx;
     }
 
     auto intermediate_datas =
@@ -358,7 +358,7 @@ class CUZK : public PippengerBase<AffinePoint<GpuCurve>>,
       }
 
       stream_id = (stream_id + 1) % grid_size_;
-      n_other_total_idx += 1;
+      ++n_other_total_idx;
     }
 
     for (unsigned int i = 0; i < grid_size_; ++i) {

--- a/tachyon/math/elliptic_curves/msm/kernels/bellman/bellman_msm_kernels.cu.h
+++ b/tachyon/math/elliptic_curves/msm/kernels/bellman/bellman_msm_kernels.cu.h
@@ -214,7 +214,7 @@ __global__ void AggregateBucketsKernel(
     auto base =
         Load<AffinePoint<Curve>, CacheOperator::kNone>(&bases[base_index]);
     if (sign) {
-      base = base.NegInPlace();
+      base.NegInPlace();
     }
     bucket = base.ToXYZZ();
   } else {

--- a/tachyon/math/elliptic_curves/short_weierstrass/affine_point_impl.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/affine_point_impl.h
@@ -19,8 +19,7 @@ constexpr ProjectivePoint<Curve> CLASS::DoubleProjective() const {
 
   // https://hyperelliptic.org/EFD/g1p/auto-shortw-projective.html#doubling-mdbl-2007-bl
   // XX = X1²
-  BaseField xx = x_;
-  xx.SquareInPlace();
+  BaseField xx = x_.Square();
 
   // w = a + 3 * XX
   BaseField w = xx;
@@ -32,42 +31,34 @@ constexpr ProjectivePoint<Curve> CLASS::DoubleProjective() const {
   }
 
   // Y1Y1 = Y1²
-  BaseField y1y1 = y_;
-  y1y1.SquareInPlace();
+  BaseField y1y1 = y_.Square();
 
   // R = 2 * Y1Y1
-  BaseField r = std::move(y1y1);
-  r.DoubleInPlace();
+  BaseField r = y1y1.Double();
 
   // sss = 4 * Y1 * R
-  BaseField sss = y_;
-  sss *= r;
+  BaseField sss = y_ * r;
   sss.DoubleInPlace().DoubleInPlace();
 
   // RR = R²
-  BaseField rr = r;
-  r.SquareInPlace();
+  BaseField rr = r.Square();
 
   // B = (X1 + R)² - XX - RR
-  BaseField b = std::move(r);
-  b += x_;
+  BaseField b = x_ + r;
   b.SquareInPlace();
   b -= xx;
   b -= rr;
 
   // h = w² - 2 * B
-  BaseField h = w;
-  h.SquareInPlace();
+  BaseField h = w.Square();
   h -= b.Double();
 
   // X3 = 2 * h * Y1
-  BaseField x = std::move(y_);
-  x *= h;
+  BaseField x = h * y_;
   x.DoubleInPlace();
 
   // Y3 = w * (B - h) - 2 * RR
-  BaseField y = std::move(b);
-  y -= h;
+  BaseField y = b - h;
   y *= w;
   y -= rr.Double();
 
@@ -85,24 +76,19 @@ constexpr PointXYZZ<Curve> CLASS::DoubleXYZZ() const {
 
   // https://hyperelliptic.org/EFD/g1p/auto-shortw-xyzz.html#doubling-mdbl-2008-s-1
   // U = 2 * Y1
-  BaseField u = y_;
-  u.DoubleInPlace();
+  BaseField u = y_.Double();
 
   // V = U²
-  BaseField v = u;
-  v.SquareInPlace();
+  BaseField v = u.Square();
 
   // W = U * V
-  BaseField w = u;
-  w *= v;
+  BaseField w = u * v;
 
   // S = X1 * V
-  BaseField s = x_;
-  s *= v;
+  BaseField s = x_ * v;
 
   // M = 3 * X1² + a
-  BaseField m = x_;
-  m.SquareInPlace();
+  BaseField m = x_.Square();
   m += m.Double();
   if constexpr (!Curve::Config::kAIsZero) {
     // TODO(chokobole): Implement constexpr version of Curve::Config::AddByA()
@@ -111,8 +97,7 @@ constexpr PointXYZZ<Curve> CLASS::DoubleXYZZ() const {
   }
 
   // X3 = M² - 2 * S
-  BaseField x = m;
-  x.SquareInPlace();
+  BaseField x = m.Square();
   x -= s.Double();
 
   // Y3 = M * (S - X3) - W * Y1

--- a/tachyon/math/elliptic_curves/short_weierstrass/jacobian_point_impl.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/jacobian_point_impl.h
@@ -181,7 +181,7 @@ constexpr CLASS& CLASS::DoubleInPlace() {
       d.SquareInPlace();
       d -= a;
       d -= c;
-      d.SquareInPlace();
+      d.DoubleInPlace();
     }
 
     // E = 3 * A

--- a/tachyon/math/elliptic_curves/short_weierstrass/point_xyzz_impl.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/point_xyzz_impl.h
@@ -23,48 +23,38 @@ constexpr CLASS& CLASS::AddInPlace(const PointXYZZ& other) {
 
   // https://hyperelliptic.org/EFD/g1p/auto-shortw-xyzz.html#addition-add-2008-s
   // U1 = X1 * ZZ2
-  BaseField u1 = x_;
-  u1 *= other.zz_;
+  BaseField u1 = x_ * other.zz_;
 
   // U2 = X2 * ZZ1
-  BaseField u2 = other.x_;
-  u2 *= zz_;
+  BaseField u2 = other.x_ * zz_;
 
   // S1 = Y1 * ZZZ2
-  BaseField s1 = y_;
-  s1 *= other.zzz_;
+  BaseField s1 = y_ * other.zzz_;
 
   // S2 = Y2 * ZZZ1
-  BaseField s2 = other.y_;
-  s2 *= zzz_;
+  BaseField s2 = other.y_ * zzz_;
 
   // P = U2 - U1
-  BaseField p = std::move(u2);
-  p -= u1;
+  BaseField p = u2 - u1;
 
   // R = S2 - S1
-  BaseField r = std::move(s2);
-  r -= s1;
+  BaseField r = s2 - s1;
 
   if (p.IsZero() && r.IsZero()) {
     return DoubleInPlace();
   }
 
   // PP = P²
-  BaseField pp = p;
-  pp.SquareInPlace();
+  BaseField pp = p.Square();
 
   // PPP = P * PP
-  BaseField ppp = std::move(p);
-  ppp *= pp;
+  BaseField ppp = p * pp;
 
   // Q = U1 * PP
-  BaseField q = std::move(u1);
-  q *= pp;
+  BaseField q = u1 * pp;
 
   // X3 = R² - PPP - 2 * Q
-  x_ = r;
-  x_.SquareInPlace();
+  x_ = r.Square();
   x_ -= ppp;
   x_ -= q.Double();
 
@@ -96,40 +86,32 @@ constexpr CLASS& CLASS::AddInPlace(const AffinePoint<Curve>& other) {
 
   // https://hyperelliptic.org/EFD/g1p/auto-shortw-xyzz.html#addition-madd-2008-s
   // U2 = X2 * ZZ1
-  BaseField u2 = other.x();
-  u2 *= zz_;
+  BaseField u2 = other.x() * zz_;
 
   // S2 = Y2 * ZZZ1
-  BaseField s2 = other.y();
-  s2 *= zzz_;
+  BaseField s2 = other.y() * zzz_;
 
   // P = U2 - X1
-  BaseField p = std::move(u2);
-  p -= x_;
+  BaseField p = u2 - x_;
 
   // R = S2 - Y1
-  BaseField r = std::move(s2);
-  r -= y_;
+  BaseField r = s2 - y_;
 
   if (p.IsZero() && r.IsZero()) {
     return DoubleInPlace();
   }
 
   // PP = P²
-  BaseField pp = p;
-  pp.SquareInPlace();
+  BaseField pp = p.Square();
 
   // PPP = P * PP
-  BaseField ppp = std::move(p);
-  ppp *= pp;
+  BaseField ppp = p * pp;
 
   // Q = X1 * PP
-  BaseField q = std::move(x_);
-  q *= pp;
+  BaseField q = x_ * pp;
 
   // X3 = R² - PPP - 2 * Q
-  x_ = r;
-  x_.SquareInPlace();
+  x_ = r.Square();
   x_ -= ppp;
   x_ -= q.Double();
 
@@ -155,32 +137,26 @@ constexpr CLASS& CLASS::DoubleInPlace() {
 
   // https://hyperelliptic.org/EFD/g1p/auto-shortw-xyzz.html#doubling-dbl-2008-s-1
   // U = 2 * Y1
-  BaseField u = y_;
-  u.DoubleInPlace();
+  BaseField u = y_.Double();
 
   // V = U²
-  BaseField v = u;
-  v.SquareInPlace();
+  BaseField v = u.Square();
 
   // W = U * V
-  BaseField w = std::move(u);
-  w *= v;
+  BaseField w = u * v;
 
   // S = X1 * V
-  BaseField s = x_;
-  s *= v;
+  BaseField s = x_ * v;
 
   // M = 3 * X1² + a * ZZ1²
-  BaseField m = std::move(x_);
-  m.SquareInPlace();
+  BaseField m = x_.Square();
   m += m.Double();
   if constexpr (!Curve::Config::kAIsZero) {
     m += Curve::Config::MulByA(zz_.Square());
   }
 
   // X3 = M² - 2 * S
-  x_ = m;
-  x_.SquareInPlace();
+  x_ = m.Square();
   x_ -= s.Double();
 
   // Y3 = M * (S - X3) - W * Y1

--- a/tachyon/math/elliptic_curves/short_weierstrass/projective_point_impl.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/projective_point_impl.h
@@ -22,25 +22,20 @@ constexpr CLASS& CLASS::AddInPlace(const ProjectivePoint& other) {
 
   // http://www.hyperelliptic.org/EFD/g1p/auto-shortw-projective.html#addition-add-1998-cmo-2
   // Y1Z2 = Y1 * Z2
-  BaseField y1z2 = y_;
-  y1z2 *= other.z_;
+  BaseField y1z2 = y_ * other.z_;
 
   // X1Z2 = X1 * Z2
-  BaseField x1z2 = x_;
-  x1z2 *= other.z_;
+  BaseField x1z2 = x_ * other.z_;
 
   // Z1Z2 = Z1 * Z2
-  BaseField z1z2 = z_;
-  z1z2 *= other.z_;
+  BaseField z1z2 = z_ * other.z_;
 
   // u = Y2 * Z1 - Y1Z2
-  BaseField u = other.y_;
-  u *= z_;
+  BaseField u = other.y_ * z_;
   u -= y1z2;
 
   // v = X2 * Z1 - X1Z2
-  BaseField v = other.x_;
-  v *= z_;
+  BaseField v = other.x_ * z_;
   v -= x1z2;
 
   if (u.IsZero() && v.IsZero()) {
@@ -48,30 +43,24 @@ constexpr CLASS& CLASS::AddInPlace(const ProjectivePoint& other) {
   }
 
   // uu = u²
-  BaseField uu = u;
-  uu.SquareInPlace();
+  BaseField uu = u.Square();
 
   // vv = v²
-  BaseField vv = v;
-  vv.SquareInPlace();
+  BaseField vv = v.Square();
 
   // vvv = v * vv
-  BaseField vvv = v;
-  vvv *= vv;
+  BaseField vvv = v * vv;
 
   // R = vv * X1Z2
-  BaseField r = std::move(vv);
-  r *= x1z2;
+  BaseField r = vv * x1z2;
 
   // A = uu * Z1Z2 - vvv - 2 * R
-  BaseField a = std::move(uu);
-  a *= z1z2;
+  BaseField a = uu * z1z2;
   a -= vvv;
   a -= r.Double();
 
   // X3 = v * A
-  x_ = std::move(v);
-  x_ *= a;
+  x_ = v * a;
 
   // Y3 = u * (R - A) - vvv * Y1Z2
   BaseField lefts[] = {std::move(u), -vvv};
@@ -79,8 +68,7 @@ constexpr CLASS& CLASS::AddInPlace(const ProjectivePoint& other) {
   y_ = BaseField::SumOfProductsSerial(lefts, rights);
 
   // Z3 = vvv * Z1Z2
-  z_ = std::move(vvv);
-  z_ *= z1z2;
+  z_ = vvv * z1z2;
 
   return *this;
 }
@@ -97,13 +85,11 @@ constexpr CLASS& CLASS::AddInPlace(const AffinePoint<Curve>& other) {
 
   // http://www.hyperelliptic.org/EFD/g1p/auto-shortw-projective.html#addition-madd-1998-cmo
   // u = Y2 * Z1 - Y1
-  BaseField u = other.y();
-  u *= z_;
+  BaseField u = other.y() * z_;
   u -= y_;
 
   // v = X2 * Z1 - X1
-  BaseField v = other.x();
-  v *= z_;
+  BaseField v = other.x() * z_;
   v -= x_;
 
   if (u.IsZero() && v.IsZero()) {
@@ -111,30 +97,24 @@ constexpr CLASS& CLASS::AddInPlace(const AffinePoint<Curve>& other) {
   }
 
   // uu = u²
-  BaseField uu = u;
-  uu.SquareInPlace();
+  BaseField uu = u.Square();
 
   // vv = v²
-  BaseField vv = v;
-  vv.SquareInPlace();
+  BaseField vv = v.Square();
 
   // vvv = v * vv
-  BaseField vvv = v;
-  vvv *= vv;
+  BaseField vvv = v * vv;
 
   // R = vv * X1
-  BaseField r = std::move(vv);
-  r *= x_;
+  BaseField r = vv * x_;
 
   // A = uu * Z1 - vvv - 2 * R
-  BaseField a = std::move(uu);
-  a *= z_;
+  BaseField a = uu * z_;
   a -= vvv;
   a -= r.Double();
 
   // X3 = v * A
-  x_ = std::move(v);
-  x_ *= a;
+  x_ = v * a;
 
   // Y3 = u * (R - A) - vvv * Y1
   BaseField lefts[] = {std::move(u), -vvv};
@@ -155,60 +135,49 @@ constexpr CLASS& CLASS::DoubleInPlace() {
 
   // https://hyperelliptic.org/EFD/g1p/auto-shortw-projective.html#doubling-dbl-2007-bl
   // XX = X1²
-  BaseField xx = x_;
-  xx.SquareInPlace();
+  BaseField xx = x_.Square();
 
   // ZZ = Z1²
-  BaseField zz = z_;
-  zz.SquareInPlace();
+  BaseField zz = z_.Square();
 
   // w = a * ZZ + 3 * XX
-  BaseField w = xx;
-  w += w.Double();
+  BaseField w = xx.Double();
+  w += xx;
   if constexpr (!Curve::Config::kAIsZero) {
     w += Curve::Config::MulByA(zz);
   }
 
   // s = 2 * Y1 * Z1
-  BaseField s = y_;
-  s *= z_;
+  BaseField s = y_ * z_;
   s.DoubleInPlace();
 
   // ss = s²
-  BaseField ss = s;
-  ss.SquareInPlace();
+  BaseField ss = s.Square();
 
   // sss = s * ss
-  BaseField sss = s;
-  sss *= ss;
+  BaseField sss = s * ss;
 
   // R = Y1 * s
-  BaseField r = y_;
-  r *= s;
+  BaseField r = y_ * s;
 
   // RR = R²
-  BaseField rr = r;
-  rr.SquareInPlace();
+  BaseField rr = r.Square();
 
   // B = (X1 + R)² - XX - RR
-  BaseField b = x_;
-  b += r;
+  BaseField b = x_ + r;
   b.SquareInPlace();
   b -= xx;
   b -= rr;
 
   // h = w² - 2 * B
-  BaseField h = w;
-  h.SquareInPlace();
+  BaseField h = w.Square();
   h -= b.Double();
 
   // X3 = h * s
-  x_ = std::move(s);
-  x_ *= h;
+  x_ = h * s;
 
   // Y3 = w * (B - h) - 2 * RR
-  y_ = std::move(b);
-  y_ -= h;
+  y_ = b - h;
   y_ *= w;
   y_ -= rr.Double();
 

--- a/tachyon/math/finite_fields/fp12.h
+++ b/tachyon/math/finite_fields/fp12.h
@@ -255,9 +255,6 @@ class Fp12 final : public QuadraticExtensionField<Fp12<Config>> {
     //   = (α₃β₃ + α₅β₄q) + (α₃β₄ + α₄β₃)x + (α₄β₄ + α₅β₃)x², where q = x³
     Fp6 b = this->c1_;
     b.MulInPlaceBy01(beta3, beta4);
-    // o = β₀ + β₃
-    Fp2 o = beta0;
-    o += beta3;
 
     // c1 = (α₀ + α₃) + (α₁ + α₄)x + (α₂ + α₅)x²
     this->c1_ += this->c0_;
@@ -271,7 +268,7 @@ class Fp12 final : public QuadraticExtensionField<Fp12<Config>> {
     //    = (α₀β₀ + α₀β₃ + α₂β₄q + α₃β₀ + α₃β₃ + α₅β₄q) +
     //      (α₀β₄ + α₁β₀ + α₁β₃ + α₃β₄ + α₄β₀ + α₄β₃)x +
     //      (α₁β₄ + α₂β₀ + α₂β₃ + α₄β₄ + α₅β₀ + α₅β₃)x², where q = x³
-    this->c1_.MulInPlaceBy01(o, beta4);
+    this->c1_.MulInPlaceBy01(beta0 + beta3, beta4);
     // c1 = (α₀β₃ + α₂β₄q + α₃β₀ + α₃β₃ + α₅β₄q) +
     //      (α₀β₄ + α₁β₃ + α₃β₄ + α₄β₀ + α₄β₃)x +
     //      (α₁β₄ + α₂β₃ + α₄β₄ + α₅β₀ + α₅β₃)x², where q = x³
@@ -314,9 +311,6 @@ class Fp12 final : public QuadraticExtensionField<Fp12<Config>> {
     //   = α₅β₄q + α₃β₄x + α₄β₄x²
     Fp6 b = this->c1_;
     b.MulInPlaceBy1(beta4);
-    // o = β₁ + β₄
-    Fp2 o = beta1;
-    o += beta4;
 
     // c1 = (α₀ + α₃) + (α₁ + α₄)x + (α₂ + α₅)x²
     this->c1_ += this->c0_;
@@ -330,7 +324,7 @@ class Fp12 final : public QuadraticExtensionField<Fp12<Config>> {
     //    = (α₀β₀ + α₂β₁q + α₂β₄q + α₃β₀ + α₅β₁q + α₅β₄q) +
     //      (α₀β₁ + α₀β₄ + α₁β₀ + α₃β₁ + α₃β₄ + α₄β₀)x +
     //      (α₁β₁ + α₁β₄ + α₂β₀ + α₄β₁ + α₄β₄ + α₅β₀)x², where q = x³
-    this->c1_.MulInPlaceBy01(beta0, o);
+    this->c1_.MulInPlaceBy01(beta0, beta1 + beta4);
     // c1 = (α₂β₄q + α₃β₀ + α₅β₁q + α₅β₄q) +
     //      (α₀β₄ + α₃β₁ + α₃β₄ + α₄β₀)x +
     //      (α₁β₄ + α₄β₁ + α₄β₄ + α₅β₀)x², where q = x³

--- a/tachyon/math/finite_fields/fp6.h
+++ b/tachyon/math/finite_fields/fp6.h
@@ -315,29 +315,15 @@ class Fp6<Config, std::enable_if_t<Config::kDegreeOverBaseField == 3>> final
     // α = (α₀ + α₁x + α₂x²) * β₁x
     //   = α₂β₁q + α₀β₁x + α₁β₁x², where q is a cubic non residue.
 
-    // t0 = α₂
-    Fp2 t0 = this->c2_;
     // t0 = α₂β₁
-    t0 *= beta1;
-    // t0 = α₂β₁q
-    t0 = Config::MulByNonResidue(t0);
+    Fp2 t0 = this->c2_ * beta1;
 
-    // t1 = α₀
-    Fp2 t1 = this->c0_;
-    // t1 = α₀β₁
-    t1 *= beta1;
-
-    // t2 = α₁
-    Fp2 t2 = this->c1_;
-    // t2 = α₁β₁
-    t2 *= beta1;
-
-    // c0 = α₂β₁q
-    this->c0_ = std::move(t0);
-    // c1 = α₀β₁
-    this->c1_ = std::move(t1);
     // c2 = α₁β₁
-    this->c2_ = std::move(t2);
+    this->c2_ = this->c1_ * beta1;
+    // c1 = α₀β₁
+    this->c1_ = this->c0_ * beta1;
+    // c0 = α₂β₁q
+    this->c0_ = Config::MulByNonResidue(t0);
     return *this;
   }
 
@@ -351,21 +337,17 @@ class Fp6<Config, std::enable_if_t<Config::kDegreeOverBaseField == 3>> final
     // optimized to multiply 5 times.
 
     // a_a = α₀β₀
-    Fp2 a_a = this->c0_;
-    a_a *= beta0;
+    Fp2 a_a = this->c0_ * beta0;
     // b_b = α₁β₁
-    Fp2 b_b = this->c1_;
-    b_b *= beta1;
+    Fp2 b_b = this->c1_ * beta1;
 
-    // t0 = β₁
-    Fp2 t0 = beta1;
+    Fp2 t0;
     {
       // tmp = α₁ + α₂
-      Fp2 tmp = this->c1_;
-      tmp += this->c2_;
+      Fp2 tmp = this->c1_ + this->c2_;
 
       // t0 = (α₁ + α₂)β₁ = α₁β₁ + α₂β₁
-      t0 *= tmp;
+      t0 = tmp * beta1;
       // t0 = α₂β₁
       t0 -= b_b;
       // t0 = α₂β₁q
@@ -374,14 +356,11 @@ class Fp6<Config, std::enable_if_t<Config::kDegreeOverBaseField == 3>> final
       t0 += a_a;
     }
 
-    // t1 = β₀
-    Fp2 t1 = beta0;
     // t1 = β₀ + β₁
-    t1 += beta1;
+    Fp2 t1 = beta0 + beta1;
     {
       // tmp = α₀ + α₁
-      Fp2 tmp = this->c0_;
-      tmp += this->c1_;
+      Fp2 tmp = this->c0_ + this->c1_;
 
       // t1 = (α₀ + α₁)(β₀ + β₁) = α₀β₀ + α₀β₁ + α₁β₀ + α₁β₁
       t1 *= tmp;
@@ -392,14 +371,13 @@ class Fp6<Config, std::enable_if_t<Config::kDegreeOverBaseField == 3>> final
     }
 
     // t2 = β₀
-    Fp2 t2 = beta0;
+    Fp2 t2;
     {
       // tmp = α₀ + α₂
-      Fp2 tmp = this->c0_;
-      tmp += this->c2_;
+      Fp2 tmp = this->c0_ + this->c2_;
 
       // t2 = (α₀ + α₂)β₀ = α₀β₀ + α₂β₀
-      t2 *= tmp;
+      t2 = tmp * beta0;
       // t2 = α₂β₀
       t2 -= a_a;
       // t2 = α₂β₀ + α₁β₁

--- a/tachyon/math/finite_fields/prime_field_util.cc
+++ b/tachyon/math/finite_fields/prime_field_util.cc
@@ -12,7 +12,7 @@ uint32_t ComputeAdicity(uint32_t k, mpz_class n) {
   uint32_t adicity = 0;
   while (n > 1) {
     if (n % k == 0) {
-      adicity += 1;
+      ++adicity;
       n /= k;
     } else {
       break;

--- a/tachyon/math/finite_fields/quadratic_extension_field.h
+++ b/tachyon/math/finite_fields/quadratic_extension_field.h
@@ -213,8 +213,7 @@ class QuadraticExtensionField
     // When q = -1, we can re-use intermediate additions to improve performance.
 
     // v0 = c0 - c1
-    BaseField v0 = c0_;
-    v0 -= c1_;
+    BaseField v0 = c0_ - c1_;
     // v1 = c0 * c1
     BaseField v1 = c0_ * c1_;
     if constexpr (Config::kNonResidueIsMinusOne) {
@@ -243,8 +242,7 @@ class QuadraticExtensionField
       // c0 = v0 + (q + 1) * c0 * c1
       // c0 = c0² + c1² * q - (q + 1) * c0 * c1 + (q + 1) * c0 * c1
       // c0 = c0² + c1² * q
-      c0_ = std::move(v0);
-      c0_ += v1;
+      c0_ = v0 + v1;
       c0_ += Config::MulByNonResidue(v1);
       // c1 = 2 * c0 * c1
       c1_ = v1.Double();

--- a/tachyon/math/polynomials/univariate/mixed_radix_evaluation_domain.h
+++ b/tachyon/math/polynomials/univariate/mixed_radix_evaluation_domain.h
@@ -158,7 +158,7 @@ class MixedRadixEvaluationDomain
       uint32_t two_adicity = 0;
       while (r < min_size) {
         r *= 2;
-        two_adicity += 1;
+        ++two_adicity;
       }
       if (two_adicity <= F::Config::kTwoAdicity) {
         best = std::min(best, r);

--- a/tachyon/math/polynomials/univariate/mixed_radix_evaluation_domain.h
+++ b/tachyon/math/polynomials/univariate/mixed_radix_evaluation_domain.h
@@ -249,8 +249,7 @@ class MixedRadixEvaluationDomain
             for (size_t i = 0; i < q; ++i) {
               a.at(k + j + i * m) = base_term;
               for (size_t l = 1; l < q; ++l) {
-                F tmp = terms[l - 1];
-                tmp *= qth_roots[(i * l) % q];
+                F tmp = terms[l - 1] * qth_roots[(i * l) % q];
                 a.at(k + j + i * m) += tmp;
               }
             }
@@ -348,10 +347,9 @@ class MixedRadixEvaluationDomain
           size_t idx = i + (c * coset_size);
           // t = the value of a corresponding to the ith element of
           // the sth coset.
-          F t = a[idx];
-          // elt = g^{k * idx}
-          t *= elt;
+          F t = a[idx] * elt;
           kth_poly_coeffs.at(i) += t;
+          // elt = g^{k * idx}
           elt *= omega_step;
         }
         elt *= omega_k;

--- a/tachyon/math/polynomials/univariate/univariate_dense_coefficients.h
+++ b/tachyon/math/polynomials/univariate/univariate_dense_coefficients.h
@@ -175,12 +175,10 @@ class UnivariateDenseCoefficients {
     std::vector<F> coefficients((size + 1) >> 1);
     OPENMP_PARALLEL_FOR(size_t i = 0; i < size; i += 2) {
       if constexpr (MulRandomWithEvens) {
-        coefficients[i >> 1] = coefficients_[i];
-        coefficients[i >> 1] *= r;
+        coefficients[i >> 1] = coefficients_[i] * r;
         coefficients[i >> 1] += coefficients_[i + 1];
       } else {
-        coefficients[i >> 1] = coefficients_[i + 1];
-        coefficients[i >> 1] *= r;
+        coefficients[i >> 1] = coefficients_[i + 1] * r;
         coefficients[i >> 1] += coefficients_[i];
       }
     }
@@ -248,9 +246,8 @@ class UnivariateDenseCoefficients {
     std::vector<F> results = base::ParallelizeMap(
         coefficients_, [&point](absl::Span<const F> chunk, size_t chunk_offset,
                                 size_t chunk_size) {
-          F result = HornerEvaluate(chunk, point);
-          result *= point.Pow(chunk_offset * chunk_size);
-          return result;
+          return HornerEvaluate(chunk, point) *
+                 point.Pow(chunk_offset * chunk_size);
         });
     return std::accumulate(results.begin(), results.end(), F::Zero(),
                            std::plus<>());

--- a/tachyon/math/polynomials/univariate/univariate_evaluation_domain.h
+++ b/tachyon/math/polynomials/univariate/univariate_evaluation_domain.h
@@ -413,13 +413,11 @@ class UnivariateEvaluationDomain : public EvaluationDomain<F, MaxDegree> {
   // Note that the coefficients are in order and evaluations are out of order(should be swapped after).
   // clang-format on
   constexpr static void ButterflyFnInOut(F& lo, F& hi, const F& root) {
-    F neg = lo;
-    neg -= hi;
+    F neg = lo - hi;
 
     lo += hi;
 
-    hi = std::move(neg);
-    hi *= root;
+    hi = neg * root;
   }
 
   // See https://en.wikipedia.org/wiki/Butterfly_diagram
@@ -456,8 +454,7 @@ class UnivariateEvaluationDomain : public EvaluationDomain<F, MaxDegree> {
   constexpr static void ButterflyFnOutIn(F& lo, F& hi, const F& root) {
     hi *= root;
 
-    F neg = lo;
-    neg -= hi;
+    F neg = lo - hi;
 
     lo += hi;
 

--- a/tachyon/zk/plonk/constraint_system/constraint_system.h
+++ b/tachyon/zk/plonk/constraint_system/constraint_system.h
@@ -192,7 +192,7 @@ class ConstraintSystem {
 
     // Make a new query
     advice_queries_.emplace_back(at, column);
-    num_advice_queries_[column.index()] += 1;
+    ++num_advice_queries_[column.index()];
     return advice_queries_.size() - 1;
   }
 

--- a/tachyon/zk/r1cs/constraint_system/quadratic_arithmetic_program.h
+++ b/tachyon/zk/r1cs/constraint_system/quadratic_arithmetic_program.h
@@ -196,8 +196,7 @@ class QuadraticArithmeticProgram {
       F x_i = x.Pow(i);
       for (F& v : chunk) {
         // (xⁱ * t(x)) / δ
-        v = x_i;
-        v *= t_x;
+        v = x_i * t_x;
         v *= delta_inverse;
         x_i *= x;
       }

--- a/tachyon/zk/r1cs/groth16/prove.h
+++ b/tachyon/zk/r1cs/groth16/prove.h
@@ -30,8 +30,7 @@ Bucket CalculateCoeff(const Bucket& initial,
   Bucket acc;
   CHECK(msm.Run(query.subspan(1), assignments, &acc));
 
-  Bucket ret = initial;
-  ret += query[0];
+  Bucket ret = initial + query[0];
   ret += acc;
   ret += vk_param;
   return ret;


### PR DESCRIPTION
# Description

This commit enhances performance by utilizing the `c = a op b` style instead of `c = a; c inplace-op b`. While the former style is nearly as performant as the latter when `a` is movable, it becomes inefficient when operating on prime fields or points on elliptic curves that are not able to be moved. This change ensures better performance and readability, reducing 2 lines to 1. Note that irrelevant changes may occur due to this adjustment.
