### PR TITLE
fix: fix gcc-13 compile errors

### DIFF
--- a/benchmark/ec/simple_ec_benchmark_reporter.h
+++ b/benchmark/ec/simple_ec_benchmark_reporter.h
@@ -1,6 +1,8 @@
 #ifndef BENCHMARK_EC_SIMPLE_EC_BENCHMARK_REPORTER_H_
 #define BENCHMARK_EC_SIMPLE_EC_BENCHMARK_REPORTER_H_
 
+#include <stdint.h>
+
 #include <vector>
 
 #include "benchmark/simple_benchmark_reporter.h"

--- a/benchmark/fft/simple_fft_benchmark_reporter.h
+++ b/benchmark/fft/simple_fft_benchmark_reporter.h
@@ -1,6 +1,8 @@
 #ifndef BENCHMARK_FFT_SIMPLE_FFT_BENCHMARK_REPORTER_H_
 #define BENCHMARK_FFT_SIMPLE_FFT_BENCHMARK_REPORTER_H_
 
+#include <stdint.h>
+
 #include <vector>
 
 #include "benchmark/simple_benchmark_reporter.h"

--- a/benchmark/msm/simple_msm_benchmark_reporter.h
+++ b/benchmark/msm/simple_msm_benchmark_reporter.h
@@ -1,6 +1,8 @@
 #ifndef BENCHMARK_MSM_SIMPLE_MSM_BENCHMARK_REPORTER_H_
 #define BENCHMARK_MSM_SIMPLE_MSM_BENCHMARK_REPORTER_H_
 
+#include <stdint.h>
+
 #include <vector>
 
 #include "benchmark/simple_benchmark_reporter.h"

--- a/tachyon/base/console/table_writer.h
+++ b/tachyon/base/console/table_writer.h
@@ -2,6 +2,7 @@
 #define TACHYON_BASE_CONSOLE_TABLE_WRITER_H_
 
 #include <stddef.h>
+#include <stdint.h>
 
 #include <ostream>
 #include <string>

--- a/tachyon/device/gpu/gpu_util.h
+++ b/tachyon/device/gpu/gpu_util.h
@@ -5,6 +5,8 @@
 #ifndef TACHYON_DEVICE_GPU_GPU_UTIL_H_
 #define TACHYON_DEVICE_GPU_GPU_UTIL_H_
 
+#include <stdint.h>
+
 #include <string>
 
 #include "tachyon/build/build_config.h"


### PR DESCRIPTION
Fixes compile errors with gcc/++-13 when running `bazel build --config linux`.
Refer to [Header dependency changes](https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes) for more information.