### PR TITLE
refac: rename group internal operations

### DIFF
--- a/tachyon/c/math/elliptic_curves/generator/ext_field.cc.tpl
+++ b/tachyon/c/math/elliptic_curves/generator/ext_field.cc.tpl
@@ -36,7 +36,7 @@ tachyon_%{type}_fq%{degree} tachyon_%{type}_fq%{degree}_neg(const tachyon_%{type
   using NativeType =
       typename TypeTraits<tachyon_%{type}_fq%{degree}>::NativeType;
   NativeType native_a = native_cast(*a);
-  return c_cast(native_a.NegInPlace());
+  return c_cast(native_a.NegateInPlace());
 }
 
 tachyon_%{type}_fq%{degree} tachyon_%{type}_fq%{degree}_sqr(const tachyon_%{type}_fq%{degree}* a) {

--- a/tachyon/c/math/elliptic_curves/generator/point.cc.tpl
+++ b/tachyon/c/math/elliptic_curves/generator/point.cc.tpl
@@ -152,22 +152,22 @@ tachyon_%{type}_%{g1_or_g2}_xyzz tachyon_%{type}_%{g1_or_g2}_xyzz_sub_mixed(cons
 
 tachyon_%{type}_%{g1_or_g2}_affine tachyon_%{type}_%{g1_or_g2}_affine_neg(const tachyon_%{type}_%{g1_or_g2}_affine* a) {
   using namespace tachyon::c::math;
-  return ToCAffinePoint(ToAffinePoint(*a).NegInPlace());
+  return ToCAffinePoint(ToAffinePoint(*a).NegateInPlace());
 }
 
 tachyon_%{type}_%{g1_or_g2}_projective tachyon_%{type}_%{g1_or_g2}_projective_neg(const tachyon_%{type}_%{g1_or_g2}_projective* a) {
   using namespace tachyon::c::math;
-  return ToCProjectivePoint(ToProjectivePoint(*a).NegInPlace());
+  return ToCProjectivePoint(ToProjectivePoint(*a).NegateInPlace());
 }
 
 tachyon_%{type}_%{g1_or_g2}_jacobian tachyon_%{type}_%{g1_or_g2}_jacobian_neg(const tachyon_%{type}_%{g1_or_g2}_jacobian* a) {
   using namespace tachyon::c::math;
-  return ToCJacobianPoint(ToJacobianPoint(*a).NegInPlace());
+  return ToCJacobianPoint(ToJacobianPoint(*a).NegateInPlace());
 }
 
 tachyon_%{type}_%{g1_or_g2}_xyzz tachyon_%{type}_%{g1_or_g2}_xyzz_neg(const tachyon_%{type}_%{g1_or_g2}_xyzz* a) {
   using namespace tachyon::c::math;
-  return ToCPointXYZZ(ToPointXYZZ(*a).NegInPlace());
+  return ToCPointXYZZ(ToPointXYZZ(*a).NegateInPlace());
 }
 
 tachyon_%{type}_%{g1_or_g2}_jacobian tachyon_%{type}_%{g1_or_g2}_affine_dbl(const tachyon_%{type}_%{g1_or_g2}_affine* a) {

--- a/tachyon/c/math/elliptic_curves/generator/prime_field.cc.tpl
+++ b/tachyon/c/math/elliptic_curves/generator/prime_field.cc.tpl
@@ -53,7 +53,7 @@ tachyon_%{type}_%{suffix} tachyon_%{type}_%{suffix}_neg(const tachyon_%{type}_%{
   using namespace tachyon::c::base;
   using NativeType = typename TypeTraits<tachyon_%{type}_%{suffix}>::NativeType;
   NativeType native_a = native_cast(*a);
-  return c_cast(native_a.NegInPlace());
+  return c_cast(native_a.NegateInPlace());
 }
 
 tachyon_%{type}_%{suffix} tachyon_%{type}_%{suffix}_dbl(const tachyon_%{type}_%{suffix}* a) {

--- a/tachyon/cc/math/finite_fields/prime_field_unittest.cc
+++ b/tachyon/cc/math/finite_fields/prime_field_unittest.cc
@@ -62,7 +62,7 @@ TEST_F(PrimeFieldTest, Div) {
   EXPECT_EQ(c::base::native_cast((cc_a_ /= cc_b_).value()), a_ /= b_);
 }
 
-TEST_F(PrimeFieldTest, Negative) {
+TEST_F(PrimeFieldTest, Negate) {
   EXPECT_EQ(c::base::native_cast((-cc_a_).value()), -a_);
 }
 

--- a/tachyon/math/base/groups.h
+++ b/tachyon/math/base/groups.h
@@ -199,7 +199,7 @@ class AdditiveGroup : public AdditiveSemigroup<G> {
   // Negation: -a
   constexpr auto operator-() const {
     const G* g = static_cast<const G*>(this);
-    return g->Negative();
+    return g->Negate();
   }
 };
 

--- a/tachyon/math/base/groups_unittest.cc
+++ b/tachyon/math/base/groups_unittest.cc
@@ -100,7 +100,7 @@ TEST(GroupsTest, Sub) {
     Int(const Int& other) : value_(other.value_) {}
 
     MOCK_METHOD(Int, Add, (const Int& other), (const));
-    MOCK_METHOD(Int, Negative, (), (const));
+    MOCK_METHOD(Int, Negate, (), (const));
 
     bool operator==(const Int& other) const { return value_ == other.value_; }
 
@@ -111,7 +111,7 @@ TEST(GroupsTest, Sub) {
   Int a(3);
   Int b(4);
   EXPECT_CALL(a, Add(testing::_)).Times(testing::Exactly(1));
-  EXPECT_CALL(b, Negative()).Times(testing::Exactly(1));
+  EXPECT_CALL(b, Negate()).Times(testing::Exactly(1));
 
   Int c = a - b;
   static_cast<void>(c);
@@ -144,14 +144,14 @@ TEST(GroupsTest, SubOverAdd) {
   static_cast<void>(c);
 }
 
-TEST(GroupsTest, NegativeOverride) {
-  class IntNegative {
+TEST(GroupsTest, NegateOverride) {
+  class IntNegate {
    public:
-    IntNegative() = default;
-    explicit IntNegative(int value) : value_(value) {}
-    IntNegative(const IntNegative& other) : value_(other.value_) {}
+    IntNegate() = default;
+    explicit IntNegate(int value) : value_(value) {}
+    IntNegate(const IntNegate& other) : value_(other.value_) {}
 
-    bool operator==(const IntNegative& other) const {
+    bool operator==(const IntNegate& other) const {
       return value_ == other.value_;
     }
 
@@ -165,7 +165,7 @@ TEST(GroupsTest, NegativeOverride) {
     explicit Int(int value) : value_(value) {}
     Int(const Int& other) : value_(other.value_) {}
 
-    IntNegative Negative() const { return IntNegative(-value_); }
+    IntNegate Negate() const { return IntNegate(-value_); }
 
     bool operator==(const Int& other) const { return value_ == other.value_; }
 
@@ -174,7 +174,7 @@ TEST(GroupsTest, NegativeOverride) {
   };
 
   Int a(3);
-  EXPECT_EQ(-a, IntNegative(-3));
+  EXPECT_EQ(-a, IntNegate(-3));
 }
 
 }  // namespace tachyon::math

--- a/tachyon/math/base/rational_field.h
+++ b/tachyon/math/base/rational_field.h
@@ -137,9 +137,7 @@ class RationalField : public Field<RationalField<F>> {
     return *this;
   }
 
-  constexpr RationalField Negative() const {
-    return {-numerator_, denominator_};
-  }
+  constexpr RationalField Negate() const { return {-numerator_, denominator_}; }
 
   constexpr RationalField& NegInPlace() {
     numerator_.NegInPlace();

--- a/tachyon/math/base/rational_field.h
+++ b/tachyon/math/base/rational_field.h
@@ -155,11 +155,11 @@ class RationalField : public Field<RationalField<F>> {
     return *this;
   }
 
-  constexpr RationalField Square() const {
+  constexpr RationalField SquareImpl() const {
     return {numerator_.Square(), denominator_.Square()};
   }
 
-  constexpr RationalField& DoSquareInPlace() {
+  constexpr RationalField& SquareImplInPlace() {
     numerator_.SquareInPlace();
     denominator_.SquareInPlace();
     return *this;

--- a/tachyon/math/base/rational_field.h
+++ b/tachyon/math/base/rational_field.h
@@ -115,11 +115,11 @@ class RationalField : public Field<RationalField<F>> {
     return *this;
   }
 
-  constexpr RationalField DoDouble() const {
+  constexpr RationalField DoubleImpl() const {
     return {numerator_.Double(), denominator_};
   }
 
-  constexpr RationalField& DoDoubleInPlace() {
+  constexpr RationalField& DoubleImplInPlace() {
     numerator_.DoubleInPlace();
     return *this;
   }

--- a/tachyon/math/base/rational_field.h
+++ b/tachyon/math/base/rational_field.h
@@ -139,8 +139,8 @@ class RationalField : public Field<RationalField<F>> {
 
   constexpr RationalField Negate() const { return {-numerator_, denominator_}; }
 
-  constexpr RationalField& NegInPlace() {
-    numerator_.NegInPlace();
+  constexpr RationalField& NegateInPlace() {
+    numerator_.NegateInPlace();
     return *this;
   }
 

--- a/tachyon/math/base/rational_field_unittest.cc
+++ b/tachyon/math/base/rational_field_unittest.cc
@@ -122,7 +122,7 @@ TEST_F(RationalFieldTest, AdditiveGroupOperators) {
   R r(GF7(3), GF7(2));
   R neg_expected(GF7(4), GF7(2));
   EXPECT_EQ(-r, neg_expected);
-  r.NegInPlace();
+  r.NegateInPlace();
   EXPECT_EQ(r, neg_expected);
 
   r = R(GF7(3), GF7(2));

--- a/tachyon/math/base/semigroups.h
+++ b/tachyon/math/base/semigroups.h
@@ -56,7 +56,7 @@ namespace tachyon::math {
 namespace internal {
 
 SUPPORTS_BINARY_OPERATOR(Mul);
-SUPPORTS_UNARY_OPERATOR(DoSquare);
+SUPPORTS_UNARY_OPERATOR(SquareImpl);
 SUPPORTS_BINARY_OPERATOR(Add);
 SUPPORTS_UNARY_OPERATOR(DoDouble);
 
@@ -117,9 +117,9 @@ class MultiplicativeSemigroup {
 
   // a.Square(): a²
   [[nodiscard]] constexpr auto Square() const {
-    if constexpr (internal::SupportsDoSquare<G>::value) {
+    if constexpr (internal::SupportsSquareImpl<G>::value) {
       const G* g = static_cast<const G*>(this);
-      return g->DoSquare();
+      return g->SquareImpl();
     } else {
       return operator*(static_cast<const G&>(*this));
     }
@@ -127,9 +127,9 @@ class MultiplicativeSemigroup {
 
   // a.SquareInPlace(): a = a²
   constexpr G& SquareInPlace() {
-    if constexpr (internal::SupportsDoSquareInPlace<G>::value) {
+    if constexpr (internal::SupportsSquareImplInPlace<G>::value) {
       G* g = static_cast<G*>(this);
-      return g->DoSquareInPlace();
+      return g->SquareImplInPlace();
     } else if constexpr (internal::SupportsMulInPlace<G, G>::value) {
       return operator*=(static_cast<const G&>(*this));
     } else {
@@ -201,7 +201,7 @@ class MultiplicativeSemigroup {
     auto it = BitIteratorBE<BigInt<N>>::begin(&exponent, true);
     auto end = BitIteratorBE<BigInt<N>>::end(&exponent);
     while (it != end) {
-      if constexpr (internal::SupportsDoSquareInPlace<G>::value ||
+      if constexpr (internal::SupportsSquareImplInPlace<G>::value ||
                     internal::SupportsMulInPlace<G, G>::value) {
         ret.SquareInPlace();
       } else {

--- a/tachyon/math/base/semigroups.h
+++ b/tachyon/math/base/semigroups.h
@@ -58,7 +58,7 @@ namespace internal {
 SUPPORTS_BINARY_OPERATOR(Mul);
 SUPPORTS_UNARY_OPERATOR(SquareImpl);
 SUPPORTS_BINARY_OPERATOR(Add);
-SUPPORTS_UNARY_OPERATOR(DoDouble);
+SUPPORTS_UNARY_OPERATOR(DoubleImpl);
 
 template <typename T, typename = void>
 struct SupportsToBigInt : std::false_type {};
@@ -245,9 +245,9 @@ class AdditiveSemigroup {
 
   // a.Double(): 2a
   [[nodiscard]] constexpr auto Double() const {
-    if constexpr (internal::SupportsDoDouble<G>::value) {
+    if constexpr (internal::SupportsDoubleImpl<G>::value) {
       const G* g = static_cast<const G*>(this);
-      return g->DoDouble();
+      return g->DoubleImpl();
     } else {
       return operator+(static_cast<const G&>(*this));
     }
@@ -255,9 +255,9 @@ class AdditiveSemigroup {
 
   // a.DoubleInPlace(): a = 2a
   constexpr G& DoubleInPlace() {
-    if constexpr (internal::SupportsDoDoubleInPlace<G>::value) {
+    if constexpr (internal::SupportsDoubleImplInPlace<G>::value) {
       G* g = static_cast<G*>(this);
-      return g->DoDoubleInPlace();
+      return g->DoubleImplInPlace();
     } else if constexpr (internal::SupportsAddInPlace<G, G>::value) {
       return operator+=(static_cast<const G&>(*this));
     } else {
@@ -416,7 +416,7 @@ class AdditiveSemigroup {
     auto it = BitIteratorBE<BigInt<N>>::begin(&scalar, true);
     auto end = BitIteratorBE<BigInt<N>>::end(&scalar);
     while (it != end) {
-      if constexpr (internal::SupportsDoDoubleInPlace<G>::value ||
+      if constexpr (internal::SupportsDoubleImplInPlace<G>::value ||
                     internal::SupportsAddInPlace<G, G>::value) {
         ret.DoubleInPlace();
       } else {

--- a/tachyon/math/elliptic_curves/bn/g2_prepared.h
+++ b/tachyon/math/elliptic_curves/bn/g2_prepared.h
@@ -62,10 +62,10 @@ class G2Prepared : public G2PreparedBase<BNCurveConfig> {
 
       G2AffinePoint q1 = MulByCharacteristic(q);
       G2AffinePoint q2 = MulByCharacteristic(q1);
-      q2.NegInPlace();
+      q2.NegateInPlace();
 
       if constexpr (Config::kXIsNegative) {
-        r.NegInPlace();
+        r.NegateInPlace();
       }
 
       ell_coeffs.push_back(r.AddInPlace(q1));

--- a/tachyon/math/elliptic_curves/msm/glv.h
+++ b/tachyon/math/elliptic_curves/msm/glv.h
@@ -80,10 +80,10 @@ class GLV {
     Point b2 = Endomorphism(p);
 
     if (result.k1.sign == Sign::kNegative) {
-      b1.NegInPlace();
+      b1.NegateInPlace();
     }
     if (result.k2.sign == Sign::kNegative) {
-      b2.NegInPlace();
+      b2.NegateInPlace();
     }
 
     RetPoint b1b2 = b1 + b2;

--- a/tachyon/math/elliptic_curves/msm/glv_unittest.cc
+++ b/tachyon/math/elliptic_curves/msm/glv_unittest.cc
@@ -48,10 +48,10 @@ TYPED_TEST(GLVTest, Decompose) {
   ScalarField k1 = ScalarField::FromMpzClass(result.k1.abs_value);
   ScalarField k2 = ScalarField::FromMpzClass(result.k2.abs_value);
   if (result.k1.sign == Sign::kNegative) {
-    k1.NegInPlace();
+    k1.NegateInPlace();
   }
   if (result.k2.sign == Sign::kNegative) {
-    k2.NegInPlace();
+    k2.NegateInPlace();
   }
   EXPECT_EQ(scalar, k1 + Point::Curve::Config::kLambda * k2);
 }

--- a/tachyon/math/elliptic_curves/msm/kernels/bellman/bellman_msm_kernels.cu.h
+++ b/tachyon/math/elliptic_curves/msm/kernels/bellman/bellman_msm_kernels.cu.h
@@ -214,7 +214,7 @@ __global__ void AggregateBucketsKernel(
     auto base =
         Load<AffinePoint<Curve>, CacheOperator::kNone>(&bases[base_index]);
     if (sign) {
-      base.NegInPlace();
+      base.NegateInPlace();
     }
     bucket = base.ToXYZZ();
   } else {
@@ -246,7 +246,7 @@ __global__ void AggregateBucketsKernel(
     auto base =
         Load<AffinePoint<Curve>, CacheOperator::kNone>(&bases[base_index]);
     if (sign) {
-      base.NegInPlace();
+      base.NegateInPlace();
     }
     bucket += base;
   }

--- a/tachyon/math/elliptic_curves/pairing/g2_projective.h
+++ b/tachyon/math/elliptic_curves/pairing/g2_projective.h
@@ -84,8 +84,8 @@ class G2Projective {
     }
   }
 
-  G2Projective& NegInPlace() {
-    y_.NegInPlace();
+  G2Projective& NegateInPlace() {
+    y_.NegateInPlace();
     return *this;
   }
 

--- a/tachyon/math/elliptic_curves/short_weierstrass/affine_point.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/affine_point.h
@@ -182,8 +182,8 @@ class AffinePoint<
 
   constexpr AffinePoint Negate() const { return {x_, -y_, infinity_}; }
 
-  constexpr AffinePoint& NegInPlace() {
-    y_.NegInPlace();
+  constexpr AffinePoint& NegateInPlace() {
+    y_.NegateInPlace();
     return *this;
   }
 

--- a/tachyon/math/elliptic_curves/short_weierstrass/affine_point.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/affine_point.h
@@ -180,7 +180,7 @@ class AffinePoint<
     return ToXYZZ() + other;
   }
 
-  constexpr AffinePoint Negative() const { return {x_, -y_, infinity_}; }
+  constexpr AffinePoint Negate() const { return {x_, -y_, infinity_}; }
 
   constexpr AffinePoint& NegInPlace() {
     y_.NegInPlace();

--- a/tachyon/math/elliptic_curves/short_weierstrass/affine_point_correctness_gpu_test.cc
+++ b/tachyon/math/elliptic_curves/short_weierstrass/affine_point_correctness_gpu_test.cc
@@ -21,7 +21,7 @@ DEFINE_LAUNCH_FIELD_BINARY_OP(Add)
 
 DEFINE_LAUNCH_UNARY_OP(kThreadNum, Double, bn254::G1AffinePointGpu,
                        bn254::G1JacobianPointGpu)
-DEFINE_LAUNCH_UNARY_OP(kThreadNum, Negative, bn254::G1AffinePointGpu,
+DEFINE_LAUNCH_UNARY_OP(kThreadNum, Negate, bn254::G1AffinePointGpu,
                        bn254::G1AffinePointGpu)
 
 #undef DEFINE_LAUNCH_FIELD_BINARY_OP
@@ -131,8 +131,8 @@ TEST_F(AffinePointCorrectnessGpuTest, Double) {
   }
 }
 
-TEST_F(AffinePointCorrectnessGpuTest, Negative) {
-  GPU_MUST_SUCCESS(LaunchNegative(xs_.get(), affine_results_.get(), N), "");
+TEST_F(AffinePointCorrectnessGpuTest, Negate) {
+  GPU_MUST_SUCCESS(LaunchNegate(xs_.get(), affine_results_.get(), N), "");
   for (size_t i = 0; i < N; ++i) {
     SCOPED_TRACE(absl::Substitute("a: $0", xs_[i].ToString()));
     auto result = ConvertPoint<bn254::G1AffinePoint>(affine_results_[i]);

--- a/tachyon/math/elliptic_curves/short_weierstrass/affine_point_unittest.cc
+++ b/tachyon/math/elliptic_curves/short_weierstrass/affine_point_unittest.cc
@@ -85,7 +85,7 @@ TEST_F(AffinePointTest, AdditiveGroupOperators) {
   EXPECT_EQ(-ap, test::AffinePoint(GF7(5), GF7(2)));
   {
     test::AffinePoint ap_tmp = ap;
-    ap_tmp.NegInPlace();
+    ap_tmp.NegateInPlace();
     EXPECT_EQ(ap_tmp, test::AffinePoint(GF7(5), GF7(2)));
   }
 

--- a/tachyon/math/elliptic_curves/short_weierstrass/jacobian_point.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/jacobian_point.h
@@ -265,8 +265,8 @@ class JacobianPoint<
   constexpr JacobianPoint& AddInPlace(const JacobianPoint& other);
   constexpr JacobianPoint Add(const AffinePoint<Curve>& other) const;
   constexpr JacobianPoint& AddInPlace(const AffinePoint<Curve>& other);
-  constexpr JacobianPoint DoDouble() const;
-  constexpr JacobianPoint& DoDoubleInPlace();
+  constexpr JacobianPoint DoubleImpl() const;
+  constexpr JacobianPoint& DoubleImplInPlace();
 
   // AdditiveGroup methods
   constexpr JacobianPoint Negate() const { return {x_, -y_, z_}; }

--- a/tachyon/math/elliptic_curves/short_weierstrass/jacobian_point.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/jacobian_point.h
@@ -269,7 +269,7 @@ class JacobianPoint<
   constexpr JacobianPoint& DoDoubleInPlace();
 
   // AdditiveGroup methods
-  constexpr JacobianPoint Negative() const { return {x_, -y_, z_}; }
+  constexpr JacobianPoint Negate() const { return {x_, -y_, z_}; }
 
   constexpr JacobianPoint& NegInPlace() {
     y_.NegInPlace();

--- a/tachyon/math/elliptic_curves/short_weierstrass/jacobian_point.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/jacobian_point.h
@@ -271,8 +271,8 @@ class JacobianPoint<
   // AdditiveGroup methods
   constexpr JacobianPoint Negate() const { return {x_, -y_, z_}; }
 
-  constexpr JacobianPoint& NegInPlace() {
-    y_.NegInPlace();
+  constexpr JacobianPoint& NegateInPlace() {
+    y_.NegateInPlace();
     return *this;
   }
 

--- a/tachyon/math/elliptic_curves/short_weierstrass/jacobian_point_impl.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/jacobian_point_impl.h
@@ -84,7 +84,7 @@ constexpr void CLASS::DoAdd(const JacobianPoint& a, const JacobianPoint& b,
 
     // J = -H * I
     BaseField j = h * i;
-    j.NegInPlace();
+    j.NegateInPlace();
 
     // r = 2 * (S2 - S1)
     BaseField r = s2 - s1;
@@ -169,7 +169,7 @@ constexpr void CLASS::DoAdd(const JacobianPoint& a, const AffinePoint<Curve>& b,
 
     // J = -H * I
     BaseField j = h * i;
-    j.NegInPlace();
+    j.NegateInPlace();
 
     // r = 2 * (S2 - Y1)
     BaseField r = s2 - a.y_;

--- a/tachyon/math/elliptic_curves/short_weierstrass/jacobian_point_impl.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/jacobian_point_impl.h
@@ -197,7 +197,7 @@ constexpr void CLASS::DoAdd(const JacobianPoint& a, const AffinePoint<Curve>& b,
 }
 
 template <typename Curve>
-constexpr CLASS CLASS::DoDouble() const {
+constexpr CLASS CLASS::DoubleImpl() const {
   if (IsZero()) {
     return JacobianPoint::Zero();
   }
@@ -208,7 +208,7 @@ constexpr CLASS CLASS::DoDouble() const {
 }
 
 template <typename Curve>
-constexpr CLASS& CLASS::DoDoubleInPlace() {
+constexpr CLASS& CLASS::DoubleImplInPlace() {
   if (IsZero()) {
     return *this;
   }

--- a/tachyon/math/elliptic_curves/short_weierstrass/jacobian_point_unittest.cc
+++ b/tachyon/math/elliptic_curves/short_weierstrass/jacobian_point_unittest.cc
@@ -118,7 +118,7 @@ TEST_F(JacobianPointTest, AdditiveGroupOperators) {
   EXPECT_EQ(-jp, test::JacobianPoint(GF7(5), GF7(2), GF7(1)));
   {
     test::JacobianPoint jp_tmp = jp;
-    jp_tmp.NegInPlace();
+    jp_tmp.NegateInPlace();
     EXPECT_EQ(jp_tmp, test::JacobianPoint(GF7(5), GF7(2), GF7(1)));
   }
 

--- a/tachyon/math/elliptic_curves/short_weierstrass/kernels/elliptic_curve_ops.cu.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/kernels/elliptic_curve_ops.cu.h
@@ -64,21 +64,21 @@ DEFINE_DOUBLE_OP(PointXYZZ, PointXYZZ)
 
 #undef DEFINE_DOUBLE_OP
 
-#define DEFINE_NEGATIVE_OP(src_type, dst_type)                             \
-  template <typename Config>                                               \
-  __global__ void Negative(const src_type<Config>* x,                      \
-                           dst_type<Config>* result, unsigned int count) { \
-    unsigned int gid = blockIdx.x * blockDim.x + threadIdx.x;              \
-    if (gid >= count) return;                                              \
-    result[gid] = -x[gid];                                                 \
+#define DEFINE_NEGATE_OP(src_type, dst_type)                                  \
+  template <typename Config>                                                  \
+  __global__ void Negate(const src_type<Config>* x, dst_type<Config>* result, \
+                         unsigned int count) {                                \
+    unsigned int gid = blockIdx.x * blockDim.x + threadIdx.x;                 \
+    if (gid >= count) return;                                                 \
+    result[gid] = -x[gid];                                                    \
   }
 
-DEFINE_NEGATIVE_OP(AffinePoint, AffinePoint)
-DEFINE_NEGATIVE_OP(JacobianPoint, JacobianPoint)
-DEFINE_NEGATIVE_OP(ProjectivePoint, ProjectivePoint)
-DEFINE_NEGATIVE_OP(PointXYZZ, PointXYZZ)
+DEFINE_NEGATE_OP(AffinePoint, AffinePoint)
+DEFINE_NEGATE_OP(JacobianPoint, JacobianPoint)
+DEFINE_NEGATE_OP(ProjectivePoint, ProjectivePoint)
+DEFINE_NEGATE_OP(PointXYZZ, PointXYZZ)
 
-#undef DEFINE_NEGATIVE_OP
+#undef DEFINE_NEGATE_OP
 
 }  // namespace tachyon::math::kernels
 

--- a/tachyon/math/elliptic_curves/short_weierstrass/non_affine_point_correctness_gpu_test.cc
+++ b/tachyon/math/elliptic_curves/short_weierstrass/non_affine_point_correctness_gpu_test.cc
@@ -34,7 +34,7 @@ DEFINE_LAUNCH_FIELD_BINARY_OP(Add)
                          bn254::G1PointXYZZGpu)
 
 DEFINE_LAUNCH_FIELD_UNARY_OP(Double)
-DEFINE_LAUNCH_FIELD_UNARY_OP(Negative)
+DEFINE_LAUNCH_FIELD_UNARY_OP(Negate)
 
 #undef DEFINE_LAUNCH_FIELD_UNARY_OP
 
@@ -182,12 +182,11 @@ TYPED_TEST(PointCorrectnessGpuTest, Double) {
   }
 }
 
-TYPED_TEST(PointCorrectnessGpuTest, Negative) {
+TYPED_TEST(PointCorrectnessGpuTest, Negate) {
   using Expected = typename TypeParam::Expected;
   size_t N = PointCorrectnessGpuTest<TypeParam>::N;
 
-  GPU_MUST_SUCCESS(LaunchNegative(this->xs_.get(), this->results_.get(), N),
-                   "");
+  GPU_MUST_SUCCESS(LaunchNegate(this->xs_.get(), this->results_.get(), N), "");
   for (size_t i = 0; i < N; ++i) {
     SCOPED_TRACE(absl::Substitute("a: $0", this->xs_[i].ToString()));
     auto result = ConvertPoint<Expected>(this->results_[i]);

--- a/tachyon/math/elliptic_curves/short_weierstrass/point_xyzz.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/point_xyzz.h
@@ -283,7 +283,7 @@ class PointXYZZ<_Curve,
   constexpr PointXYZZ& DoDoubleInPlace();
 
   // AdditiveGroup methods
-  constexpr PointXYZZ Negative() const { return {x_, -y_, zz_, zzz_}; }
+  constexpr PointXYZZ Negate() const { return {x_, -y_, zz_, zzz_}; }
 
   constexpr PointXYZZ& NegInPlace() {
     y_.NegInPlace();

--- a/tachyon/math/elliptic_curves/short_weierstrass/point_xyzz.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/point_xyzz.h
@@ -285,8 +285,8 @@ class PointXYZZ<_Curve,
   // AdditiveGroup methods
   constexpr PointXYZZ Negate() const { return {x_, -y_, zz_, zzz_}; }
 
-  constexpr PointXYZZ& NegInPlace() {
-    y_.NegInPlace();
+  constexpr PointXYZZ& NegateInPlace() {
+    y_.NegateInPlace();
     return *this;
   }
 

--- a/tachyon/math/elliptic_curves/short_weierstrass/point_xyzz.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/point_xyzz.h
@@ -279,8 +279,8 @@ class PointXYZZ<_Curve,
   constexpr PointXYZZ& AddInPlace(const PointXYZZ& other);
   constexpr PointXYZZ Add(const AffinePoint<Curve>& other) const;
   constexpr PointXYZZ& AddInPlace(const AffinePoint<Curve>& other);
-  constexpr PointXYZZ DoDouble() const;
-  constexpr PointXYZZ& DoDoubleInPlace();
+  constexpr PointXYZZ DoubleImpl() const;
+  constexpr PointXYZZ& DoubleImplInPlace();
 
   // AdditiveGroup methods
   constexpr PointXYZZ Negate() const { return {x_, -y_, zz_, zzz_}; }

--- a/tachyon/math/elliptic_curves/short_weierstrass/point_xyzz_impl.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/point_xyzz_impl.h
@@ -175,7 +175,7 @@ constexpr void CLASS::DoAdd(const PointXYZZ& a, const AffinePoint<Curve>& b,
 }
 
 template <typename Curve>
-constexpr CLASS CLASS::DoDouble() const {
+constexpr CLASS CLASS::DoubleImpl() const {
   if (IsZero()) {
     return PointXYZZ::Zero();
   }
@@ -186,7 +186,7 @@ constexpr CLASS CLASS::DoDouble() const {
 }
 
 template <typename Curve>
-constexpr CLASS& CLASS::DoDoubleInPlace() {
+constexpr CLASS& CLASS::DoubleImplInPlace() {
   if (IsZero()) {
     return *this;
   }

--- a/tachyon/math/elliptic_curves/short_weierstrass/point_xyzz_unittest.cc
+++ b/tachyon/math/elliptic_curves/short_weierstrass/point_xyzz_unittest.cc
@@ -119,7 +119,7 @@ TEST_F(PointXYZZTest, AdditiveGroupOperators) {
   EXPECT_EQ(-p, test::PointXYZZ(GF7(5), GF7(2), GF7(1), GF7(1)));
   {
     test::PointXYZZ p_tmp = p;
-    p_tmp.NegInPlace();
+    p_tmp.NegateInPlace();
     EXPECT_EQ(p_tmp, test::PointXYZZ(GF7(5), GF7(2), GF7(1), GF7(1)));
   }
 

--- a/tachyon/math/elliptic_curves/short_weierstrass/projective_point.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/projective_point.h
@@ -263,7 +263,7 @@ class ProjectivePoint<
   constexpr ProjectivePoint& DoDoubleInPlace();
 
   // AdditiveGroup methods
-  constexpr ProjectivePoint Negative() const { return {x_, -y_, z_}; }
+  constexpr ProjectivePoint Negate() const { return {x_, -y_, z_}; }
 
   constexpr ProjectivePoint& NegInPlace() {
     y_.NegInPlace();

--- a/tachyon/math/elliptic_curves/short_weierstrass/projective_point.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/projective_point.h
@@ -265,8 +265,8 @@ class ProjectivePoint<
   // AdditiveGroup methods
   constexpr ProjectivePoint Negate() const { return {x_, -y_, z_}; }
 
-  constexpr ProjectivePoint& NegInPlace() {
-    y_.NegInPlace();
+  constexpr ProjectivePoint& NegateInPlace() {
+    y_.NegateInPlace();
     return *this;
   }
 

--- a/tachyon/math/elliptic_curves/short_weierstrass/projective_point.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/projective_point.h
@@ -259,8 +259,8 @@ class ProjectivePoint<
   constexpr ProjectivePoint& AddInPlace(const ProjectivePoint& other);
   constexpr ProjectivePoint Add(const AffinePoint<Curve>& other) const;
   constexpr ProjectivePoint& AddInPlace(const AffinePoint<Curve>& other);
-  constexpr ProjectivePoint DoDouble() const;
-  constexpr ProjectivePoint& DoDoubleInPlace();
+  constexpr ProjectivePoint DoubleImpl() const;
+  constexpr ProjectivePoint& DoubleImplInPlace();
 
   // AdditiveGroup methods
   constexpr ProjectivePoint Negate() const { return {x_, -y_, z_}; }

--- a/tachyon/math/elliptic_curves/short_weierstrass/projective_point_impl.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/projective_point_impl.h
@@ -176,7 +176,7 @@ constexpr void CLASS::DoAdd(const ProjectivePoint& a,
 }
 
 template <typename Curve>
-constexpr CLASS CLASS::DoDouble() const {
+constexpr CLASS CLASS::DoubleImpl() const {
   if (IsZero()) {
     return ProjectivePoint::Zero();
   }
@@ -187,7 +187,7 @@ constexpr CLASS CLASS::DoDouble() const {
 }
 
 template <typename Curve>
-constexpr CLASS& CLASS::DoDoubleInPlace() {
+constexpr CLASS& CLASS::DoubleImplInPlace() {
   if (IsZero()) {
     return *this;
   }

--- a/tachyon/math/elliptic_curves/short_weierstrass/projective_point_unittest.cc
+++ b/tachyon/math/elliptic_curves/short_weierstrass/projective_point_unittest.cc
@@ -119,7 +119,7 @@ TEST_F(ProjectivePointTest, AdditiveGroupOperators) {
   EXPECT_EQ(-pp, test::ProjectivePoint(GF7(5), GF7(2), GF7(1)));
   {
     test::ProjectivePoint pp_tmp = pp;
-    pp_tmp.NegInPlace();
+    pp_tmp.NegateInPlace();
     EXPECT_EQ(pp_tmp, test::ProjectivePoint(GF7(5), GF7(2), GF7(1)));
   }
 

--- a/tachyon/math/finite_fields/cubic_extension_field.h
+++ b/tachyon/math/finite_fields/cubic_extension_field.h
@@ -203,7 +203,7 @@ class CubicExtensionField : public CyclotomicMultiplicativeSubgroup<Derived> {
     return *static_cast<Derived*>(this);
   }
 
-  constexpr Derived Negative() const {
+  constexpr Derived Negate() const {
     return {
         -c0_,
         -c1_,

--- a/tachyon/math/finite_fields/cubic_extension_field.h
+++ b/tachyon/math/finite_fields/cubic_extension_field.h
@@ -211,10 +211,10 @@ class CubicExtensionField : public CyclotomicMultiplicativeSubgroup<Derived> {
     };
   }
 
-  constexpr Derived& NegInPlace() {
-    c0_.NegInPlace();
-    c1_.NegInPlace();
-    c2_.NegInPlace();
+  constexpr Derived& NegateInPlace() {
+    c0_.NegateInPlace();
+    c1_.NegateInPlace();
+    c2_.NegateInPlace();
     return *static_cast<Derived*>(this);
   }
 

--- a/tachyon/math/finite_fields/cubic_extension_field.h
+++ b/tachyon/math/finite_fields/cubic_extension_field.h
@@ -172,7 +172,7 @@ class CubicExtensionField : public CyclotomicMultiplicativeSubgroup<Derived> {
     return *static_cast<Derived*>(this);
   }
 
-  constexpr Derived DoDouble() const {
+  constexpr Derived DoubleImpl() const {
     return {
         c0_.Double(),
         c1_.Double(),
@@ -180,7 +180,7 @@ class CubicExtensionField : public CyclotomicMultiplicativeSubgroup<Derived> {
     };
   }
 
-  constexpr Derived& DoDoubleInPlace() {
+  constexpr Derived& DoubleImplInPlace() {
     c0_.DoubleInPlace();
     c1_.DoubleInPlace();
     c2_.DoubleInPlace();

--- a/tachyon/math/finite_fields/cubic_extension_field.h
+++ b/tachyon/math/finite_fields/cubic_extension_field.h
@@ -246,13 +246,13 @@ class CubicExtensionField : public CyclotomicMultiplicativeSubgroup<Derived> {
     return *static_cast<Derived*>(this);
   }
 
-  constexpr Derived DoSquare() const {
+  constexpr Derived SquareImpl() const {
     Derived ret;
     DoSquareImpl(*static_cast<const Derived*>(this), ret);
     return ret;
   }
 
-  constexpr Derived& DoSquareInPlace() {
+  constexpr Derived& SquareImplInPlace() {
     DoSquareImpl(*static_cast<const Derived*>(this),
                  *static_cast<Derived*>(this));
     return *static_cast<Derived*>(this);

--- a/tachyon/math/finite_fields/cubic_extension_field_unittest.cc
+++ b/tachyon/math/finite_fields/cubic_extension_field_unittest.cc
@@ -109,7 +109,7 @@ TEST_F(CubicExtensionFieldTest, AdditiveGroupOperators) {
   GF7_3 f(GF7(3), GF7(4), GF7(5));
   GF7_3 f_neg(GF7(4), GF7(3), GF7(2));
   EXPECT_EQ(-f, f_neg);
-  f.NegInPlace();
+  f.NegateInPlace();
   EXPECT_EQ(f, f_neg);
 
   f = GF7_3(GF7(3), GF7(4), GF7(5));

--- a/tachyon/math/finite_fields/generator/generator_util.cc
+++ b/tachyon/math/finite_fields/generator/generator_util.cc
@@ -71,7 +71,7 @@ std::string GenerateFastMultiplication(int64_t value) {
     }
     ++it;
   }
-  if (is_negative) ss << ".NegInPlace()";
+  if (is_negative) ss << ".NegateInPlace()";
   return ss.str();
 }
 

--- a/tachyon/math/finite_fields/generator/prime_field_generator/prime_field_x86.h.tpl
+++ b/tachyon/math/finite_fields/generator/prime_field_generator/prime_field_x86.h.tpl
@@ -182,7 +182,7 @@ class PrimeField<_Config, std::enable_if_t<_Config::%{flag}>> final
     return *this;
   }
 
-  constexpr PrimeField Negative() const {
+  constexpr PrimeField Negate() const {
     PrimeField ret;
     %{prefix}_rawNeg(ret.value_.limbs, value_.limbs);
     return ret;

--- a/tachyon/math/finite_fields/generator/prime_field_generator/prime_field_x86.h.tpl
+++ b/tachyon/math/finite_fields/generator/prime_field_generator/prime_field_x86.h.tpl
@@ -188,7 +188,7 @@ class PrimeField<_Config, std::enable_if_t<_Config::%{flag}>> final
     return ret;
   }
 
-  constexpr PrimeField& NegInPlace() {
+  constexpr PrimeField& NegateInPlace() {
     %{prefix}_rawNeg(value_.limbs, value_.limbs);
     return *this;
   }

--- a/tachyon/math/finite_fields/goldilocks/goldilocks_prime_field_x86_special.cc
+++ b/tachyon/math/finite_fields/goldilocks/goldilocks_prime_field_x86_special.cc
@@ -158,7 +158,7 @@ CLASS CLASS::Negate() const {
 }
 
 template <typename Config>
-CLASS& CLASS::NegInPlace() {
+CLASS& CLASS::NegateInPlace() {
   ::Goldilocks::neg(reinterpret_cast<::Goldilocks::Element&>(value_),
                     reinterpret_cast<const ::Goldilocks::Element&>(value_));
   return *this;

--- a/tachyon/math/finite_fields/goldilocks/goldilocks_prime_field_x86_special.cc
+++ b/tachyon/math/finite_fields/goldilocks/goldilocks_prime_field_x86_special.cc
@@ -150,7 +150,7 @@ CLASS& CLASS::SubInPlace(const PrimeField& other) {
 }
 
 template <typename Config>
-CLASS CLASS::Negative() const {
+CLASS CLASS::Negate() const {
   PrimeField ret;
   ::Goldilocks::neg(reinterpret_cast<::Goldilocks::Element&>(ret.value_),
                     reinterpret_cast<const ::Goldilocks::Element&>(value_));

--- a/tachyon/math/finite_fields/goldilocks/goldilocks_prime_field_x86_special.cc
+++ b/tachyon/math/finite_fields/goldilocks/goldilocks_prime_field_x86_special.cc
@@ -184,7 +184,7 @@ CLASS& CLASS::MulInPlace(const PrimeField& other) {
 }
 
 template <typename Config>
-CLASS CLASS::DoSquare() const {
+CLASS CLASS::SquareImpl() const {
   PrimeField ret;
   ::Goldilocks::square(reinterpret_cast<::Goldilocks::Element&>(ret.value_),
                        reinterpret_cast<const ::Goldilocks::Element&>(value_));
@@ -192,7 +192,7 @@ CLASS CLASS::DoSquare() const {
 }
 
 template <typename Config>
-CLASS& CLASS::DoSquareInPlace() {
+CLASS& CLASS::SquareImplInPlace() {
   ::Goldilocks::square(reinterpret_cast<::Goldilocks::Element&>(value_),
                        reinterpret_cast<const ::Goldilocks::Element&>(value_));
   return *this;

--- a/tachyon/math/finite_fields/goldilocks/goldilocks_prime_field_x86_special.h
+++ b/tachyon/math/finite_fields/goldilocks/goldilocks_prime_field_x86_special.h
@@ -97,7 +97,7 @@ class PrimeField<_Config, std::enable_if_t<_Config::kIsGoldilocks>> final
   // AdditiveGroup methods
   PrimeField Sub(const PrimeField& other) const;
   PrimeField& SubInPlace(const PrimeField& other);
-  PrimeField Negative() const;
+  PrimeField Negate() const;
   PrimeField& NegInPlace();
 
   // TODO(chokobole): Support bigendian.

--- a/tachyon/math/finite_fields/goldilocks/goldilocks_prime_field_x86_special.h
+++ b/tachyon/math/finite_fields/goldilocks/goldilocks_prime_field_x86_special.h
@@ -98,7 +98,7 @@ class PrimeField<_Config, std::enable_if_t<_Config::kIsGoldilocks>> final
   PrimeField Sub(const PrimeField& other) const;
   PrimeField& SubInPlace(const PrimeField& other);
   PrimeField Negate() const;
-  PrimeField& NegInPlace();
+  PrimeField& NegateInPlace();
 
   // TODO(chokobole): Support bigendian.
   // MultiplicativeSemigroup methods

--- a/tachyon/math/finite_fields/goldilocks/goldilocks_prime_field_x86_special.h
+++ b/tachyon/math/finite_fields/goldilocks/goldilocks_prime_field_x86_special.h
@@ -104,8 +104,8 @@ class PrimeField<_Config, std::enable_if_t<_Config::kIsGoldilocks>> final
   // MultiplicativeSemigroup methods
   PrimeField Mul(const PrimeField& other) const;
   PrimeField& MulInPlace(const PrimeField& other);
-  PrimeField DoSquare() const;
-  PrimeField& DoSquareInPlace();
+  PrimeField SquareImpl() const;
+  PrimeField& SquareImplInPlace();
 
   // MultiplicativeGroup methods
   PrimeField Inverse() const;

--- a/tachyon/math/finite_fields/prime_field_generator_unittest.cc
+++ b/tachyon/math/finite_fields/prime_field_generator_unittest.cc
@@ -102,7 +102,7 @@ TYPED_TEST(PrimeFieldGeneratorTest, AdditiveGroupOperators) {
   SCOPED_TRACE(absl::Substitute("f: $0", f.ToString()));
   PrimeField f_neg = -f;
   EXPECT_TRUE((f_neg + f).IsZero());
-  f.NegInPlace();
+  f.NegateInPlace();
   EXPECT_EQ(f, f_neg);
 
   PrimeField f_double = f.Double();

--- a/tachyon/math/finite_fields/prime_field_generic.h
+++ b/tachyon/math/finite_fields/prime_field_generic.h
@@ -232,7 +232,7 @@ class PrimeField<_Config, std::enable_if_t<!_Config::kIsSpecialPrime>> final
     return ret;
   }
 
-  constexpr PrimeField& NegInPlace() {
+  constexpr PrimeField& NegateInPlace() {
     if (!IsZero()) {
       BigInt<N> tmp(Config::kModulus);
       tmp.SubInPlace(value_);

--- a/tachyon/math/finite_fields/prime_field_generic.h
+++ b/tachyon/math/finite_fields/prime_field_generic.h
@@ -262,7 +262,7 @@ class PrimeField<_Config, std::enable_if_t<!_Config::kIsSpecialPrime>> final
     return *this;
   }
 
-  constexpr PrimeField DoSquare() const {
+  constexpr PrimeField SquareImpl() const {
     if (N == 1) {
       return Mul(*this);
     }
@@ -271,7 +271,7 @@ class PrimeField<_Config, std::enable_if_t<!_Config::kIsSpecialPrime>> final
     return ret;
   }
 
-  constexpr PrimeField& DoSquareInPlace() {
+  constexpr PrimeField& SquareImplInPlace() {
     if (N == 1) {
       return MulInPlace(*this);
     }

--- a/tachyon/math/finite_fields/prime_field_generic.h
+++ b/tachyon/math/finite_fields/prime_field_generic.h
@@ -223,7 +223,7 @@ class PrimeField<_Config, std::enable_if_t<!_Config::kIsSpecialPrime>> final
     return *this;
   }
 
-  constexpr PrimeField Negative() const {
+  constexpr PrimeField Negate() const {
     PrimeField ret;
     if (!IsZero()) {
       ret.value_ = Config::kModulus;

--- a/tachyon/math/finite_fields/prime_field_generic.h
+++ b/tachyon/math/finite_fields/prime_field_generic.h
@@ -186,7 +186,7 @@ class PrimeField<_Config, std::enable_if_t<!_Config::kIsSpecialPrime>> final
     return *this;
   }
 
-  constexpr PrimeField DoDouble() const {
+  constexpr PrimeField DoubleImpl() const {
     PrimeField ret;
     uint64_t carry = 0;
     ret.value_ = value_.MulBy2(carry);
@@ -195,7 +195,7 @@ class PrimeField<_Config, std::enable_if_t<!_Config::kIsSpecialPrime>> final
     return ret;
   }
 
-  constexpr PrimeField& DoDoubleInPlace() {
+  constexpr PrimeField& DoubleImplInPlace() {
     uint64_t carry = 0;
     value_.MulBy2InPlace(carry);
     BigInt<N>::template Clamp<Config::kModulusHasSpareBit>(Config::kModulus,

--- a/tachyon/math/finite_fields/prime_field_gpu.h
+++ b/tachyon/math/finite_fields/prime_field_gpu.h
@@ -250,7 +250,7 @@ class PrimeFieldGpu final : public PrimeFieldBase<PrimeFieldGpu<_Config>> {
     return ret;
   }
 
-  __device__ constexpr PrimeFieldGpu& NegInPlace() {
+  __device__ constexpr PrimeFieldGpu& NegateInPlace() {
     BigInt<N> result;
     SubLimbs<false>(GetModulus(), value_, result);
     value_ = result;

--- a/tachyon/math/finite_fields/prime_field_gpu.h
+++ b/tachyon/math/finite_fields/prime_field_gpu.h
@@ -244,7 +244,7 @@ class PrimeFieldGpu final : public PrimeFieldBase<PrimeFieldGpu<_Config>> {
     return *this;
   }
 
-  __device__ constexpr PrimeFieldGpu Negative() const {
+  __device__ constexpr PrimeFieldGpu Negate() const {
     PrimeFieldGpu ret;
     SubLimbs<false>(GetModulus(), value_, ret.value_);
     return ret;

--- a/tachyon/math/finite_fields/prime_field_gpu_debug.h
+++ b/tachyon/math/finite_fields/prime_field_gpu_debug.h
@@ -200,7 +200,7 @@ class PrimeFieldGpuDebug final
     return *this;
   }
 
-  constexpr PrimeFieldGpuDebug Negative() const {
+  constexpr PrimeFieldGpuDebug Negate() const {
     PrimeFieldGpuDebug ret;
     SubLimbs<false>(Config::kModulus, value_, ret.value_);
     return ret;

--- a/tachyon/math/finite_fields/prime_field_gpu_debug.h
+++ b/tachyon/math/finite_fields/prime_field_gpu_debug.h
@@ -206,7 +206,7 @@ class PrimeFieldGpuDebug final
     return ret;
   }
 
-  constexpr PrimeFieldGpuDebug& NegInPlace() {
+  constexpr PrimeFieldGpuDebug& NegateInPlace() {
     BigInt<N> result;
     SubLimbs<false>(Config::kModulus, value_, result);
     value_ = result;

--- a/tachyon/math/finite_fields/prime_field_unittest.cc
+++ b/tachyon/math/finite_fields/prime_field_unittest.cc
@@ -124,7 +124,7 @@ TYPED_TEST(PrimeFieldTest, AdditiveGroupOperators) {
 
   F f(3);
   EXPECT_EQ(-f, F(4));
-  f.NegInPlace();
+  f.NegateInPlace();
   EXPECT_EQ(f, F(4));
 
   f = F(3);

--- a/tachyon/math/finite_fields/quadratic_extension_field.h
+++ b/tachyon/math/finite_fields/quadratic_extension_field.h
@@ -208,13 +208,13 @@ class QuadraticExtensionField
     return *static_cast<Derived*>(this);
   }
 
-  constexpr Derived DoSquare() const {
+  constexpr Derived SquareImpl() const {
     Derived ret;
     DoSquareImpl(*static_cast<const Derived*>(this), ret);
     return ret;
   }
 
-  constexpr Derived& DoSquareInPlace() {
+  constexpr Derived& SquareImplInPlace() {
     DoSquareImpl(*static_cast<const Derived*>(this),
                  *static_cast<Derived*>(this));
     return *static_cast<Derived*>(this);

--- a/tachyon/math/finite_fields/quadratic_extension_field.h
+++ b/tachyon/math/finite_fields/quadratic_extension_field.h
@@ -142,14 +142,14 @@ class QuadraticExtensionField
     return *static_cast<Derived*>(this);
   }
 
-  constexpr Derived DoDouble() const {
+  constexpr Derived DoubleImpl() const {
     return {
         c0_.Double(),
         c1_.Double(),
     };
   }
 
-  constexpr Derived& DoDoubleInPlace() {
+  constexpr Derived& DoubleImplInPlace() {
     c0_.DoubleInPlace();
     c1_.DoubleInPlace();
     return *static_cast<Derived*>(this);

--- a/tachyon/math/finite_fields/quadratic_extension_field.h
+++ b/tachyon/math/finite_fields/quadratic_extension_field.h
@@ -169,7 +169,7 @@ class QuadraticExtensionField
     return *static_cast<Derived*>(this);
   }
 
-  constexpr Derived Negative() const {
+  constexpr Derived Negate() const {
     return {
         -c0_,
         -c1_,

--- a/tachyon/math/finite_fields/quadratic_extension_field.h
+++ b/tachyon/math/finite_fields/quadratic_extension_field.h
@@ -64,7 +64,7 @@ class QuadraticExtensionField
   }
 
   constexpr Derived& ConjugateInPlace() {
-    c1_.NegInPlace();
+    c1_.NegateInPlace();
     return *static_cast<Derived*>(this);
   }
 
@@ -176,9 +176,9 @@ class QuadraticExtensionField
     };
   }
 
-  constexpr Derived& NegInPlace() {
-    c0_.NegInPlace();
-    c1_.NegInPlace();
+  constexpr Derived& NegateInPlace() {
+    c0_.NegateInPlace();
+    c1_.NegateInPlace();
     return *static_cast<Derived*>(this);
   }
 
@@ -360,7 +360,7 @@ class QuadraticExtensionField
     v1 = v0.Inverse();
     b.c0_ = a.c0_ * v1;
     b.c1_ = a.c1_ * v1;
-    b.c1_.NegInPlace();
+    b.c1_.NegateInPlace();
   }
 
   // c = c0_ + c1_ * X

--- a/tachyon/math/finite_fields/quadratic_extension_field_unittest.cc
+++ b/tachyon/math/finite_fields/quadratic_extension_field_unittest.cc
@@ -107,7 +107,7 @@ TEST_F(QuadraticExtensionFieldTest, AdditiveGroupOperators) {
   GF7_2 f(GF7(3), GF7(4));
   GF7_2 f_neg(GF7(4), GF7(3));
   EXPECT_EQ(-f, f_neg);
-  f.NegInPlace();
+  f.NegateInPlace();
   EXPECT_EQ(f, f_neg);
 
   f = GF7_2(GF7(3), GF7(4));

--- a/tachyon/math/polynomials/multivariate/multilinear_extension.h
+++ b/tachyon/math/polynomials/multivariate/multilinear_extension.h
@@ -130,8 +130,8 @@ class MultilinearExtension final
     return internal::MultilinearExtensionOp<Evaluations>::Negate(*this);
   }
 
-  MultilinearExtension& NegInPlace() {
-    return internal::MultilinearExtensionOp<Evaluations>::NegInPlace(*this);
+  MultilinearExtension& NegateInPlace() {
+    return internal::MultilinearExtensionOp<Evaluations>::NegateInPlace(*this);
   }
 
   // MultiplicativeSemigroup methods

--- a/tachyon/math/polynomials/multivariate/multilinear_extension.h
+++ b/tachyon/math/polynomials/multivariate/multilinear_extension.h
@@ -126,8 +126,8 @@ class MultilinearExtension final
   // AdditiveGroup methods
   OPERATION_METHOD(Sub)
 
-  MultilinearExtension Negative() const {
-    return internal::MultilinearExtensionOp<Evaluations>::Negative(*this);
+  MultilinearExtension Negate() const {
+    return internal::MultilinearExtensionOp<Evaluations>::Negate(*this);
   }
 
   MultilinearExtension& NegInPlace() {

--- a/tachyon/math/polynomials/multivariate/multilinear_extension_ops.h
+++ b/tachyon/math/polynomials/multivariate/multilinear_extension_ops.h
@@ -94,7 +94,7 @@ class MultilinearExtensionOp<MultilinearDenseEvaluations<F, MaxDegree>> {
     return self;
   }
 
-  static MultilinearExtension<D> Negative(const MultilinearExtension<D>& self) {
+  static MultilinearExtension<D> Negate(const MultilinearExtension<D>& self) {
     const std::vector<F>& i_evaluations = self.evaluations_.evaluations_;
     if (i_evaluations.empty()) {
       return self;

--- a/tachyon/math/polynomials/multivariate/multilinear_extension_ops.h
+++ b/tachyon/math/polynomials/multivariate/multilinear_extension_ops.h
@@ -106,7 +106,7 @@ class MultilinearExtensionOp<MultilinearDenseEvaluations<F, MaxDegree>> {
     return MultilinearExtension<D>(D(std::move(o_evaluations)));
   }
 
-  static MultilinearExtension<D>& NegInPlace(MultilinearExtension<D>& self) {
+  static MultilinearExtension<D>& NegateInPlace(MultilinearExtension<D>& self) {
     std::vector<F>& evaluations = self.evaluations_.evaluations_;
     if (evaluations.empty()) {
       return self;
@@ -114,7 +114,7 @@ class MultilinearExtensionOp<MultilinearDenseEvaluations<F, MaxDegree>> {
     // clang-format off
     OPENMP_PARALLEL_FOR(F& evaluation : evaluations) {
       // clang-format on
-      evaluation.NegInPlace();
+      evaluation.NegateInPlace();
     }
     return self;
   }

--- a/tachyon/math/polynomials/multivariate/multivariate_polynomial.h
+++ b/tachyon/math/polynomials/multivariate/multivariate_polynomial.h
@@ -124,8 +124,9 @@ class MultivariatePolynomial final
     return internal::MultivariatePolynomialOp<Coefficients>::Negate(*this);
   }
 
-  MultivariatePolynomial& NegInPlace() {
-    return internal::MultivariatePolynomialOp<Coefficients>::NegInPlace(*this);
+  MultivariatePolynomial& NegateInPlace() {
+    return internal::MultivariatePolynomialOp<Coefficients>::NegateInPlace(
+        *this);
   }
 #undef OPERATION_METHOD
 

--- a/tachyon/math/polynomials/multivariate/multivariate_polynomial.h
+++ b/tachyon/math/polynomials/multivariate/multivariate_polynomial.h
@@ -120,8 +120,8 @@ class MultivariatePolynomial final
   // AdditiveGroup methods
   OPERATION_METHOD(Sub)
 
-  MultivariatePolynomial Negative() const {
-    return internal::MultivariatePolynomialOp<Coefficients>::Negative(*this);
+  MultivariatePolynomial Negate() const {
+    return internal::MultivariatePolynomialOp<Coefficients>::Negate(*this);
   }
 
   MultivariatePolynomial& NegInPlace() {

--- a/tachyon/math/polynomials/multivariate/multivariate_polynomial_ops.h
+++ b/tachyon/math/polynomials/multivariate/multivariate_polynomial_ops.h
@@ -72,7 +72,7 @@ class MultivariatePolynomialOp<MultivariateSparseCoefficients<F, MaxDegree>> {
     return self;
   }
 
-  static MultivariatePolynomial<S> Negative(
+  static MultivariatePolynomial<S> Negate(
       const MultivariatePolynomial<S>& self) {
     if (self.IsZero()) {
       return self;

--- a/tachyon/math/polynomials/multivariate/multivariate_polynomial_ops.h
+++ b/tachyon/math/polynomials/multivariate/multivariate_polynomial_ops.h
@@ -86,14 +86,14 @@ class MultivariatePolynomialOp<MultivariateSparseCoefficients<F, MaxDegree>> {
         S(self.coefficients_.num_vars_, std::move(o_terms)));
   }
 
-  static MultivariatePolynomial<S>& NegInPlace(
+  static MultivariatePolynomial<S>& NegateInPlace(
       MultivariatePolynomial<S>& self) {
     if (self.IsZero()) {
       return self;
     }
     Terms& terms = self.coefficients_.terms_;
     // clang-format off
-    OPENMP_PARALLEL_FOR(Term& term : terms) { term.coefficient.NegInPlace(); }
+    OPENMP_PARALLEL_FOR(Term& term : terms) { term.coefficient.NegateInPlace(); }
     // clang-format on
     return self;
   }

--- a/tachyon/math/polynomials/univariate/univariate_evaluations.h
+++ b/tachyon/math/polynomials/univariate/univariate_evaluations.h
@@ -166,8 +166,8 @@ class UnivariateEvaluations final
                                                                        other);
   }
 
-  UnivariateEvaluations Negative() const {
-    return internal::UnivariateEvaluationsOp<F, MaxDegree>::Negative(*this);
+  UnivariateEvaluations Negate() const {
+    return internal::UnivariateEvaluationsOp<F, MaxDegree>::Negate(*this);
   }
 
   UnivariateEvaluations& NegInPlace() {

--- a/tachyon/math/polynomials/univariate/univariate_evaluations.h
+++ b/tachyon/math/polynomials/univariate/univariate_evaluations.h
@@ -170,8 +170,9 @@ class UnivariateEvaluations final
     return internal::UnivariateEvaluationsOp<F, MaxDegree>::Negate(*this);
   }
 
-  UnivariateEvaluations& NegInPlace() {
-    return internal::UnivariateEvaluationsOp<F, MaxDegree>::NegInPlace(*this);
+  UnivariateEvaluations& NegateInPlace() {
+    return internal::UnivariateEvaluationsOp<F, MaxDegree>::NegateInPlace(
+        *this);
   }
 
   // MultiplicativeSemigroup methods

--- a/tachyon/math/polynomials/univariate/univariate_evaluations_ops.h
+++ b/tachyon/math/polynomials/univariate/univariate_evaluations_ops.h
@@ -95,7 +95,7 @@ class UnivariateEvaluationsOp {
     return self;
   }
 
-  static Poly Negative(const Poly& self) {
+  static Poly Negate(const Poly& self) {
     const std::vector<F>& i_evaluations = self.evaluations_;
     if (i_evaluations.empty()) {
       return self;

--- a/tachyon/math/polynomials/univariate/univariate_evaluations_ops.h
+++ b/tachyon/math/polynomials/univariate/univariate_evaluations_ops.h
@@ -107,7 +107,7 @@ class UnivariateEvaluationsOp {
     return Poly(std::move(o_evaluations));
   }
 
-  static Poly& NegInPlace(Poly& self) {
+  static Poly& NegateInPlace(Poly& self) {
     std::vector<F>& evaluations = self.evaluations_;
     if (evaluations.empty()) {
       return self;
@@ -115,7 +115,7 @@ class UnivariateEvaluationsOp {
     // clang-format off
     OPENMP_PARALLEL_FOR(F& evaluation : evaluations) {
       // clang-format on
-      evaluation.NegInPlace();
+      evaluation.NegateInPlace();
     }
     return self;
   }

--- a/tachyon/math/polynomials/univariate/univariate_polynomial.h
+++ b/tachyon/math/polynomials/univariate/univariate_polynomial.h
@@ -190,8 +190,8 @@ class UnivariatePolynomial final
   // AdditiveGroup methods
   OPERATION_METHOD(Sub)
 
-  UnivariatePolynomial Negative() const {
-    return internal::UnivariatePolynomialOp<Coefficients>::Negative(*this);
+  UnivariatePolynomial Negate() const {
+    return internal::UnivariatePolynomialOp<Coefficients>::Negate(*this);
   }
 
   UnivariatePolynomial& NegInPlace() {

--- a/tachyon/math/polynomials/univariate/univariate_polynomial.h
+++ b/tachyon/math/polynomials/univariate/univariate_polynomial.h
@@ -194,8 +194,8 @@ class UnivariatePolynomial final
     return internal::UnivariatePolynomialOp<Coefficients>::Negate(*this);
   }
 
-  UnivariatePolynomial& NegInPlace() {
-    return internal::UnivariatePolynomialOp<Coefficients>::NegInPlace(*this);
+  UnivariatePolynomial& NegateInPlace() {
+    return internal::UnivariatePolynomialOp<Coefficients>::NegateInPlace(*this);
   }
 
   // MultiplicativeSemigroup methods

--- a/tachyon/math/polynomials/univariate/univariate_polynomial_ops.h
+++ b/tachyon/math/polynomials/univariate/univariate_polynomial_ops.h
@@ -217,7 +217,7 @@ class UnivariatePolynomialOp<UnivariateDenseCoefficients<F, MaxDegree>> {
     return self;
   }
 
-  static UnivariatePolynomial<D> Negative(const UnivariatePolynomial<D>& self) {
+  static UnivariatePolynomial<D> Negate(const UnivariatePolynomial<D>& self) {
     if (self.IsZero()) {
       return self;
     }
@@ -599,7 +599,7 @@ class UnivariatePolynomialOp<UnivariateSparseCoefficients<F, MaxDegree>> {
     return self;
   }
 
-  static UnivariatePolynomial<S> Negative(const UnivariatePolynomial<S>& self) {
+  static UnivariatePolynomial<S> Negate(const UnivariatePolynomial<S>& self) {
     if (self.IsZero()) {
       return self;
     }

--- a/tachyon/math/polynomials/univariate/univariate_polynomial_ops.h
+++ b/tachyon/math/polynomials/univariate/univariate_polynomial_ops.h
@@ -229,7 +229,7 @@ class UnivariatePolynomialOp<UnivariateDenseCoefficients<F, MaxDegree>> {
     return UnivariatePolynomial<D>(D(std::move(o_coefficients)));
   }
 
-  static UnivariatePolynomial<D>& NegInPlace(UnivariatePolynomial<D>& self) {
+  static UnivariatePolynomial<D>& NegateInPlace(UnivariatePolynomial<D>& self) {
     if (self.IsZero()) {
       return self;
     }
@@ -237,7 +237,7 @@ class UnivariatePolynomialOp<UnivariateDenseCoefficients<F, MaxDegree>> {
     // clang-format off
     OPENMP_PARALLEL_FOR(F& coefficient : coefficients) {
       // clang-format on
-      coefficient.NegInPlace();
+      coefficient.NegateInPlace();
     }
     self.coefficients_.RemoveHighDegreeZeros();
     return self;
@@ -611,13 +611,13 @@ class UnivariatePolynomialOp<UnivariateSparseCoefficients<F, MaxDegree>> {
     return UnivariatePolynomial<S>(S(std::move(o_terms)));
   }
 
-  static UnivariatePolynomial<S>& NegInPlace(UnivariatePolynomial<S>& self) {
+  static UnivariatePolynomial<S>& NegateInPlace(UnivariatePolynomial<S>& self) {
     if (self.IsZero()) {
       return self;
     }
     std::vector<Term>& terms = self.coefficients_.terms_;
     for (Term& term : terms) {
-      term.coefficient.NegInPlace();
+      term.coefficient.NegateInPlace();
     }
     return self;
   }

--- a/tachyon/node/math/elliptic_curves/short_weierstrass/affine_point.h
+++ b/tachyon/node/math/elliptic_curves/short_weierstrass/affine_point.h
@@ -25,8 +25,8 @@ void AddAffinePoint(NodeModule& m, std::string_view name) {
       .AddMethod("ne", &AffinePoint::operator!=)
       .AddMethod("add", &AffinePoint::template operator+ <const AffinePoint&>)
       .AddMethod("sub", &AffinePoint::template operator- <const AffinePoint&>)
-      .AddMethod("negative", static_cast<AffinePoint (AffinePoint::*)() const>(
-                                 &AffinePoint::operator-))
+      .AddMethod("negate", static_cast<AffinePoint (AffinePoint::*)() const>(
+                               &AffinePoint::operator-))
       .AddMethod("double", &AffinePoint::Double);
 }
 

--- a/tachyon/node/math/elliptic_curves/short_weierstrass/jacobian_point.h
+++ b/tachyon/node/math/elliptic_curves/short_weierstrass/jacobian_point.h
@@ -35,7 +35,7 @@ void AddJacobianPoint(NodeModule& m, std::string_view name) {
                  &JacobianPoint::template operator- <const JacobianPoint&>)
       .AddMethod("subMixed",
                  &JacobianPoint::template operator- <const AffinePointTy&>)
-      .AddMethod("negative",
+      .AddMethod("negate",
                  static_cast<JacobianPoint (JacobianPoint::*)() const>(
                      &JacobianPoint::operator-))
       .AddMethod("double", &JacobianPoint::Double);

--- a/tachyon/node/math/elliptic_curves/short_weierstrass/point_xyzz.h
+++ b/tachyon/node/math/elliptic_curves/short_weierstrass/point_xyzz.h
@@ -34,8 +34,8 @@ void AddPointXYZZ(NodeModule& m, std::string_view name) {
       .AddMethod("sub", &PointXYZZ::template operator- <const PointXYZZ&>)
       .AddMethod("subMixed",
                  &PointXYZZ::template operator- <const AffinePointTy&>)
-      .AddMethod("negative", static_cast<PointXYZZ (PointXYZZ::*)() const>(
-                                 &PointXYZZ::operator-))
+      .AddMethod("negate", static_cast<PointXYZZ (PointXYZZ::*)() const>(
+                               &PointXYZZ::operator-))
       .AddMethod("double", &PointXYZZ::Double);
 }
 

--- a/tachyon/node/math/elliptic_curves/short_weierstrass/projective_point.h
+++ b/tachyon/node/math/elliptic_curves/short_weierstrass/projective_point.h
@@ -35,7 +35,7 @@ void AddProjectivePoint(NodeModule& m, std::string_view name) {
                  &ProjectivePoint::template operator- <const ProjectivePoint&>)
       .AddMethod("subMixed",
                  &ProjectivePoint::template operator- <const AffinePointTy&>)
-      .AddMethod("negative",
+      .AddMethod("negate",
                  static_cast<ProjectivePoint (ProjectivePoint::*)() const>(
                      &ProjectivePoint::operator-))
       .AddMethod("double", &ProjectivePoint::Double);

--- a/tachyon/node/math/finite_fields/prime_field.h
+++ b/tachyon/node/math/finite_fields/prime_field.h
@@ -50,8 +50,8 @@ void AddPrimeField(NodeModule& m, std::string_view name) {
       .AddMethod("sub", &PrimeField::template operator- <const PrimeField&>)
       .AddMethod("mul", &PrimeField::template operator* <const PrimeField&>)
       .AddMethod("div", &PrimeField::template operator/ <const PrimeField&>)
-      .AddMethod("negative", static_cast<PrimeField (PrimeField::*)() const>(
-                                 &PrimeField::operator-))
+      .AddMethod("negate", static_cast<PrimeField (PrimeField::*)() const>(
+                               &PrimeField::operator-))
       .AddMethod("double", &PrimeField::Double)
       .AddMethod("square", &PrimeField::Square);
 }

--- a/tachyon/node/test/src/math/elliptic_curves/short_weierstrass/affine_point.spec.ts
+++ b/tachyon/node/test/src/math/elliptic_curves/short_weierstrass/affine_point.spec.ts
@@ -73,11 +73,11 @@ describe('AffinePoint', () => {
     expect(p.sub(p2).isZero()).toBe(true);
   });
 
-  test('AffinePoint.negative()', () => {
+  test('AffinePoint.negate()', () => {
     const p = tachyon.math.bn254.G1AffinePoint.generator();
-    expect(p.negative().eq(new tachyon.math.bn254.G1AffinePoint(
+    expect(p.negate().eq(new tachyon.math.bn254.G1AffinePoint(
       p.x,
-      p.y.negative(),
+      p.y.negate(),
     ))).toBe(true);
   });
 

--- a/tachyon/node/test/src/math/elliptic_curves/short_weierstrass/jacobian_point.spec.ts
+++ b/tachyon/node/test/src/math/elliptic_curves/short_weierstrass/jacobian_point.spec.ts
@@ -90,11 +90,11 @@ describe('JacobianPoint', () => {
     expect(p.subMixed(p2).isZero()).toBe(true);
   });
 
-  test('JacobianPoint.negative()', () => {
+  test('JacobianPoint.negate()', () => {
     const p = tachyon.math.bn254.G1JacobianPoint.generator();
-    expect(p.negative().eq(new tachyon.math.bn254.G1JacobianPoint(
+    expect(p.negate().eq(new tachyon.math.bn254.G1JacobianPoint(
       p.x,
-      p.y.negative(),
+      p.y.negate(),
       p.z,
     ))).toBe(true);
   });

--- a/tachyon/node/test/src/math/elliptic_curves/short_weierstrass/point_xyzz.spec.ts
+++ b/tachyon/node/test/src/math/elliptic_curves/short_weierstrass/point_xyzz.spec.ts
@@ -95,11 +95,11 @@ describe('PointXYZZ', () => {
     expect(p.subMixed(p2).isZero()).toBe(true);
   });
 
-  test('PointXYZZ.negative()', () => {
+  test('PointXYZZ.negate()', () => {
     const p = tachyon.math.bn254.G1PointXYZZ.generator();
-    expect(p.negative().eq(new tachyon.math.bn254.G1PointXYZZ(
+    expect(p.negate().eq(new tachyon.math.bn254.G1PointXYZZ(
       p.x,
-      p.y.negative(),
+      p.y.negate(),
       p.zz,
       p.zzz,
     ))).toBe(true);

--- a/tachyon/node/test/src/math/elliptic_curves/short_weierstrass/projective_point.spec.ts
+++ b/tachyon/node/test/src/math/elliptic_curves/short_weierstrass/projective_point.spec.ts
@@ -90,11 +90,11 @@ describe('ProjectivePoint', () => {
     expect(p.subMixed(p2).isZero()).toBe(true);
   });
 
-  test('ProjectivePoint.negative()', () => {
+  test('ProjectivePoint.negate()', () => {
     const p = tachyon.math.bn254.G1ProjectivePoint.generator();
-    expect(p.negative().eq(new tachyon.math.bn254.G1ProjectivePoint(
+    expect(p.negate().eq(new tachyon.math.bn254.G1ProjectivePoint(
       p.x,
-      p.y.negative(),
+      p.y.negate(),
       p.z,
     ))).toBe(true);
   });

--- a/tachyon/node/test/src/math/finite_fields/prime_field.spec.ts
+++ b/tachyon/node/test/src/math/finite_fields/prime_field.spec.ts
@@ -115,9 +115,9 @@ describe('PrimeField', () => {
     expect(f.div(f2).eq(tachyon.math.bn254.Fq.fromDecString('14592161914559516814830937163504850059130874104865215775126025263096817472390'))).toBe(true);
   });
 
-  test('PrimeField.negative()', () => {
+  test('PrimeField.negate()', () => {
     const f = tachyon.math.bn254.Fq.fromNumber(4);
-    expect(f.negative().eq(tachyon.math.bn254.Fq.fromDecString('21888242871839275222246405745257275088696311157297823662689037894645226208579'))).toBe(true);
+    expect(f.negate().eq(tachyon.math.bn254.Fq.fromDecString('21888242871839275222246405745257275088696311157297823662689037894645226208579'))).toBe(true);
   });
 
   test('PrimeField.double()', () => {

--- a/tachyon/zk/base/value.h
+++ b/tachyon/zk/base/value.h
@@ -102,9 +102,9 @@ class Value : public math::Field<Value<T>> {
     return Value::Known(-*value_);
   }
 
-  constexpr Value& NegInPlace() {
+  constexpr Value& NegateInPlace() {
     if (IsNone()) return *this;
-    value_->NegInPlace();
+    value_->NegateInPlace();
     return *this;
   }
 

--- a/tachyon/zk/base/value.h
+++ b/tachyon/zk/base/value.h
@@ -97,7 +97,7 @@ class Value : public math::Field<Value<T>> {
     return Value::Known(*value_ - other);
   }
 
-  constexpr Value Negative() const {
+  constexpr Value Negate() const {
     if (IsNone()) return Unknown();
     return Value::Known(-*value_);
   }

--- a/tachyon/zk/base/value.h
+++ b/tachyon/zk/base/value.h
@@ -119,12 +119,12 @@ class Value : public math::Field<Value<T>> {
     return Value::Known(*value_ * other);
   }
 
-  constexpr Value DoSquare() const {
+  constexpr Value SquareImpl() const {
     if (IsNone()) return Unknown();
     return Value::Known(value_->Square());
   }
 
-  constexpr Value& DoSquareInPlace() {
+  constexpr Value& SquareImplInPlace() {
     if (IsNone()) return *this;
     value_->SquareInPlace();
     return *this;

--- a/tachyon/zk/base/value.h
+++ b/tachyon/zk/base/value.h
@@ -75,12 +75,12 @@ class Value : public math::Field<Value<T>> {
     return Value::Known(*value_ + other);
   }
 
-  constexpr Value DoDouble() const {
+  constexpr Value DoubleImpl() const {
     if (IsNone()) return Unknown();
     return Value::Known(value_->Double());
   }
 
-  constexpr Value& DoDoubleInPlace() {
+  constexpr Value& DoubleImplInPlace() {
     if (IsNone()) return *this;
     value_->DoubleInPlace();
     return *this;

--- a/tachyon/zk/base/value_unittest.cc
+++ b/tachyon/zk/base/value_unittest.cc
@@ -78,13 +78,13 @@ TEST(ValueTest, AdditiveGroupOperators) {
   for (auto& test : tests) {
     if (test.a.IsNone()) {
       EXPECT_TRUE(-test.a.IsNone());
-      EXPECT_TRUE(test.a.NegInPlace().IsNone());
+      EXPECT_TRUE(test.a.NegateInPlace().IsNone());
       EXPECT_TRUE(test.a.Double().IsNone());
       EXPECT_TRUE(test.a.DoubleInPlace().IsNone());
     } else {
       EXPECT_EQ(-test.a, test.neg);
       Value<math::GF7> a_tmp = test.a;
-      a_tmp.NegInPlace();
+      a_tmp.NegateInPlace();
       EXPECT_EQ(a_tmp, test.neg);
 
       EXPECT_EQ(test.a.Double(), test.dbl);

--- a/tachyon/zk/r1cs/constraint_system/linear_combination.h
+++ b/tachyon/zk/r1cs/constraint_system/linear_combination.h
@@ -154,9 +154,9 @@ class LinearCombination {
     return LinearCombination(
         base::Map(terms_, [](const Term<F>& term) { return -term; }));
   }
-  LinearCombination& NegInPlace() {
+  LinearCombination& NegateInPlace() {
     for (Term<F>& term : terms_) {
-      term.NegInPlace();
+      term.NegateInPlace();
     }
     return *this;
   }

--- a/tachyon/zk/r1cs/constraint_system/term.h
+++ b/tachyon/zk/r1cs/constraint_system/term.h
@@ -33,8 +33,8 @@ struct Term {
       : coefficient(std::move(coefficient)), variable(std::move(variable)) {}
 
   Term operator-() const { return {-coefficient, variable}; }
-  Term& NegInPlace() {
-    coefficient.NegInPlace();
+  Term& NegateInPlace() {
+    coefficient.NegateInPlace();
     return *this;
   }
 


### PR DESCRIPTION
# Description

This PR renames some group operations after the internal discussion.

- `DoDoubleXXX()` to `DoubleImplXXX()`
- `DoSquareXXX()` to `SquareImplXXX()`
- `Negative()` to `Negate()`
- `NegInPlace()` to `NegateInPlace()`