### PR TITLE
perf: avoid copying on semigroup operations

### DIFF
--- a/tachyon/math/base/big_int.h
+++ b/tachyon/math/base/big_int.h
@@ -430,12 +430,12 @@ struct ALIGNAS(internal::LimbsAlignment(N)) BigInt {
     return *this;
   }
 
-  constexpr BigInt Add(const BigInt& other) {
+  constexpr BigInt Add(const BigInt& other) const {
     uint64_t unused = 0;
     return Add(other, unused);
   }
 
-  constexpr BigInt Add(const BigInt& other, uint64_t& carry) {
+  constexpr BigInt Add(const BigInt& other, uint64_t& carry) const {
     BigInt ret;
     DoAdd(*this, other, carry, ret);
     return ret;

--- a/tachyon/math/base/big_int.h
+++ b/tachyon/math/base/big_int.h
@@ -472,19 +472,24 @@ struct ALIGNAS(internal::LimbsAlignment(N)) BigInt {
     return *this;
   }
 
+  constexpr BigInt MulBy2() const {
+    uint64_t unused = 0;
+    return MulBy2(unused);
+  }
+
+  constexpr BigInt MulBy2(uint64_t& carry) const {
+    BigInt ret;
+    DoMulBy2(*this, carry, ret);
+    return ret;
+  }
+
   constexpr BigInt& MulBy2InPlace() {
     uint64_t unused = 0;
     return MulBy2InPlace(unused);
   }
 
   constexpr BigInt& MulBy2InPlace(uint64_t& carry) {
-    carry = 0;
-    FOR_FROM_SMALLEST(i, 0, N) {
-      uint64_t temp = limbs[i] >> 63;
-      limbs[i] <<= 1;
-      limbs[i] |= carry;
-      carry = temp;
-    }
+    DoMulBy2(*this, carry, *this);
     return *this;
   }
 
@@ -857,6 +862,15 @@ struct ALIGNAS(internal::LimbsAlignment(N)) BigInt {
       c[i] = result.result;
     }
     borrow = result.borrow;
+  }
+
+  constexpr static void DoMulBy2(const BigInt& a, uint64_t& carry, BigInt& b) {
+    FOR_FROM_SMALLEST(i, 0, N) {
+      uint64_t temp = a[i] >> 63;
+      b[i] = a[i] << 1;
+      b[i] |= carry;
+      carry = temp;
+    }
   }
 
   template <typename T>

--- a/tachyon/math/base/rational_field.h
+++ b/tachyon/math/base/rational_field.h
@@ -115,7 +115,11 @@ class RationalField : public Field<RationalField<F>> {
     return *this;
   }
 
-  constexpr RationalField& DoubleInPlace() {
+  constexpr RationalField DoDouble() const {
+    return {numerator_.Double(), denominator_};
+  }
+
+  constexpr RationalField& DoDoubleInPlace() {
     numerator_.DoubleInPlace();
     return *this;
   }

--- a/tachyon/math/base/rational_field.h
+++ b/tachyon/math/base/rational_field.h
@@ -149,7 +149,11 @@ class RationalField : public Field<RationalField<F>> {
     return *this;
   }
 
-  constexpr RationalField& SquareInPlace() {
+  constexpr RationalField Square() const {
+    return {numerator_.Square(), denominator_.Square()};
+  }
+
+  constexpr RationalField& DoSquareInPlace() {
     numerator_.SquareInPlace();
     denominator_.SquareInPlace();
     return *this;

--- a/tachyon/math/base/semigroups.h
+++ b/tachyon/math/base/semigroups.h
@@ -158,10 +158,8 @@ class MultiplicativeSemigroup {
   [[nodiscard]] constexpr auto Pow(const Scalar& scalar) const {
     if constexpr (std::is_constructible_v<BigInt<1>, Scalar>) {
       return DoPow(BigInt<1>(scalar));
-    } else if constexpr (internal::SupportsToBigInt<Scalar>::value) {
-      return DoPow(scalar.ToBigInt());
     } else {
-      static_assert(base::AlwaysFalse<G>);
+      return DoPow(scalar.ToBigInt());
     }
   }
 
@@ -291,10 +289,8 @@ class AdditiveSemigroup {
   [[nodiscard]] constexpr auto ScalarMul(const Scalar& scalar) const {
     if constexpr (std::is_constructible_v<BigInt<1>, Scalar>) {
       return DoScalarMul(BigInt<1>(scalar));
-    } else if constexpr (internal::SupportsToBigInt<Scalar>::value) {
-      return DoScalarMul(scalar.ToBigInt());
     } else {
-      static_assert(base::AlwaysFalse<G>);
+      return DoScalarMul(scalar.ToBigInt());
     }
   }
 
@@ -325,10 +321,8 @@ class AdditiveSemigroup {
       return MultiScalarMulMSMB(scalar_or_scalars, base_or_bases, outputs);
     } else if constexpr (internal::SupportsSize<ScalarOrScalars>::value) {
       return MultiScalarMulMSSB(scalar_or_scalars, base_or_bases, outputs);
-    } else if constexpr (internal::SupportsSize<BaseOrBases>::value) {
-      return MultiScalarMulSSMB(scalar_or_scalars, base_or_bases, outputs);
     } else {
-      static_assert(base::AlwaysFalse<G>);
+      return MultiScalarMulSSMB(scalar_or_scalars, base_or_bases, outputs);
     }
   }
 

--- a/tachyon/math/base/semigroups.h
+++ b/tachyon/math/base/semigroups.h
@@ -92,18 +92,11 @@ class MultiplicativeSemigroup {
       typename internal::MultiplicativeSemigroupTraits<G>::ReturnTy;
 
   // Multiplication: a * b
-  template <
-      typename G2,
-      std::enable_if_t<internal::SupportsMul<G, G2>::value ||
-                       internal::SupportsMulInPlace<G, G2>::value>* = nullptr>
+  template <typename G2,
+            std::enable_if_t<internal::SupportsMul<G, G2>::value>* = nullptr>
   constexpr auto operator*(const G2& other) const {
-    if constexpr (internal::SupportsMul<G, G2>::value) {
-      const G* g = static_cast<const G*>(this);
-      return g->Mul(other);
-    } else {
-      G g = *static_cast<const G*>(this);
-      return g.MulInPlace(other);
-    }
+    const G* g = static_cast<const G*>(this);
+    return g->Mul(other);
   }
 
   // Multiplication in place: a *= b

--- a/tachyon/math/base/semigroups.h
+++ b/tachyon/math/base/semigroups.h
@@ -209,18 +209,11 @@ class AdditiveSemigroup {
   using AddResult = typename internal::AdditiveSemigroupTraits<G>::ReturnTy;
 
   // Addition: a + b
-  template <
-      typename G2,
-      std::enable_if_t<internal::SupportsAdd<G, G2>::value ||
-                       internal::SupportsAddInPlace<G, G2>::value>* = nullptr>
+  template <typename G2,
+            std::enable_if_t<internal::SupportsAdd<G, G2>::value>* = nullptr>
   constexpr auto operator+(const G2& other) const {
-    if constexpr (internal::SupportsAdd<G, G2>::value) {
-      const G* g = static_cast<const G*>(this);
-      return g->Add(other);
-    } else {
-      G g = *static_cast<const G*>(this);
-      return g.AddInPlace(other);
-    }
+    const G* g = static_cast<const G*>(this);
+    return g->Add(other);
   }
 
   // Addition in place: a += b

--- a/tachyon/math/elliptic_curves/short_weierstrass/jacobian_point.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/jacobian_point.h
@@ -261,7 +261,9 @@ class JacobianPoint<
   }
 
   // AdditiveSemigroup methods
+  constexpr JacobianPoint Add(const JacobianPoint& other) const;
   constexpr JacobianPoint& AddInPlace(const JacobianPoint& other);
+  constexpr JacobianPoint Add(const AffinePoint<Curve>& other) const;
   constexpr JacobianPoint& AddInPlace(const AffinePoint<Curve>& other);
   constexpr JacobianPoint& DoubleInPlace();
 
@@ -279,6 +281,11 @@ class JacobianPoint<
   }
 
  private:
+  constexpr static void DoAdd(const JacobianPoint& a, const JacobianPoint& b,
+                              JacobianPoint& c);
+  constexpr static void DoAdd(const JacobianPoint& a,
+                              const AffinePoint<Curve>& b, JacobianPoint& c);
+
   BaseField x_;
   BaseField y_;
   BaseField z_;

--- a/tachyon/math/elliptic_curves/short_weierstrass/jacobian_point.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/jacobian_point.h
@@ -265,7 +265,8 @@ class JacobianPoint<
   constexpr JacobianPoint& AddInPlace(const JacobianPoint& other);
   constexpr JacobianPoint Add(const AffinePoint<Curve>& other) const;
   constexpr JacobianPoint& AddInPlace(const AffinePoint<Curve>& other);
-  constexpr JacobianPoint& DoubleInPlace();
+  constexpr JacobianPoint DoDouble() const;
+  constexpr JacobianPoint& DoDoubleInPlace();
 
   // AdditiveGroup methods
   constexpr JacobianPoint& NegInPlace() {
@@ -285,6 +286,7 @@ class JacobianPoint<
                               JacobianPoint& c);
   constexpr static void DoAdd(const JacobianPoint& a,
                               const AffinePoint<Curve>& b, JacobianPoint& c);
+  constexpr static void DoDoubleImpl(const JacobianPoint& a, JacobianPoint& b);
 
   BaseField x_;
   BaseField y_;

--- a/tachyon/math/elliptic_curves/short_weierstrass/jacobian_point_impl.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/jacobian_point_impl.h
@@ -12,6 +12,21 @@ namespace tachyon::math {
       Curve, std::enable_if_t<Curve::kType == CurveType::kShortWeierstrass>>
 
 template <typename Curve>
+constexpr CLASS CLASS::Add(const JacobianPoint& other) const {
+  if (IsZero()) {
+    return other;
+  }
+
+  if (other.IsZero()) {
+    return *this;
+  }
+
+  JacobianPoint ret;
+  DoAdd(*this, other, ret);
+  return ret;
+}
+
+template <typename Curve>
 constexpr CLASS& CLASS::AddInPlace(const JacobianPoint& other) {
   if (IsZero()) {
     return *this = other;
@@ -21,32 +36,44 @@ constexpr CLASS& CLASS::AddInPlace(const JacobianPoint& other) {
     return *this;
   }
 
+  DoAdd(*this, other, *this);
+  return *this;
+}
+
+// static
+template <typename Curve>
+constexpr void CLASS::DoAdd(const JacobianPoint& a, const JacobianPoint& b,
+                            JacobianPoint& c) {
   // http://www.hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-0.html#addition-add-2007-bl
   // Z1Z1 = Z1²
-  BaseField z1z1 = z_.Square();
+  BaseField z1z1 = a.z_.Square();
 
   // Z2Z2 = Z2²
-  BaseField z2z2 = other.z_.Square();
+  BaseField z2z2 = b.z_.Square();
 
   // U1 = X1 * Z2Z2
-  BaseField u1 = x_ * z2z2;
+  BaseField u1 = a.x_ * z2z2;
 
   // U2 = X2 * Z1Z1
-  BaseField u2 = other.x_ * z1z1;
+  BaseField u2 = b.x_ * z1z1;
 
   // S1 = Y1 * Z2 * Z2Z2
-  BaseField s1 = y_ * other.z_;
+  BaseField s1 = a.y_ * b.z_;
   s1 *= z2z2;
 
   // S2 = Y2 * Z1 * Z1Z1
-  BaseField s2 = other.y_ * z_;
+  BaseField s2 = b.y_ * a.z_;
   s2 *= z1z1;
 
   if (u1 == u2 && s1 == s2) {
     // The two points are equal, so we Double.
-    DoubleInPlace();
+    if (&a == &c) {
+      c.DoubleInPlace();
+    } else {
+      c = a.Double();
+    }
   } else {
-    // If we're adding -a and a together, z_ becomes zero as H becomes zero.
+    // If we're adding -a and a together, c.z_ becomes zero as H becomes zero.
 
     // H = U2 - U1
     BaseField h = u2 - u1;
@@ -67,24 +94,34 @@ constexpr CLASS& CLASS::AddInPlace(const JacobianPoint& other) {
     BaseField v = u1 * i;
 
     // X3 = r² + J - 2 * V
-    x_ = r.Square();
-    x_ += j;
-    x_ -= v.Double();
+    c.x_ = r.Square();
+    c.x_ += j;
+    c.x_ -= v.Double();
 
     // Y3 = r * (V - X3) + 2 * S1 * J
-    y_ = s1.Double();
-    BaseField lefts[] = {std::move(r), y_};
-    BaseField rights[] = {v - x_, std::move(j)};
-    y_ = BaseField::SumOfProductsSerial(lefts, rights);
+    BaseField lefts[] = {std::move(r), s1.Double()};
+    BaseField rights[] = {v - c.x_, std::move(j)};
+    c.y_ = BaseField::SumOfProductsSerial(lefts, rights);
 
     // Z3 = ((Z1 + Z2)² - Z1Z1 - Z2Z2) * H
     // This is equal to Z3 = 2 * Z1 * Z2 * H, and computing it this way is
     // faster.
-    z_ *= other.z_;
-    z_.DoubleInPlace();
-    z_ *= h;
+    c.z_ = a.z_ * b.z_;
+    c.z_.DoubleInPlace();
+    c.z_ *= h;
   }
-  return *this;
+}
+
+template <typename Curve>
+constexpr CLASS CLASS::Add(const AffinePoint<Curve>& other) const {
+  if (other.infinity()) return *this;
+  if (IsZero()) {
+    return JacobianPoint::FromAffine(other);
+  }
+
+  JacobianPoint ret;
+  DoAdd(*this, other, ret);
+  return ret;
 }
 
 template <typename Curve>
@@ -94,25 +131,37 @@ constexpr CLASS& CLASS::AddInPlace(const AffinePoint<Curve>& other) {
     return *this = JacobianPoint::FromAffine(other);
   }
 
+  DoAdd(*this, other, *this);
+  return *this;
+}
+
+// static
+template <typename Curve>
+constexpr void CLASS::DoAdd(const JacobianPoint& a, const AffinePoint<Curve>& b,
+                            JacobianPoint& c) {
   // http://www.hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-0.html#addition-madd-2007-bl
   // Z1Z1 = Z1²
-  BaseField z1z1 = z_.Square();
+  BaseField z1z1 = a.z_.Square();
 
   // U2 = X2 * Z1Z1
-  BaseField u2 = other.x() * z1z1;
+  BaseField u2 = b.x() * z1z1;
 
   // S2 = Y2 * Z1 * Z1Z1
-  BaseField s2 = other.y() * z_;
+  BaseField s2 = b.y() * a.z_;
   s2 *= z1z1;
 
-  if (x_ == u2 && y_ == s2) {
-    // The two points are equal, so we double.
-    DoubleInPlace();
+  if (a.x_ == u2 && a.y_ == s2) {
+    // The two points are equal, so we Double.
+    if (&a == &c) {
+      c.DoubleInPlace();
+    } else {
+      c = a.Double();
+    }
   } else {
-    // If we're adding -a and a together, z_ becomes zero as H becomes zero.
+    // If we're adding -a and a together, c.z_ becomes zero as H becomes zero.
 
     // H = U2 - X1
-    BaseField h = u2 - x_;
+    BaseField h = u2 - a.x_;
 
     // HH = H²
     BaseField hh = h.Square();
@@ -126,29 +175,28 @@ constexpr CLASS& CLASS::AddInPlace(const AffinePoint<Curve>& other) {
     j.NegInPlace();
 
     // r = 2 * (S2 - Y1)
-    BaseField r = s2 - y_;
+    BaseField r = s2 - a.y_;
     r.DoubleInPlace();
 
     // V = X1 * I
-    BaseField v = x_ * i;
+    BaseField v = a.x_ * i;
 
     // X3 = r² + J - 2 * V
-    x_ = r.Square();
-    x_ += j;
-    x_ -= v.Double();
+    c.x_ = r.Square();
+    c.x_ += j;
+    c.x_ -= v.Double();
 
     // Y3 = r * (V - X3) + 2 * Y1 * J
-    BaseField lefts[] = {std::move(r), y_.Double()};
-    BaseField rights[] = {v - x_, std::move(j)};
-    y_ = BaseField::SumOfProductsSerial(lefts, rights);
+    BaseField lefts[] = {std::move(r), a.y_.Double()};
+    BaseField rights[] = {v - c.x_, std::move(j)};
+    c.y_ = BaseField::SumOfProductsSerial(lefts, rights);
 
     // Z3 = 2 * Z1 * H;
     // Can alternatively be computed as (Z1 + H)² - Z1Z1 - HH, but the latter is
     // slower.
-    z_ *= h;
-    z_.DoubleInPlace();
+    c.z_ = a.z_ * h;
+    c.z_.DoubleInPlace();
   }
-  return *this;
 }
 
 template <typename Curve>

--- a/tachyon/math/elliptic_curves/short_weierstrass/point_xyzz.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/point_xyzz.h
@@ -275,7 +275,9 @@ class PointXYZZ<_Curve,
   }
 
   // AdditiveSemigroup methods
+  constexpr PointXYZZ Add(const PointXYZZ& other) const;
   constexpr PointXYZZ& AddInPlace(const PointXYZZ& other);
+  constexpr PointXYZZ Add(const AffinePoint<Curve>& other) const;
   constexpr PointXYZZ& AddInPlace(const AffinePoint<Curve>& other);
   constexpr PointXYZZ& DoubleInPlace();
 
@@ -293,6 +295,11 @@ class PointXYZZ<_Curve,
   }
 
  private:
+  constexpr static void DoAdd(const PointXYZZ& a, const PointXYZZ& b,
+                              PointXYZZ& c);
+  constexpr static void DoAdd(const PointXYZZ& a, const AffinePoint<Curve>& b,
+                              PointXYZZ& c);
+
   BaseField x_;
   BaseField y_;
   BaseField zz_;

--- a/tachyon/math/elliptic_curves/short_weierstrass/point_xyzz.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/point_xyzz.h
@@ -279,7 +279,8 @@ class PointXYZZ<_Curve,
   constexpr PointXYZZ& AddInPlace(const PointXYZZ& other);
   constexpr PointXYZZ Add(const AffinePoint<Curve>& other) const;
   constexpr PointXYZZ& AddInPlace(const AffinePoint<Curve>& other);
-  constexpr PointXYZZ& DoubleInPlace();
+  constexpr PointXYZZ DoDouble() const;
+  constexpr PointXYZZ& DoDoubleInPlace();
 
   // AdditiveGroup methods
   constexpr PointXYZZ& NegInPlace() {
@@ -299,6 +300,7 @@ class PointXYZZ<_Curve,
                               PointXYZZ& c);
   constexpr static void DoAdd(const PointXYZZ& a, const AffinePoint<Curve>& b,
                               PointXYZZ& c);
+  constexpr static void DoDoubleImpl(const PointXYZZ& a, PointXYZZ& b);
 
   BaseField x_;
   BaseField y_;

--- a/tachyon/math/elliptic_curves/short_weierstrass/projective_point.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/projective_point.h
@@ -259,7 +259,8 @@ class ProjectivePoint<
   constexpr ProjectivePoint& AddInPlace(const ProjectivePoint& other);
   constexpr ProjectivePoint Add(const AffinePoint<Curve>& other) const;
   constexpr ProjectivePoint& AddInPlace(const AffinePoint<Curve>& other);
-  constexpr ProjectivePoint& DoubleInPlace();
+  constexpr ProjectivePoint DoDouble() const;
+  constexpr ProjectivePoint& DoDoubleInPlace();
 
   // AdditiveGroup methods
   constexpr ProjectivePoint& NegInPlace() {
@@ -279,6 +280,8 @@ class ProjectivePoint<
                               const ProjectivePoint& b, ProjectivePoint& c);
   constexpr static void DoAdd(const ProjectivePoint& a,
                               const AffinePoint<Curve>& b, ProjectivePoint& c);
+  constexpr static void DoDoubleImpl(const ProjectivePoint& a,
+                                     ProjectivePoint& b);
 
   BaseField x_;
   BaseField y_;

--- a/tachyon/math/elliptic_curves/short_weierstrass/projective_point.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/projective_point.h
@@ -255,7 +255,9 @@ class ProjectivePoint<
   }
 
   // AdditiveSemigroup methods
+  constexpr ProjectivePoint Add(const ProjectivePoint& other) const;
   constexpr ProjectivePoint& AddInPlace(const ProjectivePoint& other);
+  constexpr ProjectivePoint Add(const AffinePoint<Curve>& other) const;
   constexpr ProjectivePoint& AddInPlace(const AffinePoint<Curve>& other);
   constexpr ProjectivePoint& DoubleInPlace();
 
@@ -273,6 +275,11 @@ class ProjectivePoint<
   }
 
  private:
+  constexpr static void DoAdd(const ProjectivePoint& a,
+                              const ProjectivePoint& b, ProjectivePoint& c);
+  constexpr static void DoAdd(const ProjectivePoint& a,
+                              const AffinePoint<Curve>& b, ProjectivePoint& c);
+
   BaseField x_;
   BaseField y_;
   BaseField z_;

--- a/tachyon/math/finite_fields/cubic_extension_field.h
+++ b/tachyon/math/finite_fields/cubic_extension_field.h
@@ -157,6 +157,14 @@ class CubicExtensionField : public CyclotomicMultiplicativeSubgroup<Derived> {
   }
 
   // AdditiveSemigroup methods
+  constexpr Derived Add(const Derived& other) const {
+    return {
+        c0_ + other.c0_,
+        c1_ + other.c1_,
+        c2_ + other.c2_,
+    };
+  }
+
   constexpr Derived& AddInPlace(const Derived& other) {
     c0_ += other.c0_;
     c1_ += other.c1_;

--- a/tachyon/math/finite_fields/cubic_extension_field.h
+++ b/tachyon/math/finite_fields/cubic_extension_field.h
@@ -172,7 +172,15 @@ class CubicExtensionField : public CyclotomicMultiplicativeSubgroup<Derived> {
     return *static_cast<Derived*>(this);
   }
 
-  constexpr Derived& DoubleInPlace() {
+  constexpr Derived DoDouble() const {
+    return {
+        c0_.Double(),
+        c1_.Double(),
+        c2_.Double(),
+    };
+  }
+
+  constexpr Derived& DoDoubleInPlace() {
     c0_.DoubleInPlace();
     c1_.DoubleInPlace();
     c2_.DoubleInPlace();

--- a/tachyon/math/finite_fields/generator/prime_field_generator/prime_field_x86.h.tpl
+++ b/tachyon/math/finite_fields/generator/prime_field_generator/prime_field_x86.h.tpl
@@ -166,6 +166,12 @@ class PrimeField<_Config, std::enable_if_t<_Config::%{flag}>> final
 
   // TODO(chokobole): Support bigendian.
   // MultiplicativeSemigroup methods
+  constexpr PrimeField Mul(const PrimeField& other) const {
+    PrimeField ret;
+    %{prefix}_rawMMul(ret.value_.limbs, value_.limbs, other.value_.limbs);
+    return ret;
+  }
+
   constexpr PrimeField& MulInPlace(const PrimeField& other) {
     %{prefix}_rawMMul(value_.limbs, value_.limbs, other.value_.limbs);
     return *this;

--- a/tachyon/math/finite_fields/generator/prime_field_generator/prime_field_x86.h.tpl
+++ b/tachyon/math/finite_fields/generator/prime_field_generator/prime_field_x86.h.tpl
@@ -146,6 +146,12 @@ class PrimeField<_Config, std::enable_if_t<_Config::%{flag}>> final
   }
 
   // AdditiveSemigroup methods
+  constexpr PrimeField Add(const PrimeField& other) const {
+    PrimeField ret;
+    %{prefix}_rawAdd(ret.value_.limbs, value_.limbs, other.value_.limbs);
+    return ret;
+  }
+
   constexpr PrimeField& AddInPlace(const PrimeField& other) {
     %{prefix}_rawAdd(value_.limbs, value_.limbs, other.value_.limbs);
     return *this;

--- a/tachyon/math/finite_fields/goldilocks/goldilocks_prime_field_x86_special.cc
+++ b/tachyon/math/finite_fields/goldilocks/goldilocks_prime_field_x86_special.cc
@@ -104,6 +104,16 @@ CLASS::operator uint64_t() const {
 }
 
 template <typename Config>
+CLASS CLASS::Add(const PrimeField& other) const {
+  PrimeField ret;
+  ::Goldilocks::add(
+      reinterpret_cast<::Goldilocks::Element&>(ret.value_),
+      reinterpret_cast<const ::Goldilocks::Element&>(value_),
+      reinterpret_cast<const ::Goldilocks::Element&>(other.value_));
+  return ret;
+}
+
+template <typename Config>
 CLASS& CLASS::AddInPlace(const PrimeField& other) {
   ::Goldilocks::add(
       reinterpret_cast<::Goldilocks::Element&>(value_),

--- a/tachyon/math/finite_fields/goldilocks/goldilocks_prime_field_x86_special.cc
+++ b/tachyon/math/finite_fields/goldilocks/goldilocks_prime_field_x86_special.cc
@@ -172,7 +172,15 @@ CLASS& CLASS::DivInPlace(const PrimeField& other) {
 }
 
 template <typename Config>
-CLASS& CLASS::SquareInPlace() {
+CLASS CLASS::DoSquare() const {
+  PrimeField ret;
+  ::Goldilocks::square(reinterpret_cast<::Goldilocks::Element&>(ret.value_),
+                       reinterpret_cast<const ::Goldilocks::Element&>(value_));
+  return ret;
+}
+
+template <typename Config>
+CLASS& CLASS::DoSquareInPlace() {
   ::Goldilocks::square(reinterpret_cast<::Goldilocks::Element&>(value_),
                        reinterpret_cast<const ::Goldilocks::Element&>(value_));
   return *this;

--- a/tachyon/math/finite_fields/goldilocks/goldilocks_prime_field_x86_special.cc
+++ b/tachyon/math/finite_fields/goldilocks/goldilocks_prime_field_x86_special.cc
@@ -123,11 +123,6 @@ CLASS& CLASS::AddInPlace(const PrimeField& other) {
 }
 
 template <typename Config>
-CLASS& CLASS::DoubleInPlace() {
-  return AddInPlace(*this);
-}
-
-template <typename Config>
 CLASS& CLASS::SubInPlace(const PrimeField& other) {
   ::Goldilocks::sub(
       reinterpret_cast<::Goldilocks::Element&>(value_),

--- a/tachyon/math/finite_fields/goldilocks/goldilocks_prime_field_x86_special.cc
+++ b/tachyon/math/finite_fields/goldilocks/goldilocks_prime_field_x86_special.cc
@@ -134,6 +134,16 @@ CLASS& CLASS::NegInPlace() {
 }
 
 template <typename Config>
+CLASS CLASS::Mul(const PrimeField& other) const {
+  PrimeField ret;
+  ::Goldilocks::mul(
+      reinterpret_cast<::Goldilocks::Element&>(ret.value_),
+      reinterpret_cast<const ::Goldilocks::Element&>(value_),
+      reinterpret_cast<const ::Goldilocks::Element&>(other.value_));
+  return ret;
+}
+
+template <typename Config>
 CLASS& CLASS::MulInPlace(const PrimeField& other) {
   ::Goldilocks::mul(
       reinterpret_cast<::Goldilocks::Element&>(value_),

--- a/tachyon/math/finite_fields/goldilocks/goldilocks_prime_field_x86_special.h
+++ b/tachyon/math/finite_fields/goldilocks/goldilocks_prime_field_x86_special.h
@@ -99,6 +99,7 @@ class PrimeField<_Config, std::enable_if_t<_Config::kIsGoldilocks>> final
 
   // TODO(chokobole): Support bigendian.
   // MultiplicativeSemigroup methods
+  PrimeField Mul(const PrimeField& other) const;
   PrimeField& MulInPlace(const PrimeField& other);
   PrimeField& DivInPlace(const PrimeField& other);
   PrimeField& SquareInPlace();

--- a/tachyon/math/finite_fields/goldilocks/goldilocks_prime_field_x86_special.h
+++ b/tachyon/math/finite_fields/goldilocks/goldilocks_prime_field_x86_special.h
@@ -92,7 +92,6 @@ class PrimeField<_Config, std::enable_if_t<_Config::kIsGoldilocks>> final
   // AdditiveSemigroup methods
   PrimeField Add(const PrimeField& other) const;
   PrimeField& AddInPlace(const PrimeField& other);
-  PrimeField& DoubleInPlace();
 
   // AdditiveGroup methods
   PrimeField& SubInPlace(const PrimeField& other);

--- a/tachyon/math/finite_fields/goldilocks/goldilocks_prime_field_x86_special.h
+++ b/tachyon/math/finite_fields/goldilocks/goldilocks_prime_field_x86_special.h
@@ -90,6 +90,7 @@ class PrimeField<_Config, std::enable_if_t<_Config::kIsGoldilocks>> final
   }
 
   // AdditiveSemigroup methods
+  PrimeField Add(const PrimeField& other) const;
   PrimeField& AddInPlace(const PrimeField& other);
   PrimeField& DoubleInPlace();
 

--- a/tachyon/math/finite_fields/goldilocks/goldilocks_prime_field_x86_special.h
+++ b/tachyon/math/finite_fields/goldilocks/goldilocks_prime_field_x86_special.h
@@ -103,7 +103,8 @@ class PrimeField<_Config, std::enable_if_t<_Config::kIsGoldilocks>> final
   PrimeField Mul(const PrimeField& other) const;
   PrimeField& MulInPlace(const PrimeField& other);
   PrimeField& DivInPlace(const PrimeField& other);
-  PrimeField& SquareInPlace();
+  PrimeField DoSquare() const;
+  PrimeField& DoSquareInPlace();
 
   // MultiplicativeGroup methods
   PrimeField& InverseInPlace();

--- a/tachyon/math/finite_fields/prime_field_generic.h
+++ b/tachyon/math/finite_fields/prime_field_generic.h
@@ -189,12 +189,23 @@ class PrimeField<_Config, std::enable_if_t<!_Config::kIsSpecialPrime>> final
 
   // TODO(chokobole): Support bigendian.
   // MultiplicativeSemigroup methods
+  constexpr PrimeField Mul(const PrimeField& other) const {
+    PrimeField ret;
+    if constexpr (Config::kCanUseNoCarryMulOptimization) {
+      DoFastMul(*this, other, ret);
+    } else {
+      DoSlowMul(*this, other, ret);
+    }
+    return ret;
+  }
+
   constexpr PrimeField& MulInPlace(const PrimeField& other) {
     if constexpr (Config::kCanUseNoCarryMulOptimization) {
-      return FastMulInPlace(other);
+      DoFastMul(*this, other, *this);
     } else {
-      return SlowMulInPlace(other);
+      DoSlowMul(*this, other, *this);
     }
+    return *this;
   }
 
   constexpr PrimeField& SquareInPlace() {
@@ -249,11 +260,12 @@ class PrimeField<_Config, std::enable_if_t<!_Config::kIsSpecialPrime>> final
   template <typename PrimeField>
   FRIEND_TEST(PrimeFieldCorrectnessTest, MultiplicativeOperators);
 
-  constexpr PrimeField& FastMulInPlace(const PrimeField& other) {
+  constexpr static void DoFastMul(const PrimeField& a, const PrimeField& b,
+                                  PrimeField& c) {
     BigInt<N> r;
     for (size_t i = 0; i < N; ++i) {
       MulResult<uint64_t> result;
-      result = internal::u64::MulAddWithCarry(r[0], value_[0], other.value_[i]);
+      result = internal::u64::MulAddWithCarry(r[0], a[0], b[i]);
       r[0] = result.lo;
 
       uint64_t k = r[0] * Config::kInverse64;
@@ -261,8 +273,7 @@ class PrimeField<_Config, std::enable_if_t<!_Config::kIsSpecialPrime>> final
       result2 = internal::u64::MulAddWithCarry(r[0], k, Config::kModulus[0]);
 
       for (size_t j = 1; j < N; ++j) {
-        result = internal::u64::MulAddWithCarry(r[j], value_[j],
-                                                other.value_[i], result.hi);
+        result = internal::u64::MulAddWithCarry(r[j], a[j], b[i], result.hi);
         r[j] = result.lo;
         result2 = internal::u64::MulAddWithCarry(r[j], k, Config::kModulus[j],
                                                  result2.hi);
@@ -270,17 +281,16 @@ class PrimeField<_Config, std::enable_if_t<!_Config::kIsSpecialPrime>> final
       }
       r[N - 1] = result.hi + result2.hi;
     }
-    value_ = r;
+    c.value_ = r;
     BigInt<N>::template Clamp<Config::kModulusHasSpareBit>(Config::kModulus,
-                                                           &value_, 0);
-    return *this;
+                                                           &c.value_, 0);
   }
 
-  constexpr PrimeField& SlowMulInPlace(const PrimeField& other) {
-    BigInt<2 * N> r = value_.MulExtend(other.value_);
+  constexpr static void DoSlowMul(const PrimeField& a, const PrimeField& b,
+                                  PrimeField& c) {
+    BigInt<2 * N> r = a.value_.MulExtend(b.value_);
     BigInt<N>::template MontgomeryReduce64<Config::kModulusHasSpareBit>(
-        r, Config::kModulus, Config::kInverse64, &value_);
-    return *this;
+        r, Config::kModulus, Config::kInverse64, &c.value_);
   }
 
   BigInt<N> value_;

--- a/tachyon/math/finite_fields/prime_field_generic.h
+++ b/tachyon/math/finite_fields/prime_field_generic.h
@@ -153,6 +153,15 @@ class PrimeField<_Config, std::enable_if_t<!_Config::kIsSpecialPrime>> final
   }
 
   // AdditiveSemigroup methods
+  constexpr PrimeField Add(const PrimeField& other) const {
+    PrimeField ret;
+    uint64_t carry = 0;
+    ret.value_ = value_.Add(other.value_, carry);
+    BigInt<N>::template Clamp<Config::kModulusHasSpareBit>(Config::kModulus,
+                                                           &ret.value_, carry);
+    return ret;
+  }
+
   constexpr PrimeField& AddInPlace(const PrimeField& other) {
     uint64_t carry = 0;
     value_.AddInPlace(other.value_, carry);

--- a/tachyon/math/finite_fields/prime_field_generic.h
+++ b/tachyon/math/finite_fields/prime_field_generic.h
@@ -170,7 +170,16 @@ class PrimeField<_Config, std::enable_if_t<!_Config::kIsSpecialPrime>> final
     return *this;
   }
 
-  constexpr PrimeField& DoubleInPlace() {
+  constexpr PrimeField DoDouble() const {
+    PrimeField ret;
+    uint64_t carry = 0;
+    ret.value_ = value_.MulBy2(carry);
+    BigInt<N>::template Clamp<Config::kModulusHasSpareBit>(Config::kModulus,
+                                                           &ret.value_, carry);
+    return ret;
+  }
+
+  constexpr PrimeField& DoDoubleInPlace() {
     uint64_t carry = 0;
     value_.MulBy2InPlace(carry);
     BigInt<N>::template Clamp<Config::kModulusHasSpareBit>(Config::kModulus,

--- a/tachyon/math/finite_fields/prime_field_gpu.h
+++ b/tachyon/math/finite_fields/prime_field_gpu.h
@@ -200,6 +200,12 @@ class PrimeFieldGpu final : public PrimeFieldBase<PrimeFieldGpu<_Config>> {
   }
 
   // AdditiveSemigroup methods
+  __device__ constexpr PrimeFieldGpu Add(const PrimeFieldGpu& other) const {
+    PrimeFieldGpu ret;
+    AddLimbs<false>(value_, other.value_, ret.value_);
+    return Clamp(ret);
+  }
+
   __device__ constexpr PrimeFieldGpu& AddInPlace(const PrimeFieldGpu& other) {
     AddLimbs<false>(value_, other.value_, value_);
     *this = Clamp(*this);

--- a/tachyon/math/finite_fields/prime_field_gpu.h
+++ b/tachyon/math/finite_fields/prime_field_gpu.h
@@ -212,10 +212,6 @@ class PrimeFieldGpu final : public PrimeFieldBase<PrimeFieldGpu<_Config>> {
     return *this;
   }
 
-  __device__ constexpr PrimeFieldGpu& DoubleInPlace() {
-    return AddInPlace(*this);
-  }
-
   // AdditiveGroup methods
   __device__ constexpr PrimeFieldGpu& SubInPlace(const PrimeFieldGpu& other) {
     uint64_t carry = SubLimbs<true>(value_, other.value_, value_);

--- a/tachyon/math/finite_fields/prime_field_gpu.h
+++ b/tachyon/math/finite_fields/prime_field_gpu.h
@@ -226,6 +226,15 @@ class PrimeFieldGpu final : public PrimeFieldBase<PrimeFieldGpu<_Config>> {
   }
 
   // MultiplicativeSemigroup methods
+  __device__ constexpr PrimeFieldGpu Mul(const PrimeFieldGpu& other) const {
+    // Forces us to think more carefully about the last carry bit if we use a
+    // modulus with fewer than 2 leading zeroes of slack.
+    static_assert(!(Config::kModulus[N - 1] >> 62));
+    PrimeFieldGpu ret;
+    MulLimbs(value_, other.value_, ret.value_);
+    return Clamp(ret);
+  }
+
   __device__ constexpr PrimeFieldGpu& MulInPlace(const PrimeFieldGpu& other) {
     // Forces us to think more carefully about the last carry bit if we use a
     // modulus with fewer than 2 leading zeroes of slack.

--- a/tachyon/math/finite_fields/prime_field_gpu.h
+++ b/tachyon/math/finite_fields/prime_field_gpu.h
@@ -252,10 +252,6 @@ class PrimeFieldGpu final : public PrimeFieldBase<PrimeFieldGpu<_Config>> {
     return *this;
   }
 
-  __device__ constexpr PrimeFieldGpu& SquareInPlace() {
-    return MulInPlace(*this);
-  }
-
   // MultiplicativeGroup methods
   __device__ constexpr PrimeFieldGpu& InverseInPlace() {
     if (IsZero()) return *this;

--- a/tachyon/math/finite_fields/prime_field_gpu_debug.h
+++ b/tachyon/math/finite_fields/prime_field_gpu_debug.h
@@ -197,8 +197,6 @@ class PrimeFieldGpuDebug final
     return *this;
   }
 
-  constexpr PrimeFieldGpuDebug& SquareInPlace() { return MulInPlace(*this); }
-
   // MultiplicativeGroup methods
   // TODO(chokobole): Share codes with PrimeField and PrimeFieldGpu.
   constexpr PrimeFieldGpuDebug& InverseInPlace() {

--- a/tachyon/math/finite_fields/prime_field_gpu_debug.h
+++ b/tachyon/math/finite_fields/prime_field_gpu_debug.h
@@ -168,8 +168,6 @@ class PrimeFieldGpuDebug final
     return *this;
   }
 
-  constexpr PrimeFieldGpuDebug& DoubleInPlace() { return AddInPlace(*this); }
-
   // AdditiveGroup methods
   constexpr PrimeFieldGpuDebug& SubInPlace(const PrimeFieldGpuDebug& other) {
     uint64_t carry = SubLimbs<true>(value_, other.value_, value_);

--- a/tachyon/math/finite_fields/prime_field_gpu_debug.h
+++ b/tachyon/math/finite_fields/prime_field_gpu_debug.h
@@ -156,6 +156,12 @@ class PrimeFieldGpuDebug final
   }
 
   // AdditiveSemigroup methods
+  constexpr PrimeFieldGpuDebug Add(const PrimeFieldGpuDebug& other) const {
+    PrimeFieldGpuDebug ret;
+    AddLimbs<false>(value_, other.value_, ret.value_);
+    return Clamp(ret);
+  }
+
   constexpr PrimeFieldGpuDebug& AddInPlace(const PrimeFieldGpuDebug& other) {
     AddLimbs<false>(value_, other.value_, value_);
     *this = Clamp(*this);

--- a/tachyon/math/finite_fields/quadratic_extension_field.h
+++ b/tachyon/math/finite_fields/quadratic_extension_field.h
@@ -135,7 +135,14 @@ class QuadraticExtensionField
     return *static_cast<Derived*>(this);
   }
 
-  constexpr Derived& DoubleInPlace() {
+  constexpr Derived DoDouble() const {
+    return {
+        c0_.Double(),
+        c1_.Double(),
+    };
+  }
+
+  constexpr Derived& DoDoubleInPlace() {
     c0_.DoubleInPlace();
     c1_.DoubleInPlace();
     return *static_cast<Derived*>(this);

--- a/tachyon/math/finite_fields/quadratic_extension_field.h
+++ b/tachyon/math/finite_fields/quadratic_extension_field.h
@@ -122,6 +122,13 @@ class QuadraticExtensionField
   }
 
   // AdditiveSemigroup methods
+  constexpr Derived Add(const Derived& other) const {
+    return {
+        c0_ + other.c0_,
+        c1_ + other.c1_,
+    };
+  }
+
   constexpr Derived& AddInPlace(const Derived& other) {
     c0_ += other.c0_;
     c1_ += other.c1_;

--- a/tachyon/math/polynomials/multivariate/multilinear_extension_ops.h
+++ b/tachyon/math/polynomials/multivariate/multilinear_extension_ops.h
@@ -2,6 +2,7 @@
 #define TACHYON_MATH_POLYNOMIALS_MULTIVARIATE_MULTILINEAR_EXTENSION_OPS_H_
 
 #include <algorithm>
+#include <utility>
 #include <vector>
 
 #include "tachyon/base/openmp_util.h"
@@ -64,6 +65,22 @@ class MultilinearExtensionOp<MultilinearDenseEvaluations<F, MaxDegree>> {
       evaluation.NegInPlace();
     }
     return self;
+  }
+
+  static MultilinearExtension<D> Mul(const MultilinearExtension<D>& self,
+                                     const MultilinearExtension<D>& other) {
+    const std::vector<F>& l_evaluations = self.evaluations_.evaluations_;
+    const std::vector<F>& r_evaluations = other.evaluations_.evaluations_;
+    if (l_evaluations.empty() || r_evaluations.empty()) {
+      // 0 * g(x) or f(x) * 0
+      return MultilinearExtension<D>::Zero();
+    }
+    CHECK_EQ(l_evaluations.size(), r_evaluations.size());
+    std::vector<F> o_evaluations(r_evaluations.size());
+    OPENMP_PARALLEL_FOR(size_t i = 0; i < l_evaluations.size(); ++i) {
+      o_evaluations[i] = l_evaluations[i] * r_evaluations[i];
+    }
+    return MultilinearExtension<D>(D(std::move(o_evaluations)));
   }
 
   static MultilinearExtension<D>& MulInPlace(

--- a/tachyon/math/polynomials/multivariate/multilinear_extension_ops.h
+++ b/tachyon/math/polynomials/multivariate/multilinear_extension_ops.h
@@ -16,6 +16,26 @@ class MultilinearExtensionOp<MultilinearDenseEvaluations<F, MaxDegree>> {
  public:
   using D = MultilinearDenseEvaluations<F, MaxDegree>;
 
+  static MultilinearExtension<D> Add(const MultilinearExtension<D>& self,
+                                     const MultilinearExtension<D>& other) {
+    const std::vector<F>& l_evaluations = self.evaluations_.evaluations_;
+    const std::vector<F>& r_evaluations = other.evaluations_.evaluations_;
+    if (l_evaluations.empty()) {
+      // 0 + g(x)
+      return other;
+    }
+    if (r_evaluations.empty()) {
+      // f(x) + 0
+      return self;
+    }
+    CHECK_EQ(l_evaluations.size(), r_evaluations.size());
+    std::vector<F> o_evaluations(r_evaluations.size());
+    OPENMP_PARALLEL_FOR(size_t i = 0; i < r_evaluations.size(); ++i) {
+      o_evaluations[i] = l_evaluations[i] + r_evaluations[i];
+    }
+    return MultilinearExtension<D>(D(std::move(o_evaluations)));
+  }
+
   static MultilinearExtension<D>& AddInPlace(
       MultilinearExtension<D>& self, const MultilinearExtension<D>& other) {
     std::vector<F>& l_evaluations = self.evaluations_.evaluations_;

--- a/tachyon/math/polynomials/multivariate/multivariate_polynomial_ops.h
+++ b/tachyon/math/polynomials/multivariate/multivariate_polynomial_ops.h
@@ -9,7 +9,6 @@
 #include <utility>
 #include <vector>
 
-#include "tachyon/base/containers/container_util.h"
 #include "tachyon/base/openmp_util.h"
 #include "tachyon/math/polynomials/multivariate/multivariate_polynomial.h"
 
@@ -36,12 +35,8 @@ class MultivariatePolynomialOp<MultivariateSparseCoefficients<F, MaxDegree>> {
 
   static MultivariatePolynomial<S>& SubInPlace(
       MultivariatePolynomial<S>& self, const MultivariatePolynomial<S>& other) {
-    Terms& l_terms = self.coefficients_.terms_;
-    const Terms& r_terms = other.coefficients_.terms_;
     if (self.IsZero()) {
-      l_terms = base::CreateVector(
-          r_terms.size(), [&r_terms](size_t idx) { return -r_terms[idx]; });
-      return self;
+      return self = -other;
     } else if (other.IsZero()) {
       return self;
     }

--- a/tachyon/math/polynomials/multivariate/multivariate_polynomial_ops.h
+++ b/tachyon/math/polynomials/multivariate/multivariate_polynomial_ops.h
@@ -51,7 +51,7 @@ class MultivariatePolynomialOp<MultivariateSparseCoefficients<F, MaxDegree>> {
 
   static MultivariatePolynomial<S>& NegInPlace(
       MultivariatePolynomial<S>& self) {
-    Terms& terms = self.terms_;
+    Terms& terms = self.coefficients_.terms_;
     // clang-format off
     OPENMP_PARALLEL_FOR(Term& term : terms) { term.coefficient.NegInPlace(); }
     // clang-format on

--- a/tachyon/math/polynomials/univariate/univariate_dense_polynomial_unittest.cc
+++ b/tachyon/math/polynomials/univariate/univariate_dense_polynomial_unittest.cc
@@ -234,7 +234,7 @@ TEST_F(UnivariateDensePolynomialTest, MultiplicativeOperators) {
           zero,
           zero,
           zero,
-          zero,
+          a,
       },
   };
 

--- a/tachyon/math/polynomials/univariate/univariate_evaluations.h
+++ b/tachyon/math/polynomials/univariate/univariate_evaluations.h
@@ -147,6 +147,10 @@ class UnivariateEvaluations final
   std::string ToString() const { return base::VectorToString(evaluations_); }
 
   // AdditiveSemigroup methods
+  UnivariateEvaluations Add(const UnivariateEvaluations& other) const {
+    return internal::UnivariateEvaluationsOp<F, MaxDegree>::Add(*this, other);
+  }
+
   UnivariateEvaluations& AddInPlace(const UnivariateEvaluations& other) {
     return internal::UnivariateEvaluationsOp<F, MaxDegree>::AddInPlace(*this,
                                                                        other);

--- a/tachyon/math/polynomials/univariate/univariate_evaluations.h
+++ b/tachyon/math/polynomials/univariate/univariate_evaluations.h
@@ -163,9 +163,17 @@ class UnivariateEvaluations final
   }
 
   // MultiplicativeSemigroup methods
+  UnivariateEvaluations Mul(const UnivariateEvaluations& other) const {
+    return internal::UnivariateEvaluationsOp<F, MaxDegree>::Mul(*this, other);
+  }
+
   UnivariateEvaluations& MulInPlace(const UnivariateEvaluations& other) {
     return internal::UnivariateEvaluationsOp<F, MaxDegree>::MulInPlace(*this,
                                                                        other);
+  }
+
+  UnivariateEvaluations Mul(const F& scalar) const {
+    return internal::UnivariateEvaluationsOp<F, MaxDegree>::Mul(*this, scalar);
   }
 
   UnivariateEvaluations& MulInPlace(const F& scalar) {

--- a/tachyon/math/polynomials/univariate/univariate_evaluations_ops.h
+++ b/tachyon/math/polynomials/univariate/univariate_evaluations_ops.h
@@ -21,6 +21,24 @@ class UnivariateEvaluationsOp {
  public:
   using Poly = UnivariateEvaluations<F, MaxDegree>;
 
+  static Poly Add(const Poly& self, const Poly& other) {
+    const std::vector<F>& l_evaluations = self.evaluations_;
+    const std::vector<F>& r_evaluations = other.evaluations_;
+    if (l_evaluations.empty()) {
+      // 0 + g(x)
+      return other;
+    }
+    if (r_evaluations.empty()) {
+      // f(x) + 0
+      return self;
+    }
+    std::vector<F> o_evaluations(r_evaluations.size());
+    OPENMP_PARALLEL_FOR(size_t i = 0; i < r_evaluations.size(); ++i) {
+      o_evaluations[i] = l_evaluations[i] + r_evaluations[i];
+    }
+    return Poly(std::move(o_evaluations));
+  }
+
   static Poly& AddInPlace(Poly& self, const Poly& other) {
     std::vector<F>& l_evaluations = self.evaluations_;
     const std::vector<F>& r_evaluations = other.evaluations_;

--- a/tachyon/math/polynomials/univariate/univariate_evaluations_ops.h
+++ b/tachyon/math/polynomials/univariate/univariate_evaluations_ops.h
@@ -68,6 +68,20 @@ class UnivariateEvaluationsOp {
     return self;
   }
 
+  static Poly Mul(const Poly& self, const Poly& other) {
+    const std::vector<F>& l_evaluations = self.evaluations_;
+    const std::vector<F>& r_evaluations = other.evaluations_;
+    if (l_evaluations.empty() || r_evaluations.empty()) {
+      // 0 * g(x) or f(x) * 0
+      return Poly::Zero();
+    }
+    std::vector<F> o_evaluations(r_evaluations.size());
+    OPENMP_PARALLEL_FOR(size_t i = 0; i < r_evaluations.size(); ++i) {
+      o_evaluations[i] = l_evaluations[i] * r_evaluations[i];
+    }
+    return Poly(std::move(o_evaluations));
+  }
+
   static Poly& MulInPlace(Poly& self, const Poly& other) {
     std::vector<F>& l_evaluations = self.evaluations_;
     const std::vector<F>& r_evaluations = other.evaluations_;
@@ -84,6 +98,15 @@ class UnivariateEvaluationsOp {
       l_evaluations[i] *= r_evaluations[i];
     }
     return self;
+  }
+
+  static Poly Mul(const Poly& self, const F& scalar) {
+    const std::vector<F>& l_evaluations = self.evaluations_;
+    std::vector<F> o_evaluations(l_evaluations.size());
+    OPENMP_PARALLEL_FOR(size_t i = 0; i < l_evaluations.size(); ++i) {
+      o_evaluations[i] = l_evaluations[i] * scalar;
+    }
+    return Poly(std::move(o_evaluations));
   }
 
   static Poly& MulInPlace(Poly& self, const F& scalar) {

--- a/tachyon/math/polynomials/univariate/univariate_polynomial.h
+++ b/tachyon/math/polynomials/univariate/univariate_polynomial.h
@@ -197,6 +197,10 @@ class UnivariatePolynomial final
   // MultiplicativeSemigroup methods
   OPERATION_METHOD(Mul)
 
+  UnivariatePolynomial Mul(const Field& scalar) const {
+    return internal::UnivariatePolynomialOp<Coefficients>::Mul(*this, scalar);
+  }
+
   UnivariatePolynomial& MulInPlace(const Field& scalar) {
     return internal::UnivariatePolynomialOp<Coefficients>::MulInPlace(*this,
                                                                       scalar);

--- a/tachyon/math/polynomials/univariate/univariate_polynomial_ops.h
+++ b/tachyon/math/polynomials/univariate/univariate_polynomial_ops.h
@@ -497,11 +497,10 @@ class UnivariatePolynomialOp<UnivariateSparseCoefficients<F, MaxDegree>> {
   }
 
   static UnivariatePolynomial<D> ToDense(const UnivariatePolynomial<S>& self) {
-    std::vector<F> coefficients;
     size_t size = self.Degree() + 1;
-    coefficients.reserve(size);
-    for (size_t i = 0; i < size; ++i) {
-      coefficients.push_back(self[i]);
+    std::vector<F> coefficients(size);
+    OPENMP_PARALLEL_FOR(size_t i = 0; i < size; ++i) {
+      coefficients[i] = self[i];
     }
     return UnivariatePolynomial<D>(D(std::move(coefficients)));
   }

--- a/tachyon/math/polynomials/univariate/univariate_polynomial_ops.h
+++ b/tachyon/math/polynomials/univariate/univariate_polynomial_ops.h
@@ -303,7 +303,7 @@ class UnivariatePolynomialOp<UnivariateDenseCoefficients<F, MaxDegree>> {
       const UnivariatePolynomial<D>& self,
       const UnivariatePolynomial<DOrS>& other) {
     if (self.IsZero()) {
-      return {UnivariatePolynomial<D>::Zero(), UnivariatePolynomial<D>::Zero()};
+      return {UnivariatePolynomial<D>::Zero(), other.ToDense()};
     } else if (other.IsZero()) {
       NOTREACHED() << "Divide by zero polynomial";
     } else if (self.Degree() < other.Degree()) {

--- a/tachyon/math/polynomials/univariate/univariate_sparse_polynomial_unittest.cc
+++ b/tachyon/math/polynomials/univariate/univariate_sparse_polynomial_unittest.cc
@@ -269,7 +269,7 @@ TEST_F(UnivariateSparsePolynomialTest, MultiplicativeOperators) {
           zero.ToDense(),
           zero.ToDense(),
           zero.ToDense(),
-          zero.ToDense(),
+          a.ToDense(),
       },
   };
 

--- a/tachyon/zk/base/value.h
+++ b/tachyon/zk/base/value.h
@@ -109,7 +109,12 @@ class Value : public math::Field<Value<T>> {
     return Value::Known(*value_ * other);
   }
 
-  constexpr Value& SquareInPlace() {
+  constexpr Value DoSquare() const {
+    if (IsNone()) return Unknown();
+    return Value::Known(value_->Square());
+  }
+
+  constexpr Value& DoSquareInPlace() {
     if (IsNone()) return *this;
     value_->SquareInPlace();
     return *this;

--- a/tachyon/zk/base/value.h
+++ b/tachyon/zk/base/value.h
@@ -75,7 +75,12 @@ class Value : public math::Field<Value<T>> {
     return Value::Known(*value_ + other);
   }
 
-  constexpr Value& DoubleInPlace() {
+  constexpr Value DoDouble() const {
+    if (IsNone()) return Unknown();
+    return Value::Known(value_->Double());
+  }
+
+  constexpr Value& DoDoubleInPlace() {
     if (IsNone()) return *this;
     value_->DoubleInPlace();
     return *this;


### PR DESCRIPTION
# Description

This PR avoids copying on semigroup operations, which are `Add()`, `Mul()`, `Double()` and `Square()`.
