### PR TITLE
test: add `no_zk` and `verify` flag for circom benchmarking

### DIFF
--- a/tachyon/zk/r1cs/groth16/proof.h
+++ b/tachyon/zk/r1cs/groth16/proof.h
@@ -19,6 +19,7 @@ class Proof {
   using G1Point = typename Curve::G1Curve::AffinePoint;
   using G2Point = typename Curve::G2Curve::AffinePoint;
 
+  Proof() = default;
   Proof(const G1Point& a, const G2Point& b, const G1Point& c)
       : a_(a), b_(b), c_(c) {}
   Proof(G1Point&& a, G2Point&& b, G1Point&& c)

--- a/vendors/circom/README.md
+++ b/vendors/circom/README.md
@@ -59,4 +59,5 @@ Optional arguments:
 
 --curve             The curve type among ('bn254', bls12_381'), by default 'bn254'
 --no_zk             Create proof without zk. By default zk is enabled. Use this flag in case you want to compare the proof with rapidsnark.
+--verify            Verify the proof. By default verify is disabled. Use this flag to verify the proof with the public inputs.
 ```

--- a/vendors/circom/README.md
+++ b/vendors/circom/README.md
@@ -58,4 +58,5 @@ public              The path to public json
 Optional arguments:
 
 --curve             The curve type among ('bn254', bls12_381'), by default 'bn254'
+--no_zk             Create proof without zk. By default zk is enabled. Use this flag in case you want to compare the proof with rapidsnark.
 ```


### PR DESCRIPTION
# Description

This PR adds a `no_zk` and `verify` flag for circom benchmarking.

With the `no_zk` flag, you can create proof without zk. By default zk is enabled. You can use this flag in case you want to compare the proof with rapidsnark.
For benchmarking proving speed, we do not need to verify proof everytime. So, `verify` flag is added in case you want to verify the proof with public inputs.