### PR TITLE
test(zk): enable `SelectorReplacerTest.Selector` test on optimization mode

### DIFF
--- a/tachyon/zk/expressions/evaluator/selector_replacer_unittest.cc
+++ b/tachyon/zk/expressions/evaluator/selector_replacer_unittest.cc
@@ -29,7 +29,7 @@ TEST_F(SelectorReplacerTest, Selector) {
   replacements.emplace_back(owned_replacements[0].get());
   replacements.emplace_back(owned_replacements[1].get());
 
-  EXPECT_DEATH(expr->ReplaceSelectors(replacements, true), "");
+  EXPECT_DEBUG_DEATH(expr->ReplaceSelectors(replacements, true), "");
   EXPECT_EQ(*expr->ReplaceSelectors(replacements, false), *replacements[1]);
 
   expr = ExpressionFactory<GF7>::Selector(plonk::Selector::Complex(1));


### PR DESCRIPTION
# Description

`ReplaceSelectors()` only crashes only when compiled with debug mode, so this commit enables it using `EXPECT_DEBUG_DEATH`.

```c++
template <typename F>
class SelectorsReplacer : public Evaluator<F, std::unique_ptr<Expression<F>>> {
  std::unique_ptr<Expression<F>> Evaluate(const Expression<F>* input) override {

          if (selector.is_simple()) {
            LOG(DFATAL) << "Simple selector found in lookup argument";
          }
  }
```