### PR TITLE
perf(circom): optimize zkey wtns reading

### DIFF
--- a/tachyon/base/compiler_specific.h
+++ b/tachyon/base/compiler_specific.h
@@ -371,4 +371,56 @@ inline constexpr bool AnalyzerAssumeTrue(bool arg) {
 #define LOGICALLY_CONST
 #endif
 
+// UNSAFE_BUFFERS() wraps code that violates the -Wunsafe-buffer-usage warning,
+// such as:
+// - pointer arithmetic,
+// - pointer subscripting, and
+// - calls to functions annotated with UNSAFE_BUFFER_USAGE.
+//
+// This indicates code whose bounds correctness cannot be ensured
+// systematically, and thus requires manual review.
+//
+// ** USE OF THIS MACRO SHOULD BE VERY RARE.** This should only be used when
+// strictly necessary. Prefer to use `base::span` instead of pointers, or other
+// safer coding patterns (like std containers) that avoid the opportunity for
+// out-of-bounds bugs to creep into the code. Any use of UNSAFE_BUFFERS() can
+// lead to a critical security bug if any assumptions are wrong, or ever become
+// wrong in the future.
+//
+// The macro should be used to wrap the minimum necessary code, to make it clear
+// what is unsafe, and prevent accidentally opting extra things out of the
+// warning.
+//
+// All usage of UNSAFE_BUFFERS() should come with a `// SAFETY: ...` comment
+// that explains how we have guaranteed that the pointer usage can never go
+// out-of-bounds, or that the requirements of the UNSAFE_BUFFER_USAGE function
+// are met. The safety comment should allow a reader to check that all
+// requirements have been met, using only local invariants. Examples of local
+// invariants include:
+// - Runtime conditions or CHECKs near the UNSAFE_BUFFERS macros
+// - Invariants guaranteed by types in the surrounding code
+// - Invariants guaranteed by function calls in the surrounding code
+// - Caller requirements, if the containing function is itself marked with
+//   UNSAFE_BUFFER_USAGE
+//
+// The last case should be an option of last resort. It is less safe and will
+// require the caller also use the UNSAFE_BUFFERS() macro. Prefer directly
+// capturing such invariants in types like `base::span`.
+//
+// Safety explanations may not rely on invariants that are not fully
+// encapsulated close to the UNSAFE_BUFFERS() usage. Instead, use safer coding
+// patterns or stronger invariants.
+#if defined(__clang__)
+// clang-format off
+// Formatting is off so that we can put each _Pragma on its own line, as
+// recommended by the gcc docs.
+#define UNSAFE_BUFFERS(...)                  \
+  _Pragma("clang unsafe_buffer_usage begin") \
+  __VA_ARGS__                                \
+  _Pragma("clang unsafe_buffer_usage end")
+// clang-format on
+#else
+#define UNSAFE_BUFFERS(...) __VA_ARGS__
+#endif
+
 #endif  // TACHYON_BASE_COMPILER_SPECIFIC_H_

--- a/tachyon/base/files/BUILD.bazel
+++ b/tachyon/base/files/BUILD.bazel
@@ -96,6 +96,21 @@ tachyon_objc_library(
 )
 
 tachyon_cc_library(
+    name = "memory_mapped_file",
+    srcs = ["memory_mapped_file.cc"] + if_posix(["memory_mapped_file_posix.cc"]),
+    hdrs = ["memory_mapped_file.h"],
+    deps = [
+        ":file",
+        ":file_util",
+        "//tachyon/base:logging",
+        "//tachyon/base/numerics:safe_math",
+        "//tachyon/base/system:sys_info",
+        "//tachyon/build:build_config",
+        "@com_google_absl//absl/types:span",
+    ],
+)
+
+tachyon_cc_library(
     name = "platform_file",
     hdrs = ["platform_file.h"],
     deps = [

--- a/tachyon/base/files/BUILD.bazel
+++ b/tachyon/base/files/BUILD.bazel
@@ -14,6 +14,19 @@ load(
 package(default_visibility = ["//visibility:public"])
 
 tachyon_cc_library(
+    name = "bin_file",
+    srcs = ["bin_file.cc"],
+    hdrs = ["bin_file.h"],
+    deps = [
+        ":file_util",
+        ":memory_mapped_file",
+        "//tachyon:export",
+        "//tachyon/base:logging",
+        "//tachyon/base/buffer:read_only_buffer",
+    ],
+)
+
+tachyon_cc_library(
     name = "file",
     srcs = ["file.cc"] + if_posix(["file_posix.cc"]),
     hdrs = ["file.h"],

--- a/tachyon/base/files/bin_file.cc
+++ b/tachyon/base/files/bin_file.cc
@@ -1,0 +1,32 @@
+#include "tachyon/base/files/bin_file.h"
+
+#include <optional>
+#include <utility>
+
+#include "tachyon/base/files/file_util.h"
+#include "tachyon/base/logging.h"
+
+namespace tachyon::base {
+
+bool BinFile::Load(const base::FilePath& path, bool use_mmap) {
+  if (use_mmap) {
+    base::File file(path, base::File::FLAG_OPEN | base::File::FLAG_READ);
+    std::unique_ptr<base::MemoryMappedFile> map(new base::MemoryMappedFile);
+    if (!map->Initialize(std::move(file),
+                          base::MemoryMappedFile::Region::kWholeFile,
+                          base::MemoryMappedFile::Access::READ_WRITE_COPY))
+      return false;
+    map_ = std::move(map);
+    return true;
+  } else {
+    std::optional<std::vector<uint8_t>> vec = base::ReadFileToBytes(path);
+    if (!vec.has_value()) {
+      LOG(ERROR) << "Failed to read file: " << path.value();
+      return false;
+    }
+    vec_ = std::move(vec).value();
+    return true;
+  }
+}
+
+}  // namespace tachyon::base

--- a/tachyon/base/files/bin_file.h
+++ b/tachyon/base/files/bin_file.h
@@ -1,0 +1,64 @@
+#ifndef TACHYON_BASE_FILES_BIN_FILE_H_
+#define TACHYON_BASE_FILES_BIN_FILE_H_
+
+#include <memory>
+#include <vector>
+
+#include "tachyon/base/buffer/read_only_buffer.h"
+#include "tachyon/base/files/memory_mapped_file.h"
+#include "tachyon/export.h"
+
+namespace tachyon::base {
+
+class TACHYON_EXPORT BinFile {
+ public:
+  BinFile() {}
+  BinFile(const BinFile& other) = delete;
+  BinFile& operator=(const BinFile& other) = delete;
+  BinFile(BinFile&& other) = default;
+  BinFile& operator=(BinFile&& other) = default;
+
+  const std::vector<uint8_t>& vec() const { return vec_; }
+  std::vector<uint8_t>& vec() { return vec_; }
+
+  const MemoryMappedFile* map() const { return map_.get(); }
+  MemoryMappedFile* map() { return map_.get(); }
+
+  const uint8_t* GetData() const {
+    if (map_) {
+      return map_->data();
+    } else {
+      return vec_.data();
+    }
+  }
+
+  uint8_t* GetData() {
+    if (map_) {
+      return map_->data();
+    } else {
+      return const_cast<uint8_t*>(vec_.data());
+    }
+  }
+
+  size_t GetDataLength() const {
+    if (map_) {
+      return map_->length();
+    } else {
+      return vec_.size();
+    }
+  }
+
+  ReadOnlyBuffer ToReadOnlyBuffer() const {
+    return {GetData(), GetDataLength()};
+  }
+
+  bool Load(const FilePath& path, bool use_mmap);
+
+ private:
+  std::vector<uint8_t> vec_;
+  std::unique_ptr<MemoryMappedFile> map_;
+};
+
+}  // namespace tachyon::base
+
+#endif  // TACHYON_BASE_FILES_BIN_FILE_H_

--- a/tachyon/base/files/memory_mapped_file.cc
+++ b/tachyon/base/files/memory_mapped_file.cc
@@ -1,0 +1,147 @@
+// Copyright 2013 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "tachyon/base/files/memory_mapped_file.h"
+
+#include <utility>
+
+#include "tachyon/base/files/file_path.h"
+#include "tachyon/base/logging.h"
+// #include "tachyon/base/notreached.h"
+#include "tachyon/base/numerics/safe_math.h"
+#include "tachyon/base/system/sys_info.h"
+#include "tachyon/build/build_config.h"
+
+namespace tachyon::base {
+
+const MemoryMappedFile::Region MemoryMappedFile::Region::kWholeFile = {0, 0};
+
+MemoryMappedFile::~MemoryMappedFile() {
+  CloseHandles();
+}
+
+#if !BUILDFLAG(IS_NACL)
+bool MemoryMappedFile::Initialize(const FilePath& file_name, Access access) {
+  if (IsValid())
+    return false;
+
+  uint32_t flags = 0;
+  switch (access) {
+    case READ_ONLY:
+      flags = File::FLAG_OPEN | File::FLAG_READ;
+      break;
+    case READ_WRITE_COPY:
+      flags = File::FLAG_OPEN | File::FLAG_READ;
+#if BUILDFLAG(IS_FUCHSIA)
+      // Fuchsia's mmap() implementation does not allow us to create a
+      // copy-on-write mapping of a file opened as read-only.
+      flags |= File::FLAG_WRITE;
+#endif
+      break;
+    case READ_WRITE:
+      flags = File::FLAG_OPEN | File::FLAG_READ | File::FLAG_WRITE;
+      break;
+    case READ_WRITE_EXTEND:
+      // Can't open with "extend" because no maximum size is known.
+      NOTREACHED();
+      break;
+#if BUILDFLAG(IS_WIN)
+    case READ_CODE_IMAGE:
+      flags |= File::FLAG_OPEN | File::FLAG_READ |
+               File::FLAG_WIN_EXCLUSIVE_WRITE | File::FLAG_WIN_EXECUTE;
+      break;
+#endif
+  }
+  file_.Initialize(file_name, flags);
+
+  if (!file_.IsValid()) {
+    DLOG(ERROR) << "Couldn't open " << file_name;
+    return false;
+  }
+
+  if (!MapFileRegionToMemory(Region::kWholeFile, access)) {
+    CloseHandles();
+    return false;
+  }
+
+  return true;
+}
+
+bool MemoryMappedFile::Initialize(File file, Access access) {
+  DCHECK_NE(READ_WRITE_EXTEND, access);
+  return Initialize(std::move(file), Region::kWholeFile, access);
+}
+
+bool MemoryMappedFile::Initialize(File file,
+                                  const Region& region,
+                                  Access access) {
+  switch (access) {
+    case READ_WRITE_EXTEND:
+      DCHECK(Region::kWholeFile != region);
+      {
+        CheckedNumeric<int64_t> region_end(region.offset);
+        region_end += region.size;
+        if (!region_end.IsValid()) {
+          DLOG(ERROR) << "Region bounds exceed maximum for base::File.";
+          return false;
+        }
+      }
+      [[fallthrough]];
+    case READ_ONLY:
+    case READ_WRITE:
+    case READ_WRITE_COPY:
+      // Ensure that the region values are valid.
+      if (region.offset < 0) {
+        DLOG(ERROR) << "Region bounds are not valid.";
+        return false;
+      }
+      break;
+#if BUILDFLAG(IS_WIN)
+    case READ_CODE_IMAGE:
+      // Can't open with "READ_CODE_IMAGE", not supported outside Windows
+      // or with a |region|.
+      NOTREACHED_IN_MIGRATION();
+      break;
+#endif
+  }
+
+  if (IsValid())
+    return false;
+
+  if (region != Region::kWholeFile)
+    DCHECK_GE(region.offset, 0);
+
+  file_ = std::move(file);
+
+  if (!MapFileRegionToMemory(region, access)) {
+    CloseHandles();
+    return false;
+  }
+
+  return true;
+}
+
+bool MemoryMappedFile::IsValid() const {
+  return !bytes_.empty();
+}
+
+// static
+void MemoryMappedFile::CalculateVMAlignedBoundaries(int64_t start,
+                                                    size_t size,
+                                                    int64_t* aligned_start,
+                                                    size_t* aligned_size,
+                                                    int32_t* offset) {
+  // Sadly, on Windows, the mmap alignment is not just equal to the page size.
+  uint64_t mask = SysInfo::VMAllocationGranularity() - 1;
+  CHECK(IsValueInRangeForNumericType<int32_t>(mask));
+  *offset = static_cast<int32_t>(static_cast<uint64_t>(start) & mask);
+  *aligned_start = static_cast<int64_t>(static_cast<uint64_t>(start) & ~mask);
+  // The CHECK above means bit 31 is not set in `mask`, which in turn means
+  // *offset is positive.  Therefore casting it to a size_t is safe.
+  *aligned_size =
+      (size + static_cast<size_t>(*offset) + static_cast<size_t>(mask)) & ~mask;
+}
+#endif  // !BUILDFLAG(IS_NACL)
+
+}  // namespace tachyon::base

--- a/tachyon/base/files/memory_mapped_file.h
+++ b/tachyon/base/files/memory_mapped_file.h
@@ -1,0 +1,170 @@
+// Copyright 2013 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef TACHYON_BASE_FILES_MEMORY_MAPPED_FILE_H_
+#define TACHYON_BASE_FILES_MEMORY_MAPPED_FILE_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <utility>
+
+#include "absl/types/span.h"
+
+#include "tachyon/export.h"
+#include "tachyon/base/files/file.h"
+// #include "tachyon/base/memory/raw_ptr_exclusion.h"
+#include "tachyon/build/build_config.h"
+
+#if BUILDFLAG(IS_WIN)
+#include "base/win/scoped_handle.h"
+#endif
+
+namespace tachyon::base {
+
+class FilePath;
+
+class TACHYON_EXPORT MemoryMappedFile {
+ public:
+  enum Access {
+    // Mapping a file into memory effectively allows for file I/O on any thread.
+    // The accessing thread could be paused while data from the file is paged
+    // into memory. Worse, a corrupted filesystem could cause a SEGV within the
+    // program instead of just an I/O error.
+    READ_ONLY,
+
+    // This provides read/write access to a file and must be used with care of
+    // the additional subtleties involved in doing so. Though the OS will do
+    // the writing of data on its own time, too many dirty pages can cause
+    // the OS to pause the thread while it writes them out. The pause can
+    // be as much as 1s on some systems.
+    READ_WRITE,
+
+    // This provides read/write access to the mapped file contents as above, but
+    // applies a copy-on-write policy such that no writes are carried through to
+    // the underlying file.
+    READ_WRITE_COPY,
+
+    // This provides read/write access but with the ability to write beyond
+    // the end of the existing file up to a maximum size specified as the
+    // "region". Depending on the OS, the file may or may not be immediately
+    // extended to the maximum size though it won't be loaded in RAM until
+    // needed. Note, however, that the maximum size will still be reserved
+    // in the process address space.
+    READ_WRITE_EXTEND,
+
+#if BUILDFLAG(IS_WIN)
+    // This provides read access, but as executable code used for prefetching
+    // DLLs into RAM to avoid inefficient hard fault patterns such as during
+    // process startup. The accessing thread could be paused while data from
+    // the file is read into memory (if needed).
+    READ_CODE_IMAGE,
+#endif
+  };
+
+  // The default constructor sets all members to invalid/null values.
+  MemoryMappedFile();
+  MemoryMappedFile(const MemoryMappedFile&) = delete;
+  MemoryMappedFile& operator=(const MemoryMappedFile&) = delete;
+  ~MemoryMappedFile();
+
+  // Used to hold information about a region [offset + size] of a file.
+  struct TACHYON_EXPORT Region {
+    static const Region kWholeFile;
+
+    bool operator==(const Region& other) const {
+      return offset == other.offset && size == other.size;
+    }
+    bool operator!=(const Region& other) const {
+      return !operator==(other);
+    }
+
+    // Start of the region (measured in bytes from the beginning of the file).
+    int64_t offset;
+
+    // Length of the region in bytes.
+    size_t size;
+  };
+
+  // Opens an existing file and maps it into memory. |access| can be read-only
+  // or read/write but not read/write+extend. If this object already points
+  // to a valid memory mapped file then this method will fail and return
+  // false. If it cannot open the file, the file does not exist, or the
+  // memory mapping fails, it will return false.
+  [[nodiscard]] bool Initialize(const FilePath& file_name, Access access);
+  [[nodiscard]] bool Initialize(const FilePath& file_name) {
+    return Initialize(file_name, READ_ONLY);
+  }
+
+  // As above, but works with an already-opened file. |access| can be read-only
+  // or read/write but not read/write+extend. MemoryMappedFile takes ownership
+  // of |file| and closes it when done. |file| must have been opened with
+  // permissions suitable for |access|. If the memory mapping fails, it will
+  // return false.
+  [[nodiscard]] bool Initialize(File file, Access access);
+  [[nodiscard]] bool Initialize(File file) {
+    return Initialize(std::move(file), READ_ONLY);
+  }
+
+  // As above, but works with a region of an already-opened file. |access|
+  // must not be READ_CODE_IMAGE. If READ_WRITE_EXTEND is specified then
+  // |region| provides the maximum size of the file. If the memory mapping
+  // fails, it return false.
+  [[nodiscard]] bool Initialize(File file, const Region& region, Access access);
+  [[nodiscard]] bool Initialize(File file, const Region& region) {
+    return Initialize(std::move(file), region, READ_ONLY);
+  }
+
+  const uint8_t* data() const { return bytes_.data(); }
+  uint8_t* data() { return bytes_.data(); }
+  size_t length() const { return bytes_.size(); }
+
+  absl::Span<const uint8_t> bytes() const { return bytes_; }
+  absl::Span<uint8_t> mutable_bytes() { return bytes_; }
+
+  // Is file_ a valid file handle that points to an open, memory mapped file?
+  bool IsValid() const;
+
+ private:
+  // Given the arbitrarily aligned memory region [start, size], returns the
+  // boundaries of the region aligned to the granularity specified by the OS,
+  // (a page on Linux, ~32k on Windows) as follows:
+  // - |aligned_start| is page aligned and <= |start|.
+  // - |aligned_size| is a multiple of the VM granularity and >= |size|.
+  // - |offset| is the displacement of |start| w.r.t |aligned_start|.
+  static void CalculateVMAlignedBoundaries(int64_t start,
+                                           size_t size,
+                                           int64_t* aligned_start,
+                                           size_t* aligned_size,
+                                           int32_t* offset);
+
+#if BUILDFLAG(IS_WIN)
+  // Maps the executable file to memory, point `bytes_` to the memory range.
+  // Return true on success.
+  bool MapImageToMemory(Access access);
+#endif
+
+  // Map the file to memory, point `bytes_` to that memory address. Return true
+  // on success, false on any kind of failure. This is a helper for
+  // Initialize().
+  bool MapFileRegionToMemory(const Region& region, Access access);
+
+  // Closes all open handles.
+  void CloseHandles();
+
+  File file_;
+
+  // RAW_PTR_EXCLUSION: Never allocated by PartitionAlloc (always mmap'ed), so
+  // there is no benefit to using a raw_span, only cost.
+  // RAW_PTR_EXCLUSION span<uint8_t> bytes_;
+  absl::Span<uint8_t> bytes_;
+
+#if BUILDFLAG(IS_WIN)
+  win::ScopedHandle file_mapping_;
+#endif
+};
+
+}  // namespace tachyon::base
+
+#endif  // TACHYON_BASE_FILES_MEMORY_MAPPED_FILE_H_

--- a/tachyon/base/files/memory_mapped_file_posix.cc
+++ b/tachyon/base/files/memory_mapped_file_posix.cc
@@ -1,0 +1,147 @@
+// Copyright 2013 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "tachyon/base/files/memory_mapped_file.h"
+
+#include <fcntl.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "tachyon/base/files/file_util.h"
+#include "tachyon/base/logging.h"
+#include "tachyon/base/numerics/safe_conversions.h"
+// #include "tachyon/base/threading/scoped_blocking_call.h"
+#include "tachyon/build/build_config.h"
+
+namespace tachyon::base {
+
+MemoryMappedFile::MemoryMappedFile() = default;
+
+#if !BUILDFLAG(IS_NACL)
+bool MemoryMappedFile::MapFileRegionToMemory(
+    const MemoryMappedFile::Region& region,
+    Access access) {
+  // TODO(chokobole):
+  // ScopedBlockingCall scoped_blocking_call(FROM_HERE, BlockingType::MAY_BLOCK);
+
+  off_t map_start = 0;
+  size_t map_size = 0u;
+  int32_t data_offset = 0;
+  size_t byte_size = 0u;
+
+  if (region == MemoryMappedFile::Region::kWholeFile) {
+    int64_t file_len = file_.GetLength();
+    if (file_len < 0) {
+      DPLOG(ERROR) << "fstat " << file_.GetPlatformFile();
+      return false;
+    }
+    if (!IsValueInRangeForNumericType<size_t>(file_len))
+      return false;
+    map_size = base::checked_cast<size_t>(file_len);
+    byte_size = map_size;
+  } else {
+    // The region can be arbitrarily aligned. mmap, instead, requires both the
+    // start and size to be page-aligned. Hence, we map here the page-aligned
+    // outer region [|aligned_start|, |aligned_start| + |size|] which contains
+    // |region| and then add up the |data_offset| displacement.
+    int64_t aligned_start = 0;
+    size_t aligned_size = 0u;
+    CalculateVMAlignedBoundaries(region.offset,
+                                 region.size,
+                                 &aligned_start,
+                                 &aligned_size,
+                                 &data_offset);
+
+    // Ensure that the casts in the mmap call below are sane.
+    if (aligned_start < 0 ||
+        !IsValueInRangeForNumericType<off_t>(aligned_start)) {
+      DLOG(ERROR) << "Region bounds are not valid for mmap";
+      return false;
+    }
+
+    map_start = base::checked_cast<off_t>(aligned_start);
+    map_size = aligned_size;
+    byte_size = region.size;
+  }
+
+  if (map_size == 0u) {
+    // mmap() requires `map_size > 0`, and this ensures an empty span indicates
+    // invalid.
+    return false;
+  }
+
+  int prot = 0;
+  int flags = MAP_SHARED;
+  switch (access) {
+    case READ_ONLY:
+      prot |= PROT_READ;
+      break;
+
+    case READ_WRITE:
+      prot |= PROT_READ | PROT_WRITE;
+      break;
+
+    case READ_WRITE_COPY:
+      prot |= PROT_READ | PROT_WRITE;
+      flags = MAP_PRIVATE;
+      break;
+
+    case READ_WRITE_EXTEND:
+      prot |= PROT_READ | PROT_WRITE;
+
+      if (!AllocateFileRegion(&file_, region.offset, region.size))
+        return false;
+
+      break;
+  }
+
+  auto* ptr = static_cast<uint8_t*>(
+      mmap(nullptr, map_size, prot, flags, file_.GetPlatformFile(), map_start));
+  if (ptr == MAP_FAILED) {
+    DPLOG(ERROR) << "mmap " << file_.GetPlatformFile();
+    return false;
+  }
+
+  // SAFETY: For the span construction to be valid, `ptr` needs to point to at
+  // least `map_size` many bytes, which is the guarantee of mmap() when it
+  // returns a valid pointer, and that `data_offset + byte_size <= map_size`.
+  //
+  // If the mapping is of the whole file, `map_size == byte_size`
+  // and `data_offset == 0`, so `data_offset + byte_size <= map_size` is
+  // trivially satisfied.
+  //
+  // If the mapping is a sub-range of the file:
+  // - `aligned_start` is page aligned and <= `start`.
+  // - `map_size` is a multiple of the VM granularity and >=
+  //   `byte_size`.
+  // - `data_offset` is the displacement of `start` w.r.t `aligned_start`.
+  // |..................|xxxxxxxxxxxxxxxxxx|.................|
+  // ^ aligned start    ^ start            |                 |
+  // ^------------------^ data_offset      |                 |
+  //                    ^------------------^ byte_size       |
+  // ^-------------------------------------------------------^ map_size
+  //
+  // The `data_offset` undoes the alignment of start. The `map_size` contains
+  // the padding before and after the mapped region to satisfy alignment. So
+  // the `data_offset + byte_size <= map_size`.
+  bytes_ = UNSAFE_BUFFERS(absl::Span(ptr + data_offset, byte_size));
+  return true;
+}
+#endif
+
+void MemoryMappedFile::CloseHandles() {
+  // TODO(chokobole):
+  // ScopedBlockingCall scoped_blocking_call(FROM_HERE, BlockingType::MAY_BLOCK);
+
+  if (!bytes_.empty()) {
+    munmap(bytes_.data(), bytes_.size());
+  }
+  file_.Close();
+  bytes_ = absl::Span<uint8_t>();
+}
+
+}  // namespace tachyon::base

--- a/tachyon/base/system/BUILD.bazel
+++ b/tachyon/base/system/BUILD.bazel
@@ -1,0 +1,14 @@
+load("//bazel:tachyon.bzl", "if_posix")
+load("//bazel:tachyon_cc.bzl", "tachyon_cc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+tachyon_cc_library(
+    name = "sys_info",
+    srcs = if_posix(["sys_info_posix.cc"]),
+    hdrs = ["sys_info.h"],
+    deps = [
+        "//tachyon:export",
+        "//tachyon/base/numerics:checked_math",
+    ],
+)

--- a/tachyon/base/system/sys_info.h
+++ b/tachyon/base/system/sys_info.h
@@ -1,0 +1,23 @@
+// Copyright 2012 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef TACHYON_BASE_SYSTEM_SYS_INFO_H_
+#define TACHYON_BASE_SYSTEM_SYS_INFO_H_
+
+#include <stddef.h>
+
+#include "tachyon/export.h"
+
+namespace tachyon::base {
+
+class TACHYON_EXPORT SysInfo {
+ public:
+  // Return the smallest amount of memory (in bytes) which the VM system will
+  // allocate.
+  static size_t VMAllocationGranularity();
+};
+
+}  // namespace tachyon::base
+
+#endif  // TACHYON_BASE_SYSTEM_SYS_INFO_H_

--- a/tachyon/base/system/sys_info_posix.cc
+++ b/tachyon/base/system/sys_info_posix.cc
@@ -1,0 +1,17 @@
+// Copyright 2011 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <unistd.h>
+
+#include "tachyon/base/numerics/checked_math.h"
+#include "tachyon/base/system/sys_info.h"
+
+namespace tachyon::base {
+
+// static
+size_t SysInfo::VMAllocationGranularity() {
+  return checked_cast<size_t>(getpagesize());
+}
+
+}  // namespace tachyon::base

--- a/vendors/circom/benchmark/circom_benchmark.cc
+++ b/vendors/circom/benchmark/circom_benchmark.cc
@@ -79,7 +79,7 @@ int RealMain(int argc, char** argv) {
 
   for (size_t i = 0; i < runners.size(); ++i) {
     std::unique_ptr<Runner<Curve, kMaxDegree>>& runner = runners[i];
-    runner->LoadZkey(base::FilePath("benchmark/sha256_512.zkey"));
+    runner->LoadZKey(base::FilePath("benchmark/sha256_512.zkey"));
 
     std::unique_ptr<Domain> domain;
     if (i == 0) {

--- a/vendors/circom/benchmark/rapidsnark_runner.h
+++ b/vendors/circom/benchmark/rapidsnark_runner.h
@@ -56,7 +56,7 @@ class RapidsnarkRunner : public Runner<Curve, MaxDegree> {
     parse_key(verification_key_, key.dataAsString().c_str());
   }
 
-  void LoadZkey(const base::FilePath& zkey_path) override {
+  void LoadZKey(const base::FilePath& zkey_path) override {
     zkey_ = BinFileUtils::openExisting(zkey_path.value(), "zkey", 1);
     zkey_header_ = ZKeyUtils::loadHeader(zkey_.get());
     prover_ = Groth16::makeProver<Engine>(

--- a/vendors/circom/benchmark/runner.h
+++ b/vendors/circom/benchmark/runner.h
@@ -20,7 +20,7 @@ class Runner {
 
   virtual ~Runner() = default;
 
-  virtual void LoadZkey(const base::FilePath& zkey_path) = 0;
+  virtual void LoadZKey(const base::FilePath& zkey_path) = 0;
   virtual zk::r1cs::groth16::Proof<Curve> Run(
       const Domain* domain, const std::vector<F>& full_assignments,
       absl::Span<const F> public_inputs, base::TimeDelta& duration) = 0;

--- a/vendors/circom/benchmark/tachyon_runner.h
+++ b/vendors/circom/benchmark/tachyon_runner.h
@@ -43,7 +43,7 @@ class TachyonRunner : public Runner<Curve, MaxDegree> {
     return zkey_->GetNumWitnessVariables();
   }
 
-  void LoadZkey(const base::FilePath& zkey_path) override {
+  void LoadZKey(const base::FilePath& zkey_path) override {
     zkey_ = ParseZKey<Curve>(zkey_path);
     CHECK(zkey_);
 

--- a/vendors/circom/circomlib/circuit/adder_circuit_unittest.cc
+++ b/vendors/circom/circomlib/circuit/adder_circuit_unittest.cc
@@ -52,7 +52,7 @@ TEST_F(AdderCircuitTest, Groth16ProveAndVerify) {
                                   zk::r1cs::QuadraticArithmeticProgram<F>>();
 }
 
-TEST_F(AdderCircuitTest, Groth16ProveAndVerifyUsingZkey) {
+TEST_F(AdderCircuitTest, Groth16ProveAndVerifyUsingZKey) {
   constexpr size_t kMaxDegree = 127;
 
   LoadRandomWitness();

--- a/vendors/circom/circomlib/circuit/multiplier_3_circuit_unittest.cc
+++ b/vendors/circom/circomlib/circuit/multiplier_3_circuit_unittest.cc
@@ -52,7 +52,7 @@ TEST_F(Multiplier3CircuitTest, Groth16ProveAndVerify) {
                                   zk::r1cs::QuadraticArithmeticProgram<F>>();
 }
 
-TEST_F(Multiplier3CircuitTest, Groth16ProveAndVerifyUsingZkey) {
+TEST_F(Multiplier3CircuitTest, Groth16ProveAndVerifyUsingZKey) {
   constexpr size_t kMaxDegree = 3;
 
   LoadRandomWitness();

--- a/vendors/circom/circomlib/wtns/BUILD.bazel
+++ b/vendors/circom/circomlib/wtns/BUILD.bazel
@@ -13,7 +13,7 @@ tachyon_cc_library(
         "@kroma_network_tachyon//tachyon/base:openmp_util",
         "@kroma_network_tachyon//tachyon/base/buffer:endian_auto_reset",
         "@kroma_network_tachyon//tachyon/base/buffer:read_only_buffer",
-        "@kroma_network_tachyon//tachyon/base/files:file_util",
+        "@kroma_network_tachyon//tachyon/base/files:bin_file",
         "@kroma_network_tachyon//tachyon/base/strings:string_util",
     ],
 )

--- a/vendors/circom/circomlib/zkey/BUILD.bazel
+++ b/vendors/circom/circomlib/zkey/BUILD.bazel
@@ -43,7 +43,7 @@ tachyon_cc_library(
         "@kroma_network_tachyon//tachyon/base/buffer:copyable",
         "@kroma_network_tachyon//tachyon/base/buffer:endian_auto_reset",
         "@kroma_network_tachyon//tachyon/base/buffer:read_only_buffer",
-        "@kroma_network_tachyon//tachyon/base/files:file_util",
+        "@kroma_network_tachyon//tachyon/base/files:bin_file",
         "@kroma_network_tachyon//tachyon/base/strings:string_util",
     ],
 )

--- a/vendors/circom/circomlib/zkey/zkey.h
+++ b/vendors/circom/circomlib/zkey/zkey.h
@@ -51,7 +51,7 @@ struct ZKey {
   base::BinFile bin_file;
 };
 
-constexpr char kZkeyMagic[4] = {'z', 'k', 'e', 'y'};
+constexpr char kZKeyMagic[4] = {'z', 'k', 'e', 'y'};
 
 // Return nullptr if the parser failed to parse.
 template <typename Curve>
@@ -69,7 +69,7 @@ std::unique_ptr<ZKey<Curve>> ParseZKey(const base::FilePath& path,
   char magic[4];
   uint32_t version;
   if (!buffer.ReadMany(magic, &version)) return nullptr;
-  if (memcmp(magic, kZkeyMagic, 4) != 0) {
+  if (memcmp(magic, kZKeyMagic, 4) != 0) {
     LOG(ERROR) << "Invalid magic: " << magic;
     return nullptr;
   }

--- a/vendors/circom/circomlib/zkey/zkey.h
+++ b/vendors/circom/circomlib/zkey/zkey.h
@@ -2,13 +2,12 @@
 #define VENDORS_CIRCOM_CIRCOMLIB_ZKEY_ZKEY_H_
 
 #include <string.h>
+#include <sys/mman.h>
 
 #include <algorithm>
 #include <memory>
-#include <optional>
 #include <string>
 #include <utility>
-#include <vector>
 
 #include "circomlib/base/modulus.h"
 #include "circomlib/base/sections.h"
@@ -17,7 +16,7 @@
 #include "tachyon/base/auto_reset.h"
 #include "tachyon/base/buffer/endian_auto_reset.h"
 #include "tachyon/base/buffer/read_only_buffer.h"
-#include "tachyon/base/files/file_util.h"
+#include "tachyon/base/files/bin_file.h"
 #include "tachyon/base/logging.h"
 #include "tachyon/base/openmp_util.h"
 #include "tachyon/base/strings/string_util.h"
@@ -34,7 +33,7 @@ template <typename Curve>
 struct ZKey {
   using F = typename Curve::G1Curve::ScalarField;
 
-  explicit ZKey(std::vector<uint8_t>&& data) : data(std::move(data)) {}
+  explicit ZKey(base::BinFile bin_file) : bin_file(std::move(bin_file)) {}
   virtual ~ZKey() = default;
 
   virtual uint32_t GetVersion() const = 0;
@@ -49,21 +48,23 @@ struct ZKey {
   virtual size_t GetNumInstanceVariables() const = 0;
   virtual size_t GetNumWitnessVariables() const = 0;
 
-  std::vector<uint8_t> data;
+  base::BinFile bin_file;
 };
 
 constexpr char kZkeyMagic[4] = {'z', 'k', 'e', 'y'};
 
 // Return nullptr if the parser failed to parse.
 template <typename Curve>
-std::unique_ptr<ZKey<Curve>> ParseZKey(const base::FilePath& path) {
-  std::optional<std::vector<uint8_t>> zkey_data = base::ReadFileToBytes(path);
-  if (!zkey_data.has_value()) {
-    LOG(ERROR) << "Failed to read file: " << path.value();
-    return nullptr;
+std::unique_ptr<ZKey<Curve>> ParseZKey(const base::FilePath& path,
+                                       bool use_mmap = true) {
+  base::BinFile bin_file;
+  CHECK(bin_file.Load(path, use_mmap));
+  if (use_mmap) {
+    PCHECK(madvise(bin_file.GetData(), bin_file.GetDataLength(),
+                   MADV_SEQUENTIAL) == 0);
   }
 
-  base::ReadOnlyBuffer buffer(zkey_data->data(), zkey_data->size());
+  base::ReadOnlyBuffer buffer = bin_file.ToReadOnlyBuffer();
   buffer.set_endian(base::Endian::kLittle);
   char magic[4];
   uint32_t version;
@@ -74,7 +75,7 @@ std::unique_ptr<ZKey<Curve>> ParseZKey(const base::FilePath& path) {
   }
   std::unique_ptr<ZKey<Curve>> zkey;
   if (version == 1) {
-    zkey.reset(new v1::ZKey<Curve>(std::move(zkey_data).value()));
+    zkey.reset(new v1::ZKey<Curve>(std::move(bin_file)));
     CHECK(zkey->ToV1()->Read(buffer));
   } else {
     LOG(ERROR) << "Invalid version: " << version;
@@ -244,8 +245,8 @@ struct ZKey : public circom::ZKey<Curve> {
   PointsC1Section<G1AffinePoint> points_c1;
   PointsH1Section<G1AffinePoint> points_h1;
 
-  explicit ZKey(std::vector<uint8_t>&& data)
-      : circom::ZKey<Curve>(std::move(data)) {}
+  explicit ZKey(base::BinFile bin_file)
+      : circom::ZKey<Curve>(std::move(bin_file)) {}
 
   // circom::ZKey methods
   uint32_t GetVersion() const override { return 1; }


### PR DESCRIPTION
# Description

Zkey and wtns files are now read using `mmap()` and is much faster!

Before

```
Start parsing zkey
Time taken for parsing zkey: 5.97333 s
Start parsing witness
Time taken for parsing witness: 0.319247 s
```

After
```
Start parsing zkey
Time taken for parsing zkey: 0.611177 s
Start parsing witness
Time taken for parsing witness: 0.097334 s
```