### PR TITLE
feat: use pmr vector for custom allocation

### DIFF
--- a/benchmark/fft/fft_runner.h
+++ b/benchmark/fft/fft_runner.h
@@ -5,6 +5,7 @@
 #include <stdint.h>
 
 #include <memory>
+#include <memory_resource>
 #include <optional>
 #include <utility>
 #include <vector>
@@ -87,7 +88,7 @@ class FFTRunner {
         ret.reset(c::base::native_cast(
             fn(c::base::c_cast((*polys_)[i].evaluations().data()), n,
                c::base::c_cast(&omega_inv), exponents[i], &duration_in_us)));
-        std::vector<F> res_vec(ret.get(), ret.get() + n);
+        std::pmr::vector<F> res_vec(ret.get(), ret.get() + n);
         results->emplace_back(
             typename RetPoly::Coefficients(std::move(res_vec)));
         // NOLINTNEXTLINE(readability/braces)
@@ -97,7 +98,7 @@ class FFTRunner {
         ret.reset(c::base::native_cast(fn(
             c::base::c_cast((*polys_)[i].coefficients().coefficients().data()),
             n, c::base::c_cast(&omega), exponents[i], &duration_in_us)));
-        std::vector<F> res_vec(ret.get(), ret.get() + n);
+        std::pmr::vector<F> res_vec(ret.get(), ret.get() + n);
         results->emplace_back(std::move(res_vec));
       }
       reporter_->AddTime(i, base::Microseconds(duration_in_us).InSecondsF());

--- a/tachyon/base/flag/flag_value_traits.h
+++ b/tachyon/base/flag/flag_value_traits.h
@@ -8,6 +8,7 @@
 #include <stdint.h>
 
 #include <limits>
+#include <memory_resource>
 #include <numeric>
 #include <string>
 #include <type_traits>
@@ -146,10 +147,10 @@ class FlagValueTraits<std::string> {
   }
 };
 
