### PR TITLE
build: add build option to disable assembly optimized field

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -49,6 +49,11 @@ bool_flag(
 )
 
 bool_flag(
+    name = "has_asm_prime_field",
+    build_setting_default = True,
+)
+
+bool_flag(
     name = "py_binding",
     build_setting_default = False,
 )
@@ -155,6 +160,11 @@ config_setting(
 config_setting(
     name = "tachyon_has_numa",
     flag_values = {"has_numa": "true"},
+)
+
+config_setting(
+    name = "tachyon_has_asm_prime_field",
+    flag_values = {"has_asm_prime_field": "true"},
 )
 
 config_setting(

--- a/bazel/tachyon.bzl
+++ b/bazel/tachyon.bzl
@@ -112,6 +112,12 @@ def if_has_numa(a, b = []):
         "//conditions:default": b,
     })
 
+def if_has_asm_prime_field(a, b = []):
+    return select({
+        "@kroma_network_tachyon//:tachyon_has_asm_prime_field": a,
+        "//conditions:default": b,
+    })
+
 def if_c_shared_object(a, b = []):
     return select({
         "@kroma_network_tachyon//:tachyon_c_shared_object": a,

--- a/bazel/tachyon_cc.bzl
+++ b/bazel/tachyon_cc.bzl
@@ -2,6 +2,7 @@ load("@local_config_cuda//cuda:build_defs.bzl", "cuda_library", "if_cuda")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test", "objc_library")
 load(
     "//bazel:tachyon.bzl",
+    "if_has_asm_prime_field",
     "if_has_avx512",
     "if_has_exception",
     "if_has_matplotlib",
@@ -46,6 +47,9 @@ def tachyon_openmp_defines():
 
 def tachyon_avx512_defines():
     return if_has_avx512(["TACHYON_HAS_AVX512"])
+
+def tachyon_asm_prime_field_defines():
+    return if_has_asm_prime_field(["TACHYON_HAS_ASM_PRIME_FIELD"])
 
 def tachyon_cuda_defines():
     return if_cuda(["TACHYON_CUDA"])

--- a/docs/how_to_use/how_to_build.md
+++ b/docs/how_to_use/how_to_build.md
@@ -196,12 +196,12 @@ sudo dpkg -i libtachyon-dev_0.1.0_amd64.deb
 
 ### Build package from source
 
-Build a Debian package with the supported scheme (only halo2 for now) and the [options](#options) you want.
+Build a Debian package with the supported scheme (only halo2 for now) and the options you want.
 To build the Halo2 Debian package, `halo2` and `has_openmp` options are recommended. Run the following commands:
 
 ```shell
-bazel build -c opt --config halo2 --//:has_openmp  --//:c_shared_object //scripts/packages/debian/runtime:debian
-bazel build -c opt --config halo2 --//:has_openmp  --//:c_shared_object //scripts/packages/debian/dev:debian
+bazel build -c opt --config ${os} --config halo2 --//:has_openmp  --//:c_shared_object //scripts/packages/debian/runtime:debian
+bazel build -c opt --config ${os} --config halo2 --//:has_openmp  --//:c_shared_object //scripts/packages/debian/dev:debian
 
 sudo dpkg -i bazel-bin/scripts/packages/debian/runtime/libtachyon_0.1.0_amd64.deb
 sudo dpkg -i bazel-bin/scripts/packages/debian/dev/libtachyon-dev_0.1.0_amd64.deb

--- a/docs/how_to_use/how_to_build.md
+++ b/docs/how_to_use/how_to_build.md
@@ -266,3 +266,11 @@ unzip -o bazel-bin/docs/doxygen/tachyon_api_docs.zip &&
 google-chrome bazel-bin/docs/doxygen/html/index.html
 # generate HTML files and open on Chrome browser.
 ```
+
+### Build without assembly-optimized prime field
+
+You may encounter an illegal instruction error when running unit tests. Although the exact cause is not yet known, thanks to @zkbitcoin, we discovered that this issue is related to [ffiasm](https://github.com/iden3/ffiasm). Temporarily disabling assembly-optimized prime field can resolve this problem.
+
+```shell
+bazel build --config ${os} --//:has_asm_prime_field=false //...
+```

--- a/tachyon/math/finite_fields/generator/prime_field_generator/build_defs.bzl
+++ b/tachyon/math/finite_fields/generator/prime_field_generator/build_defs.bzl
@@ -1,5 +1,6 @@
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("@iden3_ffiasm//:build_defs.bzl", generate_ffiasm_prime_field = "generate_prime_field")
+load("//bazel:tachyon.bzl", "if_has_asm_prime_field")
 load("//bazel:tachyon_cc.bzl", "tachyon_cc_library")
 
 SMALL_SUBGROUP_ADICITY = "small_subgroup_adicity"
@@ -33,7 +34,8 @@ def _do_generate_prime_field_impl(ctx, type):
     ]
 
     if ctx.attr.use_asm:
-        arguments.append("--use_asm")
+        if ctx.attr._has_asm_prime_field[BuildSettingInfo].value:
+            arguments.append("--use_asm")
 
     if len(ctx.attr.reduce) > 0:
         arguments.append("--reduce=%s" % (ctx.attr.reduce))
@@ -103,6 +105,9 @@ def _attrs(type):
         "gpu_hdr_tpl": attr.label(
             allow_single_file = True,
             default = Label("@kroma_network_tachyon//tachyon/math/finite_fields/generator/prime_field_generator:gpu.h.tpl"),
+        ),
+        "_has_asm_prime_field": attr.label(
+            default = Label("@kroma_network_tachyon//:has_asm_prime_field"),
         ),
         "_tool": attr.label(
             # TODO(chokobole): Change to "exec", so we can build on macos.
@@ -224,7 +229,7 @@ def _do_generate_prime_fields(
         )
 
         tachyon_cc_library(
-            name = name,
+            name = "{}_ffiasm_impl".format(name),
             hdrs = [
                 ":{}_gen_hdr".format(name),
             ] + select({
@@ -248,6 +253,24 @@ def _do_generate_prime_fields(
                 "//conditions:default": ["//tachyon/math/finite_fields:prime_field_fallback"],
             }),
             **kwargs
+        )
+
+        tachyon_cc_library(
+            name = "{}_fallback_impl".format(name),
+            hdrs = [":{}_gen_hdr".format(name)],
+            deps = [
+                ":{}_config".format(name),
+                "//tachyon/math/finite_fields:prime_field_fallback",
+            ],
+            **kwargs
+        )
+
+        tachyon_cc_library(
+            name = name,
+            deps = if_has_asm_prime_field(
+                [":{}_ffiasm_impl".format(name)],
+                [":{}_fallback_impl".format(name)],
+            ),
         )
     else:
         tachyon_cc_library(

--- a/tachyon/math/finite_fields/goldilocks/BUILD.bazel
+++ b/tachyon/math/finite_fields/goldilocks/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("//bazel:tachyon.bzl", "if_x86_64")
-load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_unittest")
+load("//bazel:tachyon_cc.bzl", "tachyon_asm_prime_field_defines", "tachyon_cc_library", "tachyon_cc_unittest")
 load(
     "//tachyon/math/finite_fields/generator/prime_field_generator:build_defs.bzl",
     "SMALL_SUBGROUP_ADICITY",
@@ -44,6 +44,7 @@ tachyon_cc_library(
     srcs = if_x86_64(["goldilocks_prime_field_x86_special.cc"]),
     hdrs = if_x86_64(["goldilocks_prime_field_x86_special.h"]),
     copts = if_x86_64(["-mavx2"]),
+    defines = tachyon_asm_prime_field_defines(),
     deps = if_x86_64([
         ":goldilocks_config",
         "//tachyon/base:random",

--- a/tachyon/math/finite_fields/goldilocks/goldilocks_prime_field.h
+++ b/tachyon/math/finite_fields/goldilocks/goldilocks_prime_field.h
@@ -3,7 +3,7 @@
 
 #include "tachyon/build/build_config.h"
 
-#if ARCH_CPU_X86_64
+#if defined(TACHYON_HAS_ASM_PRIME_FIELD) && ARCH_CPU_X86_64
 #include "tachyon/math/finite_fields/goldilocks/goldilocks_prime_field_x86_special.h"
 #else
 #include "tachyon/math/finite_fields/goldilocks/goldilocks.h"

--- a/tachyon/math/finite_fields/goldilocks/goldilocks_prime_field_x86_special.cc
+++ b/tachyon/math/finite_fields/goldilocks/goldilocks_prime_field_x86_special.cc
@@ -1,3 +1,5 @@
+#if defined(TACHYON_HAS_ASM_PRIME_FIELD)
+
 #include "tachyon/math/finite_fields/goldilocks/goldilocks_prime_field_x86_special.h"
 
 #include "third_party/goldilocks/include/goldilocks_base_field.hpp"
@@ -233,3 +235,5 @@ CLASS& CLASS::InverseInPlace() {
 template class PrimeField<GoldilocksConfig>;
 
 }  // namespace tachyon::math
+
+#endif  // TACHYON_HAS_ASM_PRIME_FIELD


### PR DESCRIPTION
# Description

@zkbitcoin reported in Tachyon Discussion group that he has a trouble with using tachyon with ffiasm on. In order to resolve the issue, this commit adds a build option without ffiasm.