### PR TITLE
refac(math): rename filenames

### DIFF
--- a/tachyon/math/finite_fields/BUILD.bazel
+++ b/tachyon/math/finite_fields/BUILD.bazel
@@ -128,8 +128,8 @@ tachyon_cc_library(
 )
 
 tachyon_cc_library(
-    name = "prime_field_generic",
-    hdrs = ["prime_field_generic.h"],
+    name = "prime_field_fallback",
+    hdrs = ["prime_field_fallback.h"],
     deps = [
         ":prime_field_base",
         "//tachyon/base:compiler_specific",
@@ -203,8 +203,8 @@ tachyon_cc_library(
 )
 
 tachyon_cc_library(
-    name = "small_prime_field_generic",
-    hdrs = ["small_prime_field_generic.h"],
+    name = "small_prime_field",
+    hdrs = ["small_prime_field.h"],
     deps = [
         ":prime_field_base",
         "//tachyon/base:logging",

--- a/tachyon/math/finite_fields/generator/prime_field_generator/build_defs.bzl
+++ b/tachyon/math/finite_fields/generator/prime_field_generator/build_defs.bzl
@@ -163,7 +163,7 @@ def _do_generate_prime_fields(
             hdrs = [":{}_gen_hdr".format(name)],
             deps = [
                 ":{}_config".format(name),
-                "//tachyon/math/finite_fields:small_prime_field_generic",
+                "//tachyon/math/finite_fields:small_prime_field",
             ],
             **kwargs
         )
@@ -245,7 +245,7 @@ def _do_generate_prime_fields(
                     ":{}_fail".format(name),
                     "//tachyon/math/finite_fields:prime_field_base",
                 ],
-                "//conditions:default": ["//tachyon/math/finite_fields:prime_field_generic"],
+                "//conditions:default": ["//tachyon/math/finite_fields:prime_field_fallback"],
             }),
             **kwargs
         )
@@ -255,7 +255,7 @@ def _do_generate_prime_fields(
             hdrs = [":{}_gen_hdr".format(name)],
             deps = [
                 ":{}_config".format(name),
-                "//tachyon/math/finite_fields:prime_field_generic",
+                "//tachyon/math/finite_fields:prime_field_fallback",
             ],
             **kwargs
         )

--- a/tachyon/math/finite_fields/generator/prime_field_generator/cpu.h.tpl
+++ b/tachyon/math/finite_fields/generator/prime_field_generator/cpu.h.tpl
@@ -2,7 +2,7 @@
 #include "%{config_header_path}"
 
 %{if kIsSmallField}
-#include "tachyon/math/finite_fields/small_prime_field_generic.h"
+#include "tachyon/math/finite_fields/small_prime_field.h"
 %{endif kIsSmallField}
 %{if !kIsSmallField}
 %{if kUseAsm}
@@ -10,7 +10,7 @@
 #include "%{prime_field_x86_hdr}"
 #else
 %{endif kUseAsm}
-#include "tachyon/math/finite_fields/prime_field_generic.h"
+#include "tachyon/math/finite_fields/prime_field_fallback.h"
 %{if kUseAsm}
 #endif
 %{endif kUseAsm}

--- a/tachyon/math/finite_fields/prime_field_fallback.h
+++ b/tachyon/math/finite_fields/prime_field_fallback.h
@@ -3,8 +3,8 @@
 // can be found in the LICENSE-MIT.arkworks and the LICENCE-APACHE.arkworks
 // file.
 
-#ifndef TACHYON_MATH_FINITE_FIELDS_PRIME_FIELD_GENERIC_H_
-#define TACHYON_MATH_FINITE_FIELDS_PRIME_FIELD_GENERIC_H_
+#ifndef TACHYON_MATH_FINITE_FIELDS_PRIME_FIELD_FALLBACK_H_
+#define TACHYON_MATH_FINITE_FIELDS_PRIME_FIELD_FALLBACK_H_
 
 #include <stddef.h>
 #include <stdint.h>
@@ -367,4 +367,4 @@ class PrimeField<_Config, std::enable_if_t<!_Config::kIsSpecialPrime &&
 
 }  // namespace tachyon::math
 
-#endif  // TACHYON_MATH_FINITE_FIELDS_PRIME_FIELD_GENERIC_H_
+#endif  // TACHYON_MATH_FINITE_FIELDS_PRIME_FIELD_FALLBACK_H_

--- a/tachyon/math/finite_fields/small_prime_field.h
+++ b/tachyon/math/finite_fields/small_prime_field.h
@@ -3,8 +3,8 @@
 // can be found in the LICENSE-MIT.arkworks and the LICENCE-APACHE.arkworks
 // file.
 
-#ifndef TACHYON_MATH_FINITE_FIELDS_SMALL_PRIME_FIELD_GENERIC_H_
-#define TACHYON_MATH_FINITE_FIELDS_SMALL_PRIME_FIELD_GENERIC_H_
+#ifndef TACHYON_MATH_FINITE_FIELDS_SMALL_PRIME_FIELD_H_
+#define TACHYON_MATH_FINITE_FIELDS_SMALL_PRIME_FIELD_H_
 
 #include <stddef.h>
 #include <stdint.h>
@@ -227,4 +227,4 @@ class PrimeField<_Config, std::enable_if_t<!_Config::kIsSpecialPrime &&
 
 }  // namespace tachyon::math
 
-#endif  // TACHYON_MATH_FINITE_FIELDS_SMALL_PRIME_FIELD_GENERIC_H_
+#endif  // TACHYON_MATH_FINITE_FIELDS_SMALL_PRIME_FIELD_H_

--- a/tachyon/math/finite_fields/small_prime_field_generic.h
+++ b/tachyon/math/finite_fields/small_prime_field_generic.h
@@ -68,7 +68,7 @@ class PrimeField<_Config, std::enable_if_t<!_Config::kIsSpecialPrime &&
     uint64_t value;
     if (!base::StringToUint64(str, &value)) return std::nullopt;
     if (value >= uint64_t{GetModulus()}) {
-      LOG(ERROR) << "value(" << str << ") is grater than modulus";
+      LOG(ERROR) << "value(" << str << ") is greater than or equal to modulus";
       return std::nullopt;
     }
     return PrimeField(value);
@@ -77,7 +77,7 @@ class PrimeField<_Config, std::enable_if_t<!_Config::kIsSpecialPrime &&
     uint64_t value;
     if (!base::HexStringToUint64(str, &value)) return std::nullopt;
     if (value >= uint64_t{GetModulus()}) {
-      LOG(ERROR) << "value(" << str << ") is grater than modulus";
+      LOG(ERROR) << "value(" << str << ") is greater than or equal to modulus";
       return std::nullopt;
     }
     return PrimeField(value);


### PR DESCRIPTION
# Description

This refactor renames the following files:

- `prime_field_generic.h` to `prime_field_fallback.h`: This file is enabled when there's no optimized assembly code for the building architecture, hence the name fallback.
- `small_prime_field_generic.h` to `small_prime_field.h`: This file is enabled for all prime fields whose modulus is less than 32 bits, hence the simplified name.