### PR TITLE
docs: fix grammatical errors

### DIFF
--- a/docs/doxygen/Doxyfile.in
+++ b/docs/doxygen/Doxyfile.in
@@ -51,7 +51,7 @@ PROJECT_NAME           = "Tachyon"
 PROJECT_NUMBER         = ${TACHYON_VERSION}
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
-# for a project that appears at the top of each page and should give viewer a
+# for a project that appears at the top of each page and should give the viewer a
 # quick idea about the purpose of the project. Keep the description short.
 
 PROJECT_BRIEF          =
@@ -196,7 +196,7 @@ STRIP_FROM_PATH        =
 # path mentioned in the documentation of a class, which tells the reader which
 # header file to include in order to use a class. If left blank only the name of
 # the header file containing the class definition is used. Otherwise one should
-# specify the list of include paths that are normally passed to the compiler
+# specify the list of included paths that are normally passed to the compiler
 # using the -I flag.
 
 STRIP_FROM_INC_PATH    =

--- a/docs/how_to_contribute/conventions.md
+++ b/docs/how_to_contribute/conventions.md
@@ -71,7 +71,7 @@ We use `VLOG` messages in our code to show us the progress of the current runnin
 
 1. `VLOG(1)` FYI - FOR YOUR INFORMATION
 
-    Provides insight to basic information of the current process. Examples include:
+    Provides insight into basic information of the current process. Examples include:
   
       - Proving schemes/elliptic curves/parameters currently in use
       - Time between steps of processes

--- a/tachyon/base/containers/circular_deque.h
+++ b/tachyon/base/containers/circular_deque.h
@@ -651,7 +651,7 @@ class circular_deque {
     // SEE BELOW VERSION if you change this. The code is mostly the same.
     if (count > size()) {
       // This could be slightly more efficient but expanding a queue with
-      // identical elements are unusual and the extra computations of emplacing
+      // identical elements is unusual and the extra computations of emplacing
       // one-by-one will typically be small relative to calling the constructor
       // for every item.
       ExpandCapacityIfNecessary(count - size());

--- a/tachyon/base/containers/circular_deque.h
+++ b/tachyon/base/containers/circular_deque.h
@@ -651,7 +651,7 @@ class circular_deque {
     // SEE BELOW VERSION if you change this. The code is mostly the same.
     if (count > size()) {
       // This could be slightly more efficient but expanding a queue with
-      // identical elements is unusual and the extra computations of emplacing
+      // identical elements are unusual and the extra computations of emplacing
       // one-by-one will typically be small relative to calling the constructor
       // for every item.
       ExpandCapacityIfNecessary(count - size());
@@ -1091,7 +1091,7 @@ class circular_deque {
   // Danger, the buffer_.capacity() is the "internal capacity" which is
   // capacity() + 1 since there is an extra item to indicate the end. Otherwise
   // being completely empty and completely full are indistinguishable (begin ==
-  // end). We could add a separate flag to avoid it, but that adds significant
+  // end). We could add a separate flag to avoid it, but that adds a significant
   // extra complexity since every computation will have to check for it. Always
   // keeping one extra unused element in the buffer makes iterator computations
   // much simpler.

--- a/tachyon/base/containers/circular_deque.h
+++ b/tachyon/base/containers/circular_deque.h
@@ -1092,9 +1092,9 @@ class circular_deque {
   // capacity() + 1 since there is an extra item to indicate the end. Otherwise
   // being completely empty and completely full are indistinguishable (begin ==
   // end). We could add a separate flag to avoid it, but that adds a significant
-  // extra complexity since every computation will have to check for it. Always
-  // keeping one extra unused element in the buffer makes iterator computations
-  // much simpler.
+  // amount of extra complexity since every computation will have to check for it.
+  // Always keeping one extra unused element in the buffer makes iterator 
+  // computations much simpler.
   //
   // Container internal code will want to use buffer_.capacity() for offset
   // computations rather than capacity().

--- a/tachyon/base/process/process_handle.h
+++ b/tachyon/base/process/process_handle.h
@@ -25,9 +25,9 @@ namespace tachyon::base {
 
 class FilePath;
 
-// ProcessHandle is a platform specific type which represents the underlying OS
+// ProcessHandle is a platform specific type that represents the underlying OS
 // handle to a process.
-// ProcessId is a number which identifies the process in the OS.
+// ProcessId is a number that identifies the process in the OS.
 #if BUILDFLAG(IS_WIN)
 typedef HANDLE ProcessHandle;
 typedef DWORD ProcessId;


### PR DESCRIPTION
This PR corrects several grammatical errors in the documentation and comments, improving readability and clarity. These changes enhance the overall quality of the project’s written content.

Hope it helps.
