### PR TITLE
docs: fix circuit testing doc

### DIFF
--- a/tachyon/zk/plonk/examples/circuit_test.h
+++ b/tachyon/zk/plonk/examples/circuit_test.h
@@ -368,15 +368,11 @@ class CircuitTest : public halo2::ProverTest<typename TestArguments::PCS,
     F expected_y = *F::FromHexString(TestData::kY);
     EXPECT_EQ(proof.y, expected_y);
 
-    if constexpr (TestData::kVanishingHPolyCommitmentsFlag) {
-      std::vector<Commitment> expected_vanishing_h_poly_commitments =
-          CreateCommitments(
-              base::ArrayToVector(TestData::kVanishingHPolyCommitments));
-      EXPECT_EQ(proof.vanishing_h_poly_commitments,
-                expected_vanishing_h_poly_commitments);
-    } else {
-      EXPECT_TRUE(proof.vanishing_h_poly_commitments.empty());
-    }
+    std::vector<Commitment> expected_vanishing_h_poly_commitments =
+        CreateCommitments(
+            base::ArrayToVector(TestData::kVanishingHPolyCommitments));
+    EXPECT_EQ(proof.vanishing_h_poly_commitments,
+              expected_vanishing_h_poly_commitments);
 
     F expected_x = *F::FromHexString(TestData::kX);
     EXPECT_EQ(proof.x, expected_x);

--- a/tachyon/zk/plonk/examples/circuit_test.h
+++ b/tachyon/zk/plonk/examples/circuit_test.h
@@ -119,7 +119,7 @@ class CircuitTest : public halo2::ProverTest<typename TestArguments::PCS,
     }
 
     std::vector<std::vector<bool>> expected_selectors =
-        base::Array2DToVector2D(TestData::kCycleStoreSelectors);
+        base::Array2DToVector2D(TestData::kSelectors);
     EXPECT_EQ(assembly.selectors(), expected_selectors);
 
     EXPECT_EQ(assembly.usable_rows(), TestData::kUsableRows);

--- a/tachyon/zk/plonk/examples/circuit_test.h
+++ b/tachyon/zk/plonk/examples/circuit_test.h
@@ -290,7 +290,7 @@ class CircuitTest : public halo2::ProverTest<typename TestArguments::PCS,
     F expected_theta = *F::FromHexString(TestData::kTheta);
     EXPECT_EQ(proof.theta, expected_theta);
 
-    if constexpr (TestData::kLookupPermutedCommitmentsPointsFlag) {
+    if constexpr (TestData::kLookupPermutedCommitmentsFlag) {
       std::vector<std::vector<lookup::Pair<Commitment>>>
           expected_lookup_permuted_commitments_vec{
               CreateLookupPermutedCommitments(

--- a/tachyon/zk/plonk/examples/circuit_test.h
+++ b/tachyon/zk/plonk/examples/circuit_test.h
@@ -295,14 +295,14 @@ class CircuitTest : public halo2::ProverTest<typename TestArguments::PCS,
           expected_lookup_permuted_commitments_vec{
               CreateLookupPermutedCommitments(
                   base::ArrayToVector(
-                      TestData::kLookupPermutedCommitmentsInputPoints[0]),
+                      TestData::kLookupPermutedCommitmentsInput[0]),
                   base::ArrayToVector(
-                      TestData::kLookupPermutedCommitmentsTablePoints[0])),
+                      TestData::kLookupPermutedCommitmentsTable[0])),
               CreateLookupPermutedCommitments(
                   base::ArrayToVector(
-                      TestData::kLookupPermutedCommitmentsInputPoints[1]),
+                      TestData::kLookupPermutedCommitmentsInput[1]),
                   base::ArrayToVector(
-                      TestData::kLookupPermutedCommitmentsTablePoints[1])),
+                      TestData::kLookupPermutedCommitmentsTable[1])),
           };
       EXPECT_EQ(proof.lookup_permuted_commitments_vec,
                 expected_lookup_permuted_commitments_vec);

