### PR TITLE
refac(halo2): change concrete struct type to trait type for rng

### DIFF
--- a/vendors/halo2/src/circuits/shuffle_circuit.rs
+++ b/vendors/halo2/src/circuits/shuffle_circuit.rs
@@ -315,7 +315,7 @@ mod test {
             };
             let mut transcript = TachyonBlake2bWrite::init(vec![]);
 
-            tachyon_create_proof::<_, _, _, _, _>(
+            tachyon_create_proof::<_, _, _, _, _, _>(
                 &mut prover,
                 &mut tachyon_pk,
                 &[circuit.clone(), circuit],
@@ -380,7 +380,7 @@ mod test {
             let mut tachyon_pk = TachyonProvingKey::from(pk_bytes.as_slice());
             let mut transcript = TachyonBlake2bWrite::init(vec![]);
 
-            tachyon_create_proof::<_, _, _, _, _>(
+            tachyon_create_proof::<_, _, _, _, _, _>(
                 &mut prover,
                 &mut tachyon_pk,
                 &[circuit.clone(), circuit.clone()],
@@ -430,7 +430,7 @@ mod test {
             let mut tachyon_pk = TachyonProvingKey::from(pk_bytes.as_slice());
             let mut transcript = TachyonPoseidonWrite::init(vec![]);
 
-            tachyon_create_proof::<_, _, _, _, _>(
+            tachyon_create_proof::<_, _, _, _, _, _>(
                 &mut prover,
                 &mut tachyon_pk,
                 &[circuit.clone(), circuit.clone()],
@@ -480,7 +480,7 @@ mod test {
             let mut tachyon_pk = TachyonProvingKey::from(pk_bytes.as_slice());
             let mut transcript = TachyonSha256Write::init(vec![]);
 
-            tachyon_create_proof::<_, _, _, _, _>(
+            tachyon_create_proof::<_, _, _, _, _, _>(
                 &mut prover,
                 &mut tachyon_pk,
                 &[circuit.clone(), circuit],

--- a/vendors/halo2/src/circuits/simple_circuit.rs
+++ b/vendors/halo2/src/circuits/simple_circuit.rs
@@ -398,7 +398,7 @@ mod test {
             };
             let mut transcript = TachyonBlake2bWrite::init(vec![]);
 
-            tachyon_create_proof::<_, _, _, _, _>(
+            tachyon_create_proof::<_, _, _, _, _, _>(
                 &mut prover,
                 &mut tachyon_pk,
                 &[circuit.clone(), circuit],
@@ -486,7 +486,7 @@ mod test {
             let mut tachyon_pk = TachyonProvingKey::from(pk_bytes.as_slice());
             let mut transcript = TachyonBlake2bWrite::init(vec![]);
 
-            tachyon_create_proof::<_, _, _, _, _>(
+            tachyon_create_proof::<_, _, _, _, _, _>(
                 &mut prover,
                 &mut tachyon_pk,
                 &[circuit.clone(), circuit.clone()],
@@ -536,7 +536,7 @@ mod test {
             let mut tachyon_pk = TachyonProvingKey::from(pk_bytes.as_slice());
             let mut transcript = TachyonPoseidonWrite::init(vec![]);
 
-            tachyon_create_proof::<_, _, _, _, _>(
+            tachyon_create_proof::<_, _, _, _, _, _>(
                 &mut prover,
                 &mut tachyon_pk,
                 &[circuit.clone(), circuit.clone()],
@@ -587,7 +587,7 @@ mod test {
             let mut tachyon_pk = TachyonProvingKey::from(pk_bytes.as_slice());
             let mut transcript = TachyonSha256Write::init(vec![]);
 
-            tachyon_create_proof::<_, _, _, _, _>(
+            tachyon_create_proof::<_, _, _, _, _, _>(
                 &mut prover,
                 &mut tachyon_pk,
                 &[circuit.clone(), circuit],

--- a/vendors/halo2/src/circuits/simple_lookup_circuit.rs
+++ b/vendors/halo2/src/circuits/simple_lookup_circuit.rs
@@ -171,7 +171,7 @@ mod test {
             };
             let mut transcript = TachyonBlake2bWrite::init(vec![]);
 
-            tachyon_create_proof::<_, _, _, _, _>(
+            tachyon_create_proof::<_, _, _, _, _, _>(
                 &mut prover,
                 &mut tachyon_pk,
                 &[circuit.clone(), circuit],
@@ -249,7 +249,7 @@ mod test {
             let mut tachyon_pk = TachyonProvingKey::from(pk_bytes.as_slice());
             let mut transcript = TachyonBlake2bWrite::init(vec![]);
 
-            tachyon_create_proof::<_, _, _, _, _>(
+            tachyon_create_proof::<_, _, _, _, _, _>(
                 &mut prover,
                 &mut tachyon_pk,
                 &[circuit.clone(), circuit.clone()],
@@ -299,7 +299,7 @@ mod test {
             let mut tachyon_pk = TachyonProvingKey::from(pk_bytes.as_slice());
             let mut transcript = TachyonPoseidonWrite::init(vec![]);
 
-            tachyon_create_proof::<_, _, _, _, _>(
+            tachyon_create_proof::<_, _, _, _, _, _>(
                 &mut prover,
                 &mut tachyon_pk,
                 &[circuit.clone(), circuit.clone()],
@@ -350,7 +350,7 @@ mod test {
             let mut tachyon_pk = TachyonProvingKey::from(pk_bytes.as_slice());
             let mut transcript = TachyonSha256Write::init(vec![]);
 
-            tachyon_create_proof::<_, _, _, _, _>(
+            tachyon_create_proof::<_, _, _, _, _, _>(
                 &mut prover,
                 &mut tachyon_pk,
                 &[circuit.clone(), circuit],

--- a/vendors/halo2/src/prover.rs
+++ b/vendors/halo2/src/prover.rs
@@ -9,7 +9,7 @@ use crate::bn254::{
     AdviceSingle, Evals, InstanceSingle, ProvingKey as TachyonProvingKey, RationalEvals,
     TachyonProver, TranscriptWriteState,
 };
-use crate::xor_shift_rng::XORShiftRng as TachyonXORShiftRng;
+use crate::xor_shift_rng::RngState;
 use ff::Field;
 use halo2_proofs::{
     circuit::Value,
@@ -25,6 +25,7 @@ use halo2curves::{
     group::{prime::PrimeCurveAffine, Curve},
     CurveAffine,
 };
+use rand_core::RngCore;
 
 /// This creates a proof for the provided `circuit` when given the public
 /// parameters `params` and the proving key [`ProvingKey`] that was
@@ -37,12 +38,13 @@ pub fn create_proof<
     E: EncodedChallenge<Scheme::Curve>,
     T: TranscriptWriteState<Scheme::Curve, E>,
     ConcreteCircuit: Circuit<Scheme::Scalar>,
+    R: RngCore + RngState,
 >(
     prover: &mut P,
     pk: &mut TachyonProvingKey<Scheme::Curve>,
     circuits: &[ConcreteCircuit],
     instances: &[&[&[Scheme::Scalar]]],
-    mut rng: TachyonXORShiftRng,
+    mut rng: R,
     transcript: &mut T,
 ) -> Result<(), Error> {
     for instance in instances.iter() {

--- a/vendors/halo2/src/xor_shift_rng.rs
+++ b/vendors/halo2/src/xor_shift_rng.rs
@@ -12,12 +12,16 @@ pub mod ffi {
     }
 }
 
+pub trait RngState {
+    fn state(&self) -> Vec<u8>;
+}
+
 pub struct XORShiftRng {
     inner: cxx::UniquePtr<ffi::XORShiftRng>,
 }
 
-impl XORShiftRng {
-    pub fn state(&self) -> Vec<u8> {
+impl RngState for XORShiftRng {
+    fn state(&self) -> Vec<u8> {
         self.inner.state()
     }
 }
@@ -63,9 +67,9 @@ impl rand_core::RngCore for XORShiftRng {
 
 #[cfg(test)]
 mod test {
-    use rand_core::{RngCore, SeedableRng};
-
+    use super::RngState;
     use crate::consts::SEED;
+    use rand_core::{RngCore, SeedableRng};
 
     #[test]
     fn test_rng() {


### PR DESCRIPTION
# Description
This PR makes rng parameter of create_proof function generic over RngCore and RngState.
Defined trait RngState and implemented for XORShiftRng