### PR TITLE
perf(halo2): apply batch commitment in `create_proof()`

### DIFF
--- a/tachyon/c/zk/plonk/halo2/bn254_prover.h
+++ b/tachyon/c/zk/plonk/halo2/bn254_prover.h
@@ -163,6 +163,55 @@ tachyon_halo2_bn254_prover_commit_lagrange(
     const tachyon_bn254_univariate_evaluations* evals);
 
 /**
+ * @brief Marks the prover to prepare for batch commitment.
+ *
+ * @param prover A pointer to the prover.
+ * @param len The number of commitments.
+ */
+TACHYON_C_EXPORT void tachyon_halo2_bn254_prover_batch_start(
+    const tachyon_halo2_bn254_prover* prover, size_t len);
+
+/**
+ * @brief Commits to a polynomial using the prover.
+ *
+ * Unlike \ref tachyon_halo2_bn254_prover_commit(), this function doesn't
+ * generate a commitment immediately to avoid expensive inverse operations.
+ *
+ * @param prover A pointer to the prover.
+ * @param poly A pointer to the polynomial to commit.
+ * @param idx The index of the commitment.
+ */
+TACHYON_C_EXPORT void tachyon_halo2_bn254_prover_batch_commit(
+    const tachyon_halo2_bn254_prover* prover,
+    const tachyon_bn254_univariate_dense_polynomial* poly, size_t idx);
+
+/**
+ * @brief Commits to polynomial evaluations (Lagrange form) using the prover.
+ *
+ * Unlike \ref tachyon_halo2_bn254_prover_commit_lagrange(),
+ * this function doesn't generate a commitment immediately to avoid expensive
+ * inverse operation.
+ *
+ * @param prover A pointer to the prover.
+ * @param evals A pointer to the evaluations to commit.
+ * @param idx The index of the commitment.
+ */
+TACHYON_C_EXPORT void tachyon_halo2_bn254_prover_batch_commit_lagrange(
+    const tachyon_halo2_bn254_prover* prover,
+    const tachyon_bn254_univariate_evaluations* evals, size_t idx);
+
+/**
+ * @brief Retrieves the resulting commitment from the prover.
+ *
+ * @param prover A pointer to the prover.
+ * @param points A pointer to the affine points.
+ * @param len The number of commitments.
+ */
+TACHYON_C_EXPORT void tachyon_halo2_bn254_prover_batch_end(
+    const tachyon_halo2_bn254_prover* prover, tachyon_bn254_g1_affine* points,
+    size_t len);
+
+/**
  * @brief Sets the random number generator state for the prover.
  *
  * Configures the internal RNG state, ensuring the reproducibility and security

--- a/tachyon/c/zk/plonk/halo2/bn254_prover_unittest.cc
+++ b/tachyon/c/zk/plonk/halo2/bn254_prover_unittest.cc
@@ -129,8 +129,8 @@ TEST_P(ProverTest, Getters) {
       tachyon_halo2_bn254_prover_get_blinder(prover_);
   const tachyon_bn254_univariate_evaluation_domain* domain =
       tachyon_halo2_bn254_prover_get_domain(prover_);
-  switch (static_cast<zk::plonk::halo2::PCSType>(prover_->pcs_type)) {
-    case zk::plonk::halo2::PCSType::kGWC: {
+  switch (static_cast<PCSType>(prover_->pcs_type)) {
+    case PCSType::kGWC: {
       EXPECT_EQ(blinder,
                 &c::base::c_cast(
                     reinterpret_cast<zk::ProverBase<GWCPCS>*>(prover_->extra)
@@ -141,7 +141,7 @@ TEST_P(ProverTest, Getters) {
               reinterpret_cast<zk::Entity<GWCPCS>*>(prover_->extra)->domain()));
       break;
     }
-    case zk::plonk::halo2::PCSType::kSHPlonk: {
+    case PCSType::kSHPlonk: {
       EXPECT_EQ(blinder,
                 &c::base::c_cast(reinterpret_cast<zk::ProverBase<SHPlonkPCS>*>(
                                      prover_->extra)
@@ -174,17 +174,17 @@ TEST_P(ProverTest, Commit) {
       tachyon_halo2_bn254_prover_commit(prover_, c::base::c_cast(&poly));
 
   math::bn254::G1ProjectivePoint expected;
-  switch (static_cast<zk::plonk::halo2::PCSType>(prover_->pcs_type)) {
-    case zk::plonk::halo2::PCSType::kGWC: {
-      switch (static_cast<zk::plonk::halo2::LSType>(prover_->ls_type)) {
-        case zk::plonk::halo2::LSType::kHalo2: {
+  switch (static_cast<PCSType>(prover_->pcs_type)) {
+    case PCSType::kGWC: {
+      switch (static_cast<LSType>(prover_->ls_type)) {
+        case LSType::kHalo2: {
           expected =
               reinterpret_cast<ProverImpl<GWCPCS, Halo2LS>*>(prover_->extra)
                   ->Commit(poly)
                   .ToProjective();
           break;
         }
-        case zk::plonk::halo2::LSType::kLogDerivativeHalo2: {
+        case LSType::kLogDerivativeHalo2: {
           expected =
               reinterpret_cast<ProverImpl<GWCPCS, LogDerivativeHalo2LS>*>(
                   prover_->extra)
@@ -195,16 +195,16 @@ TEST_P(ProverTest, Commit) {
       }
       break;
     }
-    case zk::plonk::halo2::PCSType::kSHPlonk: {
-      switch (static_cast<zk::plonk::halo2::LSType>(prover_->ls_type)) {
-        case zk::plonk::halo2::LSType::kHalo2: {
+    case PCSType::kSHPlonk: {
+      switch (static_cast<LSType>(prover_->ls_type)) {
+        case LSType::kHalo2: {
           expected =
               reinterpret_cast<ProverImpl<SHPlonkPCS, Halo2LS>*>(prover_->extra)
                   ->Commit(poly)
                   .ToProjective();
           break;
         }
-        case zk::plonk::halo2::LSType::kLogDerivativeHalo2: {
+        case LSType::kLogDerivativeHalo2: {
           expected =
               reinterpret_cast<ProverImpl<SHPlonkPCS, LogDerivativeHalo2LS>*>(
                   prover_->extra)
@@ -230,17 +230,17 @@ TEST_P(ProverTest, CommitLagrange) {
                                                  c::base::c_cast(&evals));
 
   math::bn254::G1ProjectivePoint expected;
-  switch (static_cast<zk::plonk::halo2::PCSType>(prover_->pcs_type)) {
-    case zk::plonk::halo2::PCSType::kGWC: {
-      switch (static_cast<zk::plonk::halo2::LSType>(prover_->ls_type)) {
-        case zk::plonk::halo2::LSType::kHalo2: {
+  switch (static_cast<PCSType>(prover_->pcs_type)) {
+    case PCSType::kGWC: {
+      switch (static_cast<LSType>(prover_->ls_type)) {
+        case LSType::kHalo2: {
           expected =
               reinterpret_cast<ProverImpl<GWCPCS, Halo2LS>*>(prover_->extra)
                   ->Commit(evals)
                   .ToProjective();
           break;
         }
-        case zk::plonk::halo2::LSType::kLogDerivativeHalo2: {
+        case LSType::kLogDerivativeHalo2: {
           expected =
               reinterpret_cast<ProverImpl<GWCPCS, LogDerivativeHalo2LS>*>(
                   prover_->extra)
@@ -251,16 +251,16 @@ TEST_P(ProverTest, CommitLagrange) {
       }
       break;
     }
-    case zk::plonk::halo2::PCSType::kSHPlonk: {
-      switch (static_cast<zk::plonk::halo2::LSType>(prover_->ls_type)) {
-        case zk::plonk::halo2::LSType::kHalo2: {
+    case PCSType::kSHPlonk: {
+      switch (static_cast<LSType>(prover_->ls_type)) {
+        case LSType::kHalo2: {
           expected =
               reinterpret_cast<ProverImpl<SHPlonkPCS, Halo2LS>*>(prover_->extra)
                   ->Commit(evals)
                   .ToProjective();
           break;
         }
-        case zk::plonk::halo2::LSType::kLogDerivativeHalo2: {
+        case LSType::kLogDerivativeHalo2: {
           expected =
               reinterpret_cast<ProverImpl<SHPlonkPCS, LogDerivativeHalo2LS>*>(
                   prover_->extra)
@@ -419,14 +419,14 @@ TEST_P(ProverTest, SetRng) {
       std::make_unique<RandomFieldGenerator<math::bn254::Fr>>(cpp_rng.get());
 
   math::bn254::Fr expected;
-  switch (static_cast<zk::plonk::halo2::PCSType>(prover_->pcs_type)) {
-    case zk::plonk::halo2::PCSType::kGWC: {
+  switch (static_cast<PCSType>(prover_->pcs_type)) {
+    case PCSType::kGWC: {
       expected = reinterpret_cast<zk::ProverBase<GWCPCS>*>(prover_->extra)
                      ->blinder()
                      .Generate();
       break;
     }
-    case zk::plonk::halo2::PCSType::kSHPlonk: {
+    case PCSType::kSHPlonk: {
       expected = reinterpret_cast<zk::ProverBase<SHPlonkPCS>*>(prover_->extra)
                      ->blinder()
                      .Generate();
@@ -496,14 +496,14 @@ TEST_P(ProverTest, SetTranscript) {
                                                   state_len);
 
   math::bn254::Fr expected;
-  switch (static_cast<zk::plonk::halo2::PCSType>(prover_->pcs_type)) {
-    case zk::plonk::halo2::PCSType::kGWC: {
+  switch (static_cast<PCSType>(prover_->pcs_type)) {
+    case PCSType::kGWC: {
       expected = reinterpret_cast<zk::Entity<GWCPCS>*>(prover_->extra)
                      ->transcript()
                      ->SqueezeChallenge();
       break;
     }
-    case zk::plonk::halo2::PCSType::kSHPlonk: {
+    case PCSType::kSHPlonk: {
       expected = reinterpret_cast<zk::Entity<SHPlonkPCS>*>(prover_->extra)
                      ->transcript()
                      ->SqueezeChallenge();

--- a/vendors/halo2/include/bn254_prover.h
+++ b/vendors/halo2/include/bn254_prover.h
@@ -12,6 +12,7 @@
 namespace tachyon::halo2_api::bn254 {
 
 struct Fr;
+struct G1AffinePoint;
 struct G1ProjectivePoint;
 struct G2AffinePoint;
 struct InstanceSingle;
@@ -37,6 +38,10 @@ class Prover {
   const G2AffinePoint& s_g2() const;
   rust::Box<G1ProjectivePoint> commit(const Poly& poly) const;
   rust::Box<G1ProjectivePoint> commit_lagrange(const Evals& evals) const;
+  void batch_start(size_t len) const;
+  void batch_commit(const Poly& poly, size_t i) const;
+  void batch_commit_lagrange(const Evals& evals, size_t i) const;
+  void batch_end(rust::Slice<G1AffinePoint> points) const;
   std::unique_ptr<Evals> empty_evals() const;
   std::unique_ptr<RationalEvals> empty_rational_evals() const;
   std::unique_ptr<Poly> ifft(const Evals& evals) const;

--- a/vendors/halo2/src/bn254_prover.cc
+++ b/vendors/halo2/src/bn254_prover.cc
@@ -45,6 +45,26 @@ rust::Box<G1ProjectivePoint> Prover::commit_lagrange(const Evals& evals) const {
           tachyon_halo2_bn254_prover_commit_lagrange(prover_, evals.evals())));
 }
 
+void Prover::batch_start(size_t len) const {
+  tachyon_halo2_bn254_prover_batch_start(prover_, len);
+}
+
+void Prover::batch_commit(const Poly& poly, size_t i) const {
+  tachyon_halo2_bn254_prover_batch_commit(prover_, poly.poly(), i);
+}
+
+void Prover::batch_commit_lagrange(const Evals& evals, size_t i) const {
+  tachyon_halo2_bn254_prover_batch_commit_lagrange(prover_, evals.evals(), i);
+}
+
+void Prover::batch_end(rust::Slice<G1AffinePoint> points) const {
+  tachyon_halo2_bn254_prover_batch_end(
+      prover_,
+      const_cast<tachyon_bn254_g1_affine*>(
+          reinterpret_cast<const tachyon_bn254_g1_affine*>(points.data())),
+      points.size());
+}
+
 std::unique_ptr<Evals> Prover::empty_evals() const {
   return std::make_unique<Evals>(
       tachyon_bn254_univariate_evaluation_domain_empty_evals(


### PR DESCRIPTION
# Description

Previously, `create_proof()` committed to polynomials or evaluations and then performed batch normalization. This approach was inefficient on the CPU (though acceptable on the GPU, as `ProjectivePoint` was returned) because `commit()` returned `PointXYZZ`, which then needed conversion to `ProjectivePoint` and finally to `AffinePoint`. This process has now been optimized by directly converting `PointXYZZ` to `AffinePoint`, thus improving performance.
