### PR TITLE
build(math): generate m31 field as non fft friendly field

### DIFF
--- a/tachyon/math/finite_fields/generator/prime_field_generator/config.h.tpl
+++ b/tachyon/math/finite_fields/generator/prime_field_generator/config.h.tpl
@@ -51,15 +51,14 @@ class TACHYON_EXPORT %{class}Config {
     %{one_mont_form}
   });
 
-  constexpr static BigInt<%{n}> kSubgroupGenerator = BigInt<%{n}>({
-    %{subgroup_generator}
-  });
-
   constexpr static bool kHasTwoAdicRootOfUnity = %{has_two_adic_root_of_unity};
 
   constexpr static bool kHasLargeSubgroupRootOfUnity = %{has_large_subgroup_root_of_unity};
 
 %{if kHasTwoAdicRootOfUnity}
+  constexpr static BigInt<%{n}> kSubgroupGenerator = BigInt<%{n}>({
+    %{subgroup_generator}
+  });
   constexpr static uint32_t kTwoAdicity = %{two_adicity};
   constexpr static BigInt<%{n}> kTwoAdicRootOfUnity = BigInt<%{n}>({
     %{two_adic_root_of_unity}

--- a/tachyon/math/finite_fields/generator/prime_field_generator/prime_field_generator.cc
+++ b/tachyon/math/finite_fields/generator/prime_field_generator/prime_field_generator.cc
@@ -189,11 +189,6 @@ int GenerationConfig::GenerateConfigHdr() const {
   replacements["%{inverse64}"] = base::NumberToString(modulus_info.inverse64);
   replacements["%{inverse32}"] = base::NumberToString(modulus_info.inverse32);
 
-  mpz_class subgroup_generator_mpz =
-      math::gmp::FromDecString(subgroup_generator);
-  replacements["%{subgroup_generator}"] =
-      math::MpzClassToMontString(subgroup_generator_mpz, m);
-
   std::string tpl_content;
   CHECK(base::ReadFileToString(config_hdr_tpl_path, &tpl_content));
   std::vector<std::string> tpl_lines = absl::StrSplit(tpl_content, "\n");
@@ -203,7 +198,12 @@ int GenerationConfig::GenerateConfigHdr() const {
       std::to_string(has_two_adic_root_of_unity);
   RemoveOptionalLines(tpl_lines, "kHasTwoAdicRootOfUnity",
                       has_two_adic_root_of_unity);
+  mpz_class subgroup_generator_mpz;
   if (has_two_adic_root_of_unity) {
+    subgroup_generator_mpz = math::gmp::FromDecString(subgroup_generator);
+    replacements["%{subgroup_generator}"] =
+        math::MpzClassToMontString(subgroup_generator_mpz, m);
+
     // 1) 2ˢ * t = m - 1,
     // According to Fermat's Little Theorem, the following equations hold:
     // 2) g^(m - 1) = 1 (mod m)

--- a/tachyon/math/finite_fields/mersenne31/BUILD.bazel
+++ b/tachyon/math/finite_fields/mersenne31/BUILD.bazel
@@ -1,18 +1,8 @@
-load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
-load(
-    "//tachyon/math/finite_fields/generator/prime_field_generator:build_defs.bzl",
-    "SUBGROUP_GENERATOR",
-    "generate_fft_prime_fields",
-)
+load("//tachyon/math/finite_fields/generator/prime_field_generator:build_defs.bzl", "generate_prime_fields")
 
 package(default_visibility = ["//visibility:public"])
 
-string_flag(
-    name = SUBGROUP_GENERATOR,
-    build_setting_default = "7",
-)
-
-generate_fft_prime_fields(
+generate_prime_fields(
     name = "mersenne31",
     class_name = "Mersenne31",
     flag = "kIsMersenne31",
@@ -20,5 +10,4 @@ generate_fft_prime_fields(
     # Hex: 0x7fffffff
     modulus = "2147483647",
     namespace = "tachyon::math",
-    subgroup_generator = ":" + SUBGROUP_GENERATOR,
 )


### PR DESCRIPTION
# Description

Since mersenne 31 has only 1 2-adicity, it should be treated as non-fft friendly.

```
M = 2³¹ - 1
M - 1 = 2³¹ - 2 = 2(2³⁰ - 1)
```