-template <typename T>
-class FlagValueTraits<std::vector<T>> {
+template <typename V, typename T = typename V::value_type>
+class FlagValueTraitsVectorImpl {
  public:
-  static bool ParseValue(std::string_view input, std::vector<T>* value,
+  static bool ParseValue(std::string_view input, V* value,
                          std::string* reason) {
     T element;
     if (FlagValueTraits<T>::ParseValue(input, &element, reason)) {
@@ -159,6 +160,13 @@ class FlagValueTraits<std::vector<T>> {
     return false;
   }
 };
+
+template <typename T>
+class FlagValueTraits<std::vector<T>>
+    : public FlagValueTraitsVectorImpl<std::vector<T>> {};
+template <typename T>
+class FlagValueTraits<std::pmr::vector<T>>
+    : public FlagValueTraitsVectorImpl<std::pmr::vector<T>> {};
 
 }  // namespace tachyon::base
 

--- a/tachyon/c/math/polynomials/univariate/bn254_univariate_rational_evaluations.cc
+++ b/tachyon/c/math/polynomials/univariate/bn254_univariate_rational_evaluations.cc
@@ -1,5 +1,6 @@
 #include "tachyon/c/math/polynomials/univariate/bn254_univariate_rational_evaluations.h"
 
+#include <memory_resource>
 #include <utility>
 #include <vector>
 
@@ -75,7 +76,7 @@ tachyon_bn254_univariate_rational_evaluations_batch_evaluate(
     const tachyon_bn254_univariate_rational_evaluations* rational_evals) {
   const RationalEvals& cpp_rational_eval =
       c::base::native_cast(*rational_evals);
-  std::vector<math::bn254::Fr> cpp_values(cpp_rational_eval.NumElements());
+  std::pmr::vector<math::bn254::Fr> cpp_values(cpp_rational_eval.NumElements());
   CHECK(math::RationalField<math::bn254::Fr>::BatchEvaluate(
       cpp_rational_eval.evaluations(), &cpp_values));
   Evals* cpp_evals = new Evals(Evals(std::move(cpp_values)));

--- a/tachyon/c/math/polynomials/univariate/bn254_univariate_rational_evaluations_unittest.cc
+++ b/tachyon/c/math/polynomials/univariate/bn254_univariate_rational_evaluations_unittest.cc
@@ -1,5 +1,6 @@
 #include "tachyon/c/math/polynomials/univariate/bn254_univariate_rational_evaluations.h"
 
+#include <memory_resource>
 #include <vector>
 
 #include "gtest/gtest.h"
@@ -89,7 +90,7 @@ TEST_F(UnivariateRationalEvaluationsTest, BatchEvaluate) {
   }
   tachyon_bn254_univariate_evaluations* evaluated =
       tachyon_bn254_univariate_rational_evaluations_batch_evaluate(evals_);
-  std::vector<bn254::Fr> values;
+  std::pmr::vector<bn254::Fr> values;
   values.resize(rational_values.size());
   CHECK(RationalField<bn254::Fr>::BatchEvaluate(rational_values, &values));
   EXPECT_EQ(c::base::native_cast(*evaluated).evaluations(), values);

--- a/tachyon/c/zk/plonk/halo2/bn254_instance_columns_vec.cc
+++ b/tachyon/c/zk/plonk/halo2/bn254_instance_columns_vec.cc
@@ -1,5 +1,6 @@
 #include "tachyon/c/zk/plonk/halo2/bn254_instance_columns_vec.h"
 
+#include <memory_resource>
 #include <vector>
 
 #include "tachyon/c/math/elliptic_curves/bn/bn254/fr_type_traits.h"
@@ -7,7 +8,7 @@
 
 using namespace tachyon;
 
-using ColumnsVec = std::vector<std::vector<std::vector<math::bn254::Fr>>>;
+using ColumnsVec = std::vector<std::vector<std::pmr::vector<math::bn254::Fr>>>;
 
 tachyon_halo2_bn254_instance_columns_vec*
 tachyon_halo2_bn254_instance_columns_vec_create(size_t num_circuits) {

--- a/tachyon/c/zk/plonk/halo2/bn254_instance_columns_vec_type_traits.h
+++ b/tachyon/c/zk/plonk/halo2/bn254_instance_columns_vec_type_traits.h
@@ -1,6 +1,7 @@
 #ifndef TACHYON_C_ZK_PLONK_HALO2_BN254_INSTANCE_COLUMNS_VEC_TYPE_TRAITS_H_
 #define TACHYON_C_ZK_PLONK_HALO2_BN254_INSTANCE_COLUMNS_VEC_TYPE_TRAITS_H_
 
+#include <memory_resource>
 #include <vector>
 
 #include "tachyon/c/base/type_traits_forward.h"
@@ -11,14 +12,14 @@ namespace tachyon::c::base {
 
 template <>
 struct TypeTraits<
-    std::vector<std::vector<std::vector<tachyon::math::bn254::Fr>>>> {
+    std::vector<std::vector<std::pmr::vector<tachyon::math::bn254::Fr>>>> {
   using CType = tachyon_halo2_bn254_instance_columns_vec;
 };
 
 template <>
 struct TypeTraits<tachyon_halo2_bn254_instance_columns_vec> {
   using NativeType =
-      std::vector<std::vector<std::vector<tachyon::math::bn254::Fr>>>;
+      std::vector<std::vector<std::pmr::vector<tachyon::math::bn254::Fr>>>;
 };
 
 }  // namespace tachyon::c::base

--- a/tachyon/c/zk/plonk/halo2/bn254_prover.cc
+++ b/tachyon/c/zk/plonk/halo2/bn254_prover.cc
@@ -3,6 +3,7 @@
 #include <string.h>
 
 #include <memory>
+#include <memory_resource>
 #include <utility>
 #include <vector>
 
@@ -181,7 +182,7 @@ template <typename NativeProver>
 tachyon_bn254_g1_projective* Commit(
     NativeProver* prover,
     const tachyon_bn254_univariate_dense_polynomial* poly) {
-  const std::vector<math::bn254::Fr>& scalars =
+  const std::pmr::vector<math::bn254::Fr>& scalars =
       c::base::native_cast(*poly).coefficients().coefficients();
   return prover->CommitRaw(scalars);
 }
@@ -189,7 +190,7 @@ tachyon_bn254_g1_projective* Commit(
 template <typename NativeProver>
 tachyon_bn254_g1_projective* CommitLagrange(
     NativeProver* prover, const tachyon_bn254_univariate_evaluations* evals) {
-  const std::vector<math::bn254::Fr>& scalars =
+  const std::pmr::vector<math::bn254::Fr>& scalars =
       c::base::native_cast(*evals).evaluations();
   return prover->CommitLagrangeRaw(scalars);
 }

--- a/tachyon/c/zk/plonk/halo2/buffer_reader.h
+++ b/tachyon/c/zk/plonk/halo2/buffer_reader.h
@@ -2,6 +2,7 @@
 #define TACHYON_C_ZK_PLONK_HALO2_BUFFER_READER_H_
 
 #include <memory>
+#include <memory_resource>
 #include <string>
 #include <type_traits>
 #include <utility>
@@ -106,6 +107,16 @@ class BufferReader<std::vector<T>> {
  public:
   static std::vector<T> Read(const tachyon::base::ReadOnlyBuffer& buffer) {
     return tachyon::base::CreateVector(ReadU32AsSizeT(buffer), [&buffer]() {
+      return BufferReader<T>::Read(buffer);
+    });
+  }
+};
+
+template <typename T>
+class BufferReader<std::pmr::vector<T>> {
+ public:
+  static std::pmr::vector<T> Read(const tachyon::base::ReadOnlyBuffer& buffer) {
+    return tachyon::base::CreatePmrVector(ReadU32AsSizeT(buffer), [&buffer]() {
       return BufferReader<T>::Read(buffer);
     });
   }

--- a/tachyon/c/zk/plonk/halo2/buffer_reader.h
+++ b/tachyon/c/zk/plonk/halo2/buffer_reader.h
@@ -523,14 +523,14 @@ class BufferReader<
     uint32_t k;
     CHECK(buffer.Read(&k));
     size_t n = size_t{1} << k;
-    std::vector<G1Point> g1_powers_of_tau =
-        tachyon::base::CreateVector(n, [&buffer]() {
+    std::pmr::vector<G1Point> g1_powers_of_tau =
+        tachyon::base::CreatePmrVector(n, [&buffer]() {
           G1Point point;
           ReadBuffer(buffer, point);
           return point;
         });
-    std::vector<G1Point> g1_powers_of_tau_lagrange =
-        tachyon::base::CreateVector(n, [&buffer]() {
+    std::pmr::vector<G1Point> g1_powers_of_tau_lagrange =
+        tachyon::base::CreatePmrVector(n, [&buffer]() {
           G1Point point;
           ReadBuffer(buffer, point);
           return point;

--- a/tachyon/c/zk/plonk/halo2/buffer_reader.h
+++ b/tachyon/c/zk/plonk/halo2/buffer_reader.h
@@ -202,7 +202,7 @@ class BufferReader<tachyon::math::UnivariateDensePolynomial<F, MaxDegree>> {
  public:
   static tachyon::math::UnivariateDensePolynomial<F, MaxDegree> Read(
       const tachyon::base::ReadOnlyBuffer& buffer) {
-    std::vector<F> coeffs;
+    std::pmr::vector<F> coeffs;
     ReadBuffer(buffer, coeffs);
     return tachyon::math::UnivariateDensePolynomial<F, MaxDegree>(
         tachyon::math::UnivariateDenseCoefficients<F, MaxDegree>(
@@ -215,7 +215,7 @@ class BufferReader<tachyon::math::UnivariateEvaluations<F, MaxDegree>> {
  public:
   static tachyon::math::UnivariateEvaluations<F, MaxDegree> Read(
       const tachyon::base::ReadOnlyBuffer& buffer) {
-    std::vector<F> evals;
+    std::pmr::vector<F> evals;
     ReadBuffer(buffer, evals);
     return tachyon::math::UnivariateEvaluations<F, MaxDegree>(std::move(evals));
   }

--- a/tachyon/c/zk/plonk/halo2/kzg_family_prover_impl.h
+++ b/tachyon/c/zk/plonk/halo2/kzg_family_prover_impl.h
@@ -2,6 +2,7 @@
 #define TACHYON_C_ZK_PLONK_HALO2_KZG_FAMILY_PROVER_IMPL_H_
 
 #include <algorithm>
+#include <memory_resource>
 #include <utility>
 #include <vector>
 
@@ -30,18 +31,19 @@ class KZGFamilyProverImpl : public ProverImplBase<PCS, LS> {
 
   using ProverImplBase<PCS, LS>::ProverImplBase;
 
-  CProjectivePoint* CommitRaw(const std::vector<ScalarField>& scalars) const {
+  CProjectivePoint* CommitRaw(
+      const std::pmr::vector<ScalarField>& scalars) const {
     return DoMSM(this->pcs_.GetG1PowersOfTau(), scalars);
   }
 
   CProjectivePoint* CommitLagrangeRaw(
-      const std::vector<ScalarField>& scalars) const {
+      const std::pmr::vector<ScalarField>& scalars) const {
     return DoMSM(this->pcs_.GetG1PowersOfTauLagrange(), scalars);
   }
 
  private:
   CProjectivePoint* DoMSM(const std::vector<AffinePoint>& bases,
-                          const std::vector<ScalarField>& scalars) const {
+                          const std::pmr::vector<ScalarField>& scalars) const {
     ProjectivePoint* ret = new ProjectivePoint();
     CHECK(this->pcs_.DoMSM(bases, scalars, ret));
 

--- a/tachyon/c/zk/plonk/halo2/kzg_family_prover_impl.h
+++ b/tachyon/c/zk/plonk/halo2/kzg_family_prover_impl.h
@@ -42,7 +42,7 @@ class KZGFamilyProverImpl : public ProverImplBase<PCS, LS> {
   }
 
  private:
-  CProjectivePoint* DoMSM(const std::vector<AffinePoint>& bases,
+  CProjectivePoint* DoMSM(const std::pmr::vector<AffinePoint>& bases,
                           const std::pmr::vector<ScalarField>& scalars) const {
     ProjectivePoint* ret = new ProjectivePoint();
     CHECK(this->pcs_.DoMSM(bases, scalars, ret));

--- a/tachyon/c/zk/plonk/halo2/verifier_impl.h
+++ b/tachyon/c/zk/plonk/halo2/verifier_impl.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 
+#include <memory_resource>
 #include <utility>
 #include <vector>
 
@@ -30,16 +31,16 @@ class VerifierImpl : public tachyon::zk::plonk::halo2::Verifier<PCS, LS> {
 
   [[nodiscard]] bool VerifyProof(
       const tachyon::zk::plonk::VerifyingKey<F, Commitment>& vkey,
-      std::vector<std::vector<std::vector<F>>>& instance_columns_vec) {
+      std::vector<std::vector<std::pmr::vector<F>>>& instance_columns_vec) {
     std::vector<std::vector<Evals>> cpp_instance_columns_vec =
-        tachyon::base::Map(instance_columns_vec,
-                           [](std::vector<std::vector<F>>& instance_columns) {
-                             return tachyon::base::Map(
-                                 instance_columns,
-                                 [](std::vector<F>& instance_column) {
-                                   return Evals(std::move(instance_column));
-                                 });
-                           });
+        tachyon::base::Map(
+            instance_columns_vec,
+            [](std::vector<std::pmr::vector<F>>& instance_columns) {
+              return tachyon::base::Map(
+                  instance_columns, [](std::pmr::vector<F>& instance_column) {
+                    return Evals(std::move(instance_column));
+                  });
+            });
     return Base::VerifyProof(vkey, cpp_instance_columns_vec);
   }
 

--- a/tachyon/crypto/commitments/kzg/kzg.h
+++ b/tachyon/crypto/commitments/kzg/kzg.h
@@ -55,8 +55,8 @@ class KZG {
 
   KZG() = default;
 
-  KZG(std::vector<G1Point>&& g1_powers_of_tau,
-      std::vector<G1Point>&& g1_powers_of_tau_lagrange)
+  KZG(std::pmr::vector<G1Point>&& g1_powers_of_tau,
+      std::pmr::vector<G1Point>&& g1_powers_of_tau_lagrange)
       : g1_powers_of_tau_(std::move(g1_powers_of_tau)),
         g1_powers_of_tau_lagrange_(std::move(g1_powers_of_tau_lagrange)) {
     CHECK_EQ(g1_powers_of_tau_.size(), g1_powers_of_tau_lagrange_.size());
@@ -66,11 +66,11 @@ class KZG {
 #endif
   }
 
-  const std::vector<G1Point>& g1_powers_of_tau() const {
+  const std::pmr::vector<G1Point>& g1_powers_of_tau() const {
     return g1_powers_of_tau_;
   }
 
-  const std::vector<G1Point>& g1_powers_of_tau_lagrange() const {
+  const std::pmr::vector<G1Point>& g1_powers_of_tau_lagrange() const {
     return g1_powers_of_tau_lagrange_;
   }
 
@@ -267,8 +267,8 @@ class KZG {
     return msm.Run(bases_span, scalars, &cpu_batch_commitments_[index]);
   }
 
-  std::vector<G1Point> g1_powers_of_tau_;
-  std::vector<G1Point> g1_powers_of_tau_lagrange_;
+  std::pmr::vector<G1Point> g1_powers_of_tau_;
+  std::pmr::vector<G1Point> g1_powers_of_tau_lagrange_;
   std::vector<Bucket> cpu_batch_commitments_;
 #if TACHYON_CUDA
   device::gpu::ScopedMemPool mem_pool_;
@@ -293,8 +293,8 @@ class Copyable<crypto::KZG<G1Point, MaxDegree, Commitment>> {
   }
 
   static bool ReadFrom(const ReadOnlyBuffer& buffer, PCS* pcs) {
-    std::vector<G1Point> g1_powers_of_tau;
-    std::vector<G1Point> g1_powers_of_tau_lagrange;
+    std::pmr::vector<G1Point> g1_powers_of_tau;
+    std::pmr::vector<G1Point> g1_powers_of_tau_lagrange;
     if (!buffer.ReadMany(&g1_powers_of_tau, &g1_powers_of_tau_lagrange)) {
       return false;
     }

--- a/tachyon/crypto/commitments/kzg/kzg.h
+++ b/tachyon/crypto/commitments/kzg/kzg.h
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <limits>
 #include <memory>
+#include <memory_resource>
 #include <utility>
 #include <vector>
 
@@ -156,7 +157,8 @@ class KZG {
 
     // |g1_powers_of_tau_| = [τ⁰g₁, τ¹g₁, ... , τⁿ⁻¹g₁]
     G1Point g1 = G1Point::Generator();
-    std::vector<Field> powers_of_tau = Field::GetSuccessivePowers(size, tau);
+    std::pmr::vector<Field> powers_of_tau =
+        Field::GetSuccessivePowers(size, tau);
 
     g1_powers_of_tau_.resize(size);
     if (!G1Point::BatchMapScalarFieldToPoint(g1, powers_of_tau,
@@ -166,7 +168,7 @@ class KZG {
 
     // Get |g1_powers_of_tau_lagrange_| from τ and g₁.
     std::unique_ptr<Domain> domain = Domain::Create(size);
-    std::vector<Field> lagrange_coeffs =
+    std::pmr::vector<Field> lagrange_coeffs =
         domain->EvaluateAllLagrangeCoefficients(tau);
 
     g1_powers_of_tau_lagrange_.resize(size);

--- a/tachyon/crypto/sumcheck/multilinear/sumcheck_prover.h
+++ b/tachyon/crypto/sumcheck/multilinear/sumcheck_prover.h
@@ -6,6 +6,7 @@
 #ifndef TACHYON_CRYPTO_SUMCHECK_MULTILINEAR_SUMCHECK_PROVER_H_
 #define TACHYON_CRYPTO_SUMCHECK_MULTILINEAR_SUMCHECK_PROVER_H_
 
+#include <memory_resource>
 #include <utility>
 #include <vector>
 
@@ -96,8 +97,8 @@ class SumcheckProver {
     size_t chunk_size = (size + thread_nums - 1) / thread_nums;
     size_t num_chunks = (size + chunk_size - 1) / chunk_size;
 
-    std::vector<std::vector<F>> finished_evaluations(
-        num_chunks, std::vector<F>(max_evaluations_ + 1, F::Zero()));
+    std::vector<std::pmr::vector<F>> finished_evaluations(
+        num_chunks, std::pmr::vector<F>(max_evaluations_ + 1, F::Zero()));
 
     OPENMP_PARALLEL_FOR(size_t i = 0; i < num_chunks; ++i) {
       size_t begin = i * chunk_size;

--- a/tachyon/crypto/sumcheck/multilinear/sumcheck_verifier.h
+++ b/tachyon/crypto/sumcheck/multilinear/sumcheck_verifier.h
@@ -6,6 +6,7 @@
 #ifndef TACHYON_CRYPTO_SUMCHECK_MULTILINEAR_SUMCHECK_VERIFIER_H_
 #define TACHYON_CRYPTO_SUMCHECK_MULTILINEAR_SUMCHECK_VERIFIER_H_
 
+#include <memory_resource>
 #include <utility>
 #include <vector>
 
@@ -16,7 +17,8 @@
 namespace tachyon::crypto {
 
 template <typename F>
-F InterpolateUniPoly(const std::vector<F>& poly, const F& evaluation_point);
+F InterpolateUniPoly(const std::pmr::vector<F>& poly,
+                     const F& evaluation_point);
 
 // Subclaim created when verifier is convinced.
 template <typename F>
@@ -88,7 +90,7 @@ class SumcheckVerifier {
     F expected = asserted_sum;
 
     for (size_t i = 0; i < num_variables_; ++i) {
-      const std::vector<F>& evaluations = polynomials_received_[i];
+      const std::pmr::vector<F>& evaluations = polynomials_received_[i];
       // Incorrect number of evaluations.
       CHECK_EQ(evaluations.size(), max_evaluations_ + 1);
 
@@ -114,7 +116,7 @@ class SumcheckVerifier {
   std::vector<F> randomness_;
   // A list storing the univariate polynomial in evaluation form sent by the
   // prover at each round.
-  std::vector<std::vector<F>> polynomials_received_;
+  std::vector<std::pmr::vector<F>> polynomials_received_;
 };
 
 // Interpolates the unique univariate polynomial |poly| of degree at most
@@ -123,7 +125,8 @@ class SumcheckVerifier {
 // |evaluation_point|:
 //   ∑ poly[i] * ∏ⱼ≠ᵢ(|evaluation_point| - j)/(i - j), (i = 0,1,...,|poly_size|)
 template <typename F>
-F InterpolateUniPoly(const std::vector<F>& poly, const F& evaluation_point) {
+F InterpolateUniPoly(const std::pmr::vector<F>& poly,
+                     const F& evaluation_point) {
   constexpr size_t kParallelFactor = 16;
 
   using BigInt = typename F::BigIntTy;

--- a/tachyon/math/base/semigroups.h
+++ b/tachyon/math/base/semigroups.h
@@ -5,6 +5,7 @@
 #include <stdint.h>
 
 #include <algorithm>
+#include <memory_resource>
 #include <vector>
 
 #include "absl/types/span.h"
@@ -197,25 +198,7 @@ class MultiplicativeSemigroup {
     return g;
   }
 
-  // generator: g
-  // return: [c, c * g, c * g², ..., c * g^{|size| - 1}]
-  constexpr static std::vector<MulResult> GetSuccessivePowers(
-      size_t size, const G& generator, const G& c = G::One()) {
-    std::vector<MulResult> ret(size);
-    base::Parallelize(
-        ret, [&generator, &c](absl::Span<G> chunk, size_t chunk_offset,
-                              size_t chunk_size) {
-          MulResult pow = generator.Pow(chunk_offset * chunk_size);
-          if (!c.IsOne()) pow *= c;
-          for (G& v : chunk) {
-            v = pow;
-            pow *= generator;
-          }
-        });
-    return ret;
-  }
-
-  constexpr static std::pmr::vector<MulResult> GetSuccessivePowersPmr(
+  constexpr static std::pmr::vector<MulResult> GetSuccessivePowers(
       size_t size, const G& generator, const G& c = G::One()) {
     std::pmr::vector<MulResult> ret(size);
     base::Parallelize(

--- a/tachyon/math/base/semigroups.h
+++ b/tachyon/math/base/semigroups.h
@@ -215,6 +215,22 @@ class MultiplicativeSemigroup {
     return ret;
   }
 
+  constexpr static std::pmr::vector<MulResult> GetSuccessivePowersPmr(
+      size_t size, const G& generator, const G& c = G::One()) {
+    std::pmr::vector<MulResult> ret(size);
+    base::Parallelize(
+        ret, [&generator, &c](absl::Span<G> chunk, size_t chunk_offset,
+                              size_t chunk_size) {
+          MulResult pow = generator.Pow(chunk_offset * chunk_size);
+          if (!c.IsOne()) pow *= c;
+          for (G& v : chunk) {
+            v = pow;
+            pow *= generator;
+          }
+        });
+    return ret;
+  }
+
   constexpr auto ExpPowOfTwo(uint32_t log_n) const {
     G val = *static_cast<const G*>(this);
     for (size_t i = 0; i < log_n; ++i) {

--- a/tachyon/math/base/semigroups.h
+++ b/tachyon/math/base/semigroups.h
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <memory_resource>
+#include <utility>
 #include <vector>
 
 #include "absl/types/span.h"
@@ -206,10 +207,13 @@ class MultiplicativeSemigroup {
                               size_t chunk_size) {
           MulResult pow = generator.Pow(chunk_offset * chunk_size);
           if (!c.IsOne()) pow *= c;
-          for (G& v : chunk) {
-            v = pow;
+
+          // NOTE: It is not possible to have empty chunk so this is safe
+          for (size_t i = 0; i < chunk.size() - 1; ++i) {
+            chunk[i] = pow;
             pow *= generator;
           }
+          chunk.back() = std::move(pow);
         });
     return ret;
   }
@@ -391,10 +395,13 @@ class AdditiveSemigroup {
         ret, [&generator](absl::Span<G> chunk, size_t chunk_offset,
                           size_t chunk_size) {
           AddResult scalar_mul = generator.ScalarMul(chunk_offset * chunk_size);
-          for (G& v : chunk) {
-            v = scalar_mul;
+
+          // NOTE: It is not possible to have empty chunk so this is safe
+          for (size_t i = 0; i < chunk.size() - 1; ++i) {
+            chunk[i] = scalar_mul;
             scalar_mul += generator;
           }
+          chunk.back() = std::move(scalar_mul);
         });
     return ret;
   }

--- a/tachyon/math/polynomials/univariate/lagrange_interpolation.h
+++ b/tachyon/math/polynomials/univariate/lagrange_interpolation.h
@@ -7,6 +7,7 @@
 #ifndef TACHYON_MATH_POLYNOMIALS_UNIVARIATE_LAGRANGE_INTERPOLATION_H_
 #define TACHYON_MATH_POLYNOMIALS_UNIVARIATE_LAGRANGE_INTERPOLATION_H_
 
+#include <memory_resource>
 #include <utility>
 #include <vector>
 
@@ -51,7 +52,7 @@ bool LagrangeInterpolate(
     CHECK(F::BatchInverseInPlaceSerial(chunk));
   });
 
-  std::vector<std::vector<F>> coeffs_sums = base::ParallelizeMap(
+  std::vector<std::pmr::vector<F>> coeffs_sums = base::ParallelizeMap(
       evals, [&points, &denoms](absl::Span<const F> chunk, size_t chunk_offset,
                                 size_t chunk_size) {
         // See comments in |UnivariateDenseCoefficients::FromRoots()|.
@@ -62,8 +63,8 @@ bool LagrangeInterpolate(
         // |coeffs[i]| = cᵢ
         // clang-format on
 
-        std::vector<F> coeffs(points.size());
-        std::vector<F> coeffs_sum(points.size());
+        std::pmr::vector<F> coeffs(points.size());
+        std::pmr::vector<F> coeffs_sum(points.size());
 
         size_t start = chunk_offset * chunk_size;
         for (size_t chunk_idx = 0; chunk_idx < chunk.size(); ++chunk_idx) {

--- a/tachyon/math/polynomials/univariate/naive_batch_fft.h
+++ b/tachyon/math/polynomials/univariate/naive_batch_fft.h
@@ -6,6 +6,7 @@
 #ifndef TACHYON_MATH_POLYNOMIALS_UNIVARIATE_NAIVE_BATCH_FFT_H_
 #define TACHYON_MATH_POLYNOMIALS_UNIVARIATE_NAIVE_BATCH_FFT_H_
 
+#include <memory_resource>
 #include <vector>
 
 #include "tachyon/base/bits.h"
@@ -25,11 +26,12 @@ class NaiveBatchFFT : public TwoAdicSubgroup<F> {
 
     RowMajorMatrix<F> res = RowMajorMatrix<F>::Zero(rows, cols);
 
-    std::vector<F> points = F::GetSuccessivePowers(rows, g);
+    std::pmr::vector<F> points = F::GetSuccessivePowers(rows, g);
     size_t num_points = points.size();
 
     for (size_t res_r = 0; res_r < num_points; ++res_r) {
-      std::vector<F> point_powers = F::GetSuccessivePowers(rows, points[res_r]);
+      std::pmr::vector<F> point_powers =
+          F::GetSuccessivePowers(rows, points[res_r]);
       for (size_t src_r = 0; src_r < num_points; ++src_r) {
         for (Eigen::Index col = 0; col < cols; ++col) {
           res(res_r, col) += point_powers[src_r] * mat(src_r, col);

--- a/tachyon/math/polynomials/univariate/radix2_evaluation_domain.h
+++ b/tachyon/math/polynomials/univariate/radix2_evaluation_domain.h
@@ -296,9 +296,9 @@ class Radix2EvaluationDomain : public UnivariateEvaluationDomain<F, MaxDegree>,
     size_t vec_largest_size = this->size_ / 2;
 
     // Compute biggest vector of |root_vec_| and |inv_root_vec_| first.
-    std::vector<F> largest =
+    std::pmr::vector<F> largest =
         this->GetRootsOfUnity(vec_largest_size, this->group_gen_);
-    std::vector<F> largest_inv =
+    std::pmr::vector<F> largest_inv =
         this->GetRootsOfUnity(vec_largest_size, this->group_gen_inv_);
 
     if constexpr (F::Config::kModulusBits <= 32) {
@@ -363,7 +363,7 @@ class Radix2EvaluationDomain : public UnivariateEvaluationDomain<F, MaxDegree>,
 
   // This can be used as the first half of a parallelized butterfly network.
   CONSTEXPR_IF_NOT_OPENMP void RunParallelRowChunks(
-      RowMajorMatrix<F>& mat, const std::vector<F>& twiddles,
+      RowMajorMatrix<F>& mat, const std::pmr::vector<F>& twiddles,
       const std::vector<PackedPrimeField>& packed_twiddles_rev) {
     if constexpr (F::Config::kModulusBits > 32) {
       NOTREACHED();
@@ -448,15 +448,15 @@ class Radix2EvaluationDomain : public UnivariateEvaluationDomain<F, MaxDegree>,
   }
 
   CONSTEXPR_IF_NOT_OPENMP std::vector<F> ReverseSliceIndexBits(
-      const std::vector<F>& vals) {
+      const std::pmr::vector<F>& vals) {
     size_t n = vals.size();
     if (n == 0) {
-      return vals;
+      return std::vector<F>();
     }
     CHECK(base::bits::IsPowerOfTwo(n));
     size_t log_n = base::bits::Log2Ceiling(n);
 
-    std::vector<F> ret = vals;
+    std::vector<F> ret(vals.begin(), vals.end());
     this->SwapElements(ret, n, log_n);
     return ret;
   }
@@ -492,8 +492,8 @@ class Radix2EvaluationDomain : public UnivariateEvaluationDomain<F, MaxDegree>,
   std::vector<std::vector<PackedPrimeField>> packed_roots_vec_;
   std::vector<std::vector<PackedPrimeField>> packed_inv_roots_vec_;
   // For all finite fields
-  std::vector<std::vector<F>> roots_vec_;
-  std::vector<std::vector<F>> inv_roots_vec_;
+  std::vector<std::pmr::vector<F>> roots_vec_;
+  std::vector<std::pmr::vector<F>> inv_roots_vec_;
 };
 
 }  // namespace tachyon::math

--- a/tachyon/math/polynomials/univariate/radix2_evaluation_domain.h
+++ b/tachyon/math/polynomials/univariate/radix2_evaluation_domain.h
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <cmath>
 #include <memory>
+#include <memory_resource>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -133,7 +134,7 @@ class Radix2EvaluationDomain : public UnivariateEvaluationDomain<F, MaxDegree>,
     // - divide by number of rows (since we're doing an inverse DFT)
     // - multiply by powers of the coset shift (see default coset LDE impl for
     // an explanation)
-    std::vector<F> weights = F::GetSuccessivePowers(
+    std::pmr::vector<F> weights = F::GetSuccessivePowers(
         this->size_, F::FromMontgomery(F::Config::kSubgroupGenerator),
         this->size_inv_);
     OPENMP_PARALLEL_FOR(size_t row = 0; row < weights.size(); ++row) {

--- a/tachyon/math/polynomials/univariate/two_adic_subgroup.h
+++ b/tachyon/math/polynomials/univariate/two_adic_subgroup.h
@@ -6,6 +6,7 @@
 #ifndef TACHYON_MATH_POLYNOMIALS_UNIVARIATE_TWO_ADIC_SUBGROUP_H_
 #define TACHYON_MATH_POLYNOMIALS_UNIVARIATE_TWO_ADIC_SUBGROUP_H_
 
+#include <memory_resource>
 #include <optional>
 #include <vector>
 
@@ -49,7 +50,7 @@ class TwoAdicSubgroup {
     Eigen::Index rows = mat.rows();
     Eigen::Index cols = mat.cols();
 
-    std::vector<F> weights = F::GetSuccessivePowers(
+    std::pmr::vector<F> weights = F::GetSuccessivePowers(
         rows, F::FromMontgomery(F::Config::kSubgroupGenerator));
     OPENMP_PARALLEL_NESTED_FOR(Eigen::Index row = 0; row < rows; ++row) {
       for (Eigen::Index col = 0; col < cols; ++col) {

--- a/tachyon/math/polynomials/univariate/univariate_dense_polynomial_unittest.cc
+++ b/tachyon/math/polynomials/univariate/univariate_dense_polynomial_unittest.cc
@@ -288,8 +288,8 @@ TEST_F(UnivariateDensePolynomialTest, MulScalar) {
   Poly poly = Poly::Random(kMaxDegree);
   GF7 scalar = GF7::Random();
 
-  std::vector<GF7> expected_coeffs;
-  const std::vector<GF7>& coeffs = poly.coefficients().coefficients();
+  std::pmr::vector<GF7> expected_coeffs;
+  const std::pmr::vector<GF7>& coeffs = poly.coefficients().coefficients();
   expected_coeffs.reserve(coeffs.size());
   for (size_t i = 0; i < coeffs.size(); ++i) {
     expected_coeffs.push_back(coeffs[i] * scalar);
@@ -309,8 +309,8 @@ TEST_F(UnivariateDensePolynomialTest, DivScalar) {
     scalar = GF7::Random();
   }
 
-  std::vector<GF7> expected_coeffs;
-  const std::vector<GF7>& coeffs = poly.coefficients().coefficients();
+  std::pmr::vector<GF7> expected_coeffs;
+  const std::pmr::vector<GF7>& coeffs = poly.coefficients().coefficients();
   expected_coeffs.reserve(coeffs.size());
   for (size_t i = 0; i < coeffs.size(); ++i) {
     expected_coeffs.push_back(unwrap(coeffs[i] / scalar));

--- a/tachyon/math/polynomials/univariate/univariate_evaluation_domain.h
+++ b/tachyon/math/polynomials/univariate/univariate_evaluation_domain.h
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <memory_resource>
 #include <optional>
 #include <utility>
 #include <vector>
@@ -231,8 +232,9 @@ class UnivariateEvaluationDomain : public EvaluationDomain<F, MaxDegree> {
   // Computes the first |size| roots of unity for the entire domain.
   // e.g. for the domain [1, g, g², ..., gⁿ⁻¹}] and |size| = n / 2, it
   // computes [1, g, g², ..., g^{(n / 2) - 1}]
-  constexpr std::vector<F> GetRootsOfUnity(size_t size, const F& root) const {
-    return F::GetSuccessivePowers(size, root);
+  constexpr std::pmr::vector<F> GetRootsOfUnity(size_t size,
+                                                const F& root) const {
+    return F::GetSuccessivePowersPmr(size, root);
   }
 
   // Define the following as

--- a/tachyon/math/polynomials/univariate/univariate_evaluation_domain.h
+++ b/tachyon/math/polynomials/univariate/univariate_evaluation_domain.h
@@ -341,14 +341,18 @@ class UnivariateEvaluationDomain : public EvaluationDomain<F, MaxDegree> {
             size_t n = chunk_idx * chunk_size;
             F l_i_pow = l_i * group_gen_inv_.Pow(n);
             F negative_omega_i_pow = negative_omega_i * group_gen_.Pow(n);
-            for (F& c : chunk) {
+
+            // NOTE: It is not possible to have empty chunk so this is safe
+            for (size_t i = 0; i < chunk.size() - 1; ++i) {
               // (Z_H(τ) * vᵢ)⁻¹ * (τ - h * gⁱ)
-              c = l_i_pow * (tau + negative_omega_i_pow);
+              chunk[i] = l_i_pow * (tau + negative_omega_i_pow);
               // lᵢ₊₁ = g⁻¹ * lᵢ
               l_i_pow *= group_gen_inv_;
               // (- h * gⁱ) * g
               negative_omega_i_pow *= group_gen_;
             }
+            chunk.back() = std::move(l_i_pow);
+            chunk.back() *= tau + negative_omega_i_pow;
           });
 
       // Invert |lagrange_coefficients_inverse| to get the actual

--- a/tachyon/math/polynomials/univariate/univariate_evaluation_domain.h
+++ b/tachyon/math/polynomials/univariate/univariate_evaluation_domain.h
@@ -234,7 +234,7 @@ class UnivariateEvaluationDomain : public EvaluationDomain<F, MaxDegree> {
   // computes [1, g, g², ..., g^{(n / 2) - 1}]
   constexpr std::pmr::vector<F> GetRootsOfUnity(size_t size,
                                                 const F& root) const {
-    return F::GetSuccessivePowersPmr(size, root);
+    return F::GetSuccessivePowers(size, root);
   }
 
   // Define the following as
@@ -273,7 +273,8 @@ class UnivariateEvaluationDomain : public EvaluationDomain<F, MaxDegree> {
   // is computed in time O(m). Then given the evaluations of a degree d
   // polynomial P over H, where d < m, P(τ) can be computed as P(τ) =
   // Σ{i in m} Lᵢ_H(τ) * P(gⁱ).
-  constexpr std::vector<F> EvaluateAllLagrangeCoefficients(const F& tau) const {
+  constexpr std::pmr::vector<F> EvaluateAllLagrangeCoefficients(
+      const F& tau) const {
     return EvaluatePartialLagrangeCoefficients(
         tau, base::Range<size_t>::Until(size_));
   }
@@ -283,7 +284,7 @@ class UnivariateEvaluationDomain : public EvaluationDomain<F, MaxDegree> {
   // TODO(chokobole): If we want to accept IsStartInclusive as a template
   // parameter, we need a way to get a starting index from |range|.
   template <typename T, bool IsEndInclusive>
-  constexpr std::vector<F> EvaluatePartialLagrangeCoefficients(
+  constexpr std::pmr::vector<F> EvaluatePartialLagrangeCoefficients(
       const F& tau, base::Range<T, true, IsEndInclusive> range) const {
     size_t size = range.GetSize();
     CHECK_LE(size, size_);
@@ -304,7 +305,7 @@ class UnivariateEvaluationDomain : public EvaluationDomain<F, MaxDegree> {
       // Then i-th lagrange coefficient in this case is then simply 1,
       // and all other lagrange coefficients are 0.
       // Thus we find i by brute force.
-      std::vector<F> u(size, F::Zero());
+      std::pmr::vector<F> u(size, F::Zero());
       F omega_i = GetElement(range.from);
       for (F& u_i : u) {
         if (omega_i == tau) {
@@ -332,7 +333,7 @@ class UnivariateEvaluationDomain : public EvaluationDomain<F, MaxDegree> {
       //    = (Z_H(τ) * gᵢ * v₀)⁻¹
       F l_i = unwrap((z_h_at_tau * omega_i).Inverse()) * t;
       F negative_omega_i = -omega_i;
-      std::vector<F> lagrange_coefficients_inverse(size);
+      std::pmr::vector<F> lagrange_coefficients_inverse(size);
       base::Parallelize(
           lagrange_coefficients_inverse,
           [this, &l_i, &tau, &negative_omega_i](
@@ -428,7 +429,7 @@ class UnivariateEvaluationDomain : public EvaluationDomain<F, MaxDegree> {
   }
 
   // Returns all the elements of the domain.
-  CONSTEXPR_IF_NOT_OPENMP std::vector<F> GetElements() const {
+  CONSTEXPR_IF_NOT_OPENMP std::pmr::vector<F> GetElements() const {
     return F::GetSuccessivePowers(size_, group_gen_, offset_);
   }
 

--- a/tachyon/math/polynomials/univariate/univariate_evaluation_domain_unittest.cc
+++ b/tachyon/math/polynomials/univariate/univariate_evaluation_domain_unittest.cc
@@ -113,7 +113,7 @@ TYPED_TEST(UnivariateEvaluationDomainTest, FilterPolynomial) {
         // Get all possible cosets of |subdomain| within |domain|.
         for (const bls12_381::Fr& offset : possible_offsets) {
           std::unique_ptr<BaseDomain> coset = subdomain->GetCoset(offset);
-          std::vector<bls12_381::Fr> coset_elements = coset->GetElements();
+          std::pmr::vector<bls12_381::Fr> coset_elements = coset->GetElements();
           DensePoly filter_poly = domain->GetFilterPolynomial(*coset);
           EXPECT_EQ(filter_poly.Degree(), domain_size - subdomain_size);
           for (const bls12_381::Fr& element : domain->GetElements()) {
@@ -153,7 +153,7 @@ TYPED_TEST(UnivariateEvaluationDomainTest, ContentsOfElements) {
   for (size_t coeffs = 0; coeffs < kNumCoeffs; ++coeffs) {
     size_t size = size_t{1} << coeffs;
     this->TestDomains(size, [size](const BaseDomain& d) {
-      std::vector<F> elements = d.GetElements();
+      std::pmr::vector<F> elements = d.GetElements();
       for (size_t i = 0; i < size; ++i) {
         EXPECT_EQ(elements[i], d.offset() * d.group_gen().Pow(i));
         EXPECT_EQ(elements[i], d.GetElement(i));
@@ -178,10 +178,10 @@ TYPED_TEST(UnivariateEvaluationDomainTest, NonSystematicLagrangeCoefficients) {
     F actual_eval = rand_poly.Evaluate(rand_pt);
     this->TestDomains(domain_size, [domain_size, &rand_pt, &rand_poly,
                                     &actual_eval](const BaseDomain& d) {
-      std::vector<F> lagrange_coeffs =
+      std::pmr::vector<F> lagrange_coeffs =
           d.EvaluateAllLagrangeCoefficients(rand_pt);
 
-      std::vector<F> sub_lagrange_coeffs =
+      std::pmr::vector<F> sub_lagrange_coeffs =
           d.EvaluatePartialLagrangeCoefficients(
               rand_pt, base::Range<size_t>(1, domain_size - 1));
 
@@ -218,9 +218,10 @@ TYPED_TEST(UnivariateEvaluationDomainTest, SystematicLagrangeCoefficients) {
     this->TestDomains(domain_size, [domain_size](const BaseDomain& d) {
       for (size_t i = 0; i < domain_size; ++i) {
         F x = d.GetElement(i);
-        std::vector<F> lagrange_coeffs = d.EvaluateAllLagrangeCoefficients(x);
+        std::pmr::vector<F> lagrange_coeffs =
+            d.EvaluateAllLagrangeCoefficients(x);
 
-        std::vector<F> sub_lagrange_coeffs =
+        std::pmr::vector<F> sub_lagrange_coeffs =
             d.EvaluatePartialLagrangeCoefficients(
                 x, base::Range<size_t>(1, domain_size - 1));
 
@@ -316,7 +317,7 @@ TYPED_TEST(UnivariateEvaluationDomainTest, RootsOfUnity) {
       EXPECT_TRUE(domain->EvaluateVanishingPolynomial(value).IsZero());
     }
     EXPECT_EQ(actual_roots.size(), domain->size());
-    std::vector<F> expected_roots = domain->GetElements();
+    std::pmr::vector<F> expected_roots = domain->GetElements();
     EXPECT_EQ(absl::MakeConstSpan(actual_roots),
               absl::Span(expected_roots.data(), actual_roots.size()));
   }

--- a/tachyon/math/polynomials/univariate/univariate_evaluation_domain_unittest.cc
+++ b/tachyon/math/polynomials/univariate/univariate_evaluation_domain_unittest.cc
@@ -310,7 +310,7 @@ TYPED_TEST(UnivariateEvaluationDomainTest, RootsOfUnity) {
 
   for (size_t coeffs = 0; coeffs < kNumCoeffs; ++coeffs) {
     std::unique_ptr<Domain> domain = Domain::Create(coeffs);
-    std::vector<F> actual_roots =
+    std::pmr::vector<F> actual_roots =
         domain->GetRootsOfUnity(domain->size(), domain->group_gen());
     for (const F& value : actual_roots) {
       EXPECT_TRUE(domain->EvaluateVanishingPolynomial(value).IsZero());

--- a/tachyon/math/polynomials/univariate/univariate_evaluations_ops.h
+++ b/tachyon/math/polynomials/univariate/univariate_evaluations_ops.h
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <memory_resource>
 #include <optional>
 #include <utility>
 #include <vector>
@@ -24,8 +25,8 @@ class UnivariateEvaluationsOp {
   using Poly = UnivariateEvaluations<F, MaxDegree>;
 
   static Poly Add(const Poly& self, const Poly& other) {
-    const std::vector<F>& l_evaluations = self.evaluations_;
-    const std::vector<F>& r_evaluations = other.evaluations_;
+    const std::pmr::vector<F>& l_evaluations = self.evaluations_;
+    const std::pmr::vector<F>& r_evaluations = other.evaluations_;
     if (l_evaluations.empty()) {
       // 0 + g(x)
       return other;
@@ -35,7 +36,7 @@ class UnivariateEvaluationsOp {
       return self;
     }
     CHECK_EQ(l_evaluations.size(), r_evaluations.size());
-    std::vector<F> o_evaluations(r_evaluations.size());
+    std::pmr::vector<F> o_evaluations(r_evaluations.size());
     OPENMP_PARALLEL_FOR(size_t i = 0; i < r_evaluations.size(); ++i) {
       o_evaluations[i] = l_evaluations[i] + r_evaluations[i];
     }
@@ -43,8 +44,8 @@ class UnivariateEvaluationsOp {
   }
 
   static Poly& AddInPlace(Poly& self, const Poly& other) {
-    std::vector<F>& l_evaluations = self.evaluations_;
-    const std::vector<F>& r_evaluations = other.evaluations_;
+    std::pmr::vector<F>& l_evaluations = self.evaluations_;
+    const std::pmr::vector<F>& r_evaluations = other.evaluations_;
     if (l_evaluations.empty()) {
       // 0 + g(x)
       return self = other;
@@ -61,8 +62,8 @@ class UnivariateEvaluationsOp {
   }
 
   static Poly Sub(const Poly& self, const Poly& other) {
-    const std::vector<F>& l_evaluations = self.evaluations_;
-    const std::vector<F>& r_evaluations = other.evaluations_;
+    const std::pmr::vector<F>& l_evaluations = self.evaluations_;
+    const std::pmr::vector<F>& r_evaluations = other.evaluations_;
     if (l_evaluations.empty()) {
       // 0 - g(x)
       return -other;
@@ -72,7 +73,7 @@ class UnivariateEvaluationsOp {
       return self;
     }
     CHECK_EQ(l_evaluations.size(), r_evaluations.size());
-    std::vector<F> o_evaluations(r_evaluations.size());
+    std::pmr::vector<F> o_evaluations(r_evaluations.size());
     OPENMP_PARALLEL_FOR(size_t i = 0; i < r_evaluations.size(); ++i) {
       o_evaluations[i] = l_evaluations[i] - r_evaluations[i];
     }
@@ -80,8 +81,8 @@ class UnivariateEvaluationsOp {
   }
 
   static Poly& SubInPlace(Poly& self, const Poly& other) {
-    std::vector<F>& l_evaluations = self.evaluations_;
-    const std::vector<F>& r_evaluations = other.evaluations_;
+    std::pmr::vector<F>& l_evaluations = self.evaluations_;
+    const std::pmr::vector<F>& r_evaluations = other.evaluations_;
     if (l_evaluations.empty()) {
       // 0 - g(x)
       return self = -other;
@@ -98,11 +99,11 @@ class UnivariateEvaluationsOp {
   }
 
   static Poly Negate(const Poly& self) {
-    const std::vector<F>& i_evaluations = self.evaluations_;
+    const std::pmr::vector<F>& i_evaluations = self.evaluations_;
     if (i_evaluations.empty()) {
       return self;
     }
-    std::vector<F> o_evaluations(i_evaluations.size());
+    std::pmr::vector<F> o_evaluations(i_evaluations.size());
     OPENMP_PARALLEL_FOR(size_t i = 0; i < i_evaluations.size(); ++i) {
       o_evaluations[i] = -i_evaluations[i];
     }
@@ -110,7 +111,7 @@ class UnivariateEvaluationsOp {
   }
 
   static Poly& NegateInPlace(Poly& self) {
-    std::vector<F>& evaluations = self.evaluations_;
+    std::pmr::vector<F>& evaluations = self.evaluations_;
     if (evaluations.empty()) {
       return self;
     }
@@ -123,14 +124,14 @@ class UnivariateEvaluationsOp {
   }
 
   static Poly Mul(const Poly& self, const Poly& other) {
-    const std::vector<F>& l_evaluations = self.evaluations_;
-    const std::vector<F>& r_evaluations = other.evaluations_;
+    const std::pmr::vector<F>& l_evaluations = self.evaluations_;
+    const std::pmr::vector<F>& r_evaluations = other.evaluations_;
     if (l_evaluations.empty() || r_evaluations.empty()) {
       // 0 * g(x) or f(x) * 0
       return Poly::Zero();
     }
     CHECK_EQ(l_evaluations.size(), r_evaluations.size());
-    std::vector<F> o_evaluations(r_evaluations.size());
+    std::pmr::vector<F> o_evaluations(r_evaluations.size());
     OPENMP_PARALLEL_FOR(size_t i = 0; i < r_evaluations.size(); ++i) {
       o_evaluations[i] = l_evaluations[i] * r_evaluations[i];
     }
@@ -138,8 +139,8 @@ class UnivariateEvaluationsOp {
   }
 
   static Poly& MulInPlace(Poly& self, const Poly& other) {
-    std::vector<F>& l_evaluations = self.evaluations_;
-    const std::vector<F>& r_evaluations = other.evaluations_;
+    std::pmr::vector<F>& l_evaluations = self.evaluations_;
+    const std::pmr::vector<F>& r_evaluations = other.evaluations_;
     if (l_evaluations.empty()) {
       // 0 * g(x)
       return self;
@@ -157,7 +158,7 @@ class UnivariateEvaluationsOp {
   }
 
   static Poly Mul(const Poly& self, const F& scalar) {
-    const std::vector<F>& l_evaluations = self.evaluations_;
+    const std::pmr::vector<F>& l_evaluations = self.evaluations_;
     if (l_evaluations.empty() || scalar.IsZero()) {
       // 0 * s or f(x) * 0
       return Poly::Zero();
@@ -166,7 +167,7 @@ class UnivariateEvaluationsOp {
       // f(x) * 1
       return self;
     }
-    std::vector<F> o_evaluations(l_evaluations.size());
+    std::pmr::vector<F> o_evaluations(l_evaluations.size());
     OPENMP_PARALLEL_FOR(size_t i = 0; i < l_evaluations.size(); ++i) {
       o_evaluations[i] = l_evaluations[i] * scalar;
     }
@@ -174,7 +175,7 @@ class UnivariateEvaluationsOp {
   }
 
   static Poly& MulInPlace(Poly& self, const F& scalar) {
-    std::vector<F>& l_evaluations = self.evaluations_;
+    std::pmr::vector<F>& l_evaluations = self.evaluations_;
     if (l_evaluations.empty() || scalar.IsOne()) {
       // 0 * s or f(x) * 1
       return self;
@@ -187,8 +188,8 @@ class UnivariateEvaluationsOp {
 
   CONSTEXPR_IF_NOT_OPENMP static std::optional<Poly> Div(const Poly& self,
                                                          const Poly& other) {
-    const std::vector<F>& l_evaluations = self.evaluations_;
-    const std::vector<F>& r_evaluations = other.evaluations_;
+    const std::pmr::vector<F>& l_evaluations = self.evaluations_;
+    const std::pmr::vector<F>& r_evaluations = other.evaluations_;
     // f(x) / 0
     if (UNLIKELY(r_evaluations.empty())) {
       LOG_IF_NOT_GPU(ERROR) << "Division by zero attempted";
@@ -203,7 +204,7 @@ class UnivariateEvaluationsOp {
       LOG_IF_NOT_GPU(ERROR) << "Evaluation sizes unequal for division";
       return std::nullopt;
     }
-    std::vector<F> o_evaluations(r_evaluations.size());
+    std::pmr::vector<F> o_evaluations(r_evaluations.size());
     std::atomic<bool> check_valid(true);
     OPENMP_PARALLEL_FOR(size_t i = 0; i < r_evaluations.size(); ++i) {
       const std::optional<F> div = l_evaluations[i] / r_evaluations[i];
@@ -222,8 +223,8 @@ class UnivariateEvaluationsOp {
 
   [[nodiscard]] CONSTEXPR_IF_NOT_OPENMP static std::optional<Poly*> DivInPlace(
       Poly& self, const Poly& other) {
-    std::vector<F>& l_evaluations = self.evaluations_;
-    const std::vector<F>& r_evaluations = other.evaluations_;
+    std::pmr::vector<F>& l_evaluations = self.evaluations_;
+    const std::pmr::vector<F>& r_evaluations = other.evaluations_;
     // f(x) / 0
     if (UNLIKELY(r_evaluations.empty())) {
       LOG_IF_NOT_GPU(ERROR) << "Division by zero attempted";

--- a/tachyon/math/polynomials/univariate/univariate_evaluations_unittest.cc
+++ b/tachyon/math/polynomials/univariate/univariate_evaluations_unittest.cc
@@ -227,8 +227,8 @@ TEST_F(UnivariateEvaluationsTest, MulScalar) {
   Poly poly = Poly::Random(kMaxDegree);
   GF7 scalar = GF7::Random();
 
-  std::vector<GF7> expected_evals;
-  const std::vector<GF7>& evals = poly.evaluations();
+  std::pmr::vector<GF7> expected_evals;
+  const std::pmr::vector<GF7>& evals = poly.evaluations();
   expected_evals.reserve(evals.size());
   for (size_t i = 0; i < evals.size(); ++i) {
     expected_evals.push_back(evals[i] * scalar);
@@ -248,8 +248,8 @@ TEST_F(UnivariateEvaluationsTest, DivScalar) {
     scalar = GF7::Random();
   }
 
-  std::vector<GF7> expected_evals;
-  const std::vector<GF7>& evals = poly.evaluations();
+  std::pmr::vector<GF7> expected_evals;
+  const std::pmr::vector<GF7>& evals = poly.evaluations();
   expected_evals.reserve(evals.size());
   for (size_t i = 0; i < evals.size(); ++i) {
     expected_evals.push_back(unwrap(evals[i] / scalar));
@@ -278,7 +278,7 @@ TEST_F(UnivariateEvaluationsTest, Copyable) {
 
 TEST_F(UnivariateEvaluationsTest, Hash) {
   EXPECT_TRUE(absl::VerifyTypeImplementsAbslHashCorrectly(std::make_tuple(
-      Poly(), Poly::Zero(), Poly({std::vector<GF7>(kMaxDegree + 1)}),
+      Poly(), Poly::Zero(), Poly({std::pmr::vector<GF7>(kMaxDegree + 1)}),
       Poly::One(kMaxDegree), Poly::Random(kMaxDegree),
       Poly::Random(kMaxDegree))));
 }

--- a/tachyon/math/polynomials/univariate/univariate_polynomial_ops.h
+++ b/tachyon/math/polynomials/univariate/univariate_polynomial_ops.h
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <memory_resource>
 #include <optional>
 #include <utility>
 #include <vector>
@@ -37,10 +38,12 @@ class UnivariatePolynomialOp<UnivariateDenseCoefficients<F, MaxDegree>> {
       return self;
     }
 
-    const std::vector<F>& l_coefficients = self.coefficients_.coefficients_;
-    const std::vector<F>& r_coefficients = other.coefficients_.coefficients_;
+    const std::pmr::vector<F>& l_coefficients =
+        self.coefficients_.coefficients_;
+    const std::pmr::vector<F>& r_coefficients =
+        other.coefficients_.coefficients_;
     UnivariatePolynomial<D> ret;
-    std::vector<F>& o_coefficients = ret.coefficients_.coefficients_;
+    std::pmr::vector<F>& o_coefficients = ret.coefficients_.coefficients_;
     o_coefficients.resize(
         std::max(l_coefficients.size(), r_coefficients.size()));
     OPENMP_PARALLEL_FOR(size_t i = 0; i < o_coefficients.size(); ++i) {
@@ -59,8 +62,9 @@ class UnivariatePolynomialOp<UnivariateDenseCoefficients<F, MaxDegree>> {
       return self;
     }
 
-    std::vector<F>& l_coefficients = self.coefficients_.coefficients_;
-    const std::vector<F>& r_coefficients = other.coefficients_.coefficients_;
+    std::pmr::vector<F>& l_coefficients = self.coefficients_.coefficients_;
+    const std::pmr::vector<F>& r_coefficients =
+        other.coefficients_.coefficients_;
     l_coefficients.resize(
         std::max(l_coefficients.size(), r_coefficients.size()));
     OPENMP_PARALLEL_FOR(size_t i = 0; i < r_coefficients.size(); ++i) {
@@ -82,7 +86,7 @@ class UnivariatePolynomialOp<UnivariateDenseCoefficients<F, MaxDegree>> {
     size_t degree = self.Degree();
     size_t other_degree = other.Degree();
     UnivariatePolynomial<D> ret;
-    std::vector<F>& o_coefficients = ret.coefficients_.coefficients_;
+    std::pmr::vector<F>& o_coefficients = ret.coefficients_.coefficients_;
     o_coefficients.resize(std::max(degree, other_degree) + 1);
     OPENMP_PARALLEL_FOR(size_t i = 0; i < o_coefficients.size(); ++i) {
       o_coefficients[i] = self.coefficients_[i] + other.coefficients()[i];
@@ -102,12 +106,12 @@ class UnivariatePolynomialOp<UnivariateDenseCoefficients<F, MaxDegree>> {
 
     size_t degree = self.Degree();
     size_t other_degree = other.Degree();
-    std::vector<F> upper_coeffs;
+    std::pmr::vector<F> upper_coeffs;
     if (degree < other_degree) {
-      upper_coeffs = std::vector<F>(other_degree - degree);
+      upper_coeffs = std::pmr::vector<F>(other_degree - degree);
     }
 
-    std::vector<F>& l_coefficients = self.coefficients_.coefficients_;
+    std::pmr::vector<F>& l_coefficients = self.coefficients_.coefficients_;
     const std::vector<Term>& r_terms = other.coefficients().terms_;
     OPENMP_PARALLEL_FOR(const Term& r_term : r_terms) {
       if (r_term.degree <= degree) {
@@ -132,10 +136,12 @@ class UnivariatePolynomialOp<UnivariateDenseCoefficients<F, MaxDegree>> {
       return self;
     }
 
-    const std::vector<F>& l_coefficients = self.coefficients_.coefficients_;
-    const std::vector<F>& r_coefficients = other.coefficients_.coefficients_;
+    const std::pmr::vector<F>& l_coefficients =
+        self.coefficients_.coefficients_;
+    const std::pmr::vector<F>& r_coefficients =
+        other.coefficients_.coefficients_;
     UnivariatePolynomial<D> ret;
-    std::vector<F>& o_coefficients = ret.coefficients_.coefficients_;
+    std::pmr::vector<F>& o_coefficients = ret.coefficients_.coefficients_;
     o_coefficients.resize(
         std::max(l_coefficients.size(), r_coefficients.size()));
     OPENMP_PARALLEL_FOR(size_t i = 0; i < o_coefficients.size(); ++i) {
@@ -154,8 +160,9 @@ class UnivariatePolynomialOp<UnivariateDenseCoefficients<F, MaxDegree>> {
       return self;
     }
 
-    std::vector<F>& l_coefficients = self.coefficients_.coefficients_;
-    const std::vector<F>& r_coefficients = other.coefficients_.coefficients_;
+    std::pmr::vector<F>& l_coefficients = self.coefficients_.coefficients_;
+    const std::pmr::vector<F>& r_coefficients =
+        other.coefficients_.coefficients_;
     l_coefficients.resize(
         std::max(l_coefficients.size(), r_coefficients.size()));
     OPENMP_PARALLEL_FOR(size_t i = 0; i < r_coefficients.size(); ++i) {
@@ -177,7 +184,7 @@ class UnivariatePolynomialOp<UnivariateDenseCoefficients<F, MaxDegree>> {
     size_t degree = self.Degree();
     size_t other_degree = other.Degree();
     UnivariatePolynomial<D> ret;
-    std::vector<F>& o_coefficients = ret.coefficients_.coefficients_;
+    std::pmr::vector<F>& o_coefficients = ret.coefficients_.coefficients_;
     o_coefficients.resize(std::max(degree, other_degree) + 1);
     OPENMP_PARALLEL_FOR(size_t i = 0; i < o_coefficients.size(); ++i) {
       o_coefficients[i] = self.coefficients_[i] - other.coefficients()[i];
@@ -197,12 +204,12 @@ class UnivariatePolynomialOp<UnivariateDenseCoefficients<F, MaxDegree>> {
 
     size_t degree = self.Degree();
     size_t other_degree = other.Degree();
-    std::vector<F> upper_coeffs;
+    std::pmr::vector<F> upper_coeffs;
     if (degree < other_degree) {
-      upper_coeffs = std::vector<F>(other_degree - degree);
+      upper_coeffs = std::pmr::vector<F>(other_degree - degree);
     }
 
-    std::vector<F>& l_coefficients = self.coefficients_.coefficients_;
+    std::pmr::vector<F>& l_coefficients = self.coefficients_.coefficients_;
     const std::vector<Term>& r_terms = other.coefficients().terms_;
     OPENMP_PARALLEL_FOR(const Term& r_term : r_terms) {
       if (r_term.degree <= degree) {
@@ -223,8 +230,9 @@ class UnivariatePolynomialOp<UnivariateDenseCoefficients<F, MaxDegree>> {
     if (self.IsZero()) {
       return self;
     }
-    const std::vector<F>& i_coefficients = self.coefficients_.coefficients_;
-    std::vector<F> o_coefficients(i_coefficients.size());
+    const std::pmr::vector<F>& i_coefficients =
+        self.coefficients_.coefficients_;
+    std::pmr::vector<F> o_coefficients(i_coefficients.size());
     OPENMP_PARALLEL_FOR(size_t i = 0; i < o_coefficients.size(); ++i) {
       o_coefficients[i] = -i_coefficients[i];
     }
@@ -235,7 +243,7 @@ class UnivariatePolynomialOp<UnivariateDenseCoefficients<F, MaxDegree>> {
     if (self.IsZero()) {
       return self;
     }
-    std::vector<F>& coefficients = self.coefficients_.coefficients_;
+    std::pmr::vector<F>& coefficients = self.coefficients_.coefficients_;
     // clang-format off
     OPENMP_PARALLEL_FOR(F& coefficient : coefficients) {
       // clang-format on
@@ -252,8 +260,9 @@ class UnivariatePolynomialOp<UnivariateDenseCoefficients<F, MaxDegree>> {
     } else if (scalar.IsZero()) {
       return UnivariatePolynomial<D>::Zero();
     }
-    const std::vector<F>& l_coefficients = self.coefficients_.coefficients_;
-    std::vector<F> o_coefficients(l_coefficients.size());
+    const std::pmr::vector<F>& l_coefficients =
+        self.coefficients_.coefficients_;
+    std::pmr::vector<F> o_coefficients(l_coefficients.size());
     OPENMP_PARALLEL_FOR(size_t i = 0; i < l_coefficients.size(); ++i) {
       o_coefficients[i] = l_coefficients[i] * scalar;
     }
@@ -265,7 +274,7 @@ class UnivariatePolynomialOp<UnivariateDenseCoefficients<F, MaxDegree>> {
     if (self.IsZero() || scalar.IsOne()) {
       return self;
     }
-    std::vector<F>& coefficients = self.coefficients_.coefficients_;
+    std::pmr::vector<F>& coefficients = self.coefficients_.coefficients_;
     // clang-format off
     OPENMP_PARALLEL_FOR(F& coefficient : coefficients) {
       // clang-format on
@@ -292,8 +301,9 @@ class UnivariatePolynomialOp<UnivariateDenseCoefficients<F, MaxDegree>> {
 
   static UnivariatePolynomial<D>& MulInPlace(
       UnivariatePolynomial<D>& self, const UnivariatePolynomial<D>& other) {
-    std::vector<F>& l_coefficients = self.coefficients_.coefficients_;
-    const std::vector<F>& r_coefficients = other.coefficients_.coefficients_;
+    std::pmr::vector<F>& l_coefficients = self.coefficients_.coefficients_;
+    const std::pmr::vector<F>& r_coefficients =
+        other.coefficients_.coefficients_;
     if (self.IsZero() || other.IsOne()) {
       return self;
     } else if (self.IsOne()) {
@@ -325,7 +335,7 @@ class UnivariatePolynomialOp<UnivariateDenseCoefficients<F, MaxDegree>> {
 
   static UnivariatePolynomial<D>& MulInPlace(
       UnivariatePolynomial<D>& self, const UnivariatePolynomial<S>& other) {
-    std::vector<F>& l_coefficients = self.coefficients_.coefficients_;
+    std::pmr::vector<F>& l_coefficients = self.coefficients_.coefficients_;
     if (self.IsZero() || other.IsOne()) {
       return self;
     } else if (self.IsOne()) {
@@ -442,8 +452,8 @@ class UnivariatePolynomialOp<UnivariateDenseCoefficients<F, MaxDegree>> {
   template <bool NEGATION>
   static UnivariatePolynomial<D>& Copy(UnivariatePolynomial<D>& self,
                                        const UnivariatePolynomial<S>& other) {
-    std::vector<F>& l_coefficients = self.coefficients_.coefficients_;
-    l_coefficients = std::vector<F>(other.Degree() + 1);
+    std::pmr::vector<F>& l_coefficients = self.coefficients_.coefficients_;
+    l_coefficients = std::pmr::vector<F>(other.Degree() + 1);
 
     const std::vector<Term>& r_terms = other.coefficients().terms_;
     OPENMP_PARALLEL_FOR(const Term& r_term : r_terms) {
@@ -463,9 +473,9 @@ class UnivariatePolynomialOp<UnivariateDenseCoefficients<F, MaxDegree>> {
     size_t a_degree = a.Degree();
     size_t b_degree = b.Degree();
 
-    const std::vector<F>& a_coefficients = a.coefficients_.coefficients_;
-    const std::vector<F>& b_coefficients = b.coefficients_.coefficients_;
-    std::vector<F> c_coefficients(a_degree + b_degree + 1);
+    const std::pmr::vector<F>& a_coefficients = a.coefficients_.coefficients_;
+    const std::pmr::vector<F>& b_coefficients = b.coefficients_.coefficients_;
+    std::pmr::vector<F> c_coefficients(a_degree + b_degree + 1);
     for (size_t i = 0; i < b_coefficients.size(); ++i) {
       const F& b = b_coefficients[i];
       if (b.IsZero()) {
@@ -487,9 +497,9 @@ class UnivariatePolynomialOp<UnivariateDenseCoefficients<F, MaxDegree>> {
     size_t a_degree = a.Degree();
     size_t b_degree = b.Degree();
 
-    const std::vector<F>& a_coefficients = a.coefficients_.coefficients_;
+    const std::pmr::vector<F>& a_coefficients = a.coefficients_.coefficients_;
     const std::vector<Term>& b_terms = b.coefficients().terms_;
-    std::vector<F> c_coefficients(a_degree + b_degree + 1);
+    std::pmr::vector<F> c_coefficients(a_degree + b_degree + 1);
     for (size_t i = 0; i < b_terms.size(); ++i) {
       const F& b = b_terms[i].coefficient;
       if (b.IsZero()) {
@@ -523,9 +533,9 @@ class UnivariatePolynomialOp<UnivariateDenseCoefficients<F, MaxDegree>> {
           UnivariatePolynomial<D>::Zero(), self.ToDense()};
       return true;
     }
-    std::vector<F> quotient(self.Degree() - other.Degree() + 1);
+    std::pmr::vector<F> quotient(self.Degree() - other.Degree() + 1);
     UnivariatePolynomial<D> remainder = self.ToDense();
-    std::vector<F>& r_coefficients = remainder.coefficients_.coefficients_;
+    std::pmr::vector<F>& r_coefficients = remainder.coefficients_.coefficients_;
     F divisor_leading_inv = *other.GetLeadingCoefficient().Inverse();
 
     while (!remainder.IsZero() && remainder.Degree() >= other.Degree()) {
@@ -535,7 +545,7 @@ class UnivariatePolynomialOp<UnivariateDenseCoefficients<F, MaxDegree>> {
       quotient[degree] = q_coeff;
 
       if constexpr (std::is_same_v<DOrS, D>) {
-        const std::vector<F>& d_terms = other.coefficients_.coefficients_;
+        const std::pmr::vector<F>& d_terms = other.coefficients_.coefficients_;
         for (size_t i = 0; i < d_terms.size(); ++i) {
           r_coefficients[degree + i] -= q_coeff * d_terms[i];
         }
@@ -761,7 +771,7 @@ class UnivariatePolynomialOp<UnivariateSparseCoefficients<F, MaxDegree>> {
       return UnivariatePolynomial<D>::Zero();
     }
     size_t size = self.Degree() + 1;
-    std::vector<F> coefficients(size);
+    std::pmr::vector<F> coefficients(size);
     OPENMP_PARALLEL_FOR(size_t i = 0; i < size; ++i) {
       coefficients[i] = self[i];
     }

--- a/tachyon/zk/air/plonky3/base/two_adic_multiplicative_coset.h
+++ b/tachyon/zk/air/plonky3/base/two_adic_multiplicative_coset.h
@@ -7,6 +7,7 @@
 #define TACHYON_ZK_AIR_PLONKY3_BASE_TWO_ADIC_MULTIPLICATIVE_COSET_H_
 
 #include <memory>
+#include <memory_resource>
 #include <optional>
 #include <utility>
 #include <vector>
@@ -95,7 +96,7 @@ class TwoAdicMultiplicativeCoset {
     // TODO(ashjeong): Reduce the number of thread joins since |evals| and |xs|
     // can be created independently.
     // Evals of Z_H(X) = Xⁿ - 1
-    std::vector<F> evals =
+    std::pmr::vector<F> evals =
         F::GetSuccessivePowers(1 << rate_bits, domain_->group_gen(), s_pow_n);
     std::vector<F> inv_denoms_inv_zeroifier(evals.size());
     base::Parallelize(evals, [&evals, &inv_denoms_inv_zeroifier](
@@ -113,7 +114,7 @@ class TwoAdicMultiplicativeCoset {
     });
 
     size_t sz = coset.domain()->size();
-    std::vector<F> xs =
+    std::pmr::vector<F> xs =
         F::GetSuccessivePowers(sz, coset.domain()->group_gen(), coset_shift);
 
     F coset_i = domain_->group_gen().Pow(domain_->size() - 1);

--- a/tachyon/zk/base/blinder_unittest.cc
+++ b/tachyon/zk/base/blinder_unittest.cc
@@ -1,5 +1,6 @@
 #include "tachyon/zk/base/blinder.h"
 
+#include <memory_resource>
 #include <utility>
 #include <vector>
 
@@ -49,13 +50,13 @@ TEST(BlinderUnittest, Blind) {
 
     RowIndex blinded_rows = kBlindingFactors;
     if (include_last_row) ++blinded_rows;
-    std::vector<math::GF7> values = base::CreateVector(
+    std::pmr::vector<math::GF7> values = base::CreatePmrVector(
         blinded_rows - 1, []() { return math::GF7::Random(); });
     Evals evals(std::move(values));
     ASSERT_FALSE(blinder.Blind(evals, include_last_row));
 
     RowIndex rows = kBlindingFactors + 5;
-    values = base::CreateVector(rows, []() { return math::GF7::Random(); });
+    values = base::CreatePmrVector(rows, []() { return math::GF7::Random(); });
     evals = Evals(values);
     ASSERT_TRUE(blinder.Blind(evals, include_last_row));
 

--- a/tachyon/zk/base/commitments/gwc_extension.h
+++ b/tachyon/zk/base/commitments/gwc_extension.h
@@ -55,8 +55,8 @@ class GWCExtension final
   explicit GWCExtension(crypto::GWC<Curve, MaxDegree, Commitment>&& gwc)
       : gwc_(std::move(gwc)) {}
 
-  GWCExtension(std::vector<G1Point>&& g1_powers_of_tau,
-               std::vector<G1Point>&& g1_powers_of_tau_lagrange,
+  GWCExtension(std::pmr::vector<G1Point>&& g1_powers_of_tau,
+               std::pmr::vector<G1Point>&& g1_powers_of_tau_lagrange,
                G2Point&& s_g2) {
     crypto::KZG<G1Point, MaxDegree, Commitment> kzg(
         std::move(g1_powers_of_tau), std::move(g1_powers_of_tau_lagrange));
@@ -156,11 +156,11 @@ class GWCExtension final
   friend class base::Copyable<
       GWCExtension<Curve, MaxDegree, MaxExtendedDegree, Commitment>>;
 
-  const std::vector<G1Point>& GetG1PowersOfTau() const {
+  const std::pmr::vector<G1Point>& GetG1PowersOfTau() const {
     return this->gwc_.kzg().g1_powers_of_tau();
   }
 
-  const std::vector<G1Point>& GetG1PowersOfTauLagrange() const {
+  const std::pmr::vector<G1Point>& GetG1PowersOfTauLagrange() const {
     return this->gwc_.kzg().g1_powers_of_tau_lagrange();
   }
 

--- a/tachyon/zk/base/commitments/shplonk_extension.h
+++ b/tachyon/zk/base/commitments/shplonk_extension.h
@@ -56,8 +56,8 @@ class SHPlonkExtension final
       crypto::SHPlonk<Curve, MaxDegree, Commitment>&& shplonk)
       : shplonk_(std::move(shplonk)) {}
 
-  SHPlonkExtension(std::vector<G1Point>&& g1_powers_of_tau,
-                   std::vector<G1Point>&& g1_powers_of_tau_lagrange,
+  SHPlonkExtension(std::pmr::vector<G1Point>&& g1_powers_of_tau,
+                   std::pmr::vector<G1Point>&& g1_powers_of_tau_lagrange,
                    G2Point&& s_g2) {
     crypto::KZG<G1Point, MaxDegree, Commitment> kzg(
         std::move(g1_powers_of_tau), std::move(g1_powers_of_tau_lagrange));
@@ -157,11 +157,11 @@ class SHPlonkExtension final
   friend class base::Copyable<
       SHPlonkExtension<Curve, MaxDegree, MaxExtendedDegree, Commitment>>;
 
-  const std::vector<G1Point>& GetG1PowersOfTau() const {
+  const std::pmr::vector<G1Point>& GetG1PowersOfTau() const {
     return this->shplonk_.kzg().g1_powers_of_tau();
   }
 
-  const std::vector<G1Point>& GetG1PowersOfTauLagrange() const {
+  const std::pmr::vector<G1Point>& GetG1PowersOfTauLagrange() const {
     return this->shplonk_.kzg().g1_powers_of_tau_lagrange();
   }
 

--- a/tachyon/zk/lookup/halo2/permute_expression_pair.h
+++ b/tachyon/zk/lookup/halo2/permute_expression_pair.h
@@ -8,6 +8,7 @@
 #define TACHYON_ZK_LOOKUP_HALO2_PERMUTE_EXPRESSION_PAIR_H_
 
 #include <algorithm>
+#include <memory_resource>
 #include <utility>
 #include <vector>
 
@@ -32,7 +33,7 @@ template <typename PCS, typename Evals, typename F = typename Evals::Field>
   size_t domain_size = prover->domain()->size();
   RowIndex usable_rows = prover->GetUsableRows();
 
-  std::vector<F> permuted_input_expressions = in.input().evaluations();
+  std::pmr::vector<F> permuted_input_expressions = in.input().evaluations();
 
   // sort input lookup expression values
   pdqsort(permuted_input_expressions.begin(),
@@ -52,7 +53,7 @@ template <typename PCS, typename Evals, typename F = typename Evals::Field>
     }
   }
 
-  std::vector<F> permuted_table_expressions(domain_size);
+  std::pmr::vector<F> permuted_table_expressions(domain_size);
 
   std::vector<RowIndex> repeated_input_rows;
   repeated_input_rows.reserve(usable_rows - 1);

--- a/tachyon/zk/lookup/halo2/permute_expression_pair_unittest.cc
+++ b/tachyon/zk/lookup/halo2/permute_expression_pair_unittest.cc
@@ -7,6 +7,7 @@
 #include "tachyon/zk/lookup/halo2/permute_expression_pair.h"
 
 #include <algorithm>
+#include <memory_resource>
 #include <optional>
 #include <utility>
 #include <vector>
@@ -27,11 +28,11 @@ TEST_F(PermuteExpressionPairTest, PermuteExpressionPairTest) {
   size_t n = prover_->pcs().N();
   RowIndex usable_rows = prover_->GetUsableRows();
 
-  std::vector<F> table_evals =
-      base::CreateVector(n, []() { return F::Random(); });
+  std::pmr::vector<F> table_evals =
+      base::CreatePmrVector(n, []() { return F::Random(); });
 
-  std::vector<F> input_evals =
-      base::CreateVector(n, [usable_rows, &table_evals]() {
+  std::pmr::vector<F> input_evals =
+      base::CreatePmrVector(n, [usable_rows, &table_evals]() {
         return table_evals[base::Uniform(
             base::Range<RowIndex>::Until(usable_rows))];
       });
@@ -57,11 +58,11 @@ TEST_F(PermuteExpressionPairTest, PermuteExpressionPairTest) {
 TEST_F(PermuteExpressionPairTest, PermuteExpressionPairTestWrong) {
   // set input_evals not included within table_evals;
   size_t n = prover_->pcs().N();
-  std::vector<F> input_evals =
-      base::CreateVector(n, [](size_t i) { return F(i * 2); });
+  std::pmr::vector<F> input_evals =
+      base::CreatePmrVector(n, [](size_t i) { return F(i * 2); });
 
-  std::vector<F> table_evals =
-      base::CreateVector(n, [](size_t i) { return F(i * 3); });
+  std::pmr::vector<F> table_evals =
+      base::CreatePmrVector(n, [](size_t i) { return F(i * 3); });
 
   Pair<Evals> input = {Evals(std::move(input_evals)),
                        Evals(std::move(table_evals))};

--- a/tachyon/zk/lookup/log_derivative_halo2/prover_impl.h
+++ b/tachyon/zk/lookup/log_derivative_halo2/prover_impl.h
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <memory_resource>
 #include <utility>
 #include <vector>
 
@@ -120,7 +121,7 @@ BlindedPolynomial<Poly, Evals> Prover<Poly, Evals>::ComputeMPoly(
   }
 
   // Convert atomic |m_values| to |Evals|.
-  std::vector<F> m_values(prover->pcs().N());
+  std::pmr::vector<F> m_values(prover->pcs().N());
   OPENMP_PARALLEL_FOR(RowIndex i = 0; i < usable_rows; ++i) {
     m_values[i] =
         F(storage.m_values_atomic[i].exchange(0, std::memory_order_relaxed));
@@ -219,7 +220,7 @@ BlindedPolynomial<Poly, Evals> Prover<Poly, Evals>::CreateGrandSumPoly(
   // 1 / τ(X)
   ComputeLogDerivatives(compressed_table, beta, storage.table_log_derivatives);
 
-  std::vector<F> grand_sum(n);
+  std::pmr::vector<F> grand_sum(n);
   grand_sum[0] = F::Zero();
 
   // (Σ 1/φᵢ(X)) - m(X) / τ(X)

--- a/tachyon/zk/plonk/constraint_system/constraint_system.h
+++ b/tachyon/zk/plonk/constraint_system/constraint_system.h
@@ -12,6 +12,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <memory_resource>
 #include <optional>
 #include <sstream>
 #include <string>
@@ -478,7 +479,7 @@ class ConstraintSystem {
   // find which fixed column corresponds with a given |Selector|.
   //
   // Do not call this twice. Yes, this should be a builder pattern instead.
-  std::vector<std::vector<F>> CompressSelectors(
+  std::vector<std::pmr::vector<F>> CompressSelectors(
       const std::vector<std::vector<bool>>& selectors) {
     // The number of provided selector assignments must be the number we
     // counted for this constraint system.

--- a/tachyon/zk/plonk/constraint_system/selector_compressor.h
+++ b/tachyon/zk/plonk/constraint_system/selector_compressor.h
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <memory_resource>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -35,7 +36,7 @@ class SelectorCompressor {
 
   SelectorCompressor() = default;
 
-  const std::vector<std::vector<F>>& combination_assignments() const {
+  const std::vector<std::pmr::vector<F>>& combination_assignments() const {
     return combination_assignments_;
   }
   const std::vector<SelectorAssignment<F>>& selector_assignments() const {
@@ -160,9 +161,9 @@ class SelectorCompressor {
       // appear in any gate constraint.
       std::unique_ptr<Expression<F>> expression = callback_.Run();
 
-      std::vector<F> combination_assignment =
-          base::Map(selector.activations(),
-                    [](bool b) { return b ? F::One() : F::Zero(); });
+      std::pmr::vector<F> combination_assignment =
+          base::PmrMap(selector.activations(),
+                       [](bool b) { return b ? F::One() : F::Zero(); });
       size_t combination_index = combination_assignments_.size();
       combination_assignments_.push_back(std::move(combination_assignment));
       selector_assignments_.push_back(SelectorAssignment<F>(
@@ -237,7 +238,7 @@ class SelectorCompressor {
   void ConstructCombinedSelector(
       size_t n, const std::vector<SelectorDescription>& combination) {
     // Now, compute the selector and combination assignments.
-    std::vector<F> combination_assignment(n);
+    std::pmr::vector<F> combination_assignment(n);
     size_t combination_len = combination.size();
     size_t combination_index = combination_assignments_.size();
     std::unique_ptr<Expression<F>> query = callback_.Run();
@@ -282,7 +283,7 @@ class SelectorCompressor {
     combination_assignments_.push_back(std::move(combination_assignment));
   }
 
-  std::vector<std::vector<F>> combination_assignments_;
+  std::vector<std::pmr::vector<F>> combination_assignments_;
   std::vector<SelectorAssignment<F>> selector_assignments_;
   AllocateFixedColumnCallback callback_;
   std::vector<SelectorDescription> selectors_;

--- a/tachyon/zk/plonk/constraint_system/selector_compressor_unittest.cc
+++ b/tachyon/zk/plonk/constraint_system/selector_compressor_unittest.cc
@@ -109,14 +109,14 @@ TEST_F(SelectorCompressorTest, ConstructCombinedSelector) {
       {6, &selectors_in_[6], 7},
   };
   selector_compressor.ConstructCombinedSelector(9, before_combination);
-  std::vector<F> expected_combination_assignment = {
+  std::pmr::vector<F> expected_combination_assignment = {
       F(1), F(2), F(3), F(3), F(3), F(2), F(2), F(2), F(1)};
   EXPECT_EQ(selector_compressor.combination_assignments()[0],
             expected_combination_assignment);
 }
 
 TEST_F(SelectorCompressorTest, Process) {
-  std::vector<std::vector<F>> expected_polys = {
+  std::vector<std::pmr::vector<F>> expected_polys = {
       {F(1), F(1), F(1), F(1), F(1), F(1), F(1), F(1), F(1)},
       {F(1), F(2), F(3), F(3), F(3), F(2), F(2), F(2), F(1)},
       {F(1), F(2), F(3), F(3), F(2), F(3), F(2), F(1), F(2)},

--- a/tachyon/zk/plonk/examples/circuit_test.h
+++ b/tachyon/zk/plonk/examples/circuit_test.h
@@ -1,6 +1,7 @@
 #ifndef TACHYON_ZK_PLONK_EXAMPLES_CIRCUIT_TEST_H_
 #define TACHYON_ZK_PLONK_EXAMPLES_CIRCUIT_TEST_H_
 
+#include <memory_resource>
 #include <optional>
 #include <utility>
 #include <vector>
@@ -595,9 +596,9 @@ class CircuitTest : public halo2::ProverTest<typename TestArguments::PCS,
   }
 
   static Evals CreateColumn(const std::vector<std::string_view>& column) {
-    std::vector<F> evaluations = base::Map(column, [](std::string_view coeff) {
-      return *F::FromHexString(coeff);
-    });
+    std::pmr::vector<F> evaluations = base::PmrMap(
+        column,
+        [](std::string_view coeff) { return *F::FromHexString(coeff); });
     return Evals(std::move(evaluations));
   }
 
@@ -608,8 +609,8 @@ class CircuitTest : public halo2::ProverTest<typename TestArguments::PCS,
 
   static RationalEvals CreateRationalColumn(
       const std::vector<std::string_view>& column) {
-    std::vector<math::RationalField<F>> evaluations =
-        base::Map(column, [](std::string_view coeff) {
+    std::pmr::vector<math::RationalField<F>> evaluations =
+        base::PmrMap(column, [](std::string_view coeff) {
           return math::RationalField<F>(*F::FromHexString(coeff));
         });
     return RationalEvals(std::move(evaluations));
@@ -621,7 +622,7 @@ class CircuitTest : public halo2::ProverTest<typename TestArguments::PCS,
   }
 
   static Poly CreatePoly(const std::vector<std::string_view>& poly) {
-    std::vector<F> coefficients = base::Map(
+    std::pmr::vector<F> coefficients = base::PmrMap(
         poly, [](std::string_view coeff) { return *F::FromHexString(coeff); });
     return Poly(math::UnivariateDenseCoefficients<F, halo2::kMaxDegree>(
         std::move(coefficients), true));

--- a/tachyon/zk/plonk/examples/fibonacci/fibonacci1_circuit_test_data.h
+++ b/tachyon/zk/plonk/examples/fibonacci/fibonacci1_circuit_test_data.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 
+#include <memory_resource>
 #include <utility>
 #include <vector>
 
@@ -812,8 +813,8 @@ class Fibonacci1TestData<Circuit, PCS, LS,
     F a(1);
     F b(1);
     F out(55);
-    std::vector<F> instance_column = {std::move(a), std::move(b),
-                                      std::move(out)};
+    std::pmr::vector<F> instance_column = {std::move(a), std::move(b),
+                                           std::move(out)};
     return std::vector<Evals>{Evals(std::move(instance_column))};
   }
 };
@@ -1616,8 +1617,8 @@ class Fibonacci1TestData<Circuit, PCS, LS,
     F a(1);
     F b(1);
     F out(55);
-    std::vector<F> instance_column = {std::move(a), std::move(b),
-                                      std::move(out)};
+    std::pmr::vector<F> instance_column = {std::move(a), std::move(b),
+                                           std::move(out)};
     return std::vector<Evals>{Evals(std::move(instance_column))};
   }
 };

--- a/tachyon/zk/plonk/examples/fibonacci/fibonacci2_circuit_test_data.h
+++ b/tachyon/zk/plonk/examples/fibonacci/fibonacci2_circuit_test_data.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 
+#include <memory_resource>
 #include <utility>
 #include <vector>
 
@@ -620,8 +621,8 @@ class Fibonacci2TestData : public CircuitTestData<Circuit, PCS, LS> {
     F a(1);
     F b(1);
     F out(55);
-    std::vector<F> instance_column = {std::move(a), std::move(b),
-                                      std::move(out)};
+    std::pmr::vector<F> instance_column = {std::move(a), std::move(b),
+                                           std::move(out)};
     return std::vector<Evals>{Evals(std::move(instance_column))};
   }
 };

--- a/tachyon/zk/plonk/examples/multi_lookup_circuit_test_data.h
+++ b/tachyon/zk/plonk/examples/multi_lookup_circuit_test_data.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 
+#include <memory_resource>
 #include <string_view>
 #include <utility>
 #include <vector>
@@ -436,7 +437,7 @@ class MultiLookupTestData<Circuit, PCS, LS, std::enable_if_t<IsSHPlonk<PCS>>>
 
   static std::vector<Evals> GetInstanceColumns() {
     F instance = F(2);
-    std::vector<F> instance_column = {std::move(instance)};
+    std::pmr::vector<F> instance_column = {std::move(instance)};
     return {Evals(std::move(instance_column))};
   }
 };
@@ -867,7 +868,7 @@ class MultiLookupTestData<Circuit, PCS, LS, std::enable_if_t<IsGWC<PCS>>>
 
   static std::vector<Evals> GetInstanceColumns() {
     F instance = F(2);
-    std::vector<F> instance_column = {std::move(instance)};
+    std::pmr::vector<F> instance_column = {std::move(instance)};
     return {Evals(std::move(instance_column))};
   }
 };

--- a/tachyon/zk/plonk/examples/simple_circuit_test_data.h
+++ b/tachyon/zk/plonk/examples/simple_circuit_test_data.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 
+#include <memory_resource>
 #include <string_view>
 #include <utility>
 #include <vector>
@@ -906,7 +907,7 @@ class SimpleTestData<Circuit, PCS, LS,
     F a(2);
     F b(3);
     F c = std::move(constant) * std::move(a).Square() * std::move(b).Square();
-    std::vector<F> instance_column = {std::move(c)};
+    std::pmr::vector<F> instance_column = {std::move(c)};
     return {Evals(std::move(instance_column))};
   }
 };
@@ -1800,7 +1801,7 @@ class SimpleTestData<Circuit, PCS, LS,
     F a(2);
     F b(3);
     F c = std::move(constant) * std::move(a).Square() * std::move(b).Square();
-    std::vector<F> instance_column = {std::move(c)};
+    std::pmr::vector<F> instance_column = {std::move(c)};
     return {Evals(std::move(instance_column))};
   }
 };

--- a/tachyon/zk/plonk/expressions/compress_expression.h
+++ b/tachyon/zk/plonk/expressions/compress_expression.h
@@ -8,6 +8,7 @@
 #define TACHYON_ZK_PLONK_EXPRESSIONS_COMPRESS_EXPRESSION_H_
 
 #include <memory>
+#include <memory_resource>
 #include <utility>
 #include <vector>
 
@@ -23,7 +24,7 @@ Evals CompressExpressions(
     const std::vector<std::unique_ptr<Expression<F>>>& expressions,
     const F& theta, const ProvingEvaluator<Evals>& evaluator_tpl) {
   Evals compressed_evals = domain->template Zero<Evals>();
-  std::vector<F>& compressed_values = compressed_evals.evaluations();
+  std::pmr::vector<F>& compressed_values = compressed_evals.evaluations();
 
   for (size_t expr_idx = 0; expr_idx < expressions.size(); ++expr_idx) {
     if (UNLIKELY(expr_idx == 0)) {

--- a/tachyon/zk/plonk/expressions/compress_expression_unittest.cc
+++ b/tachyon/zk/plonk/expressions/compress_expression_unittest.cc
@@ -26,7 +26,7 @@ TEST_F(CompressExpressionTest, CompressExpressions) {
 
   size_t n = prover_->pcs().N();
   ProvingEvaluator<Evals> evaluator = evaluator_;
-  std::vector<F> expected(n);
+  std::pmr::vector<F> expected(n);
   for (size_t i = 0; i < expressions.size(); ++i) {
     F value = evaluator.Evaluate(expressions[i].get());
     for (size_t j = 0; j < n; ++j) {

--- a/tachyon/zk/plonk/expressions/proving_evaluator_unittest.cc
+++ b/tachyon/zk/plonk/expressions/proving_evaluator_unittest.cc
@@ -1,6 +1,7 @@
 #include "tachyon/zk/plonk/expressions/proving_evaluator.h"
 
 #include <memory>
+#include <memory_resource>
 
 #include "tachyon/zk/plonk/expressions/evaluator/test/evaluator_test.h"
 #include "tachyon/zk/plonk/expressions/expression_factory.h"
@@ -18,11 +19,11 @@ using Expr = std::unique_ptr<Expression<GF7>>;
 class ProvingEvaluatorTest : public EvaluatorTest {
  public:
   void SetUp() override {
-    std::vector<GF7> evaluations;
+    std::pmr::vector<GF7> evaluations;
 
     for (size_t i = 0; i < 5; ++i) {
       evaluations =
-          base::CreateVector(kMaxDegree + 1, []() { return GF7::Random(); });
+          base::CreatePmrVector(kMaxDegree + 1, []() { return GF7::Random(); });
       fixed_columns_.push_back(Evals(evaluations));
       advice_columns_.push_back(Evals(evaluations));
       instance_columns_.push_back(Evals(evaluations));

--- a/tachyon/zk/plonk/halo2/synthesizer.h
+++ b/tachyon/zk/plonk/halo2/synthesizer.h
@@ -7,6 +7,7 @@
 #ifndef TACHYON_ZK_PLONK_HALO2_SYNTHESIZER_H_
 #define TACHYON_ZK_PLONK_HALO2_SYNTHESIZER_H_
 
+#include <memory_resource>
 #include <utility>
 #include <vector>
 
@@ -72,7 +73,7 @@ class Synthesizer {
         for (size_t j = 0; j < rational_advice_columns.size(); ++j) {
           if (current_phase != advice_phases[j]) continue;
           const RationalEvals& column = rational_advice_columns[j];
-          std::vector<F> evaluated(column.NumElements());
+          std::pmr::vector<F> evaluated(column.NumElements());
           CHECK(math::RationalField<F>::BatchEvaluate(column.evaluations(),
                                                       &evaluated));
           // Add blinding factors to advice columns

--- a/tachyon/zk/plonk/halo2/verifier.h
+++ b/tachyon/zk/plonk/halo2/verifier.h
@@ -126,10 +126,11 @@ class Verifier : public VerifierBase<PCS> {
   void ComputeAuxValues(const ConstraintSystem<F>& constraint_system,
                         Proof& proof) const {
     RowIndex blinding_factors = constraint_system.ComputeBlindingFactors();
-    std::vector<F> l_evals = this->domain_->EvaluatePartialLagrangeCoefficients(
-        proof.x, base::Range<int32_t, /*IsStartInclusive=*/true,
-                             /*IsEndInclusive=*/true>(
-                     -static_cast<int32_t>(blinding_factors + 1), 0));
+    std::pmr::vector<F> l_evals =
+        this->domain_->EvaluatePartialLagrangeCoefficients(
+            proof.x, base::Range<int32_t, /*IsStartInclusive=*/true,
+                                 /*IsEndInclusive=*/true>(
+                         -static_cast<int32_t>(blinding_factors + 1), 0));
     proof.l_first = l_evals[1 + blinding_factors];
     proof.l_blind = std::accumulate(
         l_evals.begin() + 1, l_evals.begin() + 1 + blinding_factors, F::Zero(),
@@ -225,10 +226,10 @@ class Verifier : public VerifierBase<PCS> {
     return *std::max_element(rows.begin(), rows.end());
   }
 
-  static F ComputeInstanceEval(const std::vector<Evals>& instance_columns,
-                               const InstanceQueryData& instance_query,
-                               const std::vector<F>& partial_lagrange_coeffs,
-                               size_t max_rotation) {
+  static F ComputeInstanceEval(
+      const std::vector<Evals>& instance_columns,
+      const InstanceQueryData& instance_query,
+      const std::pmr::vector<F>& partial_lagrange_coeffs, size_t max_rotation) {
     const std::pmr::vector<F>& instances =
         instance_columns[instance_query.column().index()].evaluations();
     size_t offset = max_rotation - instance_query.rotation().value();
@@ -241,7 +242,7 @@ class Verifier : public VerifierBase<PCS> {
   static std::vector<F> ComputeInstanceEvals(
       const std::vector<Evals>& instance_columns,
       const std::vector<InstanceQueryData>& instance_queries,
-      const std::vector<F>& partial_lagrange_coeffs, size_t max_rotation) {
+      const std::pmr::vector<F>& partial_lagrange_coeffs, size_t max_rotation) {
     return base::Map(instance_queries,
                      [&instance_columns, &partial_lagrange_coeffs,
                       max_rotation](const InstanceQueryData& instance_query) {
@@ -280,7 +281,7 @@ class Verifier : public VerifierBase<PCS> {
     RowIndex max_instances_row =
         max_instances_row_it != max_instances_rows.end() ? *max_instances_row_it
                                                          : 0;
-    std::vector<F> partial_lagrange_coeffs =
+    std::pmr::vector<F> partial_lagrange_coeffs =
         this->domain_->EvaluatePartialLagrangeCoefficients(
             x, base::Range<int32_t>(-range.max,
                                     static_cast<int32_t>(max_instances_row) +

--- a/tachyon/zk/plonk/halo2/verifier.h
+++ b/tachyon/zk/plonk/halo2/verifier.h
@@ -9,6 +9,7 @@
 
 #include <functional>
 #include <memory>
+#include <memory_resource>
 #include <utility>
 #include <vector>
 
@@ -179,7 +180,7 @@ class Verifier : public VerifierBase<PCS> {
 
   std::vector<Commitment> CommitColumns(const std::vector<Evals>& columns) {
     return base::Map(columns, [this](const Evals& column) {
-      std::vector<F> expanded_evals = column.evaluations();
+      std::pmr::vector<F> expanded_evals = column.evaluations();
       expanded_evals.resize(this->pcs_.N());
       return this->Commit(Evals(expanded_evals));
     });
@@ -228,7 +229,7 @@ class Verifier : public VerifierBase<PCS> {
                                const InstanceQueryData& instance_query,
                                const std::vector<F>& partial_lagrange_coeffs,
                                size_t max_rotation) {
-    const std::vector<F>& instances =
+    const std::pmr::vector<F>& instances =
         instance_columns[instance_query.column().index()].evaluations();
     size_t offset = max_rotation - instance_query.rotation().value();
     absl::Span<const F> sub_partial_lagrange_coeffs(partial_lagrange_coeffs);

--- a/tachyon/zk/plonk/keys/key.h
+++ b/tachyon/zk/plonk/keys/key.h
@@ -10,6 +10,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <memory_resource>
 #include <utility>
 #include <vector>
 
@@ -93,19 +94,19 @@ class TACHYON_EXPORT Key {
 
     result->fixed_columns =
         base::Map(assembly.fixed_columns(), [](const RationalEvals& evals) {
-          std::vector<F> result(evals.evaluations().size());
+          std::pmr::vector<F> result(evals.evaluations().size());
           CHECK(math::RationalField<F>::BatchEvaluate(evals.evaluations(),
                                                       &result));
           return Evals(std::move(result));
         });
     std::vector<Evals>& fixed_columns = result->fixed_columns;
 
-    std::vector<std::vector<F>> selector_polys_tmp =
+    std::vector<std::pmr::vector<F>> selector_polys_tmp =
         constraint_system.CompressSelectors(assembly.selectors());
-    std::vector<Evals> selector_polys =
-        base::Map(std::make_move_iterator(selector_polys_tmp.begin()),
-                  std::make_move_iterator(selector_polys_tmp.end()),
-                  [](std::vector<F>&& vec) { return Evals(std::move(vec)); });
+    std::vector<Evals> selector_polys = base::Map(
+        std::make_move_iterator(selector_polys_tmp.begin()),
+        std::make_move_iterator(selector_polys_tmp.end()),
+        [](std::pmr::vector<F>&& vec) { return Evals(std::move(vec)); });
     fixed_columns.insert(fixed_columns.end(),
                          std::make_move_iterator(selector_polys.begin()),
                          std::make_move_iterator(selector_polys.end()));

--- a/tachyon/zk/plonk/permutation/grand_product_argument.h
+++ b/tachyon/zk/plonk/permutation/grand_product_argument.h
@@ -1,6 +1,7 @@
 #ifndef TACHYON_ZK_PLONK_PERMUTATION_GRAND_PRODUCT_ARGUMENT_H_
 #define TACHYON_ZK_PLONK_PERMUTATION_GRAND_PRODUCT_ARGUMENT_H_
 
+#include <memory_resource>
 #include <utility>
 #include <vector>
 
@@ -44,7 +45,7 @@ class GrandProductArgument {
 
     // NOTE(chokobole): It's safe to downcast because domain is already checked.
     RowIndex size = static_cast<RowIndex>(prover->pcs().N());
-    std::vector<F> z(size + 1);
+    std::pmr::vector<F> z(size + 1);
     absl::Span<F> grand_product = absl::MakeSpan(z).subspan(1);
 
     for (RowIndex i = 0; i < size; ++i) {
@@ -74,7 +75,7 @@ class GrandProductArgument {
                                    size_t num_cols, F& last_z) {
     // NOTE(chokobole): It's safe to downcast because domain is already checked.
     RowIndex size = static_cast<RowIndex>(prover->pcs().N());
-    std::vector<F> z(size + 1, F::One());
+    std::pmr::vector<F> z(size + 1, F::One());
     absl::Span<F> grand_product = absl::MakeSpan(z).subspan(1);
 
     size_t chunk_size = base::GetNumElementsPerThread(grand_product);
@@ -105,7 +106,7 @@ class GrandProductArgument {
  private:
   template <typename PCS, typename F, typename Evals = typename PCS::Evals>
   static Evals DoCreatePoly(ProverBase<PCS>* prover, F& last_z,
-                            std::vector<F>&& grand_product) {
+                            std::pmr::vector<F>&& grand_product) {
     RowIndex usable_rows = prover->GetUsableRows();
 
     // TODO(chokobole): Apply the same optimization trick used in grand sum.

--- a/tachyon/zk/plonk/permutation/unpermuted_table.h
+++ b/tachyon/zk/plonk/permutation/unpermuted_table.h
@@ -7,6 +7,7 @@
 #ifndef TACHYON_ZK_PLONK_PERMUTATION_UNPERMUTED_TABLE_H_
 #define TACHYON_ZK_PLONK_PERMUTATION_UNPERMUTED_TABLE_H_
 
+#include <memory_resource>
 #include <utility>
 #include <vector>
 
@@ -56,7 +57,7 @@ class UnpermutedTable {
   static UnpermutedTable Construct(size_t cols, RowIndex rows,
                                    const Domain* domain) {
     // The ω is gᵀ with order 2ˢ where modulus = 2ˢ * T + 1.
-    std::vector<F> omega_powers =
+    std::pmr::vector<F> omega_powers =
         domain->GetRootsOfUnity(rows, domain->group_gen());
 
     // The δ is g^2ˢ with order T where modulus = 2ˢ * T + 1.
@@ -69,7 +70,7 @@ class UnpermutedTable {
 
     // Assign [δⁱω⁰, δⁱω¹, δⁱω², ..., δⁱωⁿ⁻¹] to each col.
     for (size_t i = 1; i < cols; ++i) {
-      std::vector<F> col(rows);
+      std::pmr::vector<F> col(rows);
       OPENMP_PARALLEL_FOR(RowIndex j = 0; j < rows; ++j) {
         col[j] = unpermuted_table[i - 1][j] * delta;
       }

--- a/tachyon/zk/plonk/permutation/unpermuted_table_unittest.cc
+++ b/tachyon/zk/plonk/permutation/unpermuted_table_unittest.cc
@@ -45,7 +45,7 @@ class UnpermutedTableTest : public math::FiniteFieldTest<F> {
 
 TEST_F(UnpermutedTableTest, Construct) {
   const F& omega = domain_->group_gen();
-  std::vector<F> omega_powers = domain_->GetRootsOfUnity(kRows, omega);
+  std::pmr::vector<F> omega_powers = domain_->GetRootsOfUnity(kRows, omega);
 
   const F delta = GetDelta<F>();
   for (size_t i = 1; i < kCols; ++i) {
@@ -59,7 +59,7 @@ TEST_F(UnpermutedTableTest, Construct) {
 TEST_F(UnpermutedTableTest, GetColumns) {
   const F& omega = domain_->group_gen();
   const F delta = GetDelta<F>();
-  std::vector<F> omega_powers = domain_->GetRootsOfUnity(kRows, omega);
+  std::pmr::vector<F> omega_powers = domain_->GetRootsOfUnity(kRows, omega);
   for (F& omega_power : omega_powers) {
     omega_power *= delta;
   }

--- a/tachyon/zk/plonk/vanishing/circuit_polynomial_builder.h
+++ b/tachyon/zk/plonk/vanishing/circuit_polynomial_builder.h
@@ -8,6 +8,7 @@
 #define TACHYON_ZK_PLONK_VANISHING_CIRCUIT_POLYNOMIAL_BUILDER_H_
 
 #include <memory>
+#include <memory_resource>
 #include <utility>
 #include <vector>
 
@@ -179,7 +180,7 @@ class CircuitPolynomialBuilder {
       value_parts.push_back(std::move(value_part));
       UpdateCurrentExtendedOmega();
     }
-    std::vector<F> extended = BuildExtendedColumnWithColumns(value_parts);
+    std::pmr::vector<F> extended = BuildExtendedColumnWithColumns(value_parts);
     return ExtendedEvals(std::move(extended));
   }
 

--- a/tachyon/zk/plonk/vanishing/vanishing_prover_impl.h
+++ b/tachyon/zk/plonk/vanishing/vanishing_prover_impl.h
@@ -7,6 +7,7 @@
 #ifndef TACHYON_ZK_PLONK_VANISHING_VANISHING_PROVER_IMPL_H_
 #define TACHYON_ZK_PLONK_VANISHING_VANISHING_PROVER_IMPL_H_
 
+#include <memory_resource>
 #include <utility>
 #include <vector>
 
@@ -99,7 +100,7 @@ void VanishingProver<Poly, Evals, ExtendedPoly,
   // Truncate it to match the size of the quotient polynomial; the
   // evaluation domain might be slightly larger than necessary because
   // it always lies on a power-of-two boundary.
-  std::vector<F>& h_coeffs = h_poly_.coefficients().coefficients();
+  std::pmr::vector<F>& h_coeffs = h_poly_.coefficients().coefficients();
   const size_t quotient_poly_degree = constraint_system.ComputeDegree() - 1;
   size_t n = prover->pcs().N();
   h_coeffs.resize(n * quotient_poly_degree, F::Zero());
@@ -168,7 +169,7 @@ void VanishingProver<Poly, Evals, ExtendedPoly, ExtendedEvals>::BatchEvaluate(
   std::vector<absl::Span<F>> h_pieces =
       base::Map(h_chunks.begin(), h_chunks.end(),
                 [](absl::Span<F> h_piece) { return h_piece; });
-  std::vector<F> coeffs(n);
+  std::pmr::vector<F> coeffs(n);
   for (size_t i = h_pieces.size() - 1; i != SIZE_MAX; --i) {
     OPENMP_PARALLEL_FOR(size_t j = 0; j < n; ++j) {
       coeffs[j] *= x_n;

--- a/tachyon/zk/plonk/vanishing/vanishing_utils.h
+++ b/tachyon/zk/plonk/vanishing/vanishing_utils.h
@@ -90,10 +90,14 @@ ExtendedEvals& DivideByVanishingPolyInPlace(
                                        size_t chunk_size) {
     size_t start = chunk_offset * chunk_size;
     F zeta_i = zeta_pow_n * coset_gen_pow_n.Pow(start);
-    for (F& coeff : chunk) {
-      coeff = zeta_i - F::One();
+
+    // NOTE: It is not possible to have empty chunk so this is safe
+    for (size_t i = 0; i < chunk.size() - 1; ++i) {
+      chunk[i] = zeta_i - F::One();
       zeta_i *= coset_gen_pow_n;
     }
+    chunk.back() = std::move(zeta_i);
+    chunk.back() -= F::One();
     CHECK(F::BatchInverseInPlaceSerial(chunk));
   });
 

--- a/tachyon/zk/plonk/vanishing/vanishing_utils.h
+++ b/tachyon/zk/plonk/vanishing/vanishing_utils.h
@@ -7,6 +7,7 @@
 #ifndef TACHYON_ZK_PLONK_VANISHING_VANISHING_UTILS_H_
 #define TACHYON_ZK_PLONK_VANISHING_VANISHING_UTILS_H_
 
+#include <memory_resource>
 #include <utility>
 #include <vector>
 
@@ -98,7 +99,7 @@ ExtendedEvals& DivideByVanishingPolyInPlace(
 
   // Multiply the inverse to obtain the quotient polynomial in the coset
   // evaluation domain.
-  std::vector<F>& evaluations = evals.evaluations();
+  std::pmr::vector<F>& evaluations = evals.evaluations();
   OPENMP_PARALLEL_FOR(size_t i = 0; i < evaluations.size(); ++i) {
     evaluations[i] *= t_evaluations[i % t_evaluations.size()];
   }
@@ -121,7 +122,7 @@ void DistributePowersZeta(Poly& poly, bool into_coset) {
   F coset_powers[] = {into_coset ? zeta : zeta_inv,
                       into_coset ? zeta_inv : zeta};
 
-  std::vector<F>& coeffs = poly.coefficients().coefficients();
+  std::pmr::vector<F>& coeffs = poly.coefficients().coefficients();
   OPENMP_PARALLEL_FOR(size_t i = 0; i < coeffs.size(); ++i) {
     size_t j = i % 3;
     if (j == 0) continue;
@@ -165,13 +166,13 @@ ExtendedPoly ExtendedToCoeff(ExtendedEvals&& evals,
 }
 
 template <typename F>
-std::vector<F> BuildExtendedColumnWithColumns(
+std::pmr::vector<F> BuildExtendedColumnWithColumns(
     const std::vector<std::vector<F>>& columns) {
   CHECK(!columns.empty());
   size_t cols = columns.size();
   size_t rows = columns[0].size();
 
-  std::vector<F> flattened_transposed_columns(cols * rows);
+  std::pmr::vector<F> flattened_transposed_columns(cols * rows);
   OPENMP_PARALLEL_NESTED_FOR(size_t i = 0; i < columns.size(); ++i) {
     for (size_t j = 0; j < rows; ++j) {
       flattened_transposed_columns[j * cols + i] = columns[i][j];

--- a/tachyon/zk/plonk/vanishing/vanishing_utils_unittest.cc
+++ b/tachyon/zk/plonk/vanishing/vanishing_utils_unittest.cc
@@ -6,6 +6,7 @@
 
 #include "tachyon/zk/plonk/vanishing/vanishing_utils.h"
 
+#include <memory_resource>
 #include <vector>
 
 #include "tachyon/math/elliptic_curves/bn/bn254/g1.h"
@@ -42,7 +43,7 @@ TEST_F(VanishingUtilsTest, BuildExtendedColumnWithColumns) {
   std::vector<std::vector<F>> columns =
       base::CreateVector(4, [](size_t i) { return std::vector<F>(N, F(i)); });
 
-  std::vector<F> extended = BuildExtendedColumnWithColumns(columns);
+  std::pmr::vector<F> extended = BuildExtendedColumnWithColumns(columns);
   EXPECT_EQ(extended.size(), 4 * N);
   for (size_t i = 0; i < extended.size(); ++i) {
     EXPECT_EQ(F(i % 4), extended[i]);

--- a/tachyon/zk/r1cs/constraint_system/qap_witness_map_result.h
+++ b/tachyon/zk/r1cs/constraint_system/qap_witness_map_result.h
@@ -1,13 +1,14 @@
 #ifndef TACHYON_ZK_R1CS_CONSTRAINT_SYSTEM_QAP_WITNESS_MAP_RESULT_H_
 #define TACHYON_ZK_R1CS_CONSTRAINT_SYSTEM_QAP_WITNESS_MAP_RESULT_H_
 
+#include <memory_resource>
 #include <vector>
 
 namespace tachyon::zk::r1cs {
 
 template <typename F>
 struct QAPWitnessMapResult {
-  std::vector<F> h;
+  std::pmr::vector<F> h;
   std::vector<F> full_assignments;
 };
 

--- a/tachyon/zk/r1cs/constraint_system/quadratic_arithmetic_program.h
+++ b/tachyon/zk/r1cs/constraint_system/quadratic_arithmetic_program.h
@@ -60,7 +60,7 @@ class QuadraticArithmeticProgram {
     // t(x) = xⁿ⁺ˡ⁺¹ - 1
     F t_x = domain->EvaluateVanishingPolynomial(x);
 
-    std::vector<F> l = domain->EvaluateAllLagrangeCoefficients(x);
+    std::pmr::vector<F> l = domain->EvaluateAllLagrangeCoefficients(x);
 
     // |num_qap_variables| = m = (l + 1 - 1) + m - l
     size_t num_qap_variables =

--- a/tachyon/zk/r1cs/constraint_system/quadratic_arithmetic_program.h
+++ b/tachyon/zk/r1cs/constraint_system/quadratic_arithmetic_program.h
@@ -203,12 +203,17 @@ class QuadraticArithmeticProgram {
                                                           size_t chunk_size) {
       size_t i = chunk_index * chunk_size;
       F x_i = x.Pow(i);
-      for (F& v : chunk) {
+
+      // NOTE: It is not possible to have empty chunk so this is safe
+      for (size_t i = 0; i < chunk.size() - 1; ++i) {
         // (xⁱ * t(x)) / δ
-        v = x_i * t_x;
-        v *= delta_inverse;
+        chunk[i] = x_i * t_x;
+        chunk[i] *= delta_inverse;
         x_i *= x;
       }
+      chunk.back() = std::move(x_i);
+      chunk.back() *= t_x;
+      chunk.back() *= delta_inverse;
     });
     return h_query;
   }

--- a/tachyon/zk/r1cs/constraint_system/quadratic_arithmetic_program.h
+++ b/tachyon/zk/r1cs/constraint_system/quadratic_arithmetic_program.h
@@ -10,6 +10,7 @@
 
 #include <functional>
 #include <memory>
+#include <memory_resource>
 #include <optional>
 #include <utility>
 #include <vector>
@@ -111,13 +112,13 @@ class QuadraticArithmeticProgram {
                             constraint_system.witness_assignments().begin(),
                             constraint_system.witness_assignments().end());
 
-    std::vector<F> h_poly =
+    std::pmr::vector<F> h_poly =
         WitnessMapFromMatrices(domain, matrices.value(), full_assignments);
     return {std::move(h_poly), std::move(full_assignments)};
   }
 
   template <typename Domain>
-  static std::vector<F> WitnessMapFromMatrices(
+  static std::pmr::vector<F> WitnessMapFromMatrices(
       const Domain* domain, const ConstraintMatrices<F>& matrices,
       absl::Span<const F> full_assignments) {
     using Evals = typename Domain::Evals;
@@ -125,9 +126,9 @@ class QuadraticArithmeticProgram {
 
     CHECK_GE(domain->size(), matrices.num_constraints);
 
-    std::vector<F> a(domain->size());
-    std::vector<F> b(domain->size());
-    std::vector<F> c(domain->size());
+    std::pmr::vector<F> a(domain->size());
+    std::pmr::vector<F> b(domain->size());
+    std::pmr::vector<F> c(domain->size());
 
     // clang-format off
     // |a[i]| = Σⱼ₌₀..ₘ (xⱼ * Aᵢ,ⱼ)    (if i < |num_constraints|)

--- a/vendors/circom/benchmark/tachyon_runner.h
+++ b/vendors/circom/benchmark/tachyon_runner.h
@@ -2,6 +2,7 @@
 #define VENDORS_CIRCOM_BENCHMARK_TACHYON_RUNNER_H_
 
 #include <memory>
+#include <memory_resource>
 #include <optional>
 #include <vector>
 
@@ -57,7 +58,7 @@ class TachyonRunner : public Runner<Curve, MaxDegree> {
                                       base::TimeDelta& delta) override {
     base::TimeTicks now = base::TimeTicks::Now();
 
-    std::vector<F> h_evals =
+    std::pmr::vector<F> h_evals =
         QuadraticArithmeticProgram<F>::WitnessMapFromMatrices(
             domain, coefficients_, full_assignments);
 

--- a/vendors/circom/circomlib/circuit/circuit_test.h
+++ b/vendors/circom/circomlib/circuit/circuit_test.h
@@ -2,6 +2,7 @@
 #define VENDORS_CIRCOM_CIRCOMLIB_CIRCUIT_CIRCUIT_TEST_H_
 
 #include <memory>
+#include <memory_resource>
 #include <utility>
 #include <vector>
 
@@ -57,7 +58,7 @@ class CircuitTest : public testing::Test {
     absl::Span<const Coefficient<F>> coefficients = zkey.GetCoefficients();
 
     std::unique_ptr<Domain> domain = Domain::Create(zkey.GetDomainSize());
-    std::vector<F> h_evals = QAP::WitnessMapFromMatrices(
+    std::pmr::vector<F> h_evals = QAP::WitnessMapFromMatrices(
         domain.get(), coefficients, full_assignments);
 
     size_t num_instance_variables = zkey.GetNumInstanceVariables();

--- a/vendors/circom/circomlib/circuit/quadratic_arithmetic_program.h
+++ b/vendors/circom/circomlib/circuit/quadratic_arithmetic_program.h
@@ -6,6 +6,7 @@
 #ifndef VENDORS_CIRCOM_CIRCOMLIB_CIRCUIT_QUADRATIC_ARITHMETIC_PROGRAM_H_
 #define VENDORS_CIRCOM_CIRCOMLIB_CIRCUIT_QUADRATIC_ARITHMETIC_PROGRAM_H_
 
+#include <memory_resource>
 #include <utility>
 #include <vector>
 
@@ -21,15 +22,15 @@ class QuadraticArithmeticProgram {
   QuadraticArithmeticProgram() = delete;
 
   template <typename Domain>
-  static std::vector<F> WitnessMapFromMatrices(
+  static std::pmr::vector<F> WitnessMapFromMatrices(
       const Domain* domain, absl::Span<const Coefficient<F>> coefficients,
       absl::Span<const F> full_assignments) {
     using Evals = typename Domain::Evals;
     using DensePoly = typename Domain::DensePoly;
 
-    std::vector<F> a(domain->size());
-    std::vector<F> b(domain->size());
-    std::vector<F> c(domain->size());
+    std::pmr::vector<F> a(domain->size());
+    std::pmr::vector<F> b(domain->size());
+    std::pmr::vector<F> c(domain->size());
 
     // See
     // https://github.com/iden3/rapidsnark/blob/b17e6fe/src/groth16.cpp#L116-L156.
@@ -40,7 +41,7 @@ class QuadraticArithmeticProgram {
 #endif
     OPENMP_PARALLEL_FOR(size_t i = 0; i < coefficients.size(); i++) {
       const Coefficient<F>& c = coefficients[i];
-      std::vector<F>& ab = (c.matrix == 0) ? a : b;
+      std::pmr::vector<F>& ab = (c.matrix == 0) ? a : b;
 
 #if defined(TACHYON_HAS_OPENMP)
       omp_set_lock(&locks[c.constraint % kNumLocks]);

--- a/vendors/circom/prover_main.cc
+++ b/vendors/circom/prover_main.cc
@@ -135,7 +135,7 @@ void CreateProof(const base::FilePath& zkey_path,
   ProverTime prover_time;
   size_t num_instance_variables = zkey->GetNumInstanceVariables();
   for (size_t i = 0; i < options.num_runs; ++i) {
-    std::vector<F> h_evals =
+    std::pmr::vector<F> h_evals =
         QuadraticArithmeticProgram<F>::WitnessMapFromMatrices(
             domain.get(), coefficients, full_assignments);
     if (options.no_zk) {


### PR DESCRIPTION
# Description

This PR does following:
- Implement utility functions for `std::pmr::vector`
- Switch `std::vector` to  `std::pmr::vector` in `UnivariateEvaluations` and `UnivariateDenseCoefficients`.

[Here is a quick benchmark of `std::pmr::vector` and `std::vector` ](https://quick-bench.com/q/EMkmBbUi0f1oISx1EIn1MY_LkcA)for simple char vector initialization. Following this, I am expecting ~10% improvement in large vector initialization and resize.