### PR TITLE
fix: change compile option `maxvx512f` to `mavx2` for goldilocks

### DIFF
--- a/third_party/goldilocks/goldilocks.BUILD
+++ b/third_party/goldilocks/goldilocks.BUILD
@@ -15,7 +15,7 @@ cc_library(
         "src/goldilocks_base_field_scalar.hpp",
         "src/goldilocks_base_field_tools.hpp",
     ],
-    copts = ["-mavx512f"],
+    copts = ["-mavx2"],
     include_prefix = "third_party/goldilocks/include",
     includes = ["src"],
     strip_include_prefix = "src",


### PR DESCRIPTION
# Description

This is to resolve a runtime error of Goldilocks when building with g++-12 and optimization mode.

Plus, if we want to build with avx512, we need to add `defines = ["__AVX512__"]`, too.

See
https://github.com/0xPolygonHermez/zkevm-prover/blob/93c36f120c3201bfaf12b8f6f2796f53e72193ff/Makefile#L31-L37 for more details.
