### PR TITLE
feat(circom): introduce `-n` flag for specifying number of proof generation

### DIFF
--- a/vendors/circom/README.md
+++ b/vendors/circom/README.md
@@ -54,6 +54,7 @@ zkey                The path to zkey file
 wtns                The path to wtns file
 proof               The path to proof json
 public              The path to public json
+n                   The number of times to run the proof generation
 
 Optional arguments:
 

--- a/vendors/circom/prover_main.cc
+++ b/vendors/circom/prover_main.cc
@@ -7,6 +7,7 @@
 #include "tachyon/base/console/iostream.h"
 #include "tachyon/base/files/file_path_flag.h"
 #include "tachyon/base/flag/flag_parser.h"
+#include "tachyon/base/time/time.h"
 #include "tachyon/math/elliptic_curves/bls12/bls12_381/bls12_381.h"
 #include "tachyon/math/elliptic_curves/bn/bn254/bn254.h"
 #include "tachyon/math/polynomials/univariate/univariate_evaluation_domain_factory.h"
@@ -116,6 +117,7 @@ int RealMain(int argc, char** argv) {
   Curve curve;
   bool no_zk = false;
   bool verify = false;
+  size_t num_runs;
   parser.AddFlag<base::FilePathFlag>(&zkey_path)
       .set_name("zkey")
       .set_help("The path to zkey file");
@@ -138,23 +140,47 @@ int RealMain(int argc, char** argv) {
       .set_help(
           "Verify the proof. By default verify is disabled. Use this flag "
           "to verify the proof with the public inputs.");
+  parser.AddFlag<base::Flag<size_t>>(&num_runs)
+      .set_short_name("-n")
+      .set_long_name("--num_runs")
+      .set_default_value(1)
+      .set_required()
+      .set_help("The number of times to run the proof generation");
 
   std::string error;
   if (!parser.Parse(argc, argv, &error)) {
     tachyon_cerr << error << std::endl;
     return 1;
   }
-
-  switch (curve) {
-    case Curve::kBN254:
-      circom::CreateProof<math::bn254::BN254Curve>(
-          zkey_path, witness_path, proof_path, public_path, no_zk, verify);
-      break;
-    case Curve::kBLS12_381:
-      circom::CreateProof<math::bls12_381::BLS12_381Curve>(
-          zkey_path, witness_path, proof_path, public_path, no_zk, verify);
-      break;
+  if (num_runs == 0) {
+    tachyon_cerr << "num_runs should be positive" << std::endl;
+    return 1;
   }
+  base::TimeDelta total_time;
+  base::TimeDelta max_time;
+  for (size_t i = 0; i < num_runs; ++i) {
+    base::TimeTicks start = base::TimeTicks::Now();
+    switch (curve) {
+      case Curve::kBN254:
+        circom::CreateProof<math::bn254::BN254Curve>(
+            zkey_path, witness_path, proof_path, public_path, no_zk, verify);
+        break;
+      case Curve::kBLS12_381:
+        circom::CreateProof<math::bls12_381::BLS12_381Curve>(
+            zkey_path, witness_path, proof_path, public_path, no_zk, verify);
+        break;
+    }
+    base::TimeDelta time_taken = base::TimeTicks::Now() - start;
+    total_time += time_taken;
+    max_time = std::max(max_time, time_taken);
+    std::cout << "Run " << (i + 1) << ", Time Taken: " << time_taken
+              << std::endl;
+  }
+
+  base::TimeDelta avg_time = total_time / num_runs;
+  std::cout << "Average Time Taken: " << avg_time << std::endl;
+  std::cout << "Maximum Time Taken: " << max_time << std::endl;
+
   return 0;
 }
 


### PR DESCRIPTION
Add benchmarking functionality to prover_main.cc:

-Introduce '-n' flag for specifying number of proof generation runs
-Implement loop for multiple proof generations
-Calculate and display average and maximum execution times
-Add per-run timing measurements
-These changes enable performance analysis across multiple iterations.