### PR TITLE
test: optimize benchmark test

### DIFF
--- a/benchmark/ec/ec_double_benchmark_gpu.cc
+++ b/benchmark/ec/ec_double_benchmark_gpu.cc
@@ -68,8 +68,8 @@ int RealMain(int argc, char** argv) {
   uint64_t max_point_num = point_nums.back();
   std::vector<bn254::G1AffinePoint> bases =
       CreatePseudoRandomPoints<bn254::G1AffinePoint>(max_point_num);
-  std::vector<bn254::Fr> scalars =
-      base::CreateVector(max_point_num, []() { return bn254::Fr::Random(); });
+  std::vector<bn254::Fr> scalars = base::CreateVectorParallel(
+      max_point_num, []() { return bn254::Fr::Random(); });
   std::cout << "Generation completed" << std::endl;
 
   std::vector<math::bn254::G1JacobianPoint> results_cpu;

--- a/tachyon/base/containers/BUILD.bazel
+++ b/tachyon/base/containers/BUILD.bazel
@@ -36,6 +36,7 @@ tachyon_cc_library(
     hdrs = ["container_util.h"],
     deps = [
         "//tachyon/base:logging",
+        "//tachyon/base:openmp_util",
         "//tachyon/base:random",
         "//tachyon/base/functional:functor_traits",
         "//tachyon/base/numerics:checked_math",

--- a/tachyon/math/base/batch_inverse_benchmark.cc
+++ b/tachyon/math/base/batch_inverse_benchmark.cc
@@ -9,7 +9,7 @@ template <typename F>
 void BM_BatchInverseSerial(benchmark::State& state) {
   using BigInt = typename F::BigIntTy;
 
-  std::vector<F> fields = base::CreateVector(
+  std::vector<F> fields = base::CreateVectorParallel(
       state.range(0), [](size_t i) { return F::FromBigInt(BigInt(i + 1)); });
   for (auto _ : state) {
     CHECK(F::BatchInverseInPlaceSerial(fields));
@@ -21,7 +21,7 @@ template <typename F>
 void BM_BatchInverse(benchmark::State& state) {
   using BigInt = typename F::BigIntTy;
 
-  std::vector<F> fields = base::CreateVector(
+  std::vector<F> fields = base::CreateVectorParallel(
       state.range(0), [](size_t i) { return F::FromBigInt(BigInt(i + 1)); });
   for (auto _ : state) {
     CHECK(F::BatchInverseInPlace(fields));
@@ -33,7 +33,7 @@ template <typename F>
 void BM_InverseParallelFor(benchmark::State& state) {
   using BigInt = typename F::BigIntTy;
 
-  std::vector<F> fields = base::CreateVector(
+  std::vector<F> fields = base::CreateVectorParallel(
       state.range(0), [](size_t i) { return F::FromBigInt(BigInt(i + 1)); });
   for (auto _ : state) {
     OPENMP_PARALLEL_FOR(size_t i = 0; i < fields.size(); ++i) {

--- a/tachyon/math/elliptic_curves/msm/test/fixed_base_msm_test_set.h
+++ b/tachyon/math/elliptic_curves/msm/test/fixed_base_msm_test_set.h
@@ -33,8 +33,8 @@ struct FixedBaseMSMTestSet {
   static FixedBaseMSMTestSet Random(size_t size, FixedBaseMSMMethod method) {
     FixedBaseMSMTestSet test_set;
     test_set.base = Point::Random();
-    test_set.scalars =
-        base::CreateVector(size, []() { return ScalarField::Random(); });
+    test_set.scalars = base::CreateVectorParallel(
+        size, []() { return ScalarField::Random(); });
     test_set.ComputeAnswer(method);
     return test_set;
   }

--- a/tachyon/math/elliptic_curves/msm/test/variable_base_msm_test_set.h
+++ b/tachyon/math/elliptic_curves/msm/test/variable_base_msm_test_set.h
@@ -34,8 +34,8 @@ struct VariableBaseMSMTestSet {
                                        VariableBaseMSMMethod method) {
     VariableBaseMSMTestSet test_set;
     test_set.bases = CreatePseudoRandomPoints<Point>(size);
-    test_set.scalars =
-        base::CreateVector(size, []() { return ScalarField::Random(); });
+    test_set.scalars = base::CreateVectorParallel(
+        size, []() { return ScalarField::Random(); });
     test_set.ComputeAnswer(method);
     return test_set;
   }
@@ -46,7 +46,7 @@ struct VariableBaseMSMTestSet {
     test_set.bases = CreatePseudoRandomPoints<Point>(size);
     std::vector<ScalarField> scalar_sets =
         base::CreateVector(scalar_size, []() { return ScalarField::Random(); });
-    test_set.scalars = base::CreateVector(
+    test_set.scalars = base::CreateVectorParallel(
         size, [&scalar_sets]() { return base::UniformElement(scalar_sets); });
     test_set.ComputeAnswer(method);
     return test_set;
@@ -56,7 +56,7 @@ struct VariableBaseMSMTestSet {
                                      VariableBaseMSMMethod method) {
     VariableBaseMSMTestSet test_set;
     test_set.bases =
-        base::CreateVector(size, []() { return Point::Generator(); });
+        base::CreateVectorParallel(size, []() { return Point::Generator(); });
     ScalarField s = ScalarField::One();
     test_set.scalars = base::CreateVector(size, [&s]() {
       ScalarField ret = s;

--- a/tachyon/math/elliptic_curves/test/BUILD.bazel
+++ b/tachyon/math/elliptic_curves/test/BUILD.bazel
@@ -7,7 +7,7 @@ tachyon_cc_library(
     testonly = True,
     hdrs = ["random.h"],
     deps = [
-        "//tachyon/base/containers:container_util",
+        "//tachyon/base:parallelize",
         "//tachyon/math/elliptic_curves:points",
     ],
 )

--- a/tachyon/math/elliptic_curves/test/BUILD.bazel
+++ b/tachyon/math/elliptic_curves/test/BUILD.bazel
@@ -6,5 +6,8 @@ tachyon_cc_library(
     name = "random",
     testonly = True,
     hdrs = ["random.h"],
-    deps = ["//tachyon/base/containers:container_util"],
+    deps = [
+        "//tachyon/base/containers:container_util",
+        "//tachyon/math/elliptic_curves:points",
+    ],
 )

--- a/tachyon/zk/base/nested_for_loop_openmp_benchmark.cc
+++ b/tachyon/zk/base/nested_for_loop_openmp_benchmark.cc
@@ -9,9 +9,10 @@ template <typename F>
 void BM_NestedForLoopParallelCols(benchmark::State& state) {
   size_t cols = state.range(0);
   size_t rows = state.range(1);
-  std::vector<std::vector<F>> table = base::CreateVector(cols, [rows]() {
-    return base::CreateVector(rows, []() { return F::Random(); });
-  });
+  std::vector<std::vector<F>> table =
+      base::CreateVectorParallel(cols, [rows]() {
+        return base::CreateVector(rows, []() { return F::Random(); });
+      });
   for (auto _ : state) {
     OPENMP_PARALLEL_FOR(size_t i = 0; i < cols; ++i) {
       for (size_t j = 0; j < rows; ++j) {
@@ -26,9 +27,10 @@ template <typename F>
 void BM_NestedForLoopParallelRows(benchmark::State& state) {
   size_t cols = state.range(0);
   size_t rows = state.range(1);
-  std::vector<std::vector<F>> table = base::CreateVector(cols, [rows]() {
-    return base::CreateVector(rows, []() { return F::Random(); });
-  });
+  std::vector<std::vector<F>> table =
+      base::CreateVectorParallel(cols, [rows]() {
+        return base::CreateVector(rows, []() { return F::Random(); });
+      });
   for (auto _ : state) {
     for (size_t i = 0; i < cols; ++i) {
       OPENMP_PARALLEL_FOR(size_t j = 0; j < rows; ++j) {
@@ -43,9 +45,10 @@ template <typename F>
 void BM_NestedForLoopParallelCollapse(benchmark::State& state) {
   size_t cols = state.range(0);
   size_t rows = state.range(1);
-  std::vector<std::vector<F>> table = base::CreateVector(cols, [rows]() {
-    return base::CreateVector(rows, []() { return F::Random(); });
-  });
+  std::vector<std::vector<F>> table =
+      base::CreateVectorParallel(cols, [rows]() {
+        return base::CreateVector(rows, []() { return F::Random(); });
+      });
   for (auto _ : state) {
     OPENMP_PARALLEL_NESTED_FOR(size_t i = 0; i < cols; ++i) {
       for (size_t j = 0; j < rows; ++j) {

--- a/tachyon/zk/base/parallelize_benchmark.cc
+++ b/tachyon/zk/base/parallelize_benchmark.cc
@@ -8,7 +8,8 @@ namespace tachyon::zk {
 template <typename F>
 void BM_Parallelize(benchmark::State& state) {
   size_t n = state.range(0);
-  std::vector<F> vec = base::CreateVector(n, []() { return F::Random(); });
+  std::vector<F> vec =
+      base::CreateVectorParallel(n, []() { return F::Random(); });
   for (auto _ : state) {
     base::Parallelize(vec, [](absl::Span<F> chunk) {
       for (F& v : chunk) {
@@ -22,7 +23,8 @@ void BM_Parallelize(benchmark::State& state) {
 template <typename F>
 void BM_ForLoop(benchmark::State& state) {
   size_t n = state.range(0);
-  std::vector<F> vec = base::CreateVector(n, []() { return F::Random(); });
+  std::vector<F> vec =
+      base::CreateVectorParallel(n, []() { return F::Random(); });
   for (auto _ : state) {
     OPENMP_PARALLEL_FOR(size_t i = 0; i < n; ++i) { vec[i].DoubleInPlace(); }
   }

--- a/vendors/circom/benchmark/circom_benchmark.cc
+++ b/vendors/circom/benchmark/circom_benchmark.cc
@@ -94,7 +94,7 @@ int RealMain(int argc, char** argv) {
       domain = Domain::Create(tachyon_runner->GetDomainSize());
 
       size_t num_instance_variables = tachyon_runner->GetNumInstanceVariables();
-      full_assignments = base::CreateVector(
+      full_assignments = base::CreateVectorParallel(
           num_instance_variables + tachyon_runner->GetNumWitnessVariables(),
           [&witness_loader](size_t i) { return witness_loader.Get(i); });
 


### PR DESCRIPTION
# Description

In benchmarks, data is typically created using base::CreateVector(). However, since benchmarks generate a large amount of data, running this process in parallel is beneficial. This PR implements parallel data creation for benchmarks.