--- a/tachyon/zk/plonk/examples/circuit_test_data.h
+++ b/tachyon/zk/plonk/examples/circuit_test_data.h
@@ -35,7 +35,6 @@ class CircuitTestData {
   constexpr static bool kPermutationProductCommitmentsFlag = false;
   constexpr static bool kLookupProductCommitmentsFlag = false;
   constexpr static bool kLookupSumCommitmentsFlag = false;
-  constexpr static bool kVanishingHPolyCommitmentsFlag = false;
   constexpr static bool kAdviceEvalsFlag = false;
   constexpr static bool kFixedEvalsFlag = false;
   constexpr static bool kCommonPermutationEvalsFlag = false;

--- a/tachyon/zk/plonk/examples/circuit_test_data.h
+++ b/tachyon/zk/plonk/examples/circuit_test_data.h
@@ -30,7 +30,7 @@ class CircuitTestData {
   constexpr static bool kPermutationsPolysFlag = false;
   constexpr static bool kAdviceCommitmentsFlag = false;
   constexpr static bool kChallengesFlag = false;
-  constexpr static bool kLookupPermutedCommitmentsPointsFlag = false;
+  constexpr static bool kLookupPermutedCommitmentsFlag = false;
   constexpr static bool kLookupMPolyCommitmentsFlag = false;
   constexpr static bool kPermutationProductCommitmentsFlag = false;
   constexpr static bool kLookupProductCommitmentsFlag = false;

--- a/tachyon/zk/plonk/examples/fibonacci/fibonacci1_circuit_test_data.h
+++ b/tachyon/zk/plonk/examples/fibonacci/fibonacci1_circuit_test_data.h
@@ -170,7 +170,7 @@ class Fibonacci1TestData<Circuit, PCS, LS,
   };
 
   // clang-format off
-  constexpr static bool kCycleStoreSelectors[][kN] = {
+  constexpr static bool kSelectors[][kN] = {
       {true,  true,  true,  true,  true,  true,  true,  true,
        false, false, false, false, false, false, false, false}
   };
@@ -974,7 +974,7 @@ class Fibonacci1TestData<Circuit, PCS, LS,
   };
 
   // clang-format off
-  constexpr static bool kCycleStoreSelectors[][kN] = {
+  constexpr static bool kSelectors[][kN] = {
       {true,  true,  true,  true,  true,  true,  true,  true,
        false, false, false, false, false, false, false, false}
   };

--- a/tachyon/zk/plonk/examples/fibonacci/fibonacci1_circuit_test_data.h
+++ b/tachyon/zk/plonk/examples/fibonacci/fibonacci1_circuit_test_data.h
@@ -37,7 +37,6 @@ class Fibonacci1TestData<Circuit, PCS, LS,
   constexpr static bool kPermutationsPolysFlag = true;
   constexpr static bool kAdviceCommitmentsFlag = true;
   constexpr static bool kPermutationProductCommitmentsFlag = true;
-  constexpr static bool kVanishingHPolyCommitmentsFlag = true;
   constexpr static bool kAdviceEvalsFlag = true;
   constexpr static bool kFixedEvalsFlag = true;
   constexpr static bool kCommonPermutationEvalsFlag = true;
@@ -841,7 +840,6 @@ class Fibonacci1TestData<Circuit, PCS, LS,
   constexpr static bool kPermutationsPolysFlag = true;
   constexpr static bool kAdviceCommitmentsFlag = true;
   constexpr static bool kPermutationProductCommitmentsFlag = true;
-  constexpr static bool kVanishingHPolyCommitmentsFlag = true;
   constexpr static bool kAdviceEvalsFlag = true;
   constexpr static bool kFixedEvalsFlag = true;
   constexpr static bool kCommonPermutationEvalsFlag = true;

--- a/tachyon/zk/plonk/examples/fibonacci/fibonacci2_circuit_test_data.h
+++ b/tachyon/zk/plonk/examples/fibonacci/fibonacci2_circuit_test_data.h
@@ -144,7 +144,7 @@ class Fibonacci2TestData : public CircuitTestData<Circuit, PCS, LS> {
   };
 
   // clang-format off
-  constexpr static bool kCycleStoreSelectors[][kN] = {
+  constexpr static bool kSelectors[][kN] = {
       { true,  true,  true,  true,  true,  true,  true,  true,
        false, false, false, false, false, false, false, false}
   };

--- a/tachyon/zk/plonk/examples/fibonacci/fibonacci2_circuit_test_data.h
+++ b/tachyon/zk/plonk/examples/fibonacci/fibonacci2_circuit_test_data.h
@@ -31,7 +31,6 @@ class Fibonacci2TestData : public CircuitTestData<Circuit, PCS, LS> {
   constexpr static bool kPermutationsPolysFlag = true;
   constexpr static bool kAdviceCommitmentsFlag = true;
   constexpr static bool kPermutationProductCommitmentsFlag = true;
-  constexpr static bool kVanishingHPolyCommitmentsFlag = true;
   constexpr static bool kAdviceEvalsFlag = true;
   constexpr static bool kFixedEvalsFlag = true;
   constexpr static bool kCommonPermutationEvalsFlag = true;

--- a/tachyon/zk/plonk/examples/fibonacci/fibonacci3_circuit_test_data.h
+++ b/tachyon/zk/plonk/examples/fibonacci/fibonacci3_circuit_test_data.h
@@ -214,7 +214,7 @@ class Fibonacci3TestData : public CircuitTestData<Circuit, PCS, LS> {
   // clang-format on
 
   // clang-format off
-  constexpr static bool kCycleStoreSelectors[][kN] = {
+  constexpr static bool kSelectors[][kN] = {
       {true, false, false, false, false, false, false, false,
        false, false, false, false, false, false, false, false}
   };

--- a/tachyon/zk/plonk/examples/fibonacci/fibonacci3_circuit_test_data.h
+++ b/tachyon/zk/plonk/examples/fibonacci/fibonacci3_circuit_test_data.h
@@ -23,7 +23,6 @@ class Fibonacci3TestData : public CircuitTestData<Circuit, PCS, LS> {
   constexpr static bool kFixedColumnsFlag = true;
   constexpr static bool kFixedPolysFlag = true;
   constexpr static bool kAdviceCommitmentsFlag = true;
-  constexpr static bool kVanishingHPolyCommitmentsFlag = true;
   constexpr static bool kAdviceEvalsFlag = true;
   constexpr static bool kFixedEvalsFlag = true;
 

--- a/tachyon/zk/plonk/examples/multi_lookup_circuit_test_data.h
+++ b/tachyon/zk/plonk/examples/multi_lookup_circuit_test_data.h
@@ -28,7 +28,6 @@ class MultiLookupTestData<Circuit, PCS, LS, std::enable_if_t<IsSHPlonk<PCS>>>
   constexpr static bool kLookupMPolyCommitmentsFlag = true;
   constexpr static bool kPermutationProductCommitmentsFlag = true;
   constexpr static bool kLookupSumCommitmentsFlag = true;
-  constexpr static bool kVanishingHPolyCommitmentsFlag = true;
   constexpr static bool kAdviceEvalsFlag = true;
   constexpr static bool kFixedEvalsFlag = true;
   constexpr static bool kCommonPermutationEvalsFlag = true;
@@ -455,7 +454,6 @@ class MultiLookupTestData<Circuit, PCS, LS, std::enable_if_t<IsGWC<PCS>>>
   constexpr static bool kLookupMPolyCommitmentsFlag = true;
   constexpr static bool kPermutationProductCommitmentsFlag = true;
   constexpr static bool kLookupSumCommitmentsFlag = true;
-  constexpr static bool kVanishingHPolyCommitmentsFlag = true;
   constexpr static bool kAdviceEvalsFlag = true;
   constexpr static bool kFixedEvalsFlag = true;
   constexpr static bool kCommonPermutationEvalsFlag = true;

--- a/tachyon/zk/plonk/examples/multi_lookup_circuit_test_data.h
+++ b/tachyon/zk/plonk/examples/multi_lookup_circuit_test_data.h
@@ -43,7 +43,7 @@ class MultiLookupTestData<Circuit, PCS, LS, std::enable_if_t<IsSHPlonk<PCS>>>
 
   constexpr static std::string_view kPinnedConstraintSystem = "";
 
-  constexpr static bool kCycleStoreSelectors[][kN] = {{}};
+  constexpr static bool kSelectors[][kN] = {{}};
 
   constexpr static std::string_view kPinnedVerifyingKey = "";
 
@@ -470,7 +470,7 @@ class MultiLookupTestData<Circuit, PCS, LS, std::enable_if_t<IsGWC<PCS>>>
 
   constexpr static std::string_view kPinnedConstraintSystem = "";
 
-  constexpr static bool kCycleStoreSelectors[][kN] = {{}};
+  constexpr static bool kSelectors[][kN] = {{}};
 
   constexpr static std::string_view kPinnedVerifyingKey = "";
 

--- a/tachyon/zk/plonk/examples/shuffle_circuit_test_data.h
+++ b/tachyon/zk/plonk/examples/shuffle_circuit_test_data.h
@@ -308,7 +308,7 @@ class ShuffleTestData<Circuit, PCS, LS, std::enable_if_t<IsSHPlonk<PCS>>>
   // clang-format on
 
   // clang-format off
-  constexpr static bool kCycleStoreSelectors[][kN] = {
+  constexpr static bool kSelectors[][kN] = {
       {true, true, true, true, true, true, true, true,
         false, false, false, false, false, false, false, false},
       {true, false, false, false, false, false, false, false,
@@ -1161,7 +1161,7 @@ class ShuffleTestData<Circuit, PCS, LS, std::enable_if_t<IsGWC<PCS>>>
   // clang-format on
 
   // clang-format off
-  constexpr static bool kCycleStoreSelectors[][kN] = {
+  constexpr static bool kSelectors[][kN] = {
       {true, true, true, true, true, true, true, true,
         false, false, false, false, false, false, false, false},
       {true, false, false, false, false, false, false, false,

--- a/tachyon/zk/plonk/examples/shuffle_circuit_test_data.h
+++ b/tachyon/zk/plonk/examples/shuffle_circuit_test_data.h
@@ -30,7 +30,6 @@ class ShuffleTestData<Circuit, PCS, LS, std::enable_if_t<IsSHPlonk<PCS>>>
   constexpr static bool kFixedPolysFlag = true;
   constexpr static bool kAdviceCommitmentsFlag = true;
   constexpr static bool kChallengesFlag = true;
-  constexpr static bool kVanishingHPolyCommitmentsFlag = true;
   constexpr static bool kAdviceEvalsFlag = true;
   constexpr static bool kFixedEvalsFlag = true;
 

--- a/tachyon/zk/plonk/examples/simple_circuit_test_data.h
+++ b/tachyon/zk/plonk/examples/simple_circuit_test_data.h
@@ -40,7 +40,6 @@ class SimpleTestData<Circuit, PCS, LS,
   constexpr static bool kPermutationsPolysFlag = true;
   constexpr static bool kAdviceCommitmentsFlag = true;
   constexpr static bool kPermutationProductCommitmentsFlag = true;
-  constexpr static bool kVanishingHPolyCommitmentsFlag = true;
   constexpr static bool kAdviceEvalsFlag = true;
   constexpr static bool kFixedEvalsFlag = true;
   constexpr static bool kCommonPermutationEvalsFlag = true;
@@ -936,7 +935,6 @@ class SimpleTestData<Circuit, PCS, LS,
   constexpr static bool kPermutationsPolysFlag = true;
   constexpr static bool kAdviceCommitmentsFlag = true;
   constexpr static bool kPermutationProductCommitmentsFlag = true;
-  constexpr static bool kVanishingHPolyCommitmentsFlag = true;
   constexpr static bool kAdviceEvalsFlag = true;
   constexpr static bool kFixedEvalsFlag = true;
   constexpr static bool kCommonPermutationEvalsFlag = true;

--- a/tachyon/zk/plonk/examples/simple_circuit_test_data.h
+++ b/tachyon/zk/plonk/examples/simple_circuit_test_data.h
@@ -203,7 +203,7 @@ class SimpleTestData<Circuit, PCS, LS,
   };
 
   // clang-format off
-  constexpr static bool kCycleStoreSelectors[][kN] = {
+  constexpr static bool kSelectors[][kN] = {
       {false, false, false,  true, false,  true, false,  true,
        false, false, false, false, false, false, false, false}
   };
@@ -1099,7 +1099,7 @@ class SimpleTestData<Circuit, PCS, LS,
   };
 
   // clang-format off
-  constexpr static bool kCycleStoreSelectors[][kN] = {
+  constexpr static bool kSelectors[][kN] = {
       {true, false, true, false, true, false, false, false,
        false, false, false, false, false, false, false, false}
   };

--- a/tachyon/zk/plonk/examples/simple_lookup_circuit_test_data.h
+++ b/tachyon/zk/plonk/examples/simple_lookup_circuit_test_data.h
@@ -29,7 +29,6 @@ class SimpleLookupTestData : public CircuitTestData<Circuit, PCS, LS> {
   constexpr static bool kAdviceCommitmentsFlag = true;
   constexpr static bool kLookupPermutedCommitmentsPointsFlag = true;
   constexpr static bool kLookupProductCommitmentsFlag = true;
-  constexpr static bool kVanishingHPolyCommitmentsFlag = true;
   constexpr static bool kAdviceEvalsFlag = true;
   constexpr static bool kFixedEvalsFlag = true;
   constexpr static bool kLookupProductEvalsFlag = true;

--- a/tachyon/zk/plonk/examples/simple_lookup_circuit_test_data.h
+++ b/tachyon/zk/plonk/examples/simple_lookup_circuit_test_data.h
@@ -129,7 +129,7 @@ class SimpleLookupTestData : public CircuitTestData<Circuit, PCS, LS> {
       },
   };
 
-  constexpr static bool kCycleStoreSelectors[][kN] = {
+  constexpr static bool kSelectors[][kN] = {
       {
           true,  true,  true,  true,  true,  true,  true,  true,
           true,  true,  true,  true,  true,  true,  true,  true,

--- a/tachyon/zk/plonk/examples/simple_lookup_circuit_test_data.h
+++ b/tachyon/zk/plonk/examples/simple_lookup_circuit_test_data.h
@@ -565,7 +565,7 @@ class SimpleLookupTestData : public CircuitTestData<Circuit, PCS, LS> {
       "0x19f2e881193a280d2d77a8bc0f9edf053732ec86f93279a580830fb2befeccd7";
 
   // clang-format off
-  constexpr static Point kLookupPermutedCommitmentsInputPoints[][1] = {
+  constexpr static Point kLookupPermutedCommitmentsInput[][1] = {
       {
           {"0x0570bae08fb2d8f086ef87cdba76c74d323b3829e63be2b8b1a0140a7c8263a1",
            "0x0eb968ee1f6663417be8e37d714a7dec22a717d74bc3c8bc1f4a4bd58da49eed"},
@@ -576,7 +576,7 @@ class SimpleLookupTestData : public CircuitTestData<Circuit, PCS, LS> {
       },
   };
 
-  constexpr static Point kLookupPermutedCommitmentsTablePoints[][1] = {
+  constexpr static Point kLookupPermutedCommitmentsTable[][1] = {
       {
           {"0x1f229d9bf8e868c447c012f97463d59ace9d0242b0a72731268ed1abd2a5126e",
            "0x29edba749b5dc16811d78ee18bce88c5c61cd56230ad68e73c578361062a317d"},

--- a/tachyon/zk/plonk/examples/simple_lookup_circuit_test_data.h
+++ b/tachyon/zk/plonk/examples/simple_lookup_circuit_test_data.h
@@ -27,7 +27,7 @@ class SimpleLookupTestData : public CircuitTestData<Circuit, PCS, LS> {
   constexpr static bool kFixedColumnsFlag = true;
   constexpr static bool kFixedPolysFlag = true;
   constexpr static bool kAdviceCommitmentsFlag = true;
-  constexpr static bool kLookupPermutedCommitmentsPointsFlag = true;
+  constexpr static bool kLookupPermutedCommitmentsFlag = true;
   constexpr static bool kLookupProductCommitmentsFlag = true;
   constexpr static bool kAdviceEvalsFlag = true;
   constexpr static bool kFixedEvalsFlag = true;

--- a/tachyon/zk/plonk/examples/tracking_testing.md
+++ b/tachyon/zk/plonk/examples/tracking_testing.md
@@ -2,20 +2,22 @@
 
 ## Currently Tested Types
 
-| Circuit             | FloorPlanner       | PCS     | LS      |
-| ------------------- | ------------------ | ------- | ------- |
-| SimpleCircuit       | SimpleFloorPlanner | SHPlonk | Halo2LS |
-| SimpleCircuit       | V1FloorPlanner     | SHPlonk | Halo2LS |
-| SimpleLookupCircuit | SimpleFloorPlanner | SHPlonk | Halo2LS |
-| SimpleLookupCircuit | V1FloorPlanner     | SHPlonk | Halo2LS |
-| ShuffleCircuit      | SimpleFloorPlanner | SHPlonk | Halo2LS |
-| ShuffleCircuit      | V1FloorPlanner     | SHPlonk | Halo2LS |
-| Fibonacci1Circuit   | SimpleFloorPlanner | SHPlonk | Halo2LS |
-| Fibonacci1Circuit   | V1FloorPlanner     | SHPlonk | Halo2LS |
-| Fibonacci2Circuit   | SimpleFloorPlanner | SHPlonk | Halo2LS |
-| Fibonacci2Circuit   | V1FloorPlanner     | SHPlonk | Halo2LS |
-| Fibonacci3Circuit   | SimpleFloorPlanner | SHPlonk | Halo2LS |
-| Fibonacci3Circuit   | V1FloorPlanner     | SHPlonk | Halo2LS |
+| Circuit             | FloorPlanner       | PCS     | LS                   |
+| ------------------- | ------------------ | ------- | -------------------- |
+| SimpleCircuit       | SimpleFloorPlanner | SHPlonk | Halo2LS              |
+| SimpleCircuit       | V1FloorPlanner     | SHPlonk | Halo2LS              |
+| SimpleLookupCircuit | SimpleFloorPlanner | SHPlonk | Halo2LS              |
+| SimpleLookupCircuit | V1FloorPlanner     | SHPlonk | Halo2LS              |
+| ShuffleCircuit      | SimpleFloorPlanner | SHPlonk | Halo2LS              |
+| ShuffleCircuit      | V1FloorPlanner     | SHPlonk | Halo2LS              |
+| Fibonacci1Circuit   | SimpleFloorPlanner | SHPlonk | Halo2LS              |
+| Fibonacci1Circuit   | V1FloorPlanner     | SHPlonk | Halo2LS              |
+| Fibonacci2Circuit   | SimpleFloorPlanner | SHPlonk | Halo2LS              |
+| Fibonacci2Circuit   | V1FloorPlanner     | SHPlonk | Halo2LS              |
+| Fibonacci3Circuit   | SimpleFloorPlanner | SHPlonk | Halo2LS              |
+| Fibonacci3Circuit   | V1FloorPlanner     | SHPlonk | Halo2LS              |
+| MultiLookupCircuit  | SimpleFloorPlanner | SHPlonk | LogDerivativeHalo2LS |
+| MultiLookupCircuit  | SimpleFloorPlanner | GWC     | LogDerivativeHalo2LS |
 
 **In Progress**:
 
@@ -53,7 +55,7 @@ Refer to the following files to learn more about these variables:
 1. :red_square: kN
 1. :red_square: kPinnedConstraintSystem
 1. :blue_square: kAssemblyFixedColumns
-1. :blue_square: kAssemblyColumns
+1. :blue_square: kAssemblyPermutationColumns
 1. :blue_square: kCycleStoreMapping
 1. :blue_square: kCycleStoreAux
 1. :blue_square: kCycleStoreSizes
@@ -97,4 +99,4 @@ Refer to the following files to learn more about these variables:
 1. :blue_square: kLookupPermutedInputPrevEvals
 1. :blue_square: kLookupPermutedTableEvals
 1. :blue_square: kLookupMEvals
-1. :blue_square: kHEval
+1. :red_square: kHEval

--- a/tachyon/zk/plonk/examples/tracking_testing.md
+++ b/tachyon/zk/plonk/examples/tracking_testing.md
@@ -72,8 +72,8 @@ Refer to the following files to learn more about these variables:
 1. :blue_square: kAdviceCommitments
 1. :blue_square: kChallenges
 1. :red_square: kTheta
-1. :blue_square: kLookupPermutedCommitmentsInputPoints
-1. :blue_square: kLookupPermutedCommitmentsTablePoints
+1. :blue_square: kLookupPermutedCommitmentsInput
+1. :blue_square: kLookupPermutedCommitmentsTable
 1. :blue_square: kLookupMPolyCommitments
 1. :red_square: kBeta
 1. :red_square: kGamma

--- a/tachyon/zk/plonk/examples/tracking_testing.md
+++ b/tachyon/zk/plonk/examples/tracking_testing.md
@@ -81,7 +81,7 @@ Refer to the following files to learn more about these variables:
 1. :blue_square: kLookupProductCommitments
 1. :blue_square: kLookupSumCommitments
 1. :red_square: kY
-1. :blue_square: kVanishingHPolyCommitments
+1. :red_square: kVanishingHPolyCommitments
 1. :red_square: kX
 1. :blue_square: kAdviceEvals
 1. :blue_square: kFixedEvals

--- a/tachyon/zk/plonk/examples/tracking_testing.md
+++ b/tachyon/zk/plonk/examples/tracking_testing.md
@@ -57,7 +57,7 @@ Refer to the following files to learn more about these variables:
 1. :blue_square: kCycleStoreMapping
 1. :blue_square: kCycleStoreAux
 1. :blue_square: kCycleStoreSizes
-1. :red_square: kCycleStoreSelectors
+1. :red_square: kSelectors
 1. :green_square: kUsableRows
 1. :red_square: kPinnedVerifyingKey
 1. :red_square: kTranscriptRepr


### PR DESCRIPTION
This PR fixes typos, changes variable names, and updates the `tracking_testing.md` doc for example circuit testing.