### PR TITLE
build(math): include a different header if gcc version ≤ 10

### DIFF
--- a/tachyon/math/base/arithmetics.h
+++ b/tachyon/math/base/arithmetics.h
@@ -18,7 +18,15 @@
 #elif ARCH_CPU_X86_64
 // See
 // https://www.intel.com/content/www/us/en/docs/cpp-compiler/developer-guide-reference/2021-8/intrinsics-for-multi-precision-arithmetic.html
+#if __GNUC__ > 10
+// See
+// https://github.com/gcc-mirror/gcc/blob/releases/gcc-11/gcc/config/i386/adxintrin.h#L25
 #include <x86gprintrin.h>
+#else
+// See
+// https://github.com/gcc-mirror/gcc/blob/releases/gcc-10/gcc/config/i386/adxintrin.h#L25
+#include <immintrin.h>
+#endif
 #endif
 
 namespace tachyon::math::internal {


### PR DESCRIPTION
# Description

This PR addresses the issue faced by many in the Tachyon discussion group when building with **g++-10**. For your information, **g++-11** is the default compiler in **Ubuntu 22.04**, and **g++-9** is the default compiler in **Ubuntu 20.04**. We guide users to upgrade to **g++-10** [to build on Ubuntu 20.04](https://github.com/kroma-network/tachyon/blob/main/docs/how_to_use/how_to_build.md#build-on-ubuntu-2004).

I checked build is possible using this Dockerfile

```dockerfile
FROM ubuntu:20.04

ARG DEBIAN_FRONTEND=noninteractive

# Install required dependencies
RUN apt-get update && \
  apt-get install -y curl gnupg git g++-10 libgmp-dev libomp-dev python3 python3-pip zip

RUN pip install numpy

# Install Bazel
RUN curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor > bazel.gpg && \
  mv bazel.gpg /etc/apt/trusted.gpg.d/ && \
  echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list && \
  apt-get update && \
  apt-get install -y bazel-6.3.0 && \
  ln -s /usr/bin/bazel-6.3.0 /usr/local/bin/bazel

# Set Python 3 as the default python
RUN ln -s /usr/bin/python3 /usr/bin/python

# Copy and build Tachyon
COPY . /usr/src/tachyon
WORKDIR /usr/src/tachyon

RUN CC=/usr/bin/gcc-10 CXX=/usr/bin/g++-10 bazel --batch build --config linux //...
```
