### PR TITLE
test: run (I)FFT benchmark under uniform conditions

### DIFF
--- a/benchmark/fft/fft_benchmark.cc
+++ b/benchmark/fft/fft_benchmark.cc
@@ -86,7 +86,7 @@ void Run(const FFTConfig& config) {
 
   std::vector<RetPoly> results;
   if constexpr (std::is_same_v<PolyOrEvals, typename Domain::Evals>) {
-    runner.Run(tachyon_bn254_univariate_evaluation_domain_ifft, degrees,
+    runner.Run(tachyon_bn254_univariate_evaluation_domain_ifft_inplace, degrees,
                &results);
     for (const FFTConfig::Vendor vendor : config.vendors()) {
       std::vector<RetPoly> results_vendor;
@@ -104,7 +104,7 @@ void Run(const FFTConfig& config) {
     // NOLINTNEXTLINE(readability/braces)
   } else if constexpr (std::is_same_v<PolyOrEvals,
                                       typename Domain::DensePoly>) {
-    runner.Run(tachyon_bn254_univariate_evaluation_domain_fft, degrees,
+    runner.Run(tachyon_bn254_univariate_evaluation_domain_fft_inplace, degrees,
                &results);
     for (const FFTConfig::Vendor vendor : config.vendors()) {
       std::vector<RetPoly> results_vendor;

--- a/benchmark/fft/fft_runner.h
+++ b/benchmark/fft/fft_runner.h
@@ -52,12 +52,13 @@ class FFTRunner {
   void Run(Fn fn, const std::vector<uint64_t>& degrees,
            std::vector<RetPoly>* results) {
     for (size_t i = 0; i < degrees.size(); ++i) {
+      PolyOrEvals poly = (*polys_)[i];
       base::TimeTicks now = base::TimeTicks::Now();
       std::unique_ptr<CRetPoly> ret;
       ret.reset(fn(
           reinterpret_cast<const tachyon_bn254_univariate_evaluation_domain*>(
               domains_[i].get()),
-          reinterpret_cast<CPolyOrEvals>(&(*polys_)[i])));
+          reinterpret_cast<CPolyOrEvals>(&poly)));
       reporter_->AddTime(i, (base::TimeTicks::Now() - now).InSecondsF());
       results->push_back(*reinterpret_cast<RetPoly*>(ret.get()));
     }

--- a/tachyon/c/math/polynomials/univariate/bn254_univariate_evaluation_domain.cc
+++ b/tachyon/c/math/polynomials/univariate/bn254_univariate_evaluation_domain.cc
@@ -1,5 +1,7 @@
 #include "tachyon/c/math/polynomials/univariate/bn254_univariate_evaluation_domain.h"
 
+#include <utility>
+
 #include "tachyon/c/math/polynomials/constants.h"
 #include "tachyon/math/base/rational_field.h"
 #include "tachyon/math/elliptic_curves/bn/bn254/fr.h"
@@ -58,6 +60,16 @@ tachyon_bn254_univariate_evaluation_domain_fft(
   return reinterpret_cast<tachyon_bn254_univariate_evaluations*>(evals);
 }
 
+tachyon_bn254_univariate_evaluations*
+tachyon_bn254_univariate_evaluation_domain_fft_inplace(
+    const tachyon_bn254_univariate_evaluation_domain* domain,
+    tachyon_bn254_univariate_dense_polynomial* poly) {
+  Domain::Evals* evals =
+      new Domain::Evals(reinterpret_cast<const Domain*>(domain)->FFT(
+          reinterpret_cast<Domain::DensePoly&&>(std::move(*poly))));
+  return reinterpret_cast<tachyon_bn254_univariate_evaluations*>(evals);
+}
+
 tachyon_bn254_univariate_dense_polynomial*
 tachyon_bn254_univariate_evaluation_domain_ifft(
     const tachyon_bn254_univariate_evaluation_domain* domain,
@@ -65,5 +77,15 @@ tachyon_bn254_univariate_evaluation_domain_ifft(
   Domain::DensePoly* poly =
       new Domain::DensePoly(reinterpret_cast<const Domain*>(domain)->IFFT(
           reinterpret_cast<const Domain::Evals&>(*evals)));
+  return reinterpret_cast<tachyon_bn254_univariate_dense_polynomial*>(poly);
+}
+
+tachyon_bn254_univariate_dense_polynomial*
+tachyon_bn254_univariate_evaluation_domain_ifft_inplace(
+    const tachyon_bn254_univariate_evaluation_domain* domain,
+    tachyon_bn254_univariate_evaluations* evals) {
+  Domain::DensePoly* poly =
+      new Domain::DensePoly(reinterpret_cast<const Domain*>(domain)->IFFT(
+          reinterpret_cast<Domain::Evals&&>(std::move(*evals))));
   return reinterpret_cast<tachyon_bn254_univariate_dense_polynomial*>(poly);
 }

--- a/tachyon/c/math/polynomials/univariate/bn254_univariate_evaluation_domain.h
+++ b/tachyon/c/math/polynomials/univariate/bn254_univariate_evaluation_domain.h
@@ -93,6 +93,20 @@ tachyon_bn254_univariate_evaluation_domain_fft(
     const tachyon_bn254_univariate_dense_polynomial* poly);
 
 /**
+ * @brief Performs the in-place Fast Fourier Transform (FFT) on a given
+ * polynomial within the domain. Note that memory space in poly is altered
+ * after this call.
+ *
+ * @param domain Pointer to the evaluation domain.
+ * @param poly Pointer to the polynomial to transform.
+ * @return Pointer to the evaluations resulting from the FFT.
+ */
+TACHYON_C_EXPORT tachyon_bn254_univariate_evaluations*
+tachyon_bn254_univariate_evaluation_domain_fft_inplace(
+    const tachyon_bn254_univariate_evaluation_domain* domain,
+    tachyon_bn254_univariate_dense_polynomial* poly);
+
+/**
  * @brief Performs the inverse Fast Fourier Transform (IFFT) on given
  * evaluations within the domain.
  *
@@ -104,6 +118,20 @@ TACHYON_C_EXPORT tachyon_bn254_univariate_dense_polynomial*
 tachyon_bn254_univariate_evaluation_domain_ifft(
     const tachyon_bn254_univariate_evaluation_domain* domain,
     const tachyon_bn254_univariate_evaluations* evals);
+
+/**
+ * @brief Performs the in-place inverse Fast Fourier Transform (IFFT) on given
+ * evaluations within the domain. Note that memory space in evals is altered
+ * after this call.
+ *
+ * @param domain Pointer to the evaluation domain.
+ * @param evals Pointer to the evaluations to transform back into a polynomial.
+ * @return Pointer to the dense polynomial resulting from the IFFT.
+ */
+TACHYON_C_EXPORT tachyon_bn254_univariate_dense_polynomial*
+tachyon_bn254_univariate_evaluation_domain_ifft_inplace(
+    const tachyon_bn254_univariate_evaluation_domain* domain,
+    tachyon_bn254_univariate_evaluations* evals);
 
 #ifdef __cplusplus
 }  // extern "C"


### PR DESCRIPTION
# Description

This commit ensures that both arkworks and Tachyon perform FFT benchmarks without incurring any copy overhead. Previously, arkworks (I)FFT didn't incur any copy overhead, while Tachyon did. Now, both implementations are configured to avoid copy overhead for consistency and accurate benchmarking.
