### PR TITLE
build: prepare circom proof generation with cuda

### DIFF
--- a/docs/how_to_use/how_to_build.md
+++ b/docs/how_to_use/how_to_build.md
@@ -272,7 +272,9 @@ export CXX=/usr/bin/clang++-15
 Make sure `CC` and `CXX` are properly updated to `clang-15` and `clang++-15`.
 These commands ensure that your build environment uses clang version 15 for compilation.
 
-### Build CUDA with rust toolchain
+### Build CUDA
+
+#### Set Action Environment Variable for Python
 
 You may run into the following problem:
 
@@ -283,9 +285,17 @@ error: linking with `external/local_config_cuda/crosstool/clang/bin/crosstool_wr
   = note: /usr/bin/env: 'python': No such file or directory
 ```
 
-If so, make your `python` point to the python interpreter.
+If you install `python` through [Anaconda](https://www.anaconda.com/), please include these lines in your `.bazelc.user`.
+
+```
+build:cuda --action_env=PATH=/opt/conda/bin
+build:cuda --host_action_env=PATH=/opt/conda/bin
+```
+
+Otherwise, install `python3` and make `python` point to it.
 
 ```shell
+sudo apt install python3
 sudo apt install python-is-python3
 ```
 
@@ -294,6 +304,21 @@ Additionally, please include these lines in your `.bazelc.user`.
 ```
 build:cuda --action_env=PATH=/usr/bin:/usr/local/bin
 build:cuda --host_action_env=PATH=/usr/bin:/usr/local/bin
+```
+
+#### Update CUDA [Compute Capabilities](https://developer.nvidia.com/cuda-gpus)
+
+You may run into the following problem:
+
+```shell
+Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
+nvcc fatal   : Unsupported gpu architecture 'compute_35'
+```
+
+To solve this, please include these lines in your `.bazelc.user`.
+
+```
+build:cuda --action_env=TACHYON_CUDA_COMPUTE_CAPABILITIES="compute_52"
 ```
 
 ### Generate C API documents using Doxygen

--- a/vendors/circom/.bazelrc
+++ b/vendors/circom/.bazelrc
@@ -15,6 +15,18 @@ build:macos_arm64 --config=macos
 build:macos_arm64 --cpu=darwin_arm64
 build:macos_arm64 --host_cpu=darwin_arm64
 
+# This config refers to building sources with nvcc.
+build:cuda --repo_env TACHYON_NEED_CUDA=1
+build:cuda --crosstool_top=@local_config_cuda//crosstool:toolchain
+build:cuda --@local_config_cuda//:enable_cuda
+build:cuda --@kroma_network_tachyon//:has_rtti
+
+# Enable googletest build with absl.
+# See https://github.com/google/googletest/blob/v1.13.0/BUILD.bazel#L67C1-L70
+build --define absl=1
+# FIXME(chokobole): If this option is enabled, gtest cannot be built with nvcc.
+build:cuda --define absl=0
+
 # gmp needs exception.
 build --@kroma_network_tachyon//:has_exception
 

--- a/vendors/circom/WORKSPACE
+++ b/vendors/circom/WORKSPACE
@@ -4,9 +4,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "kroma_network_rules_circom",
-    sha256 = "53f91f916b56e8f3070f1a594b625866afafe53057222a02796bee6f06dfc349",
-    strip_prefix = "rules_circom-977a8c486949d86bd4099a4e85deca56a9e47233",
-    urls = ["https://github.com/kroma-network/rules_circom/archive/977a8c486949d86bd4099a4e85deca56a9e47233.tar.gz"],
+    sha256 = "184998343fae865126fe5a31e126b1f8259259fd2a80315ab21251c01625aaf6",
+    strip_prefix = "rules_circom-e1f9be5c03fa91f28f92a042f483c608ab4261c6",
+    urls = ["https://github.com/kroma-network/rules_circom/archive/e1f9be5c03fa91f28f92a042f483c608ab4261c6.tar.gz"],
 )
 
 load("@kroma_network_rules_circom//:rules_circom_deps.bzl", "rules_circom_deps")


### PR DESCRIPTION
# Description

Since https://github.com/kroma-network/tachyon/pull/426 has been merged, this PR prepares the Circom prover to produce a proof with ICICLE. 