### PR TITLE
perf(math): add fast reduction for a special case

### DIFF
--- a/tachyon/math/circle/stark/BUILD.bazel
+++ b/tachyon/math/circle/stark/BUILD.bazel
@@ -31,7 +31,8 @@ generate_prime_fields(
     # Hex: 0x80000000
     modulus = "2147483648",
     namespace = "tachyon::math::stark",
-    reduce = "    return v & (static_cast<uint32_t>(kModulus[0]) - 1);",
+    reduce32 = "return v & (static_cast<uint32_t>(kModulus[0]) - 1);",
+    reduce64 = "return v & (static_cast<uint32_t>(kModulus[0]) - 1);",
     use_montgomery = False,
 )
 

--- a/tachyon/math/circle/stark/BUILD.bazel
+++ b/tachyon/math/circle/stark/BUILD.bazel
@@ -31,7 +31,7 @@ generate_prime_fields(
     # Hex: 0x80000000
     modulus = "2147483648",
     namespace = "tachyon::math::stark",
-    reduce = "    return static_cast<uint32_t>(v & (kModulus[0] - 1));",
+    reduce = "    return v & (static_cast<uint32_t>(kModulus[0]) - 1);",
     use_montgomery = False,
 )
 

--- a/tachyon/math/circle/stark/BUILD.bazel
+++ b/tachyon/math/circle/stark/BUILD.bazel
@@ -32,6 +32,7 @@ generate_prime_fields(
     modulus = "2147483648",
     namespace = "tachyon::math::stark",
     reduce = "    return static_cast<uint32_t>(v & (kModulus[0] - 1));",
+    use_montgomery = False,
 )
 
 generate_fp2s(

--- a/tachyon/math/finite_fields/generator/prime_field_generator/build_defs.bzl
+++ b/tachyon/math/finite_fields/generator/prime_field_generator/build_defs.bzl
@@ -38,8 +38,11 @@ def _do_generate_prime_field_impl(ctx, type):
     if ctx.attr.use_montgomery:
         arguments.append("--use_montgomery")
 
-    if len(ctx.attr.reduce) > 0:
-        arguments.append("--reduce=%s" % (ctx.attr.reduce))
+    if len(ctx.attr.reduce32) > 0:
+        arguments.append("--reduce32=%s" % (ctx.attr.reduce32))
+
+    if len(ctx.attr.reduce64) > 0:
+        arguments.append("--reduce64=%s" % (ctx.attr.reduce64))
 
     if type >= _FFT_PRIME_FIELD:
         arguments.append("--subgroup_generator=%s" % (ctx.attr.subgroup_generator[BuildSettingInfo].value))
@@ -81,7 +84,8 @@ def _attrs(type):
         "class_name": attr.string(mandatory = True),
         "modulus": attr.string(mandatory = True),
         "flag": attr.string(mandatory = True),
-        "reduce": attr.string(mandatory = True),
+        "reduce32": attr.string(mandatory = True),
+        "reduce64": attr.string(mandatory = True),
         "use_asm": attr.bool(mandatory = True),
         "use_montgomery": attr.bool(mandatory = True),
         "x86_hdr_tpl": attr.label(
@@ -290,7 +294,8 @@ def generate_prime_fields(
         class_name,
         modulus,
         flag,
-        reduce = "",
+        reduce32 = "",
+        reduce64 = "",
         use_asm = True,
         use_montgomery = True,
         **kwargs):
@@ -300,7 +305,8 @@ def generate_prime_fields(
             class_name = class_name,
             modulus = modulus,
             flag = flag,
-            reduce = reduce,
+            reduce32 = reduce32,
+            reduce64 = reduce64,
             use_asm = use_asm,
             use_montgomery = use_montgomery,
             name = n[0],
@@ -316,7 +322,8 @@ def generate_fft_prime_fields(
         modulus,
         flag,
         subgroup_generator,
-        reduce = "",
+        reduce32 = "",
+        reduce64 = "",
         use_asm = True,
         use_montgomery = True,
         **kwargs):
@@ -326,7 +333,8 @@ def generate_fft_prime_fields(
             class_name = class_name,
             modulus = modulus,
             flag = flag,
-            reduce = reduce,
+            reduce32 = reduce32,
+            reduce64 = reduce64,
             use_asm = use_asm,
             use_montgomery = use_montgomery,
             subgroup_generator = subgroup_generator,
@@ -345,7 +353,8 @@ def generate_large_fft_prime_fields(
         small_subgroup_adicity,
         small_subgroup_base,
         subgroup_generator,
-        reduce = "",
+        reduce32 = "",
+        reduce64 = "",
         use_asm = True,
         use_montgomery = True,
         **kwargs):
@@ -355,7 +364,8 @@ def generate_large_fft_prime_fields(
             class_name = class_name,
             modulus = modulus,
             flag = flag,
-            reduce = reduce,
+            reduce32 = reduce32,
+            reduce64 = reduce64,
             use_asm = use_asm,
             use_montgomery = use_montgomery,
             small_subgroup_adicity = small_subgroup_adicity,

--- a/tachyon/math/finite_fields/generator/prime_field_generator/build_defs.bzl
+++ b/tachyon/math/finite_fields/generator/prime_field_generator/build_defs.bzl
@@ -35,6 +35,9 @@ def _do_generate_prime_field_impl(ctx, type):
     if ctx.attr.use_asm:
         arguments.append("--use_asm")
 
+    if ctx.attr.use_montgomery:
+        arguments.append("--use_montgomery")
+
     if len(ctx.attr.reduce) > 0:
         arguments.append("--reduce=%s" % (ctx.attr.reduce))
 
@@ -80,6 +83,7 @@ def _attrs(type):
         "flag": attr.string(mandatory = True),
         "reduce": attr.string(mandatory = True),
         "use_asm": attr.bool(mandatory = True),
+        "use_montgomery": attr.bool(mandatory = True),
         "x86_hdr_tpl": attr.label(
             allow_single_file = True,
             default = Label("@kroma_network_tachyon//tachyon/math/finite_fields/generator/prime_field_generator:prime_field_x86.h.tpl"),
@@ -288,6 +292,7 @@ def generate_prime_fields(
         flag,
         reduce = "",
         use_asm = True,
+        use_montgomery = True,
         **kwargs):
     for n in _gen_name_out_pairs(name):
         generate_prime_field(
@@ -297,6 +302,7 @@ def generate_prime_fields(
             flag = flag,
             reduce = reduce,
             use_asm = use_asm,
+            use_montgomery = use_montgomery,
             name = n[0],
             out = n[1],
         )
@@ -312,6 +318,7 @@ def generate_fft_prime_fields(
         subgroup_generator,
         reduce = "",
         use_asm = True,
+        use_montgomery = True,
         **kwargs):
     for n in _gen_name_out_pairs(name):
         generate_fft_prime_field(
@@ -321,6 +328,7 @@ def generate_fft_prime_fields(
             flag = flag,
             reduce = reduce,
             use_asm = use_asm,
+            use_montgomery = use_montgomery,
             subgroup_generator = subgroup_generator,
             name = n[0],
             out = n[1],
@@ -339,6 +347,7 @@ def generate_large_fft_prime_fields(
         subgroup_generator,
         reduce = "",
         use_asm = True,
+        use_montgomery = True,
         **kwargs):
     for n in _gen_name_out_pairs(name):
         generate_large_fft_prime_field(
@@ -348,6 +357,7 @@ def generate_large_fft_prime_fields(
             flag = flag,
             reduce = reduce,
             use_asm = use_asm,
+            use_montgomery = use_montgomery,
             small_subgroup_adicity = small_subgroup_adicity,
             small_subgroup_base = small_subgroup_base,
             subgroup_generator = subgroup_generator,

--- a/tachyon/math/finite_fields/generator/prime_field_generator/config.h.tpl
+++ b/tachyon/math/finite_fields/generator/prime_field_generator/config.h.tpl
@@ -85,6 +85,20 @@ class TACHYON_EXPORT %{class}Config {
 %{endif kHasTwoAdicRootOfUnity}
 
 %{if kIsSmallField}
+  constexpr static uint32_t AddMod(uint32_t a, uint32_t b) {
+    // NOTE(chokobole): This assumes that the 2m - 2 < 2³², where m is modulus.
+    uint32_t ret = a + b;
+    if (ret >= static_cast<uint32_t>(kModulus[0])) return ret - static_cast<uint32_t>(kModulus[0]);
+    return ret;
+  }
+
+  constexpr static uint32_t SubMod(uint32_t a, uint32_t b) {
+    // NOTE(chokobole): This assumes that the 2m - 2 < 2³², where m is modulus.
+    uint32_t ret = a + static_cast<uint32_t>(kModulus[0]) - b;
+    if (ret >= static_cast<uint32_t>(kModulus[0])) return ret - static_cast<uint32_t>(kModulus[0]);
+    return ret;
+  }
+
   constexpr static uint32_t Reduce(uint64_t v) {
 %{reduce}
   }

--- a/tachyon/math/finite_fields/generator/prime_field_generator/config.h.tpl
+++ b/tachyon/math/finite_fields/generator/prime_field_generator/config.h.tpl
@@ -58,7 +58,7 @@ class TACHYON_EXPORT %{class}Config {
   constexpr static uint32_t kInverse32 = %{inverse32};
 
   constexpr static BigInt<%{n}> kOne = BigInt<%{n}>({
-    %{one_mont_form}
+    %{one}
   });
 
   constexpr static bool kHasTwoAdicRootOfUnity = %{has_two_adic_root_of_unity};

--- a/tachyon/math/finite_fields/generator/prime_field_generator/config.h.tpl
+++ b/tachyon/math/finite_fields/generator/prime_field_generator/config.h.tpl
@@ -87,20 +87,20 @@ class TACHYON_EXPORT %{class}Config {
 %{if kIsSmallField}
   constexpr static uint32_t AddMod(uint32_t a, uint32_t b) {
     // NOTE(chokobole): This assumes that the 2m - 2 < 2³², where m is modulus.
-    uint32_t ret = a + b;
-    if (ret >= static_cast<uint32_t>(kModulus[0])) return ret - static_cast<uint32_t>(kModulus[0]);
-    return ret;
+    return Reduce(a + b);
   }
 
   constexpr static uint32_t SubMod(uint32_t a, uint32_t b) {
     // NOTE(chokobole): This assumes that the 2m - 2 < 2³², where m is modulus.
-    uint32_t ret = a + static_cast<uint32_t>(kModulus[0]) - b;
-    if (ret >= static_cast<uint32_t>(kModulus[0])) return ret - static_cast<uint32_t>(kModulus[0]);
-    return ret;
+    return Reduce(a + static_cast<uint32_t>(kModulus[0]) - b);
+  }
+
+  constexpr static uint32_t Reduce(uint32_t v) {
+    %{reduce32}
   }
 
   constexpr static uint32_t Reduce(uint64_t v) {
-%{reduce}
+    %{reduce64}
   }
 %{endif kIsSmallField}
 };

--- a/tachyon/math/finite_fields/mersenne31/BUILD.bazel
+++ b/tachyon/math/finite_fields/mersenne31/BUILD.bazel
@@ -24,7 +24,7 @@ generate_prime_fields(
     # Hex: 0x7fffffff
     modulus = "2147483647",
     namespace = "tachyon::math",
-    reduce = "    return static_cast<uint32_t>(((((v >> kModulusBits) + v + 1) >> kModulusBits) + v) & kModulus[0]);",
+    reduce = "    return ((((v >> kModulusBits) + v + 1) >> kModulusBits) + v) & static_cast<uint32_t>(kModulus[0]);",
     use_montgomery = False,
 )
 

--- a/tachyon/math/finite_fields/mersenne31/BUILD.bazel
+++ b/tachyon/math/finite_fields/mersenne31/BUILD.bazel
@@ -24,7 +24,7 @@ generate_prime_fields(
     # Hex: 0x7fffffff
     modulus = "2147483647",
     namespace = "tachyon::math",
-    reduce = "    return ((((v >> kModulusBits) + v + 1) >> kModulusBits) + v) & static_cast<uint32_t>(kModulus[0]);",
+    reduce64 = "return ((((v >> kModulusBits) + v + 1) >> kModulusBits) + v) & static_cast<uint32_t>(kModulus[0]);",
     use_montgomery = False,
 )
 

--- a/tachyon/math/finite_fields/mersenne31/BUILD.bazel
+++ b/tachyon/math/finite_fields/mersenne31/BUILD.bazel
@@ -25,6 +25,7 @@ generate_prime_fields(
     modulus = "2147483647",
     namespace = "tachyon::math",
     reduce = "    return static_cast<uint32_t>(((((v >> kModulusBits) + v + 1) >> kModulusBits) + v) & kModulus[0]);",
+    use_montgomery = False,
 )
 
 tachyon_cc_library(

--- a/tachyon/math/finite_fields/prime_field_generator_unittest.cc
+++ b/tachyon/math/finite_fields/prime_field_generator_unittest.cc
@@ -57,7 +57,11 @@ TYPED_TEST(PrimeFieldGeneratorTest, One) {
   using PrimeField = TypeParam;
   EXPECT_TRUE(PrimeField::One().IsOne());
   EXPECT_FALSE(PrimeField::Zero().IsOne());
-  EXPECT_EQ(PrimeField::Config::kOne, PrimeField(1).ToMontgomery());
+  if constexpr (PrimeField::Config::kModulusBits <= 32) {
+    EXPECT_EQ(PrimeField::Config::kOne, PrimeField(1).ToBigInt());
+  } else {
+    EXPECT_EQ(PrimeField::Config::kOne, PrimeField(1).ToMontgomery());
+  }
 }
 
 TYPED_TEST(PrimeFieldGeneratorTest, BigIntConversion) {

--- a/tachyon/math/finite_fields/small_prime_field.h
+++ b/tachyon/math/finite_fields/small_prime_field.h
@@ -49,7 +49,7 @@ class PrimeField<_Config, std::enable_if_t<!_Config::kIsSpecialPrime &&
     DCHECK_LT(value_, GetModulus());
   }
   constexpr explicit PrimeField(const BigInt<N>& value) : PrimeField(value[0]) {
-    DCHECK_LT(value_, GetModulus());
+    DCHECK_LT(value[0], GetModulus());
   }
   constexpr PrimeField(const PrimeField& other) = default;
   constexpr PrimeField& operator=(const PrimeField& other) = default;

--- a/tachyon/math/finite_fields/small_prime_field.h
+++ b/tachyon/math/finite_fields/small_prime_field.h
@@ -198,9 +198,9 @@ class PrimeField<_Config, std::enable_if_t<!_Config::kIsSpecialPrime &&
     EGCD<int64_t>::Result result = EGCD<int64_t>::Compute(value_, GetModulus());
     DCHECK_EQ(result.r, 1);
     if (result.s > 0) {
-      return PrimeField(Config::Reduce(result.s));
+      return PrimeField(result.s);
     } else {
-      return PrimeField(Config::Reduce(uint64_t{GetModulus()} + result.s));
+      return PrimeField(int64_t{GetModulus()} + result.s);
     }
   }
 
@@ -209,9 +209,9 @@ class PrimeField<_Config, std::enable_if_t<!_Config::kIsSpecialPrime &&
     EGCD<int64_t>::Result result = EGCD<int64_t>::Compute(value_, GetModulus());
     DCHECK_EQ(result.r, 1);
     if (result.s > 0) {
-      value_ = Config::Reduce(result.s);
+      value_ = result.s;
     } else {
-      value_ = Config::Reduce(uint64_t{GetModulus()} + result.s);
+      value_ = int64_t{GetModulus()} + result.s;
     }
     return *this;
   }

--- a/tachyon/math/finite_fields/small_prime_field.h
+++ b/tachyon/math/finite_fields/small_prime_field.h
@@ -146,31 +146,30 @@ class PrimeField<_Config, std::enable_if_t<!_Config::kIsSpecialPrime &&
 
   // AdditiveSemigroup methods
   constexpr PrimeField Add(PrimeField other) const {
-    return PrimeField(Config::Reduce(uint64_t{value_} + other.value_));
+    return PrimeField(Config::AddMod(value_, other.value_));
   }
 
   constexpr PrimeField& AddInPlace(PrimeField other) {
-    value_ = Config::Reduce(uint64_t{value_} + other.value_);
+    value_ = Config::AddMod(value_, other.value_);
     return *this;
   }
 
   // AdditiveGroup methods
   constexpr PrimeField Sub(PrimeField other) const {
-    return PrimeField(
-        Config::Reduce(uint64_t{value_} + GetModulus() - other.value_));
+    return PrimeField(Config::SubMod(value_, other.value_));
   }
 
   constexpr PrimeField& SubInPlace(PrimeField other) {
-    value_ = Config::Reduce(uint64_t{value_} + GetModulus() - other.value_);
+    value_ = Config::SubMod(value_, other.value_);
     return *this;
   }
 
   constexpr PrimeField Negate() const {
-    return PrimeField(Config::Reduce(uint64_t{GetModulus()} - value_));
+    return PrimeField(Config::SubMod(0, value_));
   }
 
   constexpr PrimeField& NegateInPlace() {
-    value_ = Config::Reduce(uint64_t{GetModulus()} - value_);
+    value_ = Config::SubMod(0, value_);
     return *this;
   }
 

--- a/tachyon/math/finite_fields/test/BUILD.bazel
+++ b/tachyon/math/finite_fields/test/BUILD.bazel
@@ -25,7 +25,8 @@ generate_fft_prime_fields(
     flag = "kIsGF7",
     modulus = "7",
     namespace = "tachyon::math",
-    reduce = "    return static_cast<uint32_t>(v % ((1 << kModulusBits) - 1));",
+    reduce32 = "return static_cast<uint32_t>(v % ((1 << kModulusBits) - 1));",
+    reduce64 = "return static_cast<uint32_t>(static_cast<uint32_t>(v) % ((1 << kModulusBits) - 1));",
     subgroup_generator = ":" + SMALL_SUBGROUP_ADICITY,
 )
 

--- a/tachyon/math/polynomials/multivariate/multilinear_dense_evaluations_unittest.cc
+++ b/tachyon/math/polynomials/multivariate/multilinear_dense_evaluations_unittest.cc
@@ -22,8 +22,10 @@ class MultilinearDenseEvaluationsTest : public FiniteFieldTest<GF7> {
   void SetUp() override {
     polys_.push_back(Poly(Evals({GF7(2), GF7(3)})));
     polys_.push_back(Poly(Evals({GF7(4), GF7(2)})));
-    polys_.push_back(Poly(Evals({GF7(2), GF7(3), GF7(2), GF7(6), GF7(5)})));
-    polys_.push_back(Poly(Evals({GF7(3), GF7(1), GF7(1), GF7(4), GF7(2)})));
+    polys_.push_back(Poly(Evals(
+        {GF7(2), GF7(3), GF7(2), GF7(6), GF7(5), GF7(1), GF7(4), GF7(2)})));
+    polys_.push_back(Poly(Evals(
+        {GF7(3), GF7(1), GF7(1), GF7(4), GF7(2), GF7(3), GF7(2), GF7(5)})));
   }
 
  protected:
@@ -68,8 +70,8 @@ TEST_F(MultilinearDenseEvaluationsTest, IndexingOperator) {
   } tests[] = {
       {polys_[0], {2, 3}},
       {polys_[1], {4, 2}},
-      {polys_[2], {2, 3, 2, 6, 5}},
-      {polys_[3], {3, 1, 1, 4, 2}},
+      {polys_[2], {2, 3, 2, 6, 5, 1, 4, 2}},
+      {polys_[3], {3, 1, 1, 4, 2, 3, 2, 5}},
   };
 
   for (const auto& test : tests) {
@@ -123,8 +125,8 @@ TEST_F(MultilinearDenseEvaluationsTest, ToString) {
   } tests[] = {
       {polys_[0], "[2, 3]"},
       {polys_[1], "[4, 2]"},
-      {polys_[2], "[2, 3, 2, 6, 5]"},
-      {polys_[3], "[3, 1, 1, 4, 2]"},
+      {polys_[2], "[2, 3, 2, 6, 5, 1, 4, 2]"},
+      {polys_[3], "[3, 1, 1, 4, 2, 3, 2, 5]"},
   };
 
   for (const auto& test : tests) {
@@ -150,9 +152,12 @@ TEST_F(MultilinearDenseEvaluationsTest, AdditiveOperators) {
       {
           polys_[2],
           polys_[3],
-          Poly(Evals({GF7(5), GF7(4), GF7(3), GF7(3), GF7(0)})),
-          Poly(Evals({GF7(6), GF7(2), GF7(1), GF7(2), GF7(3)})),
-          Poly(Evals({GF7(1), GF7(5), GF7(6), GF7(5), GF7(4)})),
+          Poly(Evals({GF7(5), GF7(4), GF7(3), GF7(3), GF7(0), GF7(4), GF7(6),
+                      GF7(0)})),
+          Poly(Evals({GF7(6), GF7(2), GF7(1), GF7(2), GF7(3), GF7(5), GF7(2),
+                      GF7(4)})),
+          Poly(Evals({GF7(1), GF7(5), GF7(6), GF7(5), GF7(4), GF7(2), GF7(5),
+                      GF7(3)})),
       },
   };
 
@@ -188,9 +193,12 @@ TEST_F(MultilinearDenseEvaluationsTest, MultiplicativeOperators) {
       {
           polys_[2],
           polys_[3],
-          Poly(Evals({GF7(6), GF7(3), GF7(2), GF7(3), GF7(3)})),
-          Poly(Evals({GF7(3), GF7(3), GF7(2), GF7(5), GF7(6)})),
-          Poly(Evals({GF7(5), GF7(5), GF7(4), GF7(3), GF7(6)})),
+          Poly(Evals({GF7(6), GF7(3), GF7(2), GF7(3), GF7(3), GF7(3), GF7(1),
+                      GF7(3)})),
+          Poly(Evals({GF7(3), GF7(3), GF7(2), GF7(5), GF7(6), GF7(5), GF7(2),
+                      GF7(6)})),
+          Poly(Evals({GF7(5), GF7(5), GF7(4), GF7(3), GF7(6), GF7(3), GF7(4),
+                      GF7(6)})),
       },
   };
 


### PR DESCRIPTION
# Description

This PR implements followings

1. Adds faster reductions for `addition`, `subtraction` and `negation`  when the modulus of the prime field is less than 2³¹ + 1.
2. Removes redundant `Reduce()` function calls
3. Enables 32-bit custom reductions for small prime fields.
