### PR TITLE
build: bump up sp1 prover to v1.0.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,14 +60,16 @@ jobs:
       - name: Add .bazelrc.user on linux
         if: matrix.os == 'ubuntu-latest'
         run: echo "build --config linux" > .bazelrc.user &&
-             echo "build --action_env=CARGO=$HOME/.cargo/bin/cargo" >> .bazelrc.user
+             echo "build --action_env=CARGO=$HOME/.cargo/bin/cargo" >> .bazelrc.user &&
+             echo "build --@rules_rust//rust/toolchain/channel=nightly" >> .bazelrc.user
 
       - name: Add .bazelrc.user on macos
         if: matrix.os == 'macos-latest-xlarge'
         run: brew install coreutils &&
              export PATH="/opt/homebrew/opt/coreutils/libexec/gnubin:$PATH" &&
              echo "build --config macos_arm64" > .bazelrc.user &&
-             echo "build --action_env=CARGO=$HOME/.cargo/bin/cargo" >> .bazelrc.user
+             echo "build --action_env=CARGO=$HOME/.cargo/bin/cargo" >> .bazelrc.user &&
+             echo "build --@rules_rust//rust/toolchain/channel=nightly" >> .bazelrc.user
 
       - name: Build
         run: bazel build -c ${{ matrix.build_flag }} ${{ matrix.has_openmp }} //...

--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "ca6d1b6a46ca837bae679fb8a8b4bd0e835f9c9a2e02f9f3c53ce3a1b8167f04",
+  "checksum": "2708778b7ba033db1ebe4ec7316d9765ae45bbf23f0caca325e162ece2bfbdab",
   "crates": {
     "addchain 0.2.0": {
       "name": "addchain",
@@ -804,6 +804,64 @@
       },
       "license": "MIT/Apache-2.0"
     },
+    "ark-bn254 0.4.0-alpha.2": {
+      "name": "ark-bn254",
+      "version": "0.4.0-alpha.2",
+      "repository": {
+        "Git": {
+          "remote": "https://github.com/arkworks-rs/curves.git",
+          "commitish": {
+            "Tag": "v0.4.0-alpha.2"
+          },
+          "strip_prefix": "bn254"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "ark_bn254",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "ark_bn254",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "curve",
+            "default",
+            "scalar_field"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "ark-ec 0.4.2",
+              "target": "ark_ec"
+            },
+            {
+              "id": "ark-ff 0.4.2",
+              "target": "ark_ff"
+            },
+            {
+              "id": "ark-std 0.4.0",
+              "target": "ark_std"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.4.0-alpha.2"
+      },
+      "license": "MIT/Apache-2.0"
+    },
     "ark-crypto-primitives 0.4.0": {
       "name": "ark-crypto-primitives",
       "version": "0.4.0",
@@ -1037,7 +1095,7 @@
               "target": "itertools"
             },
             {
-              "id": "num-bigint 0.4.5",
+              "id": "num-bigint 0.4.6",
               "target": "num_bigint"
             },
             {
@@ -1152,7 +1210,7 @@
         "deps": {
           "common": [
             {
-              "id": "num-bigint 0.4.5",
+              "id": "num-bigint 0.4.6",
               "target": "num_bigint"
             },
             {
@@ -1354,7 +1412,7 @@
               "target": "digest"
             },
             {
-              "id": "num-bigint 0.4.5",
+              "id": "num-bigint 0.4.6",
               "target": "num_bigint"
             }
           ],
@@ -1578,62 +1636,6 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "ark-test-curves 0.4.2": {
-      "name": "ark-test-curves",
-      "version": "0.4.2",
-      "repository": {
-        "Git": {
-          "remote": "https://github.com/kroma-network/algebra.git",
-          "commitish": {
-            "Rev": "53f396c"
-          },
-          "strip_prefix": "test-curves"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "ark_test_curves",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "ark_test_curves",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "ark-ec 0.4.2",
-              "target": "ark_ec"
-            },
-            {
-              "id": "ark-ff 0.4.2",
-              "target": "ark_ff"
-            },
-            {
-              "id": "ark-std 0.4.0",
-              "target": "ark_std"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.4.2"
-      },
-      "license": "MIT OR Apache-2.0"
-    },
     "arkworks_fft_benchmark 0.0.1": {
       "name": "arkworks_fft_benchmark",
       "version": "0.0.1",
@@ -1657,12 +1659,12 @@
         "deps": {
           "common": [
             {
-              "id": "ark-poly 0.4.2",
-              "target": "ark_poly"
+              "id": "ark-bn254 0.4.0-alpha.2",
+              "target": "ark_bn254"
             },
             {
-              "id": "ark-test-curves 0.4.2",
-              "target": "ark_test_curves"
+              "id": "ark-poly 0.4.2",
+              "target": "ark_poly"
             }
           ],
           "selects": {}
@@ -1857,36 +1859,6 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "atomic-waker 1.1.2": {
-      "name": "atomic-waker",
-      "version": "1.1.2",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/atomic-waker/1.1.2/download",
-          "sha256": "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "atomic_waker",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "atomic_waker",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2018",
-        "version": "1.1.2"
-      },
-      "license": "Apache-2.0 OR MIT"
-    },
     "autocfg 1.3.0": {
       "name": "autocfg",
       "version": "1.3.0",
@@ -1974,7 +1946,7 @@
               "target": "rustc_demangle"
             },
             {
-              "id": "serde 1.0.203",
+              "id": "serde 1.0.204",
               "target": "serde"
             }
           ],
@@ -2009,7 +1981,7 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.0.98",
+              "id": "cc 1.1.7",
               "target": "cc"
             }
           ],
@@ -2079,14 +2051,6 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "default",
-            "std"
-          ],
-          "selects": {}
-        },
         "edition": "2018",
         "version": "0.22.1"
       },
@@ -2318,7 +2282,7 @@
               "target": "hex"
             },
             {
-              "id": "lazy_static 1.4.0",
+              "id": "lazy_static 1.5.0",
               "target": "lazy_static"
             },
             {
@@ -2335,7 +2299,7 @@
               "target": "rand"
             },
             {
-              "id": "serde 1.0.203",
+              "id": "serde 1.0.204",
               "target": "serde"
             },
             {
@@ -2416,7 +2380,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.203",
+              "id": "serde 1.0.204",
               "target": "serde"
             }
           ],
@@ -2494,7 +2458,7 @@
               "target": "itertools"
             },
             {
-              "id": "lazy_static 1.4.0",
+              "id": "lazy_static 1.5.0",
               "target": "lazy_static"
             },
             {
@@ -2502,7 +2466,7 @@
               "target": "lazycell"
             },
             {
-              "id": "log 0.4.21",
+              "id": "log 0.4.22",
               "target": "log"
             },
             {
@@ -2629,7 +2593,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.203",
+              "id": "serde 1.0.204",
               "target": "serde"
             }
           ],
@@ -2637,42 +2601,6 @@
         },
         "edition": "2015",
         "version": "0.6.3"
-      },
-      "license": "MIT/Apache-2.0"
-    },
-    "bitflags 1.3.2": {
-      "name": "bitflags",
-      "version": "1.3.2",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/bitflags/1.3.2/download",
-          "sha256": "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "bitflags",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "bitflags",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default"
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "1.3.2"
       },
       "license": "MIT/Apache-2.0"
     },
@@ -3064,7 +2992,7 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.0.98",
+              "id": "cc 1.1.7",
               "target": "cc"
             }
           ],
@@ -3324,6 +3252,36 @@
       },
       "license": "MIT"
     },
+    "bytemuck 1.16.1": {
+      "name": "bytemuck",
+      "version": "1.16.1",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/bytemuck/1.16.1/download",
+          "sha256": "b236fc92302c97ed75b38da1f4917b5cdda4984745740f153a5d3059e48d725e"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "bytemuck",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "bytemuck",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2018",
+        "version": "1.16.1"
+      },
+      "license": "Zlib OR Apache-2.0 OR MIT"
+    },
     "byteorder 1.5.0": {
       "name": "byteorder",
       "version": "1.5.0",
@@ -3361,50 +3319,13 @@
       },
       "license": "Unlicense OR MIT"
     },
-    "bytes 1.6.0": {
-      "name": "bytes",
-      "version": "1.6.0",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/bytes/1.6.0/download",
-          "sha256": "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "bytes",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "bytes",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default",
-            "std"
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "1.6.0"
-      },
-      "license": "MIT"
-    },
-    "cc 1.0.98": {
+    "cc 1.1.7": {
       "name": "cc",
-      "version": "1.0.98",
+      "version": "1.1.7",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cc/1.0.98/download",
-          "sha256": "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
+          "url": "https://static.crates.io/crates/cc/1.1.7/download",
+          "sha256": "26a5c3fd7bfa1ce3897a3a3501d362b2d87b7f2583ebcb4a949ec25911025cbc"
         }
       },
       "targets": [
@@ -3424,7 +3345,7 @@
           "**"
         ],
         "edition": "2018",
-        "version": "1.0.98"
+        "version": "1.1.7"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -3559,7 +3480,7 @@
               "target": "num_traits"
             },
             {
-              "id": "serde 1.0.203",
+              "id": "serde 1.0.204",
               "target": "serde"
             }
           ],
@@ -3679,13 +3600,13 @@
       },
       "license": "Apache-2.0"
     },
-    "clap 4.5.4": {
+    "clap 4.5.11": {
       "name": "clap",
-      "version": "4.5.4",
+      "version": "4.5.11",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/clap/4.5.4/download",
-          "sha256": "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+          "url": "https://static.crates.io/crates/clap/4.5.11/download",
+          "sha256": "35723e6a11662c2afb578bcf0b88bf6ea8e21282a953428f240574fcc3a2b5b3"
         }
       },
       "targets": [
@@ -3721,7 +3642,7 @@
         "deps": {
           "common": [
             {
-              "id": "clap_builder 4.5.2",
+              "id": "clap_builder 4.5.11",
               "target": "clap_builder"
             }
           ],
@@ -3731,23 +3652,23 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "clap_derive 4.5.4",
+              "id": "clap_derive 4.5.11",
               "target": "clap_derive"
             }
           ],
           "selects": {}
         },
-        "version": "4.5.4"
+        "version": "4.5.11"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "clap_builder 4.5.2": {
+    "clap_builder 4.5.11": {
       "name": "clap_builder",
-      "version": "4.5.2",
+      "version": "4.5.11",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/clap_builder/4.5.2/download",
-          "sha256": "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+          "url": "https://static.crates.io/crates/clap_builder/4.5.11/download",
+          "sha256": "49eb96cbfa7cfa35017b7cd548c75b14c3118c98b423041d70562665e07fb0fa"
         }
       },
       "targets": [
@@ -3800,17 +3721,17 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "4.5.2"
+        "version": "4.5.11"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "clap_derive 4.5.4": {
+    "clap_derive 4.5.11": {
       "name": "clap_derive",
-      "version": "4.5.4",
+      "version": "4.5.11",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/clap_derive/4.5.4/download",
-          "sha256": "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+          "url": "https://static.crates.io/crates/clap_derive/4.5.11/download",
+          "sha256": "5d029b67f89d30bbb547c89fd5161293c0aec155fc691d7924b64550662db93e"
         }
       },
       "targets": [
@@ -3857,7 +3778,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "4.5.4"
+        "version": "4.5.11"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -3891,6 +3812,36 @@
       },
       "license": "MIT OR Apache-2.0"
     },
+    "cobs 0.2.3": {
+      "name": "cobs",
+      "version": "0.2.3",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/cobs/0.2.3/download",
+          "sha256": "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "cobs",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "cobs",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2018",
+        "version": "0.2.3"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
     "colorchoice 1.0.1": {
       "name": "colorchoice",
       "version": "1.0.1",
@@ -3920,71 +3871,6 @@
         "version": "1.0.1"
       },
       "license": "MIT OR Apache-2.0"
-    },
-    "console 0.15.8": {
-      "name": "console",
-      "version": "0.15.8",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/console/0.15.8/download",
-          "sha256": "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "console",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "console",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "ansi-parsing",
-            "unicode-width"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "lazy_static 1.4.0",
-              "target": "lazy_static"
-            },
-            {
-              "id": "libc 0.2.155",
-              "target": "libc"
-            },
-            {
-              "id": "unicode-width 0.1.12",
-              "target": "unicode_width"
-            }
-          ],
-          "selects": {
-            "cfg(windows)": [
-              {
-                "id": "encode_unicode 0.3.6",
-                "target": "encode_unicode"
-              },
-              {
-                "id": "windows-sys 0.52.0",
-                "target": "windows_sys"
-              }
-            ]
-          }
-        },
-        "edition": "2018",
-        "version": "0.15.8"
-      },
-      "license": "MIT"
     },
     "const-oid 0.9.6": {
       "name": "const-oid",
@@ -4076,56 +3962,6 @@
       },
       "license": "CC0-1.0 OR MIT-0 OR Apache-2.0"
     },
-    "core-foundation 0.9.4": {
-      "name": "core-foundation",
-      "version": "0.9.4",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/core-foundation/0.9.4/download",
-          "sha256": "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "core_foundation",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "core_foundation",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default",
-            "link"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "core-foundation-sys 0.8.6",
-              "target": "core_foundation_sys"
-            },
-            {
-              "id": "libc 0.2.155",
-              "target": "libc"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.9.4"
-      },
-      "license": "MIT OR Apache-2.0"
-    },
     "core-foundation-sys 0.8.6": {
       "name": "core-foundation-sys",
       "version": "0.8.6",
@@ -4151,13 +3987,6 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "default",
-            "link"
-          ],
-          "selects": {}
-        },
         "edition": "2018",
         "version": "0.8.6"
       },
@@ -4600,7 +4429,7 @@
               "target": "crossbeam_utils"
             },
             {
-              "id": "lazy_static 1.4.0",
+              "id": "lazy_static 1.5.0",
               "target": "lazy_static"
             },
             {
@@ -4836,7 +4665,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "lazy_static 1.4.0",
+              "id": "lazy_static 1.5.0",
               "target": "lazy_static"
             }
           ],
@@ -5321,7 +5150,7 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.0.98",
+              "id": "cc 1.1.7",
               "target": "cc"
             },
             {
@@ -5688,7 +5517,7 @@
               "target": "powerfmt"
             },
             {
-              "id": "serde 1.0.203",
+              "id": "serde 1.0.204",
               "target": "serde"
             }
           ],
@@ -6332,19 +6161,19 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "encode_unicode 0.3.6": {
-      "name": "encode_unicode",
-      "version": "0.3.6",
+    "embedded-io 0.4.0": {
+      "name": "embedded-io",
+      "version": "0.4.0",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/encode_unicode/0.3.6/download",
-          "sha256": "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+          "url": "https://static.crates.io/crates/embedded-io/0.4.0/download",
+          "sha256": "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
         }
       },
       "targets": [
         {
           "Library": {
-            "crate_name": "encode_unicode",
+            "crate_name": "embedded_io",
             "crate_root": "src/lib.rs",
             "srcs": [
               "**/*.rs"
@@ -6352,68 +6181,21 @@
           }
         }
       ],
-      "library_target_name": "encode_unicode",
+      "library_target_name": "embedded_io",
       "common_attrs": {
         "compile_data_glob": [
           "**"
         ],
         "crate_features": {
           "common": [
-            "default",
-            "std"
+            "alloc"
           ],
           "selects": {}
         },
-        "edition": "2015",
-        "version": "0.3.6"
+        "edition": "2021",
+        "version": "0.4.0"
       },
-      "license": "MIT/Apache-2.0"
-    },
-    "encoding_rs 0.8.34": {
-      "name": "encoding_rs",
-      "version": "0.8.34",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/encoding_rs/0.8.34/download",
-          "sha256": "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "encoding_rs",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "encoding_rs",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "default"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "cfg-if 1.0.0",
-              "target": "cfg_if"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.8.34"
-      },
-      "license": "(Apache-2.0 OR MIT) AND BSD-3-Clause"
+      "license": "MIT OR Apache-2.0"
     },
     "equivalent 1.0.1": {
       "name": "equivalent",
@@ -6727,7 +6509,7 @@
               "target": "rand"
             },
             {
-              "id": "serde 1.0.203",
+              "id": "serde 1.0.204",
               "target": "serde"
             }
           ],
@@ -6854,7 +6636,7 @@
         "deps": {
           "common": [
             {
-              "id": "num-bigint 0.4.5",
+              "id": "num-bigint 0.4.6",
               "target": "num_bigint"
             },
             {
@@ -6874,7 +6656,7 @@
               "target": "quote"
             },
             {
-              "id": "serde 1.0.203",
+              "id": "serde 1.0.204",
               "target": "serde"
             },
             {
@@ -6955,122 +6737,6 @@
         "version": "1.0.7"
       },
       "license": "Apache-2.0 / MIT"
-    },
-    "foreign-types 0.3.2": {
-      "name": "foreign-types",
-      "version": "0.3.2",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/foreign-types/0.3.2/download",
-          "sha256": "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "foreign_types",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "foreign_types",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "foreign-types-shared 0.1.1",
-              "target": "foreign_types_shared"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2015",
-        "version": "0.3.2"
-      },
-      "license": "MIT/Apache-2.0"
-    },
-    "foreign-types-shared 0.1.1": {
-      "name": "foreign-types-shared",
-      "version": "0.1.1",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/foreign-types-shared/0.1.1/download",
-          "sha256": "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "foreign_types_shared",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "foreign_types_shared",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2015",
-        "version": "0.1.1"
-      },
-      "license": "MIT/Apache-2.0"
-    },
-    "form_urlencoded 1.2.1": {
-      "name": "form_urlencoded",
-      "version": "1.2.1",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/form_urlencoded/1.2.1/download",
-          "sha256": "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "form_urlencoded",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "form_urlencoded",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "default",
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "percent-encoding 2.3.1",
-              "target": "percent_encoding"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "1.2.1"
-      },
-      "license": "MIT OR Apache-2.0"
     },
     "fuchsia-cprng 0.1.1": {
       "name": "fuchsia-cprng",
@@ -7198,8 +6864,6 @@
         "crate_features": {
           "common": [
             "alloc",
-            "async-await",
-            "default",
             "executor",
             "futures-executor",
             "std",
@@ -7273,7 +6937,6 @@
         "crate_features": {
           "common": [
             "alloc",
-            "default",
             "futures-sink",
             "sink",
             "std"
@@ -7326,7 +6989,6 @@
         "crate_features": {
           "common": [
             "alloc",
-            "default",
             "std"
           ],
           "selects": {}
@@ -7481,53 +7143,6 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "futures-macro 0.3.30": {
-      "name": "futures-macro",
-      "version": "0.3.30",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/futures-macro/0.3.30/download",
-          "sha256": "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "futures_macro",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "futures_macro",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "proc-macro2 1.0.85",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.36",
-              "target": "quote"
-            },
-            {
-              "id": "syn 2.0.66",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.3.30"
-      },
-      "license": "MIT OR Apache-2.0"
-    },
     "futures-sink 0.3.30": {
       "name": "futures-sink",
       "version": "0.3.30",
@@ -7556,7 +7171,6 @@
         "crate_features": {
           "common": [
             "alloc",
-            "default",
             "std"
           ],
           "selects": {}
@@ -7631,13 +7245,9 @@
         "crate_features": {
           "common": [
             "alloc",
-            "async-await",
-            "async-await-macro",
             "channel",
-            "default",
             "futures-channel",
             "futures-io",
-            "futures-macro",
             "futures-sink",
             "io",
             "memchr",
@@ -7689,15 +7299,6 @@
           "selects": {}
         },
         "edition": "2018",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "futures-macro 0.3.30",
-              "target": "futures_macro"
-            }
-          ],
-          "selects": {}
-        },
         "version": "0.3.30"
       },
       "license": "MIT OR Apache-2.0"
@@ -7809,13 +7410,13 @@
       },
       "license": "MIT"
     },
-    "generic-array 1.0.0": {
+    "generic-array 1.1.0": {
       "name": "generic-array",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/generic-array/1.0.0/download",
-          "sha256": "fe739944a5406424e080edccb6add95685130b9f160d5407c639c7df0c5836b0"
+          "url": "https://static.crates.io/crates/generic-array/1.1.0/download",
+          "sha256": "96512db27971c2c3eece70a1e106fbe6c87760234e31e8f7e5634912fe52794a"
         }
       },
       "targets": [
@@ -7844,7 +7445,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.203",
+              "id": "serde 1.0.204",
               "target": "serde"
             },
             {
@@ -7855,7 +7456,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.0.0"
+        "version": "1.1.0"
       },
       "license": "MIT"
     },
@@ -8098,85 +7699,6 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "h2 0.4.5": {
-      "name": "h2",
-      "version": "0.4.5",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/h2/0.4.5/download",
-          "sha256": "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "h2",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "h2",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "atomic-waker 1.1.2",
-              "target": "atomic_waker"
-            },
-            {
-              "id": "bytes 1.6.0",
-              "target": "bytes"
-            },
-            {
-              "id": "fnv 1.0.7",
-              "target": "fnv"
-            },
-            {
-              "id": "futures-core 0.3.30",
-              "target": "futures_core"
-            },
-            {
-              "id": "futures-sink 0.3.30",
-              "target": "futures_sink"
-            },
-            {
-              "id": "http 1.1.0",
-              "target": "http"
-            },
-            {
-              "id": "indexmap 2.2.6",
-              "target": "indexmap"
-            },
-            {
-              "id": "slab 0.4.9",
-              "target": "slab"
-            },
-            {
-              "id": "tokio 1.38.0",
-              "target": "tokio"
-            },
-            {
-              "id": "tokio-util 0.7.11",
-              "target": "tokio_util"
-            },
-            {
-              "id": "tracing 0.1.40",
-              "target": "tracing"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.4.5"
-      },
-      "license": "MIT"
-    },
     "halo2 0.1.0-beta.2": {
       "name": "halo2",
       "version": "0.1.0-beta.2",
@@ -8413,7 +7935,7 @@
               "target": "halo2curves"
             },
             {
-              "id": "log 0.4.21",
+              "id": "log 0.4.22",
               "target": "log"
             },
             {
@@ -8421,7 +7943,7 @@
               "target": "maybe_rayon"
             },
             {
-              "id": "num-bigint 0.4.5",
+              "id": "num-bigint 0.4.6",
               "target": "num_bigint"
             },
             {
@@ -8528,11 +8050,11 @@
               "target": "build_script_build"
             },
             {
-              "id": "lazy_static 1.4.0",
+              "id": "lazy_static 1.5.0",
               "target": "lazy_static"
             },
             {
-              "id": "num-bigint 0.4.5",
+              "id": "num-bigint 0.4.6",
               "target": "num_bigint"
             },
             {
@@ -8552,7 +8074,7 @@
               "target": "rand_core"
             },
             {
-              "id": "serde 1.0.203",
+              "id": "serde 1.0.204",
               "target": "serde"
             },
             {
@@ -8715,7 +8237,8 @@
             "allocator-api2",
             "default",
             "inline-more",
-            "raw"
+            "raw",
+            "serde"
           ],
           "selects": {}
         },
@@ -8728,6 +8251,10 @@
             {
               "id": "allocator-api2 0.2.18",
               "target": "allocator_api2"
+            },
+            {
+              "id": "serde 1.0.204",
+              "target": "serde"
             }
           ],
           "selects": {}
@@ -8955,543 +8482,6 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "http 1.1.0": {
-      "name": "http",
-      "version": "1.1.0",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/http/1.1.0/download",
-          "sha256": "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "http",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "http",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default",
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "bytes 1.6.0",
-              "target": "bytes"
-            },
-            {
-              "id": "fnv 1.0.7",
-              "target": "fnv"
-            },
-            {
-              "id": "itoa 1.0.11",
-              "target": "itoa"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "1.1.0"
-      },
-      "license": "MIT OR Apache-2.0"
-    },
-    "http-body 1.0.0": {
-      "name": "http-body",
-      "version": "1.0.0",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/http-body/1.0.0/download",
-          "sha256": "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "http_body",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "http_body",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "bytes 1.6.0",
-              "target": "bytes"
-            },
-            {
-              "id": "http 1.1.0",
-              "target": "http"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "1.0.0"
-      },
-      "license": "MIT"
-    },
-    "http-body-util 0.1.1": {
-      "name": "http-body-util",
-      "version": "0.1.1",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/http-body-util/0.1.1/download",
-          "sha256": "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "http_body_util",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "http_body_util",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "bytes 1.6.0",
-              "target": "bytes"
-            },
-            {
-              "id": "futures-core 0.3.30",
-              "target": "futures_core"
-            },
-            {
-              "id": "http 1.1.0",
-              "target": "http"
-            },
-            {
-              "id": "http-body 1.0.0",
-              "target": "http_body"
-            },
-            {
-              "id": "pin-project-lite 0.2.14",
-              "target": "pin_project_lite"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.1.1"
-      },
-      "license": "MIT"
-    },
-    "httparse 1.8.0": {
-      "name": "httparse",
-      "version": "1.8.0",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/httparse/1.8.0/download",
-          "sha256": "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "httparse",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "httparse",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default",
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "httparse 1.8.0",
-              "target": "build_script_build"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "1.8.0"
-      },
-      "build_script_attrs": {
-        "data_glob": [
-          "**"
-        ]
-      },
-      "license": "MIT/Apache-2.0"
-    },
-    "hyper 1.3.1": {
-      "name": "hyper",
-      "version": "1.3.1",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/hyper/1.3.1/download",
-          "sha256": "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "hyper",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "hyper",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "client",
-            "default",
-            "http1",
-            "http2"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "bytes 1.6.0",
-              "target": "bytes"
-            },
-            {
-              "id": "futures-channel 0.3.30",
-              "target": "futures_channel"
-            },
-            {
-              "id": "futures-util 0.3.30",
-              "target": "futures_util"
-            },
-            {
-              "id": "h2 0.4.5",
-              "target": "h2"
-            },
-            {
-              "id": "http 1.1.0",
-              "target": "http"
-            },
-            {
-              "id": "http-body 1.0.0",
-              "target": "http_body"
-            },
-            {
-              "id": "httparse 1.8.0",
-              "target": "httparse"
-            },
-            {
-              "id": "itoa 1.0.11",
-              "target": "itoa"
-            },
-            {
-              "id": "pin-project-lite 0.2.14",
-              "target": "pin_project_lite"
-            },
-            {
-              "id": "smallvec 1.13.2",
-              "target": "smallvec"
-            },
-            {
-              "id": "tokio 1.38.0",
-              "target": "tokio"
-            },
-            {
-              "id": "want 0.3.1",
-              "target": "want"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "1.3.1"
-      },
-      "license": "MIT"
-    },
-    "hyper-rustls 0.26.0": {
-      "name": "hyper-rustls",
-      "version": "0.26.0",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/hyper-rustls/0.26.0/download",
-          "sha256": "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "hyper_rustls",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "hyper_rustls",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "futures-util 0.3.30",
-              "target": "futures_util"
-            },
-            {
-              "id": "http 1.1.0",
-              "target": "http"
-            },
-            {
-              "id": "hyper 1.3.1",
-              "target": "hyper"
-            },
-            {
-              "id": "hyper-util 0.1.5",
-              "target": "hyper_util"
-            },
-            {
-              "id": "rustls 0.22.4",
-              "target": "rustls"
-            },
-            {
-              "id": "rustls-pki-types 1.7.0",
-              "target": "rustls_pki_types",
-              "alias": "pki_types"
-            },
-            {
-              "id": "tokio 1.38.0",
-              "target": "tokio"
-            },
-            {
-              "id": "tokio-rustls 0.25.0",
-              "target": "tokio_rustls"
-            },
-            {
-              "id": "tower-service 0.3.2",
-              "target": "tower_service"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.26.0"
-      },
-      "license": "Apache-2.0 OR ISC OR MIT"
-    },
-    "hyper-tls 0.6.0": {
-      "name": "hyper-tls",
-      "version": "0.6.0",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/hyper-tls/0.6.0/download",
-          "sha256": "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "hyper_tls",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "hyper_tls",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "bytes 1.6.0",
-              "target": "bytes"
-            },
-            {
-              "id": "http-body-util 0.1.1",
-              "target": "http_body_util"
-            },
-            {
-              "id": "hyper 1.3.1",
-              "target": "hyper"
-            },
-            {
-              "id": "hyper-util 0.1.5",
-              "target": "hyper_util"
-            },
-            {
-              "id": "native-tls 0.2.12",
-              "target": "native_tls"
-            },
-            {
-              "id": "tokio 1.38.0",
-              "target": "tokio"
-            },
-            {
-              "id": "tokio-native-tls 0.3.1",
-              "target": "tokio_native_tls"
-            },
-            {
-              "id": "tower-service 0.3.2",
-              "target": "tower_service"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.6.0"
-      },
-      "license": "MIT/Apache-2.0"
-    },
-    "hyper-util 0.1.5": {
-      "name": "hyper-util",
-      "version": "0.1.5",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/hyper-util/0.1.5/download",
-          "sha256": "7b875924a60b96e5d7b9ae7b066540b1dd1cbd90d1828f54c92e02a283351c56"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "hyper_util",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "hyper_util",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "client",
-            "client-legacy",
-            "default",
-            "http1",
-            "http2",
-            "tokio"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "bytes 1.6.0",
-              "target": "bytes"
-            },
-            {
-              "id": "futures-channel 0.3.30",
-              "target": "futures_channel"
-            },
-            {
-              "id": "futures-util 0.3.30",
-              "target": "futures_util"
-            },
-            {
-              "id": "http 1.1.0",
-              "target": "http"
-            },
-            {
-              "id": "http-body 1.0.0",
-              "target": "http_body"
-            },
-            {
-              "id": "hyper 1.3.1",
-              "target": "hyper"
-            },
-            {
-              "id": "pin-project-lite 0.2.14",
-              "target": "pin_project_lite"
-            },
-            {
-              "id": "socket2 0.5.7",
-              "target": "socket2"
-            },
-            {
-              "id": "tokio 1.38.0",
-              "target": "tokio"
-            },
-            {
-              "id": "tower 0.4.13",
-              "target": "tower"
-            },
-            {
-              "id": "tower-service 0.3.2",
-              "target": "tower_service"
-            },
-            {
-              "id": "tracing 0.1.40",
-              "target": "tracing"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.1.5"
-      },
-      "license": "MIT"
-    },
     "iana-time-zone 0.1.60": {
       "name": "iana-time-zone",
       "version": "0.1.60",
@@ -9614,7 +8604,7 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.0.98",
+              "id": "cc 1.1.7",
               "target": "cc"
             }
           ],
@@ -9652,57 +8642,6 @@
         "version": "1.0.1"
       },
       "license": "MIT/Apache-2.0"
-    },
-    "idna 0.5.0": {
-      "name": "idna",
-      "version": "0.5.0",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/idna/0.5.0/download",
-          "sha256": "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "idna",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "idna",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "default",
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "unicode-bidi 0.3.15",
-              "target": "unicode_bidi"
-            },
-            {
-              "id": "unicode-normalization 0.1.23",
-              "target": "unicode_normalization"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.5.0"
-      },
-      "license": "MIT OR Apache-2.0"
     },
     "impl-trait-for-tuples 0.2.2": {
       "name": "impl-trait-for-tuples",
@@ -9796,7 +8735,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "serde 1.0.203",
+              "id": "serde 1.0.204",
               "target": "serde"
             }
           ],
@@ -9864,7 +8803,7 @@
               "target": "hashbrown"
             },
             {
-              "id": "serde 1.0.203",
+              "id": "serde 1.0.204",
               "target": "serde"
             }
           ],
@@ -9874,147 +8813,6 @@
         "version": "2.2.6"
       },
       "license": "Apache-2.0 OR MIT"
-    },
-    "indicatif 0.17.8": {
-      "name": "indicatif",
-      "version": "0.17.8",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/indicatif/0.17.8/download",
-          "sha256": "763a5a8f45087d6bcea4222e7b72c291a054edf80e4ef6efd2a4979878c7bea3"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "indicatif",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "indicatif",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default",
-            "unicode-width"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "console 0.15.8",
-              "target": "console"
-            },
-            {
-              "id": "number_prefix 0.4.0",
-              "target": "number_prefix"
-            },
-            {
-              "id": "portable-atomic 1.6.0",
-              "target": "portable_atomic"
-            },
-            {
-              "id": "unicode-width 0.1.12",
-              "target": "unicode_width"
-            }
-          ],
-          "selects": {
-            "cfg(target_arch = \"wasm32\")": [
-              {
-                "id": "instant 0.1.13",
-                "target": "instant"
-              }
-            ]
-          }
-        },
-        "edition": "2021",
-        "version": "0.17.8"
-      },
-      "license": "MIT"
-    },
-    "instant 0.1.13": {
-      "name": "instant",
-      "version": "0.1.13",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/instant/0.1.13/download",
-          "sha256": "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "instant",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "instant",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "cfg-if 1.0.0",
-              "target": "cfg_if"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.1.13"
-      },
-      "license": "BSD-3-Clause"
-    },
-    "ipnet 2.9.0": {
-      "name": "ipnet",
-      "version": "2.9.0",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/ipnet/2.9.0/download",
-          "sha256": "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "ipnet",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "ipnet",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default",
-            "std"
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "2.9.0"
-      },
-      "license": "MIT OR Apache-2.0"
     },
     "is_terminal_polyfill 1.70.0": {
       "name": "is_terminal_polyfill",
@@ -10142,6 +8940,53 @@
         },
         "edition": "2018",
         "version": "0.12.1"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "itertools 0.13.0": {
+      "name": "itertools",
+      "version": "0.13.0",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/itertools/0.13.0/download",
+          "sha256": "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "itertools",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "itertools",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "use_alloc",
+            "use_std"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "either 1.12.0",
+              "target": "either"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.13.0"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -10402,13 +9247,13 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "lazy_static 1.4.0": {
+    "lazy_static 1.5.0": {
       "name": "lazy_static",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/lazy_static/1.4.0/download",
-          "sha256": "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+          "url": "https://static.crates.io/crates/lazy_static/1.5.0/download",
+          "sha256": "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
         }
       },
       "targets": [
@@ -10437,16 +9282,16 @@
         "deps": {
           "common": [
             {
-              "id": "spin 0.5.2",
+              "id": "spin 0.9.8",
               "target": "spin"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "1.4.0"
+        "version": "1.5.0"
       },
-      "license": "MIT/Apache-2.0"
+      "license": "MIT OR Apache-2.0"
     },
     "lazycell 1.3.0": {
       "name": "lazycell",
@@ -10688,7 +9533,7 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.0.98",
+              "id": "cc 1.1.7",
               "target": "cc"
             }
           ],
@@ -10811,13 +9656,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "log 0.4.21": {
+    "log 0.4.22": {
       "name": "log",
-      "version": "0.4.21",
+      "version": "0.4.22",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/log/0.4.21/download",
-          "sha256": "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+          "url": "https://static.crates.io/crates/log/0.4.22/download",
+          "sha256": "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
         }
       },
       "targets": [
@@ -10843,7 +9688,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.4.21"
+        "version": "0.4.22"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -11125,36 +9970,6 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "mime 0.3.17": {
-      "name": "mime",
-      "version": "0.3.17",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/mime/0.3.17/download",
-          "sha256": "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "mime",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "mime",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2015",
-        "version": "0.3.17"
-      },
-      "license": "MIT OR Apache-2.0"
-    },
     "minimal-lexical 0.2.1": {
       "name": "minimal-lexical",
       "version": "0.2.1",
@@ -11229,180 +10044,6 @@
         "version": "0.7.3"
       },
       "license": "MIT OR Zlib OR Apache-2.0"
-    },
-    "mio 0.8.11": {
-      "name": "mio",
-      "version": "0.8.11",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/mio/0.8.11/download",
-          "sha256": "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "mio",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "mio",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "net",
-            "os-ext",
-            "os-poll"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [],
-          "selects": {
-            "cfg(target_os = \"wasi\")": [
-              {
-                "id": "libc 0.2.155",
-                "target": "libc"
-              },
-              {
-                "id": "wasi 0.11.0+wasi-snapshot-preview1",
-                "target": "wasi"
-              }
-            ],
-            "cfg(unix)": [
-              {
-                "id": "libc 0.2.155",
-                "target": "libc"
-              }
-            ],
-            "cfg(windows)": [
-              {
-                "id": "windows-sys 0.48.0",
-                "target": "windows_sys"
-              }
-            ]
-          }
-        },
-        "edition": "2018",
-        "version": "0.8.11"
-      },
-      "license": "MIT"
-    },
-    "native-tls 0.2.12": {
-      "name": "native-tls",
-      "version": "0.2.12",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/native-tls/0.2.12/download",
-          "sha256": "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "native_tls",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "native_tls",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "native-tls 0.2.12",
-              "target": "build_script_build"
-            }
-          ],
-          "selects": {
-            "cfg(not(any(target_os = \"windows\", target_vendor = \"apple\")))": [
-              {
-                "id": "log 0.4.21",
-                "target": "log"
-              },
-              {
-                "id": "openssl 0.10.64",
-                "target": "openssl"
-              },
-              {
-                "id": "openssl-probe 0.1.5",
-                "target": "openssl_probe"
-              },
-              {
-                "id": "openssl-sys 0.9.102",
-                "target": "openssl_sys"
-              }
-            ],
-            "cfg(target_os = \"macos\")": [
-              {
-                "id": "tempfile 3.10.1",
-                "target": "tempfile"
-              }
-            ],
-            "cfg(target_os = \"windows\")": [
-              {
-                "id": "schannel 0.1.23",
-                "target": "schannel"
-              }
-            ],
-            "cfg(target_vendor = \"apple\")": [
-              {
-                "id": "libc 0.2.155",
-                "target": "libc"
-              },
-              {
-                "id": "security-framework 2.11.0",
-                "target": "security_framework"
-              },
-              {
-                "id": "security-framework-sys 2.11.0",
-                "target": "security_framework_sys"
-              }
-            ]
-          }
-        },
-        "edition": "2015",
-        "version": "0.2.12"
-      },
-      "build_script_attrs": {
-        "data_glob": [
-          "**"
-        ],
-        "link_deps": {
-          "common": [],
-          "selects": {
-            "cfg(not(any(target_os = \"windows\", target_vendor = \"apple\")))": [
-              {
-                "id": "openssl-sys 0.9.102",
-                "target": "openssl_sys"
-              }
-            ]
-          }
-        }
-      },
-      "license": "MIT OR Apache-2.0"
     },
     "nohash-hasher 0.2.0": {
       "name": "nohash-hasher",
@@ -11573,7 +10214,7 @@
         "deps": {
           "common": [
             {
-              "id": "num-bigint 0.4.5",
+              "id": "num-bigint 0.4.6",
               "target": "num_bigint"
             },
             {
@@ -11681,13 +10322,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "num-bigint 0.4.5": {
+    "num-bigint 0.4.6": {
       "name": "num-bigint",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/num-bigint/0.4.5/download",
-          "sha256": "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
+          "url": "https://static.crates.io/crates/num-bigint/0.4.6/download",
+          "sha256": "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
         }
       },
       "targets": [
@@ -11732,7 +10373,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.4.5"
+        "version": "0.4.6"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -11944,7 +10585,7 @@
         "deps": {
           "common": [
             {
-              "id": "num-bigint 0.4.5",
+              "id": "num-bigint 0.4.6",
               "target": "num_bigint"
             },
             {
@@ -12184,94 +10825,6 @@
       },
       "license": "BSD-3-Clause OR MIT OR Apache-2.0"
     },
-    "number_prefix 0.4.0": {
-      "name": "number_prefix",
-      "version": "0.4.0",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/number_prefix/0.4.0/download",
-          "sha256": "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "number_prefix",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "number_prefix",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default",
-            "std"
-          ],
-          "selects": {}
-        },
-        "edition": "2015",
-        "version": "0.4.0"
-      },
-      "license": "MIT"
-    },
-    "nums 0.1.0": {
-      "name": "nums",
-      "version": "0.1.0",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/nums/0.1.0/download",
-          "sha256": "cf3c74f925fb8cfc49a8022f2afce48a0683b70f9e439885594e84c5edbf5b01"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "nums",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "nums",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "num-bigint 0.4.5",
-              "target": "num_bigint"
-            },
-            {
-              "id": "num-integer 0.1.46",
-              "target": "num_integer"
-            },
-            {
-              "id": "num-traits 0.2.19",
-              "target": "num_traits"
-            },
-            {
-              "id": "rand 0.8.5",
-              "target": "rand"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.1.0"
-      },
-      "license": "MIT OR Apache-2.0"
-    },
     "object 0.35.0": {
       "name": "object",
       "version": "0.35.0",
@@ -12363,6 +10916,44 @@
       },
       "license": "MIT OR Apache-2.0"
     },
+    "oneshot 0.1.8": {
+      "name": "oneshot",
+      "version": "0.1.8",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/oneshot/0.1.8/download",
+          "sha256": "e296cf87e61c9cfc1a61c3c63a0f7f286ed4554e0e22be84e8a38e1d264a2a29"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "oneshot",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "oneshot",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "async",
+            "default",
+            "std"
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.1.8"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
     "opaque-debug 0.3.1": {
       "name": "opaque-debug",
       "version": "0.3.1",
@@ -12392,261 +10983,6 @@
         "version": "0.3.1"
       },
       "license": "MIT OR Apache-2.0"
-    },
-    "openssl 0.10.64": {
-      "name": "openssl",
-      "version": "0.10.64",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/openssl/0.10.64/download",
-          "sha256": "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "openssl",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "openssl",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "bitflags 2.5.0",
-              "target": "bitflags"
-            },
-            {
-              "id": "cfg-if 1.0.0",
-              "target": "cfg_if"
-            },
-            {
-              "id": "foreign-types 0.3.2",
-              "target": "foreign_types"
-            },
-            {
-              "id": "libc 0.2.155",
-              "target": "libc"
-            },
-            {
-              "id": "once_cell 1.19.0",
-              "target": "once_cell"
-            },
-            {
-              "id": "openssl 0.10.64",
-              "target": "build_script_build"
-            },
-            {
-              "id": "openssl-sys 0.9.102",
-              "target": "openssl_sys",
-              "alias": "ffi"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "openssl-macros 0.1.1",
-              "target": "openssl_macros"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "0.10.64"
-      },
-      "build_script_attrs": {
-        "data_glob": [
-          "**"
-        ],
-        "link_deps": {
-          "common": [
-            {
-              "id": "openssl-sys 0.9.102",
-              "target": "openssl_sys",
-              "alias": "ffi"
-            }
-          ],
-          "selects": {}
-        }
-      },
-      "license": "Apache-2.0"
-    },
-    "openssl-macros 0.1.1": {
-      "name": "openssl-macros",
-      "version": "0.1.1",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/openssl-macros/0.1.1/download",
-          "sha256": "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "openssl_macros",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "openssl_macros",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "proc-macro2 1.0.85",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.36",
-              "target": "quote"
-            },
-            {
-              "id": "syn 2.0.66",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.1.1"
-      },
-      "license": "MIT/Apache-2.0"
-    },
-    "openssl-probe 0.1.5": {
-      "name": "openssl-probe",
-      "version": "0.1.5",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/openssl-probe/0.1.5/download",
-          "sha256": "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "openssl_probe",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "openssl_probe",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2015",
-        "version": "0.1.5"
-      },
-      "license": "MIT/Apache-2.0"
-    },
-    "openssl-sys 0.9.102": {
-      "name": "openssl-sys",
-      "version": "0.9.102",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/openssl-sys/0.9.102/download",
-          "sha256": "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "openssl_sys",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_main",
-            "crate_root": "build/main.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "openssl_sys",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "libc 0.2.155",
-              "target": "libc"
-            },
-            {
-              "id": "openssl-sys 0.9.102",
-              "target": "build_script_main"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.9.102"
-      },
-      "build_script_attrs": {
-        "data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "cc 1.0.98",
-              "target": "cc"
-            },
-            {
-              "id": "pkg-config 0.3.30",
-              "target": "pkg_config"
-            },
-            {
-              "id": "vcpkg 0.2.15",
-              "target": "vcpkg"
-            }
-          ],
-          "selects": {}
-        },
-        "links": "openssl"
-      },
-      "license": "MIT"
     },
     "option-ext 0.2.0": {
       "name": "option-ext",
@@ -12708,16 +11044,13 @@
       },
       "license": "MIT"
     },
-    "p3-air 0.1.0": {
+    "p3-air 0.1.3-succinct": {
       "name": "p3-air",
-      "version": "0.1.0",
+      "version": "0.1.3-succinct",
       "repository": {
-        "Git": {
-          "remote": "https://github.com/Plonky3/Plonky3.git",
-          "commitish": {
-            "Rev": "3b5265f9d5af36534a46caebf0617595cfb42c5a"
-          },
-          "strip_prefix": "air"
+        "Http": {
+          "url": "https://static.crates.io/crates/p3-air/0.1.3-succinct/download",
+          "sha256": "45e909ef66fa5d77ff0fd3cb5af4b33b27fa6fb68d02b9b1e70edbc29383e565"
         }
       },
       "targets": [
@@ -12739,18 +11072,18 @@
         "deps": {
           "common": [
             {
-              "id": "p3-field 0.1.0",
+              "id": "p3-field 0.1.3-succinct",
               "target": "p3_field"
             },
             {
-              "id": "p3-matrix 0.1.0",
+              "id": "p3-matrix 0.1.3-succinct",
               "target": "p3_matrix"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.1.0"
+        "version": "0.1.3-succinct"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -12782,16 +11115,10 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "nightly-features"
-          ],
-          "selects": {}
-        },
         "deps": {
           "common": [
             {
-              "id": "num-bigint 0.4.5",
+              "id": "num-bigint 0.4.6",
               "target": "num_bigint"
             },
             {
@@ -12815,7 +11142,7 @@
               "target": "rand"
             },
             {
-              "id": "serde 1.0.203",
+              "id": "serde 1.0.204",
               "target": "serde"
             }
           ],
@@ -12826,16 +11153,82 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "p3-blake3 0.1.0": {
-      "name": "p3-blake3",
-      "version": "0.1.0",
+    "p3-baby-bear 0.1.3-succinct": {
+      "name": "p3-baby-bear",
+      "version": "0.1.3-succinct",
       "repository": {
-        "Git": {
-          "remote": "https://github.com/Plonky3/Plonky3.git",
-          "commitish": {
-            "Rev": "3b5265f9d5af36534a46caebf0617595cfb42c5a"
-          },
-          "strip_prefix": "blake3"
+        "Http": {
+          "url": "https://static.crates.io/crates/p3-baby-bear/0.1.3-succinct/download",
+          "sha256": "46965470aac1cddfe52f535424b59d52f2fffef0fdeb9dbed19da39b1d8f048a"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "p3_baby_bear",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "p3_baby_bear",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "nightly-features"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "num-bigint 0.4.6",
+              "target": "num_bigint"
+            },
+            {
+              "id": "p3-field 0.1.3-succinct",
+              "target": "p3_field"
+            },
+            {
+              "id": "p3-mds 0.1.3-succinct",
+              "target": "p3_mds"
+            },
+            {
+              "id": "p3-poseidon2 0.1.3-succinct",
+              "target": "p3_poseidon2"
+            },
+            {
+              "id": "p3-symmetric 0.1.3-succinct",
+              "target": "p3_symmetric"
+            },
+            {
+              "id": "rand 0.8.5",
+              "target": "rand"
+            },
+            {
+              "id": "serde 1.0.204",
+              "target": "serde"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.1.3-succinct"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "p3-blake3 0.1.3-succinct": {
+      "name": "p3-blake3",
+      "version": "0.1.3-succinct",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/p3-blake3/0.1.3-succinct/download",
+          "sha256": "36ef32d6ea21dd5cf9fec8a31bf0c64e6ceee8901dbf50966b83a443093c2aba"
         }
       },
       "targets": [
@@ -12867,27 +11260,24 @@
               "target": "blake3"
             },
             {
-              "id": "p3-symmetric 0.1.0",
+              "id": "p3-symmetric 0.1.3-succinct",
               "target": "p3_symmetric"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.1.0"
+        "version": "0.1.3-succinct"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "p3-bn254-fr 0.1.0": {
+    "p3-bn254-fr 0.1.3-succinct": {
       "name": "p3-bn254-fr",
-      "version": "0.1.0",
+      "version": "0.1.3-succinct",
       "repository": {
-        "Git": {
-          "remote": "https://github.com/Plonky3/Plonky3.git",
-          "commitish": {
-            "Rev": "3b5265f9d5af36534a46caebf0617595cfb42c5a"
-          },
-          "strip_prefix": "bn254-fr"
+        "Http": {
+          "url": "https://static.crates.io/crates/p3-bn254-fr/0.1.3-succinct/download",
+          "sha256": "7e3edfca6be3b3109adf8e3330baec30c3fc5f9f4d63d27aaec1b471ca51ed67"
         }
       },
       "targets": [
@@ -12913,19 +11303,19 @@
               "target": "ff"
             },
             {
-              "id": "num-bigint 0.4.5",
+              "id": "num-bigint 0.4.6",
               "target": "num_bigint"
             },
             {
-              "id": "p3-field 0.1.0",
+              "id": "p3-field 0.1.3-succinct",
               "target": "p3_field"
             },
             {
-              "id": "p3-poseidon2 0.1.0",
+              "id": "p3-poseidon2 0.1.3-succinct",
               "target": "p3_poseidon2"
             },
             {
-              "id": "p3-symmetric 0.1.0",
+              "id": "p3-symmetric 0.1.3-succinct",
               "target": "p3_symmetric"
             },
             {
@@ -12933,14 +11323,14 @@
               "target": "rand"
             },
             {
-              "id": "serde 1.0.203",
+              "id": "serde 1.0.204",
               "target": "serde"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.1.0"
+        "version": "0.1.3-succinct"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -13002,16 +11392,68 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "p3-commit 0.1.0": {
-      "name": "p3-commit",
-      "version": "0.1.0",
+    "p3-challenger 0.1.3-succinct": {
+      "name": "p3-challenger",
+      "version": "0.1.3-succinct",
       "repository": {
-        "Git": {
-          "remote": "https://github.com/kroma-network/Plonky3.git",
-          "commitish": {
-            "Rev": "3b5265f"
-          },
-          "strip_prefix": "commit"
+        "Http": {
+          "url": "https://static.crates.io/crates/p3-challenger/0.1.3-succinct/download",
+          "sha256": "a6662ea899a5d848b60c699944491d72757873b5e1fd46798e4712f90a03a4e9"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "p3_challenger",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "p3_challenger",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "p3-field 0.1.3-succinct",
+              "target": "p3_field"
+            },
+            {
+              "id": "p3-maybe-rayon 0.1.3-succinct",
+              "target": "p3_maybe_rayon"
+            },
+            {
+              "id": "p3-symmetric 0.1.3-succinct",
+              "target": "p3_symmetric"
+            },
+            {
+              "id": "p3-util 0.1.3-succinct",
+              "target": "p3_util"
+            },
+            {
+              "id": "tracing 0.1.40",
+              "target": "tracing"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.1.3-succinct"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "p3-commit 0.1.3-succinct": {
+      "name": "p3-commit",
+      "version": "0.1.3-succinct",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/p3-commit/0.1.3-succinct/download",
+          "sha256": "fc3563918b5cc44ef5280bf9b51753e70dc78802de25e3fb81ed6c94617ccb6e"
         }
       },
       "targets": [
@@ -13037,30 +11479,30 @@
               "target": "itertools"
             },
             {
-              "id": "p3-challenger 0.1.0",
+              "id": "p3-challenger 0.1.3-succinct",
               "target": "p3_challenger"
             },
             {
-              "id": "p3-field 0.1.0",
+              "id": "p3-field 0.1.3-succinct",
               "target": "p3_field"
             },
             {
-              "id": "p3-matrix 0.1.0",
+              "id": "p3-matrix 0.1.3-succinct",
               "target": "p3_matrix"
             },
             {
-              "id": "p3-util 0.1.0",
+              "id": "p3-util 0.1.3-succinct",
               "target": "p3_util"
             },
             {
-              "id": "serde 1.0.203",
+              "id": "serde 1.0.204",
               "target": "serde"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.1.0"
+        "version": "0.1.3-succinct"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -13122,6 +11564,61 @@
       },
       "license": "MIT OR Apache-2.0"
     },
+    "p3-dft 0.1.3-succinct": {
+      "name": "p3-dft",
+      "version": "0.1.3-succinct",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/p3-dft/0.1.3-succinct/download",
+          "sha256": "510095701819d83c9509fe825bbf1ebfe50426ae75149df5fe1dcfd18261323a"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "p3_dft",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "p3_dft",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "p3-field 0.1.3-succinct",
+              "target": "p3_field"
+            },
+            {
+              "id": "p3-matrix 0.1.3-succinct",
+              "target": "p3_matrix"
+            },
+            {
+              "id": "p3-maybe-rayon 0.1.3-succinct",
+              "target": "p3_maybe_rayon"
+            },
+            {
+              "id": "p3-util 0.1.3-succinct",
+              "target": "p3_util"
+            },
+            {
+              "id": "tracing 0.1.40",
+              "target": "tracing"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.1.3-succinct"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
     "p3-field 0.1.0": {
       "name": "p3-field",
       "version": "0.1.0",
@@ -13157,7 +11654,7 @@
               "target": "itertools"
             },
             {
-              "id": "num-bigint 0.4.5",
+              "id": "num-bigint 0.4.6",
               "target": "num_bigint"
             },
             {
@@ -13173,7 +11670,7 @@
               "target": "rand"
             },
             {
-              "id": "serde 1.0.203",
+              "id": "serde 1.0.204",
               "target": "serde"
             }
           ],
@@ -13184,16 +11681,72 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "p3-fri 0.1.0": {
-      "name": "p3-fri",
-      "version": "0.1.0",
+    "p3-field 0.1.3-succinct": {
+      "name": "p3-field",
+      "version": "0.1.3-succinct",
       "repository": {
-        "Git": {
-          "remote": "https://github.com/kroma-network/Plonky3.git",
-          "commitish": {
-            "Rev": "3b5265f"
-          },
-          "strip_prefix": "fri"
+        "Http": {
+          "url": "https://static.crates.io/crates/p3-field/0.1.3-succinct/download",
+          "sha256": "61f1977a0a65789f719aa824119c332c4676b000bdbfe94d312fb6244a70d601"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "p3_field",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "p3_field",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "itertools 0.12.1",
+              "target": "itertools"
+            },
+            {
+              "id": "num-bigint 0.4.6",
+              "target": "num_bigint"
+            },
+            {
+              "id": "num-traits 0.2.19",
+              "target": "num_traits"
+            },
+            {
+              "id": "p3-util 0.1.3-succinct",
+              "target": "p3_util"
+            },
+            {
+              "id": "rand 0.8.5",
+              "target": "rand"
+            },
+            {
+              "id": "serde 1.0.204",
+              "target": "serde"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.1.3-succinct"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "p3-fri 0.1.3-succinct": {
+      "name": "p3-fri",
+      "version": "0.1.3-succinct",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/p3-fri/0.1.3-succinct/download",
+          "sha256": "c22ddb958f200d9289cc73ff68847b0167ca0c14557b791dd9e318f98c2d1b28"
         }
       },
       "targets": [
@@ -13219,39 +11772,39 @@
               "target": "itertools"
             },
             {
-              "id": "p3-challenger 0.1.0",
+              "id": "p3-challenger 0.1.3-succinct",
               "target": "p3_challenger"
             },
             {
-              "id": "p3-commit 0.1.0",
+              "id": "p3-commit 0.1.3-succinct",
               "target": "p3_commit"
             },
             {
-              "id": "p3-dft 0.1.0",
+              "id": "p3-dft 0.1.3-succinct",
               "target": "p3_dft"
             },
             {
-              "id": "p3-field 0.1.0",
+              "id": "p3-field 0.1.3-succinct",
               "target": "p3_field"
             },
             {
-              "id": "p3-interpolation 0.1.0",
+              "id": "p3-interpolation 0.1.3-succinct",
               "target": "p3_interpolation"
             },
             {
-              "id": "p3-matrix 0.1.0",
+              "id": "p3-matrix 0.1.3-succinct",
               "target": "p3_matrix"
             },
             {
-              "id": "p3-maybe-rayon 0.1.0",
+              "id": "p3-maybe-rayon 0.1.3-succinct",
               "target": "p3_maybe_rayon"
             },
             {
-              "id": "p3-util 0.1.0",
+              "id": "p3-util 0.1.3-succinct",
               "target": "p3_util"
             },
             {
-              "id": "serde 1.0.203",
+              "id": "serde 1.0.204",
               "target": "serde"
             },
             {
@@ -13262,20 +11815,17 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.1.0"
+        "version": "0.1.3-succinct"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "p3-interpolation 0.1.0": {
+    "p3-interpolation 0.1.3-succinct": {
       "name": "p3-interpolation",
-      "version": "0.1.0",
+      "version": "0.1.3-succinct",
       "repository": {
-        "Git": {
-          "remote": "https://github.com/kroma-network/Plonky3.git",
-          "commitish": {
-            "Rev": "3b5265f"
-          },
-          "strip_prefix": "interpolation"
+        "Http": {
+          "url": "https://static.crates.io/crates/p3-interpolation/0.1.3-succinct/download",
+          "sha256": "d032cda212f6b408d7d5b0b9a8270a9455acb93742fe55a0880d82be8e90e500"
         }
       },
       "targets": [
@@ -13297,35 +11847,32 @@
         "deps": {
           "common": [
             {
-              "id": "p3-field 0.1.0",
+              "id": "p3-field 0.1.3-succinct",
               "target": "p3_field"
             },
             {
-              "id": "p3-matrix 0.1.0",
+              "id": "p3-matrix 0.1.3-succinct",
               "target": "p3_matrix"
             },
             {
-              "id": "p3-util 0.1.0",
+              "id": "p3-util 0.1.3-succinct",
               "target": "p3_util"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.1.0"
+        "version": "0.1.3-succinct"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "p3-keccak 0.1.0": {
+    "p3-keccak 0.1.3-succinct": {
       "name": "p3-keccak",
-      "version": "0.1.0",
+      "version": "0.1.3-succinct",
       "repository": {
-        "Git": {
-          "remote": "https://github.com/Plonky3/Plonky3.git",
-          "commitish": {
-            "Rev": "3b5265f9d5af36534a46caebf0617595cfb42c5a"
-          },
-          "strip_prefix": "keccak"
+        "Http": {
+          "url": "https://static.crates.io/crates/p3-keccak/0.1.3-succinct/download",
+          "sha256": "7c56abdd5a8a780049d2f8e92cea1df57b55a2ef50a40d1103f2732f7a00e4b1"
         }
       },
       "targets": [
@@ -13347,7 +11894,7 @@
         "deps": {
           "common": [
             {
-              "id": "p3-symmetric 0.1.0",
+              "id": "p3-symmetric 0.1.3-succinct",
               "target": "p3_symmetric"
             },
             {
@@ -13358,20 +11905,17 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.1.0"
+        "version": "0.1.3-succinct"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "p3-keccak-air 0.1.0": {
+    "p3-keccak-air 0.1.3-succinct": {
       "name": "p3-keccak-air",
-      "version": "0.1.0",
+      "version": "0.1.3-succinct",
       "repository": {
-        "Git": {
-          "remote": "https://github.com/Plonky3/Plonky3.git",
-          "commitish": {
-            "Rev": "3b5265f9d5af36534a46caebf0617595cfb42c5a"
-          },
-          "strip_prefix": "keccak-air"
+        "Http": {
+          "url": "https://static.crates.io/crates/p3-keccak-air/0.1.3-succinct/download",
+          "sha256": "e8398f1694ccc38513df0b8cab5f9ef7325423f27cd9e4fa20bdc77d5079cf1b"
         }
       },
       "targets": [
@@ -13393,34 +11937,42 @@
         "deps": {
           "common": [
             {
-              "id": "p3-air 0.1.0",
+              "id": "p3-air 0.1.3-succinct",
               "target": "p3_air"
             },
             {
-              "id": "p3-field 0.1.0",
+              "id": "p3-field 0.1.3-succinct",
               "target": "p3_field"
             },
             {
-              "id": "p3-matrix 0.1.0",
+              "id": "p3-matrix 0.1.3-succinct",
               "target": "p3_matrix"
             },
             {
-              "id": "p3-maybe-rayon 0.1.0",
+              "id": "p3-maybe-rayon 0.1.3-succinct",
               "target": "p3_maybe_rayon"
             },
             {
-              "id": "p3-util 0.1.0",
+              "id": "p3-util 0.1.3-succinct",
               "target": "p3_util"
             },
             {
               "id": "tracing 0.1.40",
               "target": "tracing"
+            },
+            {
+              "id": "tracing-forest 0.1.6",
+              "target": "tracing_forest"
+            },
+            {
+              "id": "tracing-subscriber 0.3.18",
+              "target": "tracing_subscriber"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.1.0"
+        "version": "0.1.3-succinct"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -13475,7 +12027,7 @@
               "target": "rand"
             },
             {
-              "id": "serde 1.0.203",
+              "id": "serde 1.0.204",
               "target": "serde"
             },
             {
@@ -13490,6 +12042,69 @@
       },
       "license": "MIT OR Apache-2.0"
     },
+    "p3-matrix 0.1.3-succinct": {
+      "name": "p3-matrix",
+      "version": "0.1.3-succinct",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/p3-matrix/0.1.3-succinct/download",
+          "sha256": "d548ee0b834f8e2ebc5037073acd101a3b0ca41a2d1d28a15ba0ccd9059495b0"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "p3_matrix",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "p3_matrix",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "itertools 0.12.1",
+              "target": "itertools"
+            },
+            {
+              "id": "p3-field 0.1.3-succinct",
+              "target": "p3_field"
+            },
+            {
+              "id": "p3-maybe-rayon 0.1.3-succinct",
+              "target": "p3_maybe_rayon"
+            },
+            {
+              "id": "p3-util 0.1.3-succinct",
+              "target": "p3_util"
+            },
+            {
+              "id": "rand 0.8.5",
+              "target": "rand"
+            },
+            {
+              "id": "serde 1.0.204",
+              "target": "serde"
+            },
+            {
+              "id": "tracing 0.1.40",
+              "target": "tracing"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.1.3-succinct"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
     "p3-maybe-rayon 0.1.0": {
       "name": "p3-maybe-rayon",
       "version": "0.1.0",
@@ -13500,6 +12115,36 @@
             "Rev": "3b5265f"
           },
           "strip_prefix": "maybe-rayon"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "p3_maybe_rayon",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "p3_maybe_rayon",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2021",
+        "version": "0.1.0"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "p3-maybe-rayon 0.1.3-succinct": {
+      "name": "p3-maybe-rayon",
+      "version": "0.1.3-succinct",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/p3-maybe-rayon/0.1.3-succinct/download",
+          "sha256": "55f5575d3d61bedb3e05681abb0f36b8bb339d65aa395d50756bfa64e9cd3f46"
         }
       },
       "targets": [
@@ -13535,7 +12180,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.1.0"
+        "version": "0.1.3-succinct"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -13605,16 +12250,76 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "p3-merkle-tree 0.1.0": {
-      "name": "p3-merkle-tree",
-      "version": "0.1.0",
+    "p3-mds 0.1.3-succinct": {
+      "name": "p3-mds",
+      "version": "0.1.3-succinct",
       "repository": {
-        "Git": {
-          "remote": "https://github.com/Plonky3/Plonky3.git",
-          "commitish": {
-            "Rev": "3b5265f9d5af36534a46caebf0617595cfb42c5a"
-          },
-          "strip_prefix": "merkle-tree"
+        "Http": {
+          "url": "https://static.crates.io/crates/p3-mds/0.1.3-succinct/download",
+          "sha256": "6a6e57ed310d59245f93e24ee805ea7aa16fc9c505551b76a15f5e50f29d177e"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "p3_mds",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "p3_mds",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "itertools 0.12.1",
+              "target": "itertools"
+            },
+            {
+              "id": "p3-dft 0.1.3-succinct",
+              "target": "p3_dft"
+            },
+            {
+              "id": "p3-field 0.1.3-succinct",
+              "target": "p3_field"
+            },
+            {
+              "id": "p3-matrix 0.1.3-succinct",
+              "target": "p3_matrix"
+            },
+            {
+              "id": "p3-symmetric 0.1.3-succinct",
+              "target": "p3_symmetric"
+            },
+            {
+              "id": "p3-util 0.1.3-succinct",
+              "target": "p3_util"
+            },
+            {
+              "id": "rand 0.8.5",
+              "target": "rand"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.1.3-succinct"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "p3-merkle-tree 0.1.3-succinct": {
+      "name": "p3-merkle-tree",
+      "version": "0.1.3-succinct",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/p3-merkle-tree/0.1.3-succinct/download",
+          "sha256": "af46b41cba75d483ec8a553cbab1d2d794935ae3403d75394acfa4fb2c977cce"
         }
       },
       "targets": [
@@ -13640,31 +12345,31 @@
               "target": "itertools"
             },
             {
-              "id": "p3-commit 0.1.0",
+              "id": "p3-commit 0.1.3-succinct",
               "target": "p3_commit"
             },
             {
-              "id": "p3-field 0.1.0",
+              "id": "p3-field 0.1.3-succinct",
               "target": "p3_field"
             },
             {
-              "id": "p3-matrix 0.1.0",
+              "id": "p3-matrix 0.1.3-succinct",
               "target": "p3_matrix"
             },
             {
-              "id": "p3-maybe-rayon 0.1.0",
+              "id": "p3-maybe-rayon 0.1.3-succinct",
               "target": "p3_maybe_rayon"
             },
             {
-              "id": "p3-symmetric 0.1.0",
+              "id": "p3-symmetric 0.1.3-succinct",
               "target": "p3_symmetric"
             },
             {
-              "id": "p3-util 0.1.0",
+              "id": "p3-util 0.1.3-succinct",
               "target": "p3_util"
             },
             {
-              "id": "serde 1.0.203",
+              "id": "serde 1.0.204",
               "target": "serde"
             },
             {
@@ -13675,7 +12380,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.1.0"
+        "version": "0.1.3-succinct"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -13737,6 +12442,61 @@
       },
       "license": "MIT OR Apache-2.0"
     },
+    "p3-poseidon2 0.1.3-succinct": {
+      "name": "p3-poseidon2",
+      "version": "0.1.3-succinct",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/p3-poseidon2/0.1.3-succinct/download",
+          "sha256": "adaba6f14c197203530e233badce0ca1126ba3bf3c9ff766505b497bdad0bee1"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "p3_poseidon2",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "p3_poseidon2",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "gcd 2.3.0",
+              "target": "gcd"
+            },
+            {
+              "id": "p3-field 0.1.3-succinct",
+              "target": "p3_field"
+            },
+            {
+              "id": "p3-mds 0.1.3-succinct",
+              "target": "p3_mds"
+            },
+            {
+              "id": "p3-symmetric 0.1.3-succinct",
+              "target": "p3_symmetric"
+            },
+            {
+              "id": "rand 0.8.5",
+              "target": "rand"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.1.3-succinct"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
     "p3-symmetric 0.1.0": {
       "name": "p3-symmetric",
       "version": "0.1.0",
@@ -13776,7 +12536,7 @@
               "target": "p3_field"
             },
             {
-              "id": "serde 1.0.203",
+              "id": "serde 1.0.204",
               "target": "serde"
             }
           ],
@@ -13787,16 +12547,60 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "p3-uni-stark 0.1.0": {
-      "name": "p3-uni-stark",
-      "version": "0.1.0",
+    "p3-symmetric 0.1.3-succinct": {
+      "name": "p3-symmetric",
+      "version": "0.1.3-succinct",
       "repository": {
-        "Git": {
-          "remote": "https://github.com/Plonky3/Plonky3.git",
-          "commitish": {
-            "Rev": "3b5265f9d5af36534a46caebf0617595cfb42c5a"
-          },
-          "strip_prefix": "uni-stark"
+        "Http": {
+          "url": "https://static.crates.io/crates/p3-symmetric/0.1.3-succinct/download",
+          "sha256": "57ecc4282566eb14f48be7707f6745c4dff6be664984d59ec0fb1849cd82b5c2"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "p3_symmetric",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "p3_symmetric",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "itertools 0.12.1",
+              "target": "itertools"
+            },
+            {
+              "id": "p3-field 0.1.3-succinct",
+              "target": "p3_field"
+            },
+            {
+              "id": "serde 1.0.204",
+              "target": "serde"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.1.3-succinct"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "p3-uni-stark 0.1.3-succinct": {
+      "name": "p3-uni-stark",
+      "version": "0.1.3-succinct",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/p3-uni-stark/0.1.3-succinct/download",
+          "sha256": "1af5c038b22b058bf1d49fb1ea3dd6c240a3e46c3278fde5c444e0034f7ffe37"
         }
       },
       "targets": [
@@ -13822,50 +12626,62 @@
               "target": "itertools"
             },
             {
-              "id": "p3-air 0.1.0",
+              "id": "p3-air 0.1.3-succinct",
               "target": "p3_air"
             },
             {
-              "id": "p3-challenger 0.1.0",
+              "id": "p3-challenger 0.1.3-succinct",
               "target": "p3_challenger"
             },
             {
-              "id": "p3-commit 0.1.0",
+              "id": "p3-commit 0.1.3-succinct",
               "target": "p3_commit"
             },
             {
-              "id": "p3-dft 0.1.0",
+              "id": "p3-dft 0.1.3-succinct",
               "target": "p3_dft"
             },
             {
-              "id": "p3-field 0.1.0",
+              "id": "p3-field 0.1.3-succinct",
               "target": "p3_field"
             },
             {
-              "id": "p3-matrix 0.1.0",
+              "id": "p3-matrix 0.1.3-succinct",
               "target": "p3_matrix"
             },
             {
-              "id": "p3-maybe-rayon 0.1.0",
+              "id": "p3-maybe-rayon 0.1.3-succinct",
               "target": "p3_maybe_rayon"
             },
             {
-              "id": "p3-util 0.1.0",
+              "id": "p3-util 0.1.3-succinct",
               "target": "p3_util"
             },
             {
-              "id": "serde 1.0.203",
+              "id": "postcard 1.0.8",
+              "target": "postcard"
+            },
+            {
+              "id": "serde 1.0.204",
               "target": "serde"
             },
             {
               "id": "tracing 0.1.40",
               "target": "tracing"
+            },
+            {
+              "id": "tracing-forest 0.1.6",
+              "target": "tracing_forest"
+            },
+            {
+              "id": "tracing-subscriber 0.3.18",
+              "target": "tracing_subscriber"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.1.0"
+        "version": "0.1.3-succinct"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -13900,7 +12716,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.203",
+              "id": "serde 1.0.204",
               "target": "serde"
             }
           ],
@@ -13908,6 +12724,45 @@
         },
         "edition": "2021",
         "version": "0.1.0"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "p3-util 0.1.3-succinct": {
+      "name": "p3-util",
+      "version": "0.1.3-succinct",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/p3-util/0.1.3-succinct/download",
+          "sha256": "79f3fef0e00d9d7246385e758c4cd39b4efcbbcea31752471491ab502631385e"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "p3_util",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "p3_util",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "serde 1.0.204",
+              "target": "serde"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.1.3-succinct"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -14001,7 +12856,7 @@
               "target": "rand"
             },
             {
-              "id": "serde 1.0.203",
+              "id": "serde 1.0.204",
               "target": "serde"
             }
           ],
@@ -14313,7 +13168,7 @@
               "target": "group"
             },
             {
-              "id": "lazy_static 1.4.0",
+              "id": "lazy_static 1.5.0",
               "target": "lazy_static"
             },
             {
@@ -14387,7 +13242,7 @@
               "target": "group"
             },
             {
-              "id": "lazy_static 1.4.0",
+              "id": "lazy_static 1.5.0",
               "target": "lazy_static"
             },
             {
@@ -14462,130 +13317,6 @@
         ]
       },
       "license": "MIT OR Apache-2.0"
-    },
-    "percent-encoding 2.3.1": {
-      "name": "percent-encoding",
-      "version": "2.3.1",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/percent-encoding/2.3.1/download",
-          "sha256": "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "percent_encoding",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "percent_encoding",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "default",
-            "std"
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "2.3.1"
-      },
-      "license": "MIT OR Apache-2.0"
-    },
-    "pin-project 1.1.5": {
-      "name": "pin-project",
-      "version": "1.1.5",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/pin-project/1.1.5/download",
-          "sha256": "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "pin_project",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "pin_project",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2021",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "pin-project-internal 1.1.5",
-              "target": "pin_project_internal"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "1.1.5"
-      },
-      "license": "Apache-2.0 OR MIT"
-    },
-    "pin-project-internal 1.1.5": {
-      "name": "pin-project-internal",
-      "version": "1.1.5",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/pin-project-internal/1.1.5/download",
-          "sha256": "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "pin_project_internal",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "pin_project_internal",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "proc-macro2 1.0.85",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.36",
-              "target": "quote"
-            },
-            {
-              "id": "syn 2.0.66",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "1.1.5"
-      },
-      "license": "Apache-2.0 OR MIT"
     },
     "pin-project-lite 0.2.14": {
       "name": "pin-project-lite",
@@ -14697,36 +13428,6 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "pkg-config 0.3.30": {
-      "name": "pkg-config",
-      "version": "0.3.30",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/pkg-config/0.3.30/download",
-          "sha256": "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "pkg_config",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "pkg_config",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2015",
-        "version": "0.3.30"
-      },
-      "license": "MIT OR Apache-2.0"
-    },
     "platforms 3.4.0": {
       "name": "platforms",
       "version": "3.4.0",
@@ -14791,19 +13492,19 @@
               "target": "ff"
             },
             {
-              "id": "p3-bn254-fr 0.1.0",
+              "id": "p3-bn254-fr 0.1.3-succinct",
               "target": "p3_bn254_fr"
             },
             {
-              "id": "p3-field 0.1.0",
+              "id": "p3-field 0.1.3-succinct",
               "target": "p3_field"
             },
             {
-              "id": "p3-poseidon2 0.1.0",
+              "id": "p3-poseidon2 0.1.3-succinct",
               "target": "p3_poseidon2"
             },
             {
-              "id": "p3-symmetric 0.1.0",
+              "id": "p3-symmetric 0.1.3-succinct",
               "target": "p3_symmetric"
             },
             {
@@ -14817,66 +13518,6 @@
         "version": "0.0.1"
       },
       "license": "MIT OR Apache-2.0"
-    },
-    "portable-atomic 1.6.0": {
-      "name": "portable-atomic",
-      "version": "1.6.0",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/portable-atomic/1.6.0/download",
-          "sha256": "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "portable_atomic",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "portable_atomic",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default",
-            "fallback"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "portable-atomic 1.6.0",
-              "target": "build_script_build"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "1.6.0"
-      },
-      "build_script_attrs": {
-        "data_glob": [
-          "**"
-        ]
-      },
-      "license": "Apache-2.0 OR MIT"
     },
     "poseidon 0.2.0": {
       "name": "poseidon",
@@ -14920,6 +13561,60 @@
         },
         "edition": "2021",
         "version": "0.2.0"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "postcard 1.0.8": {
+      "name": "postcard",
+      "version": "1.0.8",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/postcard/1.0.8/download",
+          "sha256": "a55c51ee6c0db07e68448e336cf8ea4131a620edefebf9893e759b2d793420f8"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "postcard",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "postcard",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "alloc",
+            "embedded-io"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "cobs 0.2.3",
+              "target": "cobs"
+            },
+            {
+              "id": "embedded-io 0.4.0",
+              "target": "embedded_io"
+            },
+            {
+              "id": "serde 1.0.204",
+              "target": "serde"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "1.0.8"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -15201,6 +13896,68 @@
         "data_glob": [
           "**"
         ]
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "psm 0.1.21": {
+      "name": "psm",
+      "version": "0.1.21",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/psm/0.1.21/download",
+          "sha256": "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "psm",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "psm",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "psm 0.1.21",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2015",
+        "version": "0.1.21"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "cc 1.1.7",
+              "target": "cc"
+            }
+          ],
+          "selects": {}
+        }
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -16150,233 +14907,6 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "reqwest 0.12.4": {
-      "name": "reqwest",
-      "version": "0.12.4",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/reqwest/0.12.4/download",
-          "sha256": "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "reqwest",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "reqwest",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "__rustls",
-            "__tls",
-            "charset",
-            "default",
-            "default-tls",
-            "h2",
-            "http2",
-            "macos-system-configuration",
-            "rustls-pki-types",
-            "rustls-tls",
-            "rustls-tls-webpki-roots",
-            "stream",
-            "trust-dns"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "base64 0.22.1",
-              "target": "base64"
-            },
-            {
-              "id": "bytes 1.6.0",
-              "target": "bytes"
-            },
-            {
-              "id": "futures-core 0.3.30",
-              "target": "futures_core"
-            },
-            {
-              "id": "futures-util 0.3.30",
-              "target": "futures_util"
-            },
-            {
-              "id": "http 1.1.0",
-              "target": "http"
-            },
-            {
-              "id": "serde 1.0.203",
-              "target": "serde"
-            },
-            {
-              "id": "serde_urlencoded 0.7.1",
-              "target": "serde_urlencoded"
-            },
-            {
-              "id": "sync_wrapper 0.1.2",
-              "target": "sync_wrapper"
-            },
-            {
-              "id": "tower-service 0.3.2",
-              "target": "tower_service"
-            },
-            {
-              "id": "url 2.5.0",
-              "target": "url"
-            }
-          ],
-          "selects": {
-            "cfg(not(target_arch = \"wasm32\"))": [
-              {
-                "id": "encoding_rs 0.8.34",
-                "target": "encoding_rs"
-              },
-              {
-                "id": "h2 0.4.5",
-                "target": "h2"
-              },
-              {
-                "id": "http-body 1.0.0",
-                "target": "http_body"
-              },
-              {
-                "id": "http-body-util 0.1.1",
-                "target": "http_body_util"
-              },
-              {
-                "id": "hyper 1.3.1",
-                "target": "hyper"
-              },
-              {
-                "id": "hyper-rustls 0.26.0",
-                "target": "hyper_rustls"
-              },
-              {
-                "id": "hyper-tls 0.6.0",
-                "target": "hyper_tls"
-              },
-              {
-                "id": "hyper-util 0.1.5",
-                "target": "hyper_util"
-              },
-              {
-                "id": "ipnet 2.9.0",
-                "target": "ipnet"
-              },
-              {
-                "id": "log 0.4.21",
-                "target": "log"
-              },
-              {
-                "id": "mime 0.3.17",
-                "target": "mime"
-              },
-              {
-                "id": "native-tls 0.2.12",
-                "target": "native_tls",
-                "alias": "native_tls_crate"
-              },
-              {
-                "id": "once_cell 1.19.0",
-                "target": "once_cell"
-              },
-              {
-                "id": "percent-encoding 2.3.1",
-                "target": "percent_encoding"
-              },
-              {
-                "id": "pin-project-lite 0.2.14",
-                "target": "pin_project_lite"
-              },
-              {
-                "id": "rustls 0.22.4",
-                "target": "rustls"
-              },
-              {
-                "id": "rustls-pemfile 2.1.2",
-                "target": "rustls_pemfile"
-              },
-              {
-                "id": "rustls-pki-types 1.7.0",
-                "target": "rustls_pki_types"
-              },
-              {
-                "id": "tokio 1.38.0",
-                "target": "tokio"
-              },
-              {
-                "id": "tokio-native-tls 0.3.1",
-                "target": "tokio_native_tls"
-              },
-              {
-                "id": "tokio-rustls 0.25.0",
-                "target": "tokio_rustls"
-              },
-              {
-                "id": "tokio-util 0.7.11",
-                "target": "tokio_util"
-              },
-              {
-                "id": "webpki-roots 0.26.1",
-                "target": "webpki_roots"
-              }
-            ],
-            "cfg(target_arch = \"wasm32\")": [
-              {
-                "id": "js-sys 0.3.69",
-                "target": "js_sys"
-              },
-              {
-                "id": "serde_json 1.0.117",
-                "target": "serde_json"
-              },
-              {
-                "id": "wasm-bindgen 0.2.92",
-                "target": "wasm_bindgen"
-              },
-              {
-                "id": "wasm-bindgen-futures 0.4.42",
-                "target": "wasm_bindgen_futures"
-              },
-              {
-                "id": "wasm-streams 0.4.0",
-                "target": "wasm_streams"
-              },
-              {
-                "id": "web-sys 0.3.69",
-                "target": "web_sys"
-              }
-            ],
-            "cfg(target_os = \"macos\")": [
-              {
-                "id": "system-configuration 0.5.1",
-                "target": "system_configuration"
-              }
-            ],
-            "cfg(windows)": [
-              {
-                "id": "winreg 0.52.0",
-                "target": "winreg"
-              }
-            ]
-          }
-        },
-        "edition": "2021",
-        "version": "0.12.4"
-      },
-      "license": "MIT OR Apache-2.0"
-    },
     "rfc6979 0.4.0": {
       "name": "rfc6979",
       "version": "0.4.0",
@@ -16420,130 +14950,19 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "ring 0.17.8": {
-      "name": "ring",
-      "version": "0.17.8",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/ring/0.17.8/download",
-          "sha256": "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "ring",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "ring",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "default",
-            "dev_urandom_fallback"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "cfg-if 1.0.0",
-              "target": "cfg_if"
-            },
-            {
-              "id": "getrandom 0.2.15",
-              "target": "getrandom"
-            },
-            {
-              "id": "ring 0.17.8",
-              "target": "build_script_build"
-            },
-            {
-              "id": "untrusted 0.9.0",
-              "target": "untrusted"
-            }
-          ],
-          "selects": {
-            "cfg(all(any(target_os = \"android\", target_os = \"linux\"), any(target_arch = \"aarch64\", target_arch = \"arm\")))": [
-              {
-                "id": "libc 0.2.155",
-                "target": "libc"
-              }
-            ],
-            "cfg(all(target_arch = \"aarch64\", target_os = \"windows\"))": [
-              {
-                "id": "windows-sys 0.52.0",
-                "target": "windows_sys"
-              }
-            ],
-            "cfg(any(target_arch = \"aarch64\", target_arch = \"arm\", target_arch = \"x86\", target_arch = \"x86_64\"))": [
-              {
-                "id": "spin 0.9.8",
-                "target": "spin"
-              }
-            ]
-          }
-        },
-        "edition": "2021",
-        "version": "0.17.8"
-      },
-      "build_script_attrs": {
-        "data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "cc 1.0.98",
-              "target": "cc"
-            }
-          ],
-          "selects": {}
-        },
-        "build_script_env": {
-          "common": {
-            "CARGO_MANIFEST_LINKS": "ring_core_0_17_8"
-          },
-          "selects": {}
-        },
-        "links": "ring_core_0_17_8"
-      },
-      "license": null
-    },
-    "rrs-lib 0.1.0": {
-      "name": "rrs-lib",
+    "rrs-succinct 0.1.0": {
+      "name": "rrs-succinct",
       "version": "0.1.0",
       "repository": {
-        "Git": {
-          "remote": "https://github.com/GregAC/rrs.git",
-          "commitish": {
-            "Branch": "main"
-          },
-          "strip_prefix": "rrs-lib"
+        "Http": {
+          "url": "https://static.crates.io/crates/rrs-succinct/0.1.0/download",
+          "sha256": "3372685893a9f67d18e98e792d690017287fd17379a83d798d958e517d380fa9"
         }
       },
       "targets": [
         {
           "Library": {
-            "crate_name": "rrs_lib",
+            "crate_name": "rrs_succinct",
             "crate_root": "src/lib.rs",
             "srcs": [
               "**/*.rs"
@@ -16551,7 +14970,7 @@
           }
         }
       ],
-      "library_target_name": "rrs_lib",
+      "library_target_name": "rrs_succinct",
       "common_attrs": {
         "compile_data_glob": [
           "**"
@@ -16797,248 +15216,6 @@
       },
       "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
     },
-    "rustls 0.22.4": {
-      "name": "rustls",
-      "version": "0.22.4",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/rustls/0.22.4/download",
-          "sha256": "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "rustls",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "rustls",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default",
-            "log",
-            "logging",
-            "ring",
-            "tls12"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "log 0.4.21",
-              "target": "log"
-            },
-            {
-              "id": "ring 0.17.8",
-              "target": "ring"
-            },
-            {
-              "id": "rustls 0.22.4",
-              "target": "build_script_build"
-            },
-            {
-              "id": "rustls-pki-types 1.7.0",
-              "target": "rustls_pki_types",
-              "alias": "pki_types"
-            },
-            {
-              "id": "rustls-webpki 0.102.4",
-              "target": "webpki"
-            },
-            {
-              "id": "subtle 2.5.0",
-              "target": "subtle"
-            },
-            {
-              "id": "zeroize 1.8.1",
-              "target": "zeroize"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.22.4"
-      },
-      "build_script_attrs": {
-        "data_glob": [
-          "**"
-        ],
-        "link_deps": {
-          "common": [
-            {
-              "id": "ring 0.17.8",
-              "target": "ring"
-            }
-          ],
-          "selects": {}
-        }
-      },
-      "license": "Apache-2.0 OR ISC OR MIT"
-    },
-    "rustls-pemfile 2.1.2": {
-      "name": "rustls-pemfile",
-      "version": "2.1.2",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/rustls-pemfile/2.1.2/download",
-          "sha256": "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "rustls_pemfile",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "rustls_pemfile",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default",
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "base64 0.22.1",
-              "target": "base64"
-            },
-            {
-              "id": "rustls-pki-types 1.7.0",
-              "target": "rustls_pki_types",
-              "alias": "pki_types"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "2.1.2"
-      },
-      "license": "Apache-2.0 OR ISC OR MIT"
-    },
-    "rustls-pki-types 1.7.0": {
-      "name": "rustls-pki-types",
-      "version": "1.7.0",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/rustls-pki-types/1.7.0/download",
-          "sha256": "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "rustls_pki_types",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "rustls_pki_types",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "default",
-            "std"
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "1.7.0"
-      },
-      "license": "MIT OR Apache-2.0"
-    },
-    "rustls-webpki 0.102.4": {
-      "name": "rustls-webpki",
-      "version": "0.102.4",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/rustls-webpki/0.102.4/download",
-          "sha256": "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "webpki",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "webpki",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "ring",
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "ring 0.17.8",
-              "target": "ring"
-            },
-            {
-              "id": "rustls-pki-types 1.7.0",
-              "target": "rustls_pki_types",
-              "alias": "pki_types"
-            },
-            {
-              "id": "untrusted 0.9.0",
-              "target": "untrusted"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.102.4"
-      },
-      "license": "ISC"
-    },
     "rustversion 1.0.17": {
       "name": "rustversion",
       "version": "1.0.17",
@@ -17276,45 +15453,6 @@
       },
       "license": "Apache-2.0"
     },
-    "schannel 0.1.23": {
-      "name": "schannel",
-      "version": "0.1.23",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/schannel/0.1.23/download",
-          "sha256": "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "schannel",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "schannel",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "windows-sys 0.52.0",
-              "target": "windows_sys"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.1.23"
-      },
-      "license": "MIT"
-    },
     "scopeguard 1.2.0": {
       "name": "scopeguard",
       "version": "1.2.0",
@@ -17442,122 +15580,6 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "security-framework 2.11.0": {
-      "name": "security-framework",
-      "version": "2.11.0",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/security-framework/2.11.0/download",
-          "sha256": "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "security_framework",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "security_framework",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "OSX_10_10",
-            "OSX_10_11",
-            "OSX_10_9",
-            "default"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "bitflags 2.5.0",
-              "target": "bitflags"
-            },
-            {
-              "id": "core-foundation 0.9.4",
-              "target": "core_foundation"
-            },
-            {
-              "id": "core-foundation-sys 0.8.6",
-              "target": "core_foundation_sys"
-            },
-            {
-              "id": "libc 0.2.155",
-              "target": "libc"
-            },
-            {
-              "id": "security-framework-sys 2.11.0",
-              "target": "security_framework_sys"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "2.11.0"
-      },
-      "license": "MIT OR Apache-2.0"
-    },
-    "security-framework-sys 2.11.0": {
-      "name": "security-framework-sys",
-      "version": "2.11.0",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/security-framework-sys/2.11.0/download",
-          "sha256": "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "security_framework_sys",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "security_framework_sys",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "OSX_10_10",
-            "OSX_10_11",
-            "OSX_10_9",
-            "default"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "core-foundation-sys 0.8.6",
-              "target": "core_foundation_sys"
-            },
-            {
-              "id": "libc 0.2.155",
-              "target": "libc"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "2.11.0"
-      },
-      "license": "MIT OR Apache-2.0"
-    },
     "semver 1.0.23": {
       "name": "semver",
       "version": "1.0.23",
@@ -17618,13 +15640,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "serde 1.0.203": {
+    "serde 1.0.204": {
       "name": "serde",
-      "version": "1.0.203",
+      "version": "1.0.204",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/serde/1.0.203/download",
-          "sha256": "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+          "url": "https://static.crates.io/crates/serde/1.0.204/download",
+          "sha256": "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
         }
       },
       "targets": [
@@ -17666,7 +15688,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.203",
+              "id": "serde 1.0.204",
               "target": "build_script_build"
             }
           ],
@@ -17676,13 +15698,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "serde_derive 1.0.203",
+              "id": "serde_derive 1.0.204",
               "target": "serde_derive"
             }
           ],
           "selects": {}
         },
-        "version": "1.0.203"
+        "version": "1.0.204"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -17719,7 +15741,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.203",
+              "id": "serde 1.0.204",
               "target": "serde"
             }
           ],
@@ -17730,13 +15752,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "serde_derive 1.0.203": {
+    "serde_derive 1.0.204": {
       "name": "serde_derive",
-      "version": "1.0.203",
+      "version": "1.0.204",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/serde_derive/1.0.203/download",
-          "sha256": "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+          "url": "https://static.crates.io/crates/serde_derive/1.0.204/download",
+          "sha256": "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
         }
       },
       "targets": [
@@ -17779,17 +15801,17 @@
           "selects": {}
         },
         "edition": "2015",
-        "version": "1.0.203"
+        "version": "1.0.204"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "serde_json 1.0.117": {
+    "serde_json 1.0.121": {
       "name": "serde_json",
-      "version": "1.0.117",
+      "version": "1.0.121",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/serde_json/1.0.117/download",
-          "sha256": "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+          "url": "https://static.crates.io/crates/serde_json/1.0.121/download",
+          "sha256": "4ab380d7d9f22ef3f21ad3e6c1ebe8e4fc7a2000ccba2e4d71fc96f15b2cb609"
         }
       },
       "targets": [
@@ -17831,22 +15853,26 @@
               "target": "itoa"
             },
             {
+              "id": "memchr 2.7.2",
+              "target": "memchr"
+            },
+            {
               "id": "ryu 1.0.18",
               "target": "ryu"
             },
             {
-              "id": "serde 1.0.203",
+              "id": "serde 1.0.204",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.117",
+              "id": "serde_json 1.0.121",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.0.117"
+        "version": "1.0.121"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -17855,64 +15881,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "serde_urlencoded 0.7.1": {
-      "name": "serde_urlencoded",
-      "version": "0.7.1",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/serde_urlencoded/0.7.1/download",
-          "sha256": "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "serde_urlencoded",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "serde_urlencoded",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "form_urlencoded 1.2.1",
-              "target": "form_urlencoded"
-            },
-            {
-              "id": "itoa 1.0.11",
-              "target": "itoa"
-            },
-            {
-              "id": "ryu 1.0.18",
-              "target": "ryu"
-            },
-            {
-              "id": "serde 1.0.203",
-              "target": "serde"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.7.1"
-      },
-      "license": "MIT/Apache-2.0"
-    },
-    "serde_with 3.8.1": {
+    "serde_with 3.9.0": {
       "name": "serde_with",
-      "version": "3.8.1",
+      "version": "3.9.0",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/serde_with/3.8.1/download",
-          "sha256": "0ad483d2ab0149d5a5ebcd9972a3852711e0153d863bf5a5d0391d28883c4a20"
+          "url": "https://static.crates.io/crates/serde_with/3.9.0/download",
+          "sha256": "69cecfa94848272156ea67b2b1a53f20fc7bc638c4a46d2f8abde08f05f4b857"
         }
       },
       "targets": [
@@ -17958,7 +15933,7 @@
               "alias": "indexmap_2"
             },
             {
-              "id": "serde 1.0.203",
+              "id": "serde 1.0.204",
               "target": "serde"
             },
             {
@@ -17973,27 +15948,27 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "serde_derive 1.0.203",
+              "id": "serde_derive 1.0.204",
               "target": "serde_derive"
             },
             {
-              "id": "serde_with_macros 3.8.1",
+              "id": "serde_with_macros 3.9.0",
               "target": "serde_with_macros"
             }
           ],
           "selects": {}
         },
-        "version": "3.8.1"
+        "version": "3.9.0"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "serde_with_macros 3.8.1": {
+    "serde_with_macros 3.9.0": {
       "name": "serde_with_macros",
-      "version": "3.8.1",
+      "version": "3.9.0",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/serde_with_macros/3.8.1/download",
-          "sha256": "65569b702f41443e8bc8bbb1c5779bd0450bbe723b56198980e80ec45780bce2"
+          "url": "https://static.crates.io/crates/serde_with_macros/3.9.0/download",
+          "sha256": "a8fee4991ef4f274617a51ad4af30519438dacb2f56ac773b08a1922ff743350"
         }
       },
       "targets": [
@@ -18034,7 +16009,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "3.8.1"
+        "version": "3.9.0"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -18080,7 +16055,7 @@
               "target": "futures"
             },
             {
-              "id": "log 0.4.21",
+              "id": "log 0.4.22",
               "target": "log"
             },
             {
@@ -18359,7 +16334,7 @@
         "deps": {
           "common": [
             {
-              "id": "lazy_static 1.4.0",
+              "id": "lazy_static 1.5.0",
               "target": "lazy_static"
             }
           ],
@@ -18406,45 +16381,6 @@
         "version": "1.3.0"
       },
       "license": "MIT OR Apache-2.0"
-    },
-    "signal-hook-registry 1.4.2": {
-      "name": "signal-hook-registry",
-      "version": "1.4.2",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/signal-hook-registry/1.4.2/download",
-          "sha256": "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "signal_hook_registry",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "signal_hook_registry",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "libc 0.2.155",
-              "target": "libc"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2015",
-        "version": "1.4.2"
-      },
-      "license": "Apache-2.0/MIT"
     },
     "signature 2.2.0": {
       "name": "signature",
@@ -18631,8 +16567,6 @@
         ],
         "crate_features": {
           "common": [
-            "const_generics",
-            "const_new",
             "write"
           ],
           "selects": {}
@@ -18692,67 +16626,14 @@
       },
       "license": "Apache-2.0"
     },
-    "socket2 0.5.7": {
-      "name": "socket2",
-      "version": "0.5.7",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/socket2/0.5.7/download",
-          "sha256": "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "socket2",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "socket2",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "all"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [],
-          "selects": {
-            "cfg(unix)": [
-              {
-                "id": "libc 0.2.155",
-                "target": "libc"
-              }
-            ],
-            "cfg(windows)": [
-              {
-                "id": "windows-sys 0.52.0",
-                "target": "windows_sys"
-              }
-            ]
-          }
-        },
-        "edition": "2021",
-        "version": "0.5.7"
-      },
-      "license": "MIT OR Apache-2.0"
-    },
-    "sp1-core 0.1.0": {
+    "sp1-core 1.0.1": {
       "name": "sp1-core",
-      "version": "0.1.0",
+      "version": "1.0.1",
       "repository": {
         "Git": {
           "remote": "https://github.com/kroma-network/sp1.git",
           "commitish": {
-            "Rev": "353bf42"
+            "Rev": "dd032eb"
           },
           "strip_prefix": "core"
         }
@@ -18792,6 +16673,10 @@
               "target": "blake3"
             },
             {
+              "id": "bytemuck 1.16.1",
+              "target": "bytemuck"
+            },
+            {
               "id": "cfg-if 1.0.0",
               "target": "cfg_if"
             },
@@ -18808,15 +16693,19 @@
               "target": "elliptic_curve"
             },
             {
-              "id": "generic-array 1.0.0",
+              "id": "generic-array 1.1.0",
               "target": "generic_array"
+            },
+            {
+              "id": "hashbrown 0.14.5",
+              "target": "hashbrown"
             },
             {
               "id": "hex 0.4.3",
               "target": "hex"
             },
             {
-              "id": "itertools 0.12.1",
+              "id": "itertools 0.13.0",
               "target": "itertools"
             },
             {
@@ -18824,7 +16713,7 @@
               "target": "k256"
             },
             {
-              "id": "log 0.4.21",
+              "id": "log 0.4.22",
               "target": "log"
             },
             {
@@ -18836,7 +16725,7 @@
               "target": "num"
             },
             {
-              "id": "num-bigint 0.4.5",
+              "id": "num-bigint 0.4.6",
               "target": "num_bigint"
             },
             {
@@ -18844,87 +16733,92 @@
               "target": "num_cpus"
             },
             {
-              "id": "p3-air 0.1.0",
+              "id": "p3-air 0.1.3-succinct",
               "target": "p3_air"
             },
             {
-              "id": "p3-baby-bear 0.1.0",
+              "id": "p3-baby-bear 0.1.3-succinct",
               "target": "p3_baby_bear"
             },
             {
-              "id": "p3-blake3 0.1.0",
+              "id": "p3-blake3 0.1.3-succinct",
               "target": "p3_blake3"
             },
             {
-              "id": "p3-challenger 0.1.0",
+              "id": "p3-challenger 0.1.3-succinct",
               "target": "p3_challenger"
             },
             {
-              "id": "p3-commit 0.1.0",
+              "id": "p3-commit 0.1.3-succinct",
               "target": "p3_commit"
             },
             {
-              "id": "p3-dft 0.1.0",
+              "id": "p3-dft 0.1.3-succinct",
               "target": "p3_dft"
             },
             {
-              "id": "p3-field 0.1.0",
+              "id": "p3-field 0.1.3-succinct",
               "target": "p3_field"
             },
             {
-              "id": "p3-fri 0.1.0",
+              "id": "p3-fri 0.1.3-succinct",
               "target": "p3_fri"
             },
             {
-              "id": "p3-keccak 0.1.0",
+              "id": "p3-keccak 0.1.3-succinct",
               "target": "p3_keccak"
             },
             {
-              "id": "p3-keccak-air 0.1.0",
+              "id": "p3-keccak-air 0.1.3-succinct",
               "target": "p3_keccak_air"
             },
             {
-              "id": "p3-matrix 0.1.0",
+              "id": "p3-matrix 0.1.3-succinct",
               "target": "p3_matrix"
             },
             {
-              "id": "p3-maybe-rayon 0.1.0",
+              "id": "p3-maybe-rayon 0.1.3-succinct",
               "target": "p3_maybe_rayon"
             },
             {
-              "id": "p3-merkle-tree 0.1.0",
+              "id": "p3-merkle-tree 0.1.3-succinct",
               "target": "p3_merkle_tree"
             },
             {
-              "id": "p3-poseidon2 0.1.0",
+              "id": "p3-poseidon2 0.1.3-succinct",
               "target": "p3_poseidon2"
             },
             {
-              "id": "p3-symmetric 0.1.0",
+              "id": "p3-symmetric 0.1.3-succinct",
               "target": "p3_symmetric"
             },
             {
-              "id": "p3-uni-stark 0.1.0",
+              "id": "p3-uni-stark 0.1.3-succinct",
               "target": "p3_uni_stark"
             },
             {
-              "id": "p3-util 0.1.0",
+              "id": "p3-util 0.1.3-succinct",
               "target": "p3_util"
+            },
+            {
+              "id": "rand 0.8.5",
+              "target": "rand"
             },
             {
               "id": "rayon-scan 0.1.1",
               "target": "rayon_scan"
             },
             {
-              "id": "rrs-lib 0.1.0",
-              "target": "rrs_lib"
+              "id": "rrs-succinct 0.1.0",
+              "target": "rrs_succinct",
+              "alias": "rrs_lib"
             },
             {
-              "id": "serde 1.0.203",
+              "id": "serde 1.0.204",
               "target": "serde"
             },
             {
-              "id": "serde_with 3.8.1",
+              "id": "serde_with 3.9.0",
               "target": "serde_with"
             },
             {
@@ -18937,7 +16831,7 @@
               "alias": "amcl"
             },
             {
-              "id": "sp1-primitives 0.1.0",
+              "id": "sp1-primitives 1.0.1",
               "target": "sp1_primitives"
             },
             {
@@ -18979,7 +16873,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "sp1-derive 0.1.0",
+              "id": "sp1-derive 1.0.1",
               "target": "sp1_derive"
             },
             {
@@ -18989,18 +16883,18 @@
           ],
           "selects": {}
         },
-        "version": "0.1.0"
+        "version": "1.0.1"
       },
-      "license": null
+      "license": "MIT OR Apache-2.0"
     },
-    "sp1-derive 0.1.0": {
+    "sp1-derive 1.0.1": {
       "name": "sp1-derive",
-      "version": "0.1.0",
+      "version": "1.0.1",
       "repository": {
         "Git": {
           "remote": "https://github.com/kroma-network/sp1.git",
           "commitish": {
-            "Rev": "353bf42"
+            "Rev": "dd032eb"
           },
           "strip_prefix": "derive"
         }
@@ -19039,18 +16933,18 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.1.0"
+        "version": "1.0.1"
       },
-      "license": null
+      "license": "MIT OR Apache-2.0"
     },
-    "sp1-primitives 0.1.0": {
+    "sp1-primitives 1.0.1": {
       "name": "sp1-primitives",
-      "version": "0.1.0",
+      "version": "1.0.1",
       "repository": {
         "Git": {
           "remote": "https://github.com/kroma-network/sp1.git",
           "commitish": {
-            "Rev": "353bf42"
+            "Rev": "dd032eb"
           },
           "strip_prefix": "primitives"
         }
@@ -19074,45 +16968,45 @@
         "deps": {
           "common": [
             {
-              "id": "itertools 0.12.1",
+              "id": "itertools 0.13.0",
               "target": "itertools"
             },
             {
-              "id": "lazy_static 1.4.0",
+              "id": "lazy_static 1.5.0",
               "target": "lazy_static"
             },
             {
-              "id": "p3-baby-bear 0.1.0",
+              "id": "p3-baby-bear 0.1.3-succinct",
               "target": "p3_baby_bear"
             },
             {
-              "id": "p3-field 0.1.0",
+              "id": "p3-field 0.1.3-succinct",
               "target": "p3_field"
             },
             {
-              "id": "p3-poseidon2 0.1.0",
+              "id": "p3-poseidon2 0.1.3-succinct",
               "target": "p3_poseidon2"
             },
             {
-              "id": "p3-symmetric 0.1.0",
+              "id": "p3-symmetric 0.1.3-succinct",
               "target": "p3_symmetric"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.1.0"
+        "version": "1.0.1"
       },
-      "license": null
+      "license": "MIT OR Apache-2.0"
     },
-    "sp1-prover 0.1.0": {
+    "sp1-prover 1.0.1": {
       "name": "sp1-prover",
-      "version": "0.1.0",
+      "version": "1.0.1",
       "repository": {
         "Git": {
           "remote": "https://github.com/kroma-network/sp1.git",
           "commitish": {
-            "Rev": "353bf42"
+            "Rev": "dd032eb"
           },
           "strip_prefix": "prover"
         }
@@ -19135,7 +17029,7 @@
         ],
         "data": {
           "common": [
-            "src/fibonacci/program/elf/riscv32im-succinct-zkvm-elf"
+            "elf/riscv32im-succinct-zkvm-elf"
           ],
           "selects": {}
         },
@@ -19146,15 +17040,11 @@
               "target": "anyhow"
             },
             {
-              "id": "backtrace 0.3.72",
-              "target": "backtrace"
-            },
-            {
               "id": "bincode 1.3.3",
               "target": "bincode"
             },
             {
-              "id": "clap 4.5.4",
+              "id": "clap 4.5.11",
               "target": "clap"
             },
             {
@@ -19162,43 +17052,39 @@
               "target": "dirs"
             },
             {
-              "id": "futures 0.3.30",
-              "target": "futures"
-            },
-            {
               "id": "hex 0.4.3",
               "target": "hex"
             },
             {
-              "id": "indicatif 0.17.8",
-              "target": "indicatif"
-            },
-            {
-              "id": "itertools 0.12.1",
+              "id": "itertools 0.13.0",
               "target": "itertools"
             },
             {
-              "id": "num-bigint 0.4.5",
+              "id": "num-bigint 0.4.6",
               "target": "num_bigint"
             },
             {
-              "id": "p3-baby-bear 0.1.0",
+              "id": "oneshot 0.1.8",
+              "target": "oneshot"
+            },
+            {
+              "id": "p3-baby-bear 0.1.3-succinct",
               "target": "p3_baby_bear"
             },
             {
-              "id": "p3-bn254-fr 0.1.0",
+              "id": "p3-bn254-fr 0.1.3-succinct",
               "target": "p3_bn254_fr"
             },
             {
-              "id": "p3-challenger 0.1.0",
+              "id": "p3-challenger 0.1.3-succinct",
               "target": "p3_challenger"
             },
             {
-              "id": "p3-commit 0.1.0",
+              "id": "p3-commit 0.1.3-succinct",
               "target": "p3_commit"
             },
             {
-              "id": "p3-field 0.1.0",
+              "id": "p3-field 0.1.3-succinct",
               "target": "p3_field"
             },
             {
@@ -19206,15 +17092,11 @@
               "target": "rayon"
             },
             {
-              "id": "reqwest 0.12.4",
-              "target": "reqwest"
-            },
-            {
-              "id": "serde 1.0.203",
+              "id": "serde 1.0.204",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.117",
+              "id": "serde_json 1.0.121",
               "target": "serde_json"
             },
             {
@@ -19222,39 +17104,31 @@
               "target": "serial_test"
             },
             {
-              "id": "sha2 0.10.8",
-              "target": "sha2"
-            },
-            {
-              "id": "size 0.4.1",
-              "target": "size"
-            },
-            {
-              "id": "sp1-core 0.1.0",
+              "id": "sp1-core 1.0.1",
               "target": "sp1_core"
             },
             {
-              "id": "sp1-primitives 0.1.0",
+              "id": "sp1-primitives 1.0.1",
               "target": "sp1_primitives"
             },
             {
-              "id": "sp1-recursion-circuit 0.1.0",
+              "id": "sp1-recursion-circuit 1.0.1",
               "target": "sp1_recursion_circuit"
             },
             {
-              "id": "sp1-recursion-compiler 0.1.0",
+              "id": "sp1-recursion-compiler 1.0.1",
               "target": "sp1_recursion_compiler"
             },
             {
-              "id": "sp1-recursion-core 0.1.0",
+              "id": "sp1-recursion-core 1.0.1",
               "target": "sp1_recursion_core"
             },
             {
-              "id": "sp1-recursion-gnark-ffi 0.1.0",
+              "id": "sp1-recursion-gnark-ffi 1.0.1",
               "target": "sp1_recursion_gnark_ffi"
             },
             {
-              "id": "sp1-recursion-program 0.1.0",
+              "id": "sp1-recursion-program 1.0.1",
               "target": "sp1_recursion_program"
             },
             {
@@ -19270,10 +17144,6 @@
               "target": "thiserror"
             },
             {
-              "id": "tokio 1.38.0",
-              "target": "tokio"
-            },
-            {
               "id": "tracing 0.1.40",
               "target": "tracing"
             },
@@ -19285,18 +17155,18 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.1.0"
+        "version": "1.0.1"
       },
-      "license": null
+      "license": "MIT OR Apache-2.0"
     },
-    "sp1-recursion-circuit 0.1.0": {
+    "sp1-recursion-circuit 1.0.1": {
       "name": "sp1-recursion-circuit",
-      "version": "0.1.0",
+      "version": "1.0.1",
       "repository": {
         "Git": {
           "remote": "https://github.com/kroma-network/sp1.git",
           "commitish": {
-            "Rev": "353bf42"
+            "Rev": "dd032eb"
           },
           "strip_prefix": "recursion/circuit"
         }
@@ -19324,59 +17194,59 @@
               "target": "bincode"
             },
             {
-              "id": "itertools 0.12.1",
+              "id": "itertools 0.13.0",
               "target": "itertools"
             },
             {
-              "id": "p3-air 0.1.0",
+              "id": "p3-air 0.1.3-succinct",
               "target": "p3_air"
             },
             {
-              "id": "p3-baby-bear 0.1.0",
+              "id": "p3-baby-bear 0.1.3-succinct",
               "target": "p3_baby_bear"
             },
             {
-              "id": "p3-bn254-fr 0.1.0",
+              "id": "p3-bn254-fr 0.1.3-succinct",
               "target": "p3_bn254_fr"
             },
             {
-              "id": "p3-commit 0.1.0",
+              "id": "p3-commit 0.1.3-succinct",
               "target": "p3_commit"
             },
             {
-              "id": "p3-field 0.1.0",
+              "id": "p3-field 0.1.3-succinct",
               "target": "p3_field"
             },
             {
-              "id": "p3-fri 0.1.0",
+              "id": "p3-fri 0.1.3-succinct",
               "target": "p3_fri"
             },
             {
-              "id": "p3-matrix 0.1.0",
+              "id": "p3-matrix 0.1.3-succinct",
               "target": "p3_matrix"
             },
             {
-              "id": "p3-util 0.1.0",
+              "id": "p3-util 0.1.3-succinct",
               "target": "p3_util"
             },
             {
-              "id": "serde 1.0.203",
+              "id": "serde 1.0.204",
               "target": "serde"
             },
             {
-              "id": "sp1-core 0.1.0",
+              "id": "sp1-core 1.0.1",
               "target": "sp1_core"
             },
             {
-              "id": "sp1-recursion-compiler 0.1.0",
+              "id": "sp1-recursion-compiler 1.0.1",
               "target": "sp1_recursion_compiler"
             },
             {
-              "id": "sp1-recursion-core 0.1.0",
+              "id": "sp1-recursion-core 1.0.1",
               "target": "sp1_recursion_core"
             },
             {
-              "id": "sp1-recursion-program 0.1.0",
+              "id": "sp1-recursion-program 1.0.1",
               "target": "sp1_recursion_program"
             }
           ],
@@ -19386,24 +17256,24 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "sp1-recursion-derive 0.1.0",
+              "id": "sp1-recursion-derive 1.0.1",
               "target": "sp1_recursion_derive"
             }
           ],
           "selects": {}
         },
-        "version": "0.1.0"
+        "version": "1.0.1"
       },
-      "license": null
+      "license": "MIT OR Apache-2.0"
     },
-    "sp1-recursion-compiler 0.1.0": {
+    "sp1-recursion-compiler 1.0.1": {
       "name": "sp1-recursion-compiler",
-      "version": "0.1.0",
+      "version": "1.0.1",
       "repository": {
         "Git": {
           "remote": "https://github.com/kroma-network/sp1.git",
           "commitish": {
-            "Rev": "353bf42"
+            "Rev": "dd032eb"
           },
           "strip_prefix": "recursion/compiler"
         }
@@ -19431,59 +17301,63 @@
               "target": "backtrace"
             },
             {
-              "id": "itertools 0.12.1",
+              "id": "itertools 0.13.0",
               "target": "itertools"
             },
             {
-              "id": "p3-air 0.1.0",
+              "id": "p3-air 0.1.3-succinct",
               "target": "p3_air"
             },
             {
-              "id": "p3-baby-bear 0.1.0",
+              "id": "p3-baby-bear 0.1.3-succinct",
               "target": "p3_baby_bear"
             },
             {
-              "id": "p3-bn254-fr 0.1.0",
+              "id": "p3-bn254-fr 0.1.3-succinct",
               "target": "p3_bn254_fr"
             },
             {
-              "id": "p3-commit 0.1.0",
+              "id": "p3-commit 0.1.3-succinct",
               "target": "p3_commit"
             },
             {
-              "id": "p3-field 0.1.0",
+              "id": "p3-field 0.1.3-succinct",
               "target": "p3_field"
             },
             {
-              "id": "p3-fri 0.1.0",
+              "id": "p3-fri 0.1.3-succinct",
               "target": "p3_fri"
             },
             {
-              "id": "p3-matrix 0.1.0",
+              "id": "p3-matrix 0.1.3-succinct",
               "target": "p3_matrix"
             },
             {
-              "id": "p3-poseidon2 0.1.0",
+              "id": "p3-poseidon2 0.1.3-succinct",
               "target": "p3_poseidon2"
             },
             {
-              "id": "p3-symmetric 0.1.0",
+              "id": "p3-symmetric 0.1.3-succinct",
               "target": "p3_symmetric"
             },
             {
-              "id": "p3-util 0.1.0",
+              "id": "p3-util 0.1.3-succinct",
               "target": "p3_util"
             },
             {
-              "id": "serde 1.0.203",
+              "id": "serde 1.0.204",
               "target": "serde"
             },
             {
-              "id": "sp1-core 0.1.0",
+              "id": "sp1-core 1.0.1",
               "target": "sp1_core"
             },
             {
-              "id": "sp1-recursion-core 0.1.0",
+              "id": "sp1-primitives 1.0.1",
+              "target": "sp1_primitives"
+            },
+            {
+              "id": "sp1-recursion-core 1.0.1",
               "target": "sp1_recursion_core"
             },
             {
@@ -19497,24 +17371,24 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "sp1-recursion-derive 0.1.0",
+              "id": "sp1-recursion-derive 1.0.1",
               "target": "sp1_recursion_derive"
             }
           ],
           "selects": {}
         },
-        "version": "0.1.0"
+        "version": "1.0.1"
       },
-      "license": null
+      "license": "MIT OR Apache-2.0"
     },
-    "sp1-recursion-core 0.1.0": {
+    "sp1-recursion-core 1.0.1": {
       "name": "sp1-recursion-core",
-      "version": "0.1.0",
+      "version": "1.0.1",
       "repository": {
         "Git": {
           "remote": "https://github.com/kroma-network/sp1.git",
           "commitish": {
-            "Rev": "353bf42"
+            "Rev": "dd032eb"
           },
           "strip_prefix": "recursion/core"
         }
@@ -19554,75 +17428,83 @@
               "target": "hashbrown"
             },
             {
-              "id": "itertools 0.12.1",
+              "id": "itertools 0.13.0",
               "target": "itertools"
             },
             {
-              "id": "p3-air 0.1.0",
+              "id": "num_cpus 1.16.0",
+              "target": "num_cpus"
+            },
+            {
+              "id": "p3-air 0.1.3-succinct",
               "target": "p3_air"
             },
             {
-              "id": "p3-baby-bear 0.1.0",
+              "id": "p3-baby-bear 0.1.3-succinct",
               "target": "p3_baby_bear"
             },
             {
-              "id": "p3-bn254-fr 0.1.0",
+              "id": "p3-bn254-fr 0.1.3-succinct",
               "target": "p3_bn254_fr"
             },
             {
-              "id": "p3-challenger 0.1.0",
+              "id": "p3-challenger 0.1.3-succinct",
               "target": "p3_challenger"
             },
             {
-              "id": "p3-commit 0.1.0",
+              "id": "p3-commit 0.1.3-succinct",
               "target": "p3_commit"
             },
             {
-              "id": "p3-dft 0.1.0",
+              "id": "p3-dft 0.1.3-succinct",
               "target": "p3_dft"
             },
             {
-              "id": "p3-field 0.1.0",
+              "id": "p3-field 0.1.3-succinct",
               "target": "p3_field"
             },
             {
-              "id": "p3-fri 0.1.0",
+              "id": "p3-fri 0.1.3-succinct",
               "target": "p3_fri"
             },
             {
-              "id": "p3-matrix 0.1.0",
+              "id": "p3-matrix 0.1.3-succinct",
               "target": "p3_matrix"
             },
             {
-              "id": "p3-maybe-rayon 0.1.0",
+              "id": "p3-maybe-rayon 0.1.3-succinct",
               "target": "p3_maybe_rayon"
             },
             {
-              "id": "p3-merkle-tree 0.1.0",
+              "id": "p3-merkle-tree 0.1.3-succinct",
               "target": "p3_merkle_tree"
             },
             {
-              "id": "p3-poseidon2 0.1.0",
+              "id": "p3-poseidon2 0.1.3-succinct",
               "target": "p3_poseidon2"
             },
             {
-              "id": "p3-symmetric 0.1.0",
+              "id": "p3-symmetric 0.1.3-succinct",
               "target": "p3_symmetric"
             },
             {
-              "id": "serde 1.0.203",
+              "id": "p3-util 0.1.3-succinct",
+              "target": "p3_util"
+            },
+            {
+              "id": "serde 1.0.204",
               "target": "serde"
             },
             {
-              "id": "serde_with 3.8.1",
+              "id": "serde_with 3.9.0",
               "target": "serde_with"
             },
             {
-              "id": "sp1-core 0.1.0",
+              "id": "sp1-core 1.0.1",
               "target": "sp1_core"
             },
             {
-              "id": "sp1-primitives 0.1.0",
+              "id": "sp1-primitives 1.0.1",
               "target": "sp1_primitives"
             },
             {
@@ -19644,24 +17526,24 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "sp1-derive 0.1.0",
+              "id": "sp1-derive 1.0.1",
               "target": "sp1_derive"
             }
           ],
           "selects": {}
         },
-        "version": "0.1.0"
+        "version": "1.0.1"
       },
-      "license": null
+      "license": "MIT OR Apache-2.0"
     },
-    "sp1-recursion-derive 0.1.0": {
+    "sp1-recursion-derive 1.0.1": {
       "name": "sp1-recursion-derive",
-      "version": "0.1.0",
+      "version": "1.0.1",
       "repository": {
         "Git": {
           "remote": "https://github.com/kroma-network/sp1.git",
           "commitish": {
-            "Rev": "353bf42"
+            "Rev": "dd032eb"
           },
           "strip_prefix": "recursion/derive"
         }
@@ -19700,18 +17582,18 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.1.0"
+        "version": "1.0.1"
       },
-      "license": null
+      "license": "MIT OR Apache-2.0"
     },
-    "sp1-recursion-gnark-ffi 0.1.0": {
+    "sp1-recursion-gnark-ffi 1.0.1": {
       "name": "sp1-recursion-gnark-ffi",
-      "version": "0.1.0",
+      "version": "1.0.1",
       "repository": {
         "Git": {
           "remote": "https://github.com/kroma-network/sp1.git",
           "commitish": {
-            "Rev": "353bf42"
+            "Rev": "dd032eb"
           },
           "strip_prefix": "recursion/gnark-ffi"
         }
@@ -19744,43 +17626,67 @@
         "deps": {
           "common": [
             {
+              "id": "anyhow 1.0.86",
+              "target": "anyhow"
+            },
+            {
+              "id": "bincode 1.3.3",
+              "target": "bincode"
+            },
+            {
               "id": "cfg-if 1.0.0",
               "target": "cfg_if"
             },
             {
-              "id": "log 0.4.21",
+              "id": "hex 0.4.3",
+              "target": "hex"
+            },
+            {
+              "id": "log 0.4.22",
               "target": "log"
             },
             {
-              "id": "num-bigint 0.4.5",
+              "id": "num-bigint 0.4.6",
               "target": "num_bigint"
             },
             {
-              "id": "p3-baby-bear 0.1.0",
+              "id": "p3-baby-bear 0.1.3-succinct",
               "target": "p3_baby_bear"
             },
             {
-              "id": "p3-field 0.1.0",
+              "id": "p3-field 0.1.3-succinct",
               "target": "p3_field"
+            },
+            {
+              "id": "p3-symmetric 0.1.3-succinct",
+              "target": "p3_symmetric"
             },
             {
               "id": "rand 0.8.5",
               "target": "rand"
             },
             {
-              "id": "serde 1.0.203",
+              "id": "serde 1.0.204",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.117",
+              "id": "serde_json 1.0.121",
               "target": "serde_json"
             },
             {
-              "id": "sp1-recursion-compiler 0.1.0",
+              "id": "sha2 0.10.8",
+              "target": "sha2"
+            },
+            {
+              "id": "sp1-core 1.0.1",
+              "target": "sp1_core"
+            },
+            {
+              "id": "sp1-recursion-compiler 1.0.1",
               "target": "sp1_recursion_compiler"
             },
             {
-              "id": "sp1-recursion-gnark-ffi 0.1.0",
+              "id": "sp1-recursion-gnark-ffi 1.0.1",
               "target": "build_script_build"
             },
             {
@@ -19791,7 +17697,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.1.0"
+        "version": "1.0.1"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -19804,7 +17710,7 @@
               "target": "bindgen"
             },
             {
-              "id": "cc 1.0.98",
+              "id": "cc 1.1.7",
               "target": "cc"
             },
             {
@@ -19815,16 +17721,16 @@
           "selects": {}
         }
       },
-      "license": null
+      "license": "MIT OR Apache-2.0"
     },
-    "sp1-recursion-program 0.1.0": {
+    "sp1-recursion-program 1.0.1": {
       "name": "sp1-recursion-program",
-      "version": "0.1.0",
+      "version": "1.0.1",
       "repository": {
         "Git": {
           "remote": "https://github.com/kroma-network/sp1.git",
           "commitish": {
-            "Rev": "353bf42"
+            "Rev": "dd032eb"
           },
           "strip_prefix": "recursion/program"
         }
@@ -19848,59 +17754,59 @@
         "deps": {
           "common": [
             {
-              "id": "itertools 0.12.1",
+              "id": "itertools 0.13.0",
               "target": "itertools"
             },
             {
-              "id": "p3-air 0.1.0",
+              "id": "p3-air 0.1.3-succinct",
               "target": "p3_air"
             },
             {
-              "id": "p3-baby-bear 0.1.0",
+              "id": "p3-baby-bear 0.1.3-succinct",
               "target": "p3_baby_bear"
             },
             {
-              "id": "p3-challenger 0.1.0",
+              "id": "p3-challenger 0.1.3-succinct",
               "target": "p3_challenger"
             },
             {
-              "id": "p3-commit 0.1.0",
+              "id": "p3-commit 0.1.3-succinct",
               "target": "p3_commit"
             },
             {
-              "id": "p3-dft 0.1.0",
+              "id": "p3-dft 0.1.3-succinct",
               "target": "p3_dft"
             },
             {
-              "id": "p3-field 0.1.0",
+              "id": "p3-field 0.1.3-succinct",
               "target": "p3_field"
             },
             {
-              "id": "p3-fri 0.1.0",
+              "id": "p3-fri 0.1.3-succinct",
               "target": "p3_fri"
             },
             {
-              "id": "p3-matrix 0.1.0",
+              "id": "p3-matrix 0.1.3-succinct",
               "target": "p3_matrix"
             },
             {
-              "id": "p3-maybe-rayon 0.1.0",
+              "id": "p3-maybe-rayon 0.1.3-succinct",
               "target": "p3_maybe_rayon"
             },
             {
-              "id": "p3-merkle-tree 0.1.0",
+              "id": "p3-merkle-tree 0.1.3-succinct",
               "target": "p3_merkle_tree"
             },
             {
-              "id": "p3-poseidon2 0.1.0",
+              "id": "p3-poseidon2 0.1.3-succinct",
               "target": "p3_poseidon2"
             },
             {
-              "id": "p3-symmetric 0.1.0",
+              "id": "p3-symmetric 0.1.3-succinct",
               "target": "p3_symmetric"
             },
             {
-              "id": "p3-util 0.1.0",
+              "id": "p3-util 0.1.3-succinct",
               "target": "p3_util"
             },
             {
@@ -19908,20 +17814,28 @@
               "target": "rand"
             },
             {
-              "id": "serde 1.0.203",
+              "id": "serde 1.0.204",
               "target": "serde"
             },
             {
-              "id": "sp1-core 0.1.0",
+              "id": "sp1-core 1.0.1",
               "target": "sp1_core"
             },
             {
-              "id": "sp1-recursion-compiler 0.1.0",
+              "id": "sp1-primitives 1.0.1",
+              "target": "sp1_primitives"
+            },
+            {
+              "id": "sp1-recursion-compiler 1.0.1",
               "target": "sp1_recursion_compiler"
             },
             {
-              "id": "sp1-recursion-core 0.1.0",
+              "id": "sp1-recursion-core 1.0.1",
               "target": "sp1_recursion_core"
+            },
+            {
+              "id": "stacker 0.1.15",
+              "target": "stacker"
             },
             {
               "id": "tracing 0.1.40",
@@ -19931,39 +17845,9 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.1.0"
+        "version": "1.0.1"
       },
-      "license": null
-    },
-    "spin 0.5.2": {
-      "name": "spin",
-      "version": "0.5.2",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/spin/0.5.2/download",
-          "sha256": "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "spin",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "spin",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2015",
-        "version": "0.5.2"
-      },
-      "license": "MIT"
+      "license": "MIT OR Apache-2.0"
     },
     "spin 0.9.8": {
       "name": "spin",
@@ -20046,6 +17930,87 @@
         "version": "0.7.3"
       },
       "license": "Apache-2.0 OR MIT"
+    },
+    "stacker 0.1.15": {
+      "name": "stacker",
+      "version": "0.1.15",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/stacker/0.1.15/download",
+          "sha256": "c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "stacker",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "stacker",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "cfg-if 1.0.0",
+              "target": "cfg_if"
+            },
+            {
+              "id": "libc 0.2.155",
+              "target": "libc"
+            },
+            {
+              "id": "psm 0.1.21",
+              "target": "psm"
+            },
+            {
+              "id": "stacker 0.1.15",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {
+            "cfg(windows)": [
+              {
+                "id": "winapi 0.3.9",
+                "target": "winapi"
+              }
+            ]
+          }
+        },
+        "edition": "2015",
+        "version": "0.1.15"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "cc 1.1.7",
+              "target": "cc"
+            }
+          ],
+          "selects": {}
+        }
+      },
+      "license": "MIT OR Apache-2.0"
     },
     "static_assertions 1.1.0": {
       "name": "static_assertions",
@@ -20436,144 +18401,6 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "sync_wrapper 0.1.2": {
-      "name": "sync_wrapper",
-      "version": "0.1.2",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/sync_wrapper/0.1.2/download",
-          "sha256": "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "sync_wrapper",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "sync_wrapper",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2018",
-        "version": "0.1.2"
-      },
-      "license": "Apache-2.0"
-    },
-    "system-configuration 0.5.1": {
-      "name": "system-configuration",
-      "version": "0.5.1",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/system-configuration/0.5.1/download",
-          "sha256": "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "system_configuration",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "system_configuration",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "bitflags 1.3.2",
-              "target": "bitflags"
-            },
-            {
-              "id": "core-foundation 0.9.4",
-              "target": "core_foundation"
-            },
-            {
-              "id": "system-configuration-sys 0.5.0",
-              "target": "system_configuration_sys"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.5.1"
-      },
-      "license": "MIT OR Apache-2.0"
-    },
-    "system-configuration-sys 0.5.0": {
-      "name": "system-configuration-sys",
-      "version": "0.5.0",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/system-configuration-sys/0.5.0/download",
-          "sha256": "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "system_configuration_sys",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "system_configuration_sys",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "core-foundation-sys 0.8.6",
-              "target": "core_foundation_sys"
-            },
-            {
-              "id": "libc 0.2.155",
-              "target": "libc"
-            },
-            {
-              "id": "system-configuration-sys 0.5.0",
-              "target": "build_script_build"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.5.0"
-      },
-      "build_script_attrs": {
-        "data_glob": [
-          "**"
-        ]
-      },
-      "license": "MIT OR Apache-2.0"
-    },
     "tachyon_halo2 0.0.1": {
       "name": "tachyon_halo2",
       "version": "0.0.1",
@@ -20623,11 +18450,11 @@
               "target": "halo2curves"
             },
             {
-              "id": "log 0.4.21",
+              "id": "log 0.4.22",
               "target": "log"
             },
             {
-              "id": "num-bigint 0.4.5",
+              "id": "num-bigint 0.4.6",
               "target": "num_bigint"
             },
             {
@@ -20799,43 +18626,43 @@
               "target": "cxx"
             },
             {
-              "id": "p3-challenger 0.1.0",
+              "id": "p3-challenger 0.1.3-succinct",
               "target": "p3_challenger"
             },
             {
-              "id": "p3-commit 0.1.0",
+              "id": "p3-commit 0.1.3-succinct",
               "target": "p3_commit"
             },
             {
-              "id": "p3-dft 0.1.0",
+              "id": "p3-dft 0.1.3-succinct",
               "target": "p3_dft"
             },
             {
-              "id": "p3-field 0.1.0",
+              "id": "p3-field 0.1.3-succinct",
               "target": "p3_field"
             },
             {
-              "id": "p3-fri 0.1.0",
+              "id": "p3-fri 0.1.3-succinct",
               "target": "p3_fri"
             },
             {
-              "id": "p3-matrix 0.1.0",
+              "id": "p3-matrix 0.1.3-succinct",
               "target": "p3_matrix"
             },
             {
-              "id": "p3-maybe-rayon 0.1.0",
+              "id": "p3-maybe-rayon 0.1.3-succinct",
               "target": "p3_maybe_rayon"
             },
             {
-              "id": "p3-util 0.1.0",
+              "id": "p3-util 0.1.3-succinct",
               "target": "p3_util"
             },
             {
-              "id": "sp1-core 0.1.0",
+              "id": "sp1-core 1.0.1",
               "target": "sp1_core"
             },
             {
-              "id": "sp1-prover 0.1.0",
+              "id": "sp1-prover 1.0.1",
               "target": "sp1_prover"
             }
           ],
@@ -21128,7 +18955,7 @@
               "target": "powerfmt"
             },
             {
-              "id": "serde 1.0.203",
+              "id": "serde 1.0.204",
               "target": "serde"
             },
             {
@@ -21326,413 +19153,6 @@
       },
       "license": "CC0-1.0"
     },
-    "tinyvec 1.6.0": {
-      "name": "tinyvec",
-      "version": "1.6.0",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/tinyvec/1.6.0/download",
-          "sha256": "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "tinyvec",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "tinyvec",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "default",
-            "tinyvec_macros"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "tinyvec_macros 0.1.1",
-              "target": "tinyvec_macros"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "1.6.0"
-      },
-      "license": "Zlib OR Apache-2.0 OR MIT"
-    },
-    "tinyvec_macros 0.1.1": {
-      "name": "tinyvec_macros",
-      "version": "0.1.1",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/tinyvec_macros/0.1.1/download",
-          "sha256": "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "tinyvec_macros",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "tinyvec_macros",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2018",
-        "version": "0.1.1"
-      },
-      "license": "MIT OR Apache-2.0 OR Zlib"
-    },
-    "tokio 1.38.0": {
-      "name": "tokio",
-      "version": "1.38.0",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/tokio/1.38.0/download",
-          "sha256": "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "tokio",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "tokio",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "bytes",
-            "default",
-            "fs",
-            "full",
-            "io-std",
-            "io-util",
-            "libc",
-            "macros",
-            "mio",
-            "net",
-            "num_cpus",
-            "parking_lot",
-            "process",
-            "rt",
-            "rt-multi-thread",
-            "signal",
-            "signal-hook-registry",
-            "socket2",
-            "sync",
-            "time",
-            "tokio-macros",
-            "windows-sys"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "bytes 1.6.0",
-              "target": "bytes"
-            },
-            {
-              "id": "mio 0.8.11",
-              "target": "mio"
-            },
-            {
-              "id": "num_cpus 1.16.0",
-              "target": "num_cpus"
-            },
-            {
-              "id": "parking_lot 0.12.3",
-              "target": "parking_lot"
-            },
-            {
-              "id": "pin-project-lite 0.2.14",
-              "target": "pin_project_lite"
-            }
-          ],
-          "selects": {
-            "cfg(not(target_family = \"wasm\"))": [
-              {
-                "id": "socket2 0.5.7",
-                "target": "socket2"
-              }
-            ],
-            "cfg(tokio_taskdump)": [
-              {
-                "id": "backtrace 0.3.72",
-                "target": "backtrace"
-              }
-            ],
-            "cfg(unix)": [
-              {
-                "id": "libc 0.2.155",
-                "target": "libc"
-              },
-              {
-                "id": "signal-hook-registry 1.4.2",
-                "target": "signal_hook_registry"
-              }
-            ],
-            "cfg(windows)": [
-              {
-                "id": "windows-sys 0.48.0",
-                "target": "windows_sys"
-              }
-            ]
-          }
-        },
-        "edition": "2021",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "tokio-macros 2.3.0",
-              "target": "tokio_macros"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "1.38.0"
-      },
-      "license": "MIT"
-    },
-    "tokio-macros 2.3.0": {
-      "name": "tokio-macros",
-      "version": "2.3.0",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/tokio-macros/2.3.0/download",
-          "sha256": "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "tokio_macros",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "tokio_macros",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "proc-macro2 1.0.85",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.36",
-              "target": "quote"
-            },
-            {
-              "id": "syn 2.0.66",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "2.3.0"
-      },
-      "license": "MIT"
-    },
-    "tokio-native-tls 0.3.1": {
-      "name": "tokio-native-tls",
-      "version": "0.3.1",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/tokio-native-tls/0.3.1/download",
-          "sha256": "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "tokio_native_tls",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "tokio_native_tls",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "native-tls 0.2.12",
-              "target": "native_tls"
-            },
-            {
-              "id": "tokio 1.38.0",
-              "target": "tokio"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.3.1"
-      },
-      "license": "MIT"
-    },
-    "tokio-rustls 0.25.0": {
-      "name": "tokio-rustls",
-      "version": "0.25.0",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/tokio-rustls/0.25.0/download",
-          "sha256": "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "tokio_rustls",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "tokio_rustls",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default",
-            "logging",
-            "ring",
-            "tls12"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "rustls 0.22.4",
-              "target": "rustls"
-            },
-            {
-              "id": "rustls-pki-types 1.7.0",
-              "target": "rustls_pki_types",
-              "alias": "pki_types"
-            },
-            {
-              "id": "tokio 1.38.0",
-              "target": "tokio"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.25.0"
-      },
-      "license": "MIT/Apache-2.0"
-    },
-    "tokio-util 0.7.11": {
-      "name": "tokio-util",
-      "version": "0.7.11",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/tokio-util/0.7.11/download",
-          "sha256": "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "tokio_util",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "tokio_util",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "codec",
-            "default",
-            "io"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "bytes 1.6.0",
-              "target": "bytes"
-            },
-            {
-              "id": "futures-core 0.3.30",
-              "target": "futures_core"
-            },
-            {
-              "id": "futures-sink 0.3.30",
-              "target": "futures_sink"
-            },
-            {
-              "id": "pin-project-lite 0.2.14",
-              "target": "pin_project_lite"
-            },
-            {
-              "id": "tokio 1.38.0",
-              "target": "tokio"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.7.11"
-      },
-      "license": "MIT"
-    },
     "toml_datetime 0.6.6": {
       "name": "toml_datetime",
       "version": "0.6.6",
@@ -21870,142 +19290,6 @@
         "version": "0.21.1"
       },
       "license": "MIT OR Apache-2.0"
-    },
-    "tower 0.4.13": {
-      "name": "tower",
-      "version": "0.4.13",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/tower/0.4.13/download",
-          "sha256": "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "tower",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "tower",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "__common",
-            "futures-core",
-            "futures-util",
-            "make",
-            "pin-project",
-            "pin-project-lite",
-            "tokio",
-            "util"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "futures-core 0.3.30",
-              "target": "futures_core"
-            },
-            {
-              "id": "futures-util 0.3.30",
-              "target": "futures_util"
-            },
-            {
-              "id": "pin-project 1.1.5",
-              "target": "pin_project"
-            },
-            {
-              "id": "pin-project-lite 0.2.14",
-              "target": "pin_project_lite"
-            },
-            {
-              "id": "tokio 1.38.0",
-              "target": "tokio"
-            },
-            {
-              "id": "tower-layer 0.3.2",
-              "target": "tower_layer"
-            },
-            {
-              "id": "tower-service 0.3.2",
-              "target": "tower_service"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.4.13"
-      },
-      "license": "MIT"
-    },
-    "tower-layer 0.3.2": {
-      "name": "tower-layer",
-      "version": "0.3.2",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/tower-layer/0.3.2/download",
-          "sha256": "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "tower_layer",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "tower_layer",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2018",
-        "version": "0.3.2"
-      },
-      "license": "MIT"
-    },
-    "tower-service 0.3.2": {
-      "name": "tower-service",
-      "version": "0.3.2",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/tower-service/0.3.2/download",
-          "sha256": "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "tower_service",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "tower_service",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2018",
-        "version": "0.3.2"
-      },
-      "license": "MIT"
     },
     "tracing 0.1.40": {
       "name": "tracing",
@@ -22269,7 +19553,7 @@
         "deps": {
           "common": [
             {
-              "id": "log 0.4.21",
+              "id": "log 0.4.22",
               "target": "log"
             },
             {
@@ -22423,36 +19707,6 @@
       },
       "license": "MIT"
     },
-    "try-lock 0.2.5": {
-      "name": "try-lock",
-      "version": "0.2.5",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/try-lock/0.2.5/download",
-          "sha256": "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "try_lock",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "try_lock",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2015",
-        "version": "0.2.5"
-      },
-      "license": "MIT"
-    },
     "typenum 1.17.0": {
       "name": "typenum",
       "version": "1.17.0",
@@ -22512,43 +19766,6 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "unicode-bidi 0.3.15": {
-      "name": "unicode-bidi",
-      "version": "0.3.15",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/unicode-bidi/0.3.15/download",
-          "sha256": "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "unicode_bidi",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "unicode_bidi",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "hardcoded-data",
-            "std"
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.3.15"
-      },
-      "license": "MIT OR Apache-2.0"
-    },
     "unicode-ident 1.0.12": {
       "name": "unicode-ident",
       "version": "1.0.12",
@@ -22578,170 +19795,6 @@
         "version": "1.0.12"
       },
       "license": "(MIT OR Apache-2.0) AND Unicode-DFS-2016"
-    },
-    "unicode-normalization 0.1.23": {
-      "name": "unicode-normalization",
-      "version": "0.1.23",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/unicode-normalization/0.1.23/download",
-          "sha256": "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "unicode_normalization",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "unicode_normalization",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "tinyvec 1.6.0",
-              "target": "tinyvec"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.1.23"
-      },
-      "license": "MIT/Apache-2.0"
-    },
-    "unicode-width 0.1.12": {
-      "name": "unicode-width",
-      "version": "0.1.12",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/unicode-width/0.1.12/download",
-          "sha256": "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "unicode_width",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "unicode_width",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default"
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.1.12"
-      },
-      "license": "MIT OR Apache-2.0"
-    },
-    "untrusted 0.9.0": {
-      "name": "untrusted",
-      "version": "0.9.0",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/untrusted/0.9.0/download",
-          "sha256": "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "untrusted",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "untrusted",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2018",
-        "version": "0.9.0"
-      },
-      "license": "ISC"
-    },
-    "url 2.5.0": {
-      "name": "url",
-      "version": "2.5.0",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/url/2.5.0/download",
-          "sha256": "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "url",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "url",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "form_urlencoded 1.2.1",
-              "target": "form_urlencoded"
-            },
-            {
-              "id": "idna 0.5.0",
-              "target": "idna"
-            },
-            {
-              "id": "percent-encoding 2.3.1",
-              "target": "percent_encoding"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "2.5.0"
-      },
-      "license": "MIT OR Apache-2.0"
     },
     "utf8parse 0.2.1": {
       "name": "utf8parse",
@@ -22832,36 +19885,6 @@
       },
       "license": "MIT"
     },
-    "vcpkg 0.2.15": {
-      "name": "vcpkg",
-      "version": "0.2.15",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/vcpkg/0.2.15/download",
-          "sha256": "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "vcpkg",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "vcpkg",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2015",
-        "version": "0.2.15"
-      },
-      "license": "MIT/Apache-2.0"
-    },
     "version_check 0.9.4": {
       "name": "version_check",
       "version": "0.9.4",
@@ -22892,45 +19915,6 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "want 0.3.1": {
-      "name": "want",
-      "version": "0.3.1",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/want/0.3.1/download",
-          "sha256": "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "want",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "want",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "try-lock 0.2.5",
-              "target": "try_lock"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.3.1"
-      },
-      "license": "MIT"
-    },
     "wasi 0.11.0+wasi-snapshot-preview1": {
       "name": "wasi",
       "version": "0.11.0+wasi-snapshot-preview1",
@@ -22956,13 +19940,6 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "default",
-            "std"
-          ],
-          "selects": {}
-        },
         "edition": "2018",
         "version": "0.11.0+wasi-snapshot-preview1"
       },
@@ -23080,7 +20057,7 @@
               "target": "bumpalo"
             },
             {
-              "id": "log 0.4.21",
+              "id": "log 0.4.22",
               "target": "log"
             },
             {
@@ -23108,60 +20085,6 @@
         },
         "edition": "2018",
         "version": "0.2.92"
-      },
-      "license": "MIT OR Apache-2.0"
-    },
-    "wasm-bindgen-futures 0.4.42": {
-      "name": "wasm-bindgen-futures",
-      "version": "0.4.42",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/wasm-bindgen-futures/0.4.42/download",
-          "sha256": "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "wasm_bindgen_futures",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "wasm_bindgen_futures",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "cfg-if 1.0.0",
-              "target": "cfg_if"
-            },
-            {
-              "id": "js-sys 0.3.69",
-              "target": "js_sys"
-            },
-            {
-              "id": "wasm-bindgen 0.2.92",
-              "target": "wasm_bindgen"
-            }
-          ],
-          "selects": {
-            "cfg(target_feature = \"atomics\")": [
-              {
-                "id": "web-sys 0.3.69",
-                "target": "web_sys"
-              }
-            ]
-          }
-        },
-        "edition": "2018",
-        "version": "0.4.42"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -23329,149 +20252,6 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "wasm-streams 0.4.0": {
-      "name": "wasm-streams",
-      "version": "0.4.0",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/wasm-streams/0.4.0/download",
-          "sha256": "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "wasm_streams",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "wasm_streams",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "futures-util 0.3.30",
-              "target": "futures_util"
-            },
-            {
-              "id": "js-sys 0.3.69",
-              "target": "js_sys"
-            },
-            {
-              "id": "wasm-bindgen 0.2.92",
-              "target": "wasm_bindgen"
-            },
-            {
-              "id": "wasm-bindgen-futures 0.4.42",
-              "target": "wasm_bindgen_futures"
-            },
-            {
-              "id": "web-sys 0.3.69",
-              "target": "web_sys"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.4.0"
-      },
-      "license": "MIT OR Apache-2.0"
-    },
-    "web-sys 0.3.69": {
-      "name": "web-sys",
-      "version": "0.3.69",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/web-sys/0.3.69/download",
-          "sha256": "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "web_sys",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "web_sys",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "AbortController",
-            "AbortSignal",
-            "Blob",
-            "BlobPropertyBag",
-            "Event",
-            "EventTarget",
-            "File",
-            "FormData",
-            "Headers",
-            "MessageEvent",
-            "QueuingStrategy",
-            "ReadableByteStreamController",
-            "ReadableStream",
-            "ReadableStreamByobReader",
-            "ReadableStreamByobRequest",
-            "ReadableStreamDefaultController",
-            "ReadableStreamDefaultReader",
-            "ReadableStreamGetReaderOptions",
-            "ReadableStreamReadResult",
-            "ReadableStreamReaderMode",
-            "ReadableStreamType",
-            "ReadableWritablePair",
-            "Request",
-            "RequestCredentials",
-            "RequestInit",
-            "RequestMode",
-            "Response",
-            "ServiceWorkerGlobalScope",
-            "StreamPipeOptions",
-            "TransformStream",
-            "TransformStreamDefaultController",
-            "Transformer",
-            "UnderlyingSink",
-            "UnderlyingSource",
-            "Window",
-            "Worker",
-            "WorkerGlobalScope",
-            "WritableStream",
-            "WritableStreamDefaultController",
-            "WritableStreamDefaultWriter"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "js-sys 0.3.69",
-              "target": "js_sys"
-            },
-            {
-              "id": "wasm-bindgen 0.2.92",
-              "target": "wasm_bindgen"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.3.69"
-      },
-      "license": "MIT OR Apache-2.0"
-    },
     "web-time 1.1.0": {
       "name": "web-time",
       "version": "1.1.0",
@@ -23516,46 +20296,6 @@
         "version": "1.1.0"
       },
       "license": "MIT OR Apache-2.0"
-    },
-    "webpki-roots 0.26.1": {
-      "name": "webpki-roots",
-      "version": "0.26.1",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/webpki-roots/0.26.1/download",
-          "sha256": "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "webpki_roots",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "webpki_roots",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "rustls-pki-types 1.7.0",
-              "target": "rustls_pki_types",
-              "alias": "pki_types"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.26.1"
-      },
-      "license": "MPL-2.0"
     },
     "which 4.4.2": {
       "name": "which",
@@ -23651,12 +20391,16 @@
           "common": [
             "consoleapi",
             "errhandlingapi",
+            "fibersapi",
             "fileapi",
             "handleapi",
+            "memoryapi",
             "minwindef",
             "ntsecapi",
             "processenv",
+            "processthreadsapi",
             "profileapi",
+            "winbase",
             "winnt"
           ],
           "selects": {}
@@ -23868,23 +20612,8 @@
             "Win32",
             "Win32_Foundation",
             "Win32_Globalization",
-            "Win32_Networking",
-            "Win32_Networking_WinSock",
-            "Win32_Security",
-            "Win32_Storage",
-            "Win32_Storage_FileSystem",
             "Win32_System",
             "Win32_System_Com",
-            "Win32_System_Console",
-            "Win32_System_Diagnostics",
-            "Win32_System_Diagnostics_Debug",
-            "Win32_System_IO",
-            "Win32_System_Pipes",
-            "Win32_System_Registry",
-            "Win32_System_SystemServices",
-            "Win32_System_Threading",
-            "Win32_System_Time",
-            "Win32_System_WindowsProgramming",
             "Win32_UI",
             "Win32_UI_Shell",
             "default"
@@ -23938,11 +20667,6 @@
             "Win32_NetworkManagement_IpHelper",
             "Win32_Networking",
             "Win32_Networking_WinSock",
-            "Win32_Security",
-            "Win32_Security_Authentication",
-            "Win32_Security_Authentication_Identity",
-            "Win32_Security_Credentials",
-            "Win32_Security_Cryptography",
             "Win32_Storage",
             "Win32_Storage_FileSystem",
             "Win32_System",
@@ -23950,13 +20674,8 @@
             "Win32_System_Console",
             "Win32_System_Diagnostics",
             "Win32_System_Diagnostics_Debug",
-            "Win32_System_IO",
-            "Win32_System_Memory",
             "Win32_System_Threading",
-            "Win32_System_WindowsProgramming",
             "Win32_UI",
-            "Win32_UI_Input",
-            "Win32_UI_Input_KeyboardAndMouse",
             "Win32_UI_Shell",
             "default"
           ],
@@ -24969,49 +21688,6 @@
       },
       "license": "MIT"
     },
-    "winreg 0.52.0": {
-      "name": "winreg",
-      "version": "0.52.0",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/winreg/0.52.0/download",
-          "sha256": "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "winreg",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "winreg",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "cfg-if 1.0.0",
-              "target": "cfg_if"
-            },
-            {
-              "id": "windows-sys 0.48.0",
-              "target": "windows_sys"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.52.0"
-      },
-      "license": "MIT"
-    },
     "wyz 0.5.1": {
       "name": "wyz",
       "version": "0.5.1",
@@ -25173,7 +21849,6 @@
         "crate_features": {
           "common": [
             "alloc",
-            "default",
             "zeroize_derive"
           ],
           "selects": {}
@@ -25243,12 +21918,9 @@
       "name": "zkhash",
       "version": "0.2.0",
       "repository": {
-        "Git": {
-          "remote": "https://github.com/HorizenLabs/poseidon2.git",
-          "commitish": {
-            "Rev": "bb476b9"
-          },
-          "strip_prefix": "plain_implementations"
+        "Http": {
+          "url": "https://static.crates.io/crates/zkhash/0.2.0/download",
+          "sha256": "4352d1081da6922701401cdd4cbf29a2723feb4cfabb5771f6fee8e9276da1c7"
         }
       },
       "targets": [
@@ -25325,7 +21997,7 @@
               "target": "jubjub"
             },
             {
-              "id": "lazy_static 1.4.0",
+              "id": "lazy_static 1.5.0",
               "target": "lazy_static"
             },
             {
@@ -25338,7 +22010,7 @@
               "alias": "random"
             },
             {
-              "id": "serde 1.0.203",
+              "id": "serde 1.0.204",
               "target": "serde"
             },
             {
@@ -25359,7 +22031,7 @@
         "edition": "2018",
         "version": "0.2.0"
       },
-      "license": null
+      "license": "MIT OR Apache-2.0"
     }
   },
   "binary_crates": [],
@@ -25394,13 +22066,6 @@
       "powerpc-unknown-linux-gnu",
       "s390x-unknown-linux-gnu",
       "x86_64-linux-android"
-    ],
-    "cfg(all(any(target_os = \"android\", target_os = \"linux\"), any(target_arch = \"aarch64\", target_arch = \"arm\")))": [
-      "aarch64-linux-android",
-      "aarch64-unknown-linux-gnu",
-      "arm-unknown-linux-gnueabi",
-      "armv7-linux-androideabi",
-      "armv7-unknown-linux-gnueabi"
     ],
     "cfg(all(not(curve25519_dalek_backend = \"fiat\"), not(curve25519_dalek_backend = \"serial\"), target_arch = \"x86_64\"))": [
       "x86_64-apple-darwin",
@@ -25450,9 +22115,6 @@
     "cfg(all(target_arch = \"aarch64\", target_os = \"linux\"))": [
       "aarch64-unknown-linux-gnu"
     ],
-    "cfg(all(target_arch = \"aarch64\", target_os = \"windows\"))": [
-      "aarch64-pc-windows-msvc"
-    ],
     "cfg(all(target_arch = \"aarch64\", target_vendor = \"apple\"))": [
       "aarch64-apple-darwin",
       "aarch64-apple-ios",
@@ -25478,33 +22140,6 @@
       "wasm32-unknown-unknown"
     ],
     "cfg(any())": [],
-    "cfg(any(target_arch = \"aarch64\", target_arch = \"arm\", target_arch = \"x86\", target_arch = \"x86_64\"))": [
-      "aarch64-apple-darwin",
-      "aarch64-apple-ios",
-      "aarch64-apple-ios-sim",
-      "aarch64-fuchsia",
-      "aarch64-linux-android",
-      "aarch64-pc-windows-msvc",
-      "aarch64-unknown-linux-gnu",
-      "arm-unknown-linux-gnueabi",
-      "armv7-linux-androideabi",
-      "armv7-unknown-linux-gnueabi",
-      "i686-apple-darwin",
-      "i686-linux-android",
-      "i686-pc-windows-msvc",
-      "i686-unknown-freebsd",
-      "i686-unknown-linux-gnu",
-      "thumbv7em-none-eabi",
-      "thumbv8m.main-none-eabi",
-      "x86_64-apple-darwin",
-      "x86_64-apple-ios",
-      "x86_64-fuchsia",
-      "x86_64-linux-android",
-      "x86_64-pc-windows-msvc",
-      "x86_64-unknown-freebsd",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-none"
-    ],
     "cfg(any(target_arch = \"aarch64\", target_arch = \"x86_64\", target_arch = \"x86\"))": [
       "aarch64-apple-darwin",
       "aarch64-apple-ios",
@@ -25674,92 +22309,6 @@
       "x86_64-unknown-linux-gnu",
       "x86_64-unknown-none"
     ],
-    "cfg(not(any(target_os = \"windows\", target_vendor = \"apple\")))": [
-      "aarch64-fuchsia",
-      "aarch64-linux-android",
-      "aarch64-unknown-linux-gnu",
-      "arm-unknown-linux-gnueabi",
-      "armv7-linux-androideabi",
-      "armv7-unknown-linux-gnueabi",
-      "i686-linux-android",
-      "i686-unknown-freebsd",
-      "i686-unknown-linux-gnu",
-      "powerpc-unknown-linux-gnu",
-      "riscv32imc-unknown-none-elf",
-      "riscv64gc-unknown-none-elf",
-      "s390x-unknown-linux-gnu",
-      "thumbv7em-none-eabi",
-      "thumbv8m.main-none-eabi",
-      "wasm32-unknown-unknown",
-      "wasm32-wasi",
-      "x86_64-fuchsia",
-      "x86_64-linux-android",
-      "x86_64-unknown-freebsd",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-none"
-    ],
-    "cfg(not(target_arch = \"wasm32\"))": [
-      "aarch64-apple-darwin",
-      "aarch64-apple-ios",
-      "aarch64-apple-ios-sim",
-      "aarch64-fuchsia",
-      "aarch64-linux-android",
-      "aarch64-pc-windows-msvc",
-      "aarch64-unknown-linux-gnu",
-      "arm-unknown-linux-gnueabi",
-      "armv7-linux-androideabi",
-      "armv7-unknown-linux-gnueabi",
-      "i686-apple-darwin",
-      "i686-linux-android",
-      "i686-pc-windows-msvc",
-      "i686-unknown-freebsd",
-      "i686-unknown-linux-gnu",
-      "powerpc-unknown-linux-gnu",
-      "riscv32imc-unknown-none-elf",
-      "riscv64gc-unknown-none-elf",
-      "s390x-unknown-linux-gnu",
-      "thumbv7em-none-eabi",
-      "thumbv8m.main-none-eabi",
-      "x86_64-apple-darwin",
-      "x86_64-apple-ios",
-      "x86_64-fuchsia",
-      "x86_64-linux-android",
-      "x86_64-pc-windows-msvc",
-      "x86_64-unknown-freebsd",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-none"
-    ],
-    "cfg(not(target_family = \"wasm\"))": [
-      "aarch64-apple-darwin",
-      "aarch64-apple-ios",
-      "aarch64-apple-ios-sim",
-      "aarch64-fuchsia",
-      "aarch64-linux-android",
-      "aarch64-pc-windows-msvc",
-      "aarch64-unknown-linux-gnu",
-      "arm-unknown-linux-gnueabi",
-      "armv7-linux-androideabi",
-      "armv7-unknown-linux-gnueabi",
-      "i686-apple-darwin",
-      "i686-linux-android",
-      "i686-pc-windows-msvc",
-      "i686-unknown-freebsd",
-      "i686-unknown-linux-gnu",
-      "powerpc-unknown-linux-gnu",
-      "riscv32imc-unknown-none-elf",
-      "riscv64gc-unknown-none-elf",
-      "s390x-unknown-linux-gnu",
-      "thumbv7em-none-eabi",
-      "thumbv8m.main-none-eabi",
-      "x86_64-apple-darwin",
-      "x86_64-apple-ios",
-      "x86_64-fuchsia",
-      "x86_64-linux-android",
-      "x86_64-pc-windows-msvc",
-      "x86_64-unknown-freebsd",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-none"
-    ],
     "cfg(not(windows))": [
       "aarch64-apple-darwin",
       "aarch64-apple-ios",
@@ -25814,7 +22363,6 @@
       "x86_64-unknown-none"
     ],
     "cfg(target_env = \"sgx\")": [],
-    "cfg(target_feature = \"atomics\")": [],
     "cfg(target_os = \"android\")": [
       "aarch64-linux-android",
       "armv7-linux-androideabi",
@@ -25827,11 +22375,6 @@
     ],
     "cfg(target_os = \"haiku\")": [],
     "cfg(target_os = \"hermit\")": [],
-    "cfg(target_os = \"macos\")": [
-      "aarch64-apple-darwin",
-      "i686-apple-darwin",
-      "x86_64-apple-darwin"
-    ],
     "cfg(target_os = \"redox\")": [],
     "cfg(target_os = \"wasi\")": [
       "wasm32-wasi"
@@ -25841,15 +22384,6 @@
       "i686-pc-windows-msvc",
       "x86_64-pc-windows-msvc"
     ],
-    "cfg(target_vendor = \"apple\")": [
-      "aarch64-apple-darwin",
-      "aarch64-apple-ios",
-      "aarch64-apple-ios-sim",
-      "i686-apple-darwin",
-      "x86_64-apple-darwin",
-      "x86_64-apple-ios"
-    ],
-    "cfg(tokio_taskdump)": [],
     "cfg(tracing_unstable)": [],
     "cfg(unix)": [
       "aarch64-apple-darwin",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,12 +136,22 @@ checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "ark-bn254"
+version = "0.4.0-alpha.2"
+source = "git+https://github.com/arkworks-rs/curves.git?tag=v0.4.0-alpha.2#5a0b8eca0b7f7714d48489da2e2fbf83f4165631"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-std 0.4.0",
+]
+
+[[package]]
+name = "ark-bn254"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a22f4561524cd949590d78d7d4c5df8f592430d221f7f3c9497bbafd8972120f"
 dependencies = [
- "ark-ec 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ark-ff 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ark-ec",
+ "ark-ff",
  "ark-std 0.4.0",
 ]
 
@@ -150,10 +160,10 @@ name = "ark-crypto-primitives"
 version = "0.4.0"
 source = "git+https://github.com/kroma-network/crypto-primitives.git?rev=99f5aff#99f5aff812b90caea22f969ee3df167a5e447685"
 dependencies = [
- "ark-ec 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ark-ff 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ark-ec",
+ "ark-ff",
  "ark-relations",
- "ark-serialize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ark-serialize",
  "ark-snark",
  "ark-std 0.4.0",
  "blake2",
@@ -168,9 +178,9 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
 dependencies = [
- "ark-ff 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ark-poly 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ark-serialize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ark-ff",
+ "ark-poly",
+ "ark-serialize",
  "ark-std 0.4.0",
  "derivative",
  "hashbrown 0.13.2",
@@ -181,59 +191,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "ark-ec"
-version = "0.4.2"
-source = "git+https://github.com/kroma-network/algebra.git?rev=53f396c#53f396cccdb37dea4c71764353ae374d99464b93"
-dependencies = [
- "ark-ff 0.4.2 (git+https://github.com/kroma-network/algebra.git?rev=53f396c)",
- "ark-poly 0.4.2 (git+https://github.com/kroma-network/algebra.git?rev=53f396c)",
- "ark-serialize 0.4.2 (git+https://github.com/kroma-network/algebra.git?rev=53f396c)",
- "ark-std 0.4.0",
- "derivative",
- "hashbrown 0.14.5",
- "itertools 0.12.1",
- "num-bigint 0.4.5",
- "num-traits",
- "zeroize",
-]
-
-[[package]]
 name = "ark-ff"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
 dependencies = [
- "ark-ff-asm 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ark-ff-macros 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ark-serialize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ark-ff-asm",
+ "ark-ff-macros",
+ "ark-serialize",
  "ark-std 0.4.0",
  "derivative",
  "digest 0.10.7",
  "itertools 0.10.5",
- "num-bigint 0.4.5",
+ "num-bigint 0.4.6",
  "num-traits",
  "paste",
  "rayon",
  "rustc_version",
- "zeroize",
-]
-
-[[package]]
-name = "ark-ff"
-version = "0.4.2"
-source = "git+https://github.com/kroma-network/algebra.git?rev=53f396c#53f396cccdb37dea4c71764353ae374d99464b93"
-dependencies = [
- "ark-ff-asm 0.4.2 (git+https://github.com/kroma-network/algebra.git?rev=53f396c)",
- "ark-ff-macros 0.4.2 (git+https://github.com/kroma-network/algebra.git?rev=53f396c)",
- "ark-serialize 0.4.2 (git+https://github.com/kroma-network/algebra.git?rev=53f396c)",
- "ark-std 0.4.0",
- "arrayvec 0.7.4",
- "derivative",
- "digest 0.10.7",
- "itertools 0.12.1",
- "num-bigint 0.4.5",
- "num-traits",
- "paste",
  "zeroize",
 ]
 
@@ -248,37 +222,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "ark-ff-asm"
-version = "0.4.2"
-source = "git+https://github.com/kroma-network/algebra.git?rev=53f396c#53f396cccdb37dea4c71764353ae374d99464b93"
-dependencies = [
- "quote",
- "syn 2.0.66",
-]
-
-[[package]]
 name = "ark-ff-macros"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
- "num-bigint 0.4.5",
+ "num-bigint 0.4.6",
  "num-traits",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "ark-ff-macros"
-version = "0.4.2"
-source = "git+https://github.com/kroma-network/algebra.git?rev=53f396c#53f396cccdb37dea4c71764353ae374d99464b93"
-dependencies = [
- "num-bigint 0.4.5",
- "num-traits",
- "proc-macro2",
- "quote",
- "syn 2.0.66",
 ]
 
 [[package]]
@@ -287,24 +240,12 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
 dependencies = [
- "ark-ff 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ark-serialize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ark-ff",
+ "ark-serialize",
  "ark-std 0.4.0",
  "derivative",
  "hashbrown 0.13.2",
  "rayon",
-]
-
-[[package]]
-name = "ark-poly"
-version = "0.4.2"
-source = "git+https://github.com/kroma-network/algebra.git?rev=53f396c#53f396cccdb37dea4c71764353ae374d99464b93"
-dependencies = [
- "ark-ff 0.4.2 (git+https://github.com/kroma-network/algebra.git?rev=53f396c)",
- "ark-serialize 0.4.2 (git+https://github.com/kroma-network/algebra.git?rev=53f396c)",
- "ark-std 0.4.0",
- "derivative",
- "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -313,7 +254,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00796b6efc05a3f48225e59cb6a2cda78881e7c390872d5786aaf112f31fb4f0"
 dependencies = [
- "ark-ff 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ark-ff",
  "ark-std 0.4.0",
  "tracing",
  "tracing-subscriber 0.2.25",
@@ -325,21 +266,10 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
- "ark-serialize-derive 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ark-serialize-derive",
  "ark-std 0.4.0",
  "digest 0.10.7",
- "num-bigint 0.4.5",
-]
-
-[[package]]
-name = "ark-serialize"
-version = "0.4.2"
-source = "git+https://github.com/kroma-network/algebra.git?rev=53f396c#53f396cccdb37dea4c71764353ae374d99464b93"
-dependencies = [
- "ark-serialize-derive 0.4.2 (git+https://github.com/kroma-network/algebra.git?rev=53f396c)",
- "ark-std 0.4.0",
- "digest 0.10.7",
- "num-bigint 0.4.5",
+ "num-bigint 0.4.6",
 ]
 
 [[package]]
@@ -354,24 +284,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "ark-serialize-derive"
-version = "0.4.2"
-source = "git+https://github.com/kroma-network/algebra.git?rev=53f396c#53f396cccdb37dea4c71764353ae374d99464b93"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
-]
-
-[[package]]
 name = "ark-snark"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84d3cc6833a335bb8a600241889ead68ee89a3cf8448081fb7694c0fe503da63"
 dependencies = [
- "ark-ff 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ark-ff",
  "ark-relations",
- "ark-serialize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ark-serialize",
  "ark-std 0.4.0",
 ]
 
@@ -397,21 +317,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "ark-test-curves"
-version = "0.4.2"
-source = "git+https://github.com/kroma-network/algebra.git?rev=53f396c#53f396cccdb37dea4c71764353ae374d99464b93"
-dependencies = [
- "ark-ec 0.4.2 (git+https://github.com/kroma-network/algebra.git?rev=53f396c)",
- "ark-ff 0.4.2 (git+https://github.com/kroma-network/algebra.git?rev=53f396c)",
- "ark-std 0.4.0",
-]
-
-[[package]]
 name = "arkworks_fft_benchmark"
 version = "0.0.1"
 dependencies = [
- "ark-poly 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ark-test-curves",
+ "ark-bn254 0.4.0-alpha.2",
+ "ark-poly",
  "tachyon_rs",
 ]
 
@@ -419,9 +329,9 @@ dependencies = [
 name = "arkworks_msm_benchmark"
 version = "0.0.1"
 dependencies = [
- "ark-bn254",
- "ark-ec 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ark-ff 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ark-bn254 0.4.0",
+ "ark-ec",
+ "ark-ff",
  "ark-std 0.4.0",
  "tachyon_rs",
 ]
@@ -430,9 +340,9 @@ dependencies = [
 name = "arkworks_poseidon_benchmark"
 version = "0.0.1"
 dependencies = [
- "ark-bn254",
+ "ark-bn254 0.4.0",
  "ark-crypto-primitives",
- "ark-ff 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ark-ff",
  "tachyon_rs",
 ]
 
@@ -453,12 +363,6 @@ name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
-
-[[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -570,7 +474,7 @@ version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -601,12 +505,6 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -732,22 +630,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
+name = "bytemuck"
+version = "1.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b236fc92302c97ed75b38da1f4917b5cdda4984745740f153a5d3059e48d725e"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
-name = "bytes"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
-
-[[package]]
 name = "cc"
-version = "1.0.98"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
+checksum = "26a5c3fd7bfa1ce3897a3a3501d362b2d87b7f2583ebcb4a949ec25911025cbc"
 
 [[package]]
 name = "cexpr"
@@ -796,9 +694,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.4"
+version = "4.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+checksum = "35723e6a11662c2afb578bcf0b88bf6ea8e21282a953428f240574fcc3a2b5b3"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -806,9 +704,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.2"
+version = "4.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+checksum = "49eb96cbfa7cfa35017b7cd548c75b14c3118c98b423041d70562665e07fb0fa"
 dependencies = [
  "anstream",
  "anstyle",
@@ -818,9 +716,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.4"
+version = "4.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+checksum = "5d029b67f89d30bbb547c89fd5161293c0aec155fc691d7924b64550662db93e"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -835,23 +733,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
+name = "cobs"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
-
-[[package]]
-name = "console"
-version = "0.15.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
-dependencies = [
- "encode_unicode",
- "lazy_static",
- "libc",
- "unicode-width",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "const-oid"
@@ -870,16 +761,6 @@ name = "constant_time_eq"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
-
-[[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "core-foundation-sys"
@@ -1279,19 +1160,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "encode_unicode"
-version = "0.3.6"
+name = "embedded-io"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
-
-[[package]]
-name = "encoding_rs"
-version = "0.8.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
-dependencies = [
- "cfg-if 1.0.0",
-]
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
 
 [[package]]
 name = "equivalent"
@@ -1374,7 +1246,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b96fbccd88dbb1fac4ee4a07c2fcc4ca719a74ffbd9d2b9d41d8c8eb073d8b20"
 dependencies = [
- "num-bigint 0.4.5",
+ "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
  "proc-macro2",
@@ -1394,30 +1266,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
-name = "form_urlencoded"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
-dependencies = [
- "percent-encoding",
-]
 
 [[package]]
 name = "fuchsia-cprng"
@@ -1497,17 +1345,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
-name = "futures-macro"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
-]
-
-[[package]]
 name = "futures-sink"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1528,7 +1365,6 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-io",
- "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -1556,9 +1392,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe739944a5406424e080edccb6add95685130b9f160d5407c639c7df0c5836b0"
+checksum = "96512db27971c2c3eece70a1e106fbe6c87760234e31e8f7e5634912fe52794a"
 dependencies = [
  "serde",
  "typenum",
@@ -1608,25 +1444,6 @@ dependencies = [
  "ff 0.13.0",
  "rand_core 0.6.4",
  "subtle",
-]
-
-[[package]]
-name = "h2"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap 2.2.6",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
 ]
 
 [[package]]
@@ -1682,7 +1499,7 @@ dependencies = [
  "halo2curves",
  "log",
  "maybe-rayon",
- "num-bigint 0.4.5",
+ "num-bigint 0.4.6",
  "num-integer",
  "poseidon",
  "rand_chacha",
@@ -1707,7 +1524,7 @@ dependencies = [
  "halo2curves",
  "log",
  "maybe-rayon",
- "num-bigint 0.4.5",
+ "num-bigint 0.4.6",
  "num-integer",
  "poseidon",
  "rand_chacha",
@@ -1728,7 +1545,7 @@ dependencies = [
  "ff 0.13.0",
  "group 0.13.0",
  "lazy_static",
- "num-bigint 0.4.5",
+ "num-bigint 0.4.6",
  "num-traits",
  "pasta_curves 0.5.1",
  "paste",
@@ -1763,6 +1580,7 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
  "allocator-api2",
+ "serde",
 ]
 
 [[package]]
@@ -1810,119 +1628,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "http"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http-body"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
-dependencies = [
- "bytes",
- "http",
-]
-
-[[package]]
-name = "http-body-util"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
-dependencies = [
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "pin-project-lite",
-]
-
-[[package]]
-name = "httparse"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
-
-[[package]]
-name = "hyper"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "httparse",
- "itoa",
- "pin-project-lite",
- "smallvec",
- "tokio",
- "want",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
-dependencies = [
- "futures-util",
- "http",
- "hyper",
- "hyper-util",
- "rustls",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b875924a60b96e5d7b9ae7b066540b1dd1cbd90d1828f54c92e02a283351c56"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-util",
- "http",
- "http-body",
- "hyper",
- "pin-project-lite",
- "socket2",
- "tokio",
- "tower",
- "tower-service",
- "tracing",
-]
-
-[[package]]
 name = "iana-time-zone"
 version = "0.1.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1950,16 +1655,6 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
-name = "idna"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
-]
 
 [[package]]
 name = "impl-trait-for-tuples"
@@ -1995,34 +1690,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indicatif"
-version = "0.17.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "763a5a8f45087d6bcea4222e7b72c291a054edf80e4ef6efd2a4979878c7bea3"
-dependencies = [
- "console",
- "instant",
- "number_prefix",
- "portable-atomic",
- "unicode-width",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "ipnet"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2042,6 +1709,15 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -2100,11 +1776,11 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.5.2",
+ "spin",
 ]
 
 [[package]]
@@ -2135,7 +1811,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags",
  "libc",
 ]
 
@@ -2166,9 +1842,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "matchers"
@@ -2217,12 +1893,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2145869435ace5ea6ea3d35f59be559317ec9a0d04e1812d5f185a87b6d36f1a"
 
 [[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2235,34 +1905,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87dfd01fe195c66b572b37921ad8803d010623c0aca821bea2302239d155cdae"
 dependencies = [
  "adler",
-]
-
-[[package]]
-name = "mio"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
-dependencies = [
- "libc",
- "wasi",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -2297,7 +1939,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
 dependencies = [
- "num-bigint 0.4.5",
+ "num-bigint 0.4.6",
  "num-complex",
  "num-integer",
  "num-iter",
@@ -2318,9 +1960,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -2368,7 +2010,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "num-bigint 0.4.5",
+ "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
 ]
@@ -2414,24 +2056,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
-name = "nums"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3c74f925fb8cfc49a8022f2afce48a0683b70f9e439885594e84c5edbf5b01"
-dependencies = [
- "num-bigint 0.4.5",
- "num-integer",
- "num-traits",
- "rand 0.8.5",
-]
-
-[[package]]
 name = "object"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2447,54 +2071,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "oneshot"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e296cf87e61c9cfc1a61c3c63a0f7f286ed4554e0e22be84e8a38e1d264a2a29"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
-name = "openssl"
-version = "0.10.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
-dependencies = [
- "bitflags 2.5.0",
- "cfg-if 1.0.0",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -2510,11 +2096,12 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p3-air"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a#3b5265f9d5af36534a46caebf0617595cfb42c5a"
+version = "0.1.3-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e909ef66fa5d77ff0fd3cb5af4b33b27fa6fb68d02b9b1e70edbc29383e565"
 dependencies = [
- "p3-field 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-matrix 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
+ "p3-field 0.1.3-succinct",
+ "p3-matrix 0.1.3-succinct",
 ]
 
 [[package]]
@@ -2522,62 +2109,51 @@ name = "p3-baby-bear"
 version = "0.1.0"
 source = "git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f#3b5265f9d5af36534a46caebf0617595cfb42c5a"
 dependencies = [
- "num-bigint 0.4.5",
- "p3-field 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
- "p3-mds 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
- "p3-poseidon2 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
- "p3-symmetric 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
+ "num-bigint 0.4.6",
+ "p3-field 0.1.0",
+ "p3-mds 0.1.0",
+ "p3-poseidon2 0.1.0",
+ "p3-symmetric 0.1.0",
  "rand 0.8.5",
  "serde",
 ]
 
 [[package]]
 name = "p3-baby-bear"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a#3b5265f9d5af36534a46caebf0617595cfb42c5a"
+version = "0.1.3-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46965470aac1cddfe52f535424b59d52f2fffef0fdeb9dbed19da39b1d8f048a"
 dependencies = [
- "num-bigint 0.4.5",
- "p3-field 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-mds 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-poseidon2 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-symmetric 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
+ "num-bigint 0.4.6",
+ "p3-field 0.1.3-succinct",
+ "p3-mds 0.1.3-succinct",
+ "p3-poseidon2 0.1.3-succinct",
+ "p3-symmetric 0.1.3-succinct",
  "rand 0.8.5",
  "serde",
 ]
 
 [[package]]
 name = "p3-blake3"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a#3b5265f9d5af36534a46caebf0617595cfb42c5a"
+version = "0.1.3-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36ef32d6ea21dd5cf9fec8a31bf0c64e6ceee8901dbf50966b83a443093c2aba"
 dependencies = [
  "blake3",
- "p3-symmetric 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
+ "p3-symmetric 0.1.3-succinct",
 ]
 
 [[package]]
 name = "p3-bn254-fr"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a#3b5265f9d5af36534a46caebf0617595cfb42c5a"
+version = "0.1.3-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3edfca6be3b3109adf8e3330baec30c3fc5f9f4d63d27aaec1b471ca51ed67"
 dependencies = [
  "ff 0.13.0",
- "num-bigint 0.4.5",
- "p3-field 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-poseidon2 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-symmetric 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "rand 0.8.5",
- "serde",
-]
-
-[[package]]
-name = "p3-bn254-fr"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=54069b1#54069b141e6f22a045d34edb91eb404decbfbd09"
-dependencies = [
- "ff 0.13.0",
- "num-bigint 0.4.5",
- "p3-field 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=54069b1)",
- "p3-poseidon2 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=54069b1)",
- "p3-symmetric 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=54069b1)",
+ "num-bigint 0.4.6",
+ "p3-field 0.1.3-succinct",
+ "p3-poseidon2 0.1.3-succinct",
+ "p3-symmetric 0.1.3-succinct",
  "rand 0.8.5",
  "serde",
 ]
@@ -2587,48 +2163,37 @@ name = "p3-challenger"
 version = "0.1.0"
 source = "git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f#3b5265f9d5af36534a46caebf0617595cfb42c5a"
 dependencies = [
- "p3-field 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
- "p3-maybe-rayon 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
- "p3-symmetric 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
- "p3-util 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
+ "p3-field 0.1.0",
+ "p3-maybe-rayon 0.1.0",
+ "p3-symmetric 0.1.0",
+ "p3-util 0.1.0",
  "tracing",
 ]
 
 [[package]]
 name = "p3-challenger"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a#3b5265f9d5af36534a46caebf0617595cfb42c5a"
+version = "0.1.3-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6662ea899a5d848b60c699944491d72757873b5e1fd46798e4712f90a03a4e9"
 dependencies = [
- "p3-field 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-maybe-rayon 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-symmetric 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-util 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
+ "p3-field 0.1.3-succinct",
+ "p3-maybe-rayon 0.1.3-succinct",
+ "p3-symmetric 0.1.3-succinct",
+ "p3-util 0.1.3-succinct",
  "tracing",
 ]
 
 [[package]]
 name = "p3-commit"
-version = "0.1.0"
-source = "git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f#3b5265f9d5af36534a46caebf0617595cfb42c5a"
+version = "0.1.3-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc3563918b5cc44ef5280bf9b51753e70dc78802de25e3fb81ed6c94617ccb6e"
 dependencies = [
  "itertools 0.12.1",
- "p3-challenger 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
- "p3-field 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
- "p3-matrix 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
- "p3-util 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
- "serde",
-]
-
-[[package]]
-name = "p3-commit"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a#3b5265f9d5af36534a46caebf0617595cfb42c5a"
-dependencies = [
- "itertools 0.12.1",
- "p3-challenger 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-field 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-matrix 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-util 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
+ "p3-challenger 0.1.3-succinct",
+ "p3-field 0.1.3-succinct",
+ "p3-matrix 0.1.3-succinct",
+ "p3-util 0.1.3-succinct",
  "serde",
 ]
 
@@ -2637,34 +2202,23 @@ name = "p3-dft"
 version = "0.1.0"
 source = "git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f#3b5265f9d5af36534a46caebf0617595cfb42c5a"
 dependencies = [
- "p3-field 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
- "p3-matrix 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
- "p3-maybe-rayon 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
- "p3-util 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
+ "p3-field 0.1.0",
+ "p3-matrix 0.1.0",
+ "p3-maybe-rayon 0.1.0",
+ "p3-util 0.1.0",
  "tracing",
 ]
 
 [[package]]
 name = "p3-dft"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a#3b5265f9d5af36534a46caebf0617595cfb42c5a"
+version = "0.1.3-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "510095701819d83c9509fe825bbf1ebfe50426ae75149df5fe1dcfd18261323a"
 dependencies = [
- "p3-field 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-matrix 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-maybe-rayon 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-util 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "tracing",
-]
-
-[[package]]
-name = "p3-dft"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=54069b1#54069b141e6f22a045d34edb91eb404decbfbd09"
-dependencies = [
- "p3-field 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=54069b1)",
- "p3-matrix 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=54069b1)",
- "p3-maybe-rayon 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=54069b1)",
- "p3-util 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=54069b1)",
+ "p3-field 0.1.3-succinct",
+ "p3-matrix 0.1.3-succinct",
+ "p3-maybe-rayon 0.1.3-succinct",
+ "p3-util 0.1.3-succinct",
  "tracing",
 ]
 
@@ -2674,117 +2228,81 @@ version = "0.1.0"
 source = "git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f#3b5265f9d5af36534a46caebf0617595cfb42c5a"
 dependencies = [
  "itertools 0.12.1",
- "num-bigint 0.4.5",
+ "num-bigint 0.4.6",
  "num-traits",
- "p3-util 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
+ "p3-util 0.1.0",
  "rand 0.8.5",
  "serde",
 ]
 
 [[package]]
 name = "p3-field"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a#3b5265f9d5af36534a46caebf0617595cfb42c5a"
+version = "0.1.3-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61f1977a0a65789f719aa824119c332c4676b000bdbfe94d312fb6244a70d601"
 dependencies = [
  "itertools 0.12.1",
- "num-bigint 0.4.5",
+ "num-bigint 0.4.6",
  "num-traits",
- "p3-util 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "rand 0.8.5",
- "serde",
-]
-
-[[package]]
-name = "p3-field"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=54069b1#54069b141e6f22a045d34edb91eb404decbfbd09"
-dependencies = [
- "itertools 0.12.1",
- "num-bigint 0.4.5",
- "num-integer",
- "num-traits",
- "nums",
- "p3-util 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=54069b1)",
+ "p3-util 0.1.3-succinct",
  "rand 0.8.5",
  "serde",
 ]
 
 [[package]]
 name = "p3-fri"
-version = "0.1.0"
-source = "git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f#3b5265f9d5af36534a46caebf0617595cfb42c5a"
+version = "0.1.3-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c22ddb958f200d9289cc73ff68847b0167ca0c14557b791dd9e318f98c2d1b28"
 dependencies = [
  "itertools 0.12.1",
- "p3-challenger 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
- "p3-commit 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
- "p3-dft 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
- "p3-field 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
- "p3-interpolation 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
- "p3-matrix 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
- "p3-maybe-rayon 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
- "p3-util 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
- "serde",
- "tracing",
-]
-
-[[package]]
-name = "p3-fri"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a#3b5265f9d5af36534a46caebf0617595cfb42c5a"
-dependencies = [
- "itertools 0.12.1",
- "p3-challenger 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-commit 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-dft 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-field 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-interpolation 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-matrix 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-maybe-rayon 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-util 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
+ "p3-challenger 0.1.3-succinct",
+ "p3-commit",
+ "p3-dft 0.1.3-succinct",
+ "p3-field 0.1.3-succinct",
+ "p3-interpolation",
+ "p3-matrix 0.1.3-succinct",
+ "p3-maybe-rayon 0.1.3-succinct",
+ "p3-util 0.1.3-succinct",
  "serde",
  "tracing",
 ]
 
 [[package]]
 name = "p3-interpolation"
-version = "0.1.0"
-source = "git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f#3b5265f9d5af36534a46caebf0617595cfb42c5a"
+version = "0.1.3-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d032cda212f6b408d7d5b0b9a8270a9455acb93742fe55a0880d82be8e90e500"
 dependencies = [
- "p3-field 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
- "p3-matrix 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
- "p3-util 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
-]
-
-[[package]]
-name = "p3-interpolation"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a#3b5265f9d5af36534a46caebf0617595cfb42c5a"
-dependencies = [
- "p3-field 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-matrix 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-util 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
+ "p3-field 0.1.3-succinct",
+ "p3-matrix 0.1.3-succinct",
+ "p3-util 0.1.3-succinct",
 ]
 
 [[package]]
 name = "p3-keccak"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a#3b5265f9d5af36534a46caebf0617595cfb42c5a"
+version = "0.1.3-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c56abdd5a8a780049d2f8e92cea1df57b55a2ef50a40d1103f2732f7a00e4b1"
 dependencies = [
- "p3-symmetric 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
+ "p3-symmetric 0.1.3-succinct",
  "tiny-keccak 2.0.2",
 ]
 
 [[package]]
 name = "p3-keccak-air"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a#3b5265f9d5af36534a46caebf0617595cfb42c5a"
+version = "0.1.3-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8398f1694ccc38513df0b8cab5f9ef7325423f27cd9e4fa20bdc77d5079cf1b"
 dependencies = [
  "p3-air",
- "p3-field 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-matrix 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-maybe-rayon 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-util 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
+ "p3-field 0.1.3-succinct",
+ "p3-matrix 0.1.3-succinct",
+ "p3-maybe-rayon 0.1.3-succinct",
+ "p3-util 0.1.3-succinct",
  "tracing",
+ "tracing-forest",
+ "tracing-subscriber 0.3.18",
 ]
 
 [[package]]
@@ -2793,9 +2311,9 @@ version = "0.1.0"
 source = "git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f#3b5265f9d5af36534a46caebf0617595cfb42c5a"
 dependencies = [
  "itertools 0.12.1",
- "p3-field 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
- "p3-maybe-rayon 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
- "p3-util 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
+ "p3-field 0.1.0",
+ "p3-maybe-rayon 0.1.0",
+ "p3-util 0.1.0",
  "rand 0.8.5",
  "serde",
  "tracing",
@@ -2803,27 +2321,14 @@ dependencies = [
 
 [[package]]
 name = "p3-matrix"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a#3b5265f9d5af36534a46caebf0617595cfb42c5a"
+version = "0.1.3-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d548ee0b834f8e2ebc5037073acd101a3b0ca41a2d1d28a15ba0ccd9059495b0"
 dependencies = [
  "itertools 0.12.1",
- "p3-field 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-maybe-rayon 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-util 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "rand 0.8.5",
- "serde",
- "tracing",
-]
-
-[[package]]
-name = "p3-matrix"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=54069b1#54069b141e6f22a045d34edb91eb404decbfbd09"
-dependencies = [
- "itertools 0.12.1",
- "p3-field 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=54069b1)",
- "p3-maybe-rayon 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=54069b1)",
- "p3-util 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=54069b1)",
+ "p3-field 0.1.3-succinct",
+ "p3-maybe-rayon 0.1.3-succinct",
+ "p3-util 0.1.3-succinct",
  "rand 0.8.5",
  "serde",
  "tracing",
@@ -2833,77 +2338,58 @@ dependencies = [
 name = "p3-maybe-rayon"
 version = "0.1.0"
 source = "git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f#3b5265f9d5af36534a46caebf0617595cfb42c5a"
+
+[[package]]
+name = "p3-maybe-rayon"
+version = "0.1.3-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55f5575d3d61bedb3e05681abb0f36b8bb339d65aa395d50756bfa64e9cd3f46"
 dependencies = [
  "rayon",
 ]
 
 [[package]]
-name = "p3-maybe-rayon"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a#3b5265f9d5af36534a46caebf0617595cfb42c5a"
-dependencies = [
- "rayon",
-]
-
-[[package]]
-name = "p3-maybe-rayon"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=54069b1#54069b141e6f22a045d34edb91eb404decbfbd09"
-
-[[package]]
 name = "p3-mds"
 version = "0.1.0"
 source = "git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f#3b5265f9d5af36534a46caebf0617595cfb42c5a"
 dependencies = [
  "itertools 0.12.1",
- "p3-dft 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
- "p3-field 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
- "p3-matrix 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
- "p3-symmetric 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
- "p3-util 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
+ "p3-dft 0.1.0",
+ "p3-field 0.1.0",
+ "p3-matrix 0.1.0",
+ "p3-symmetric 0.1.0",
+ "p3-util 0.1.0",
  "rand 0.8.5",
 ]
 
 [[package]]
 name = "p3-mds"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a#3b5265f9d5af36534a46caebf0617595cfb42c5a"
+version = "0.1.3-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6e57ed310d59245f93e24ee805ea7aa16fc9c505551b76a15f5e50f29d177e"
 dependencies = [
  "itertools 0.12.1",
- "p3-dft 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-field 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-matrix 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-symmetric 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-util 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "rand 0.8.5",
-]
-
-[[package]]
-name = "p3-mds"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=54069b1#54069b141e6f22a045d34edb91eb404decbfbd09"
-dependencies = [
- "itertools 0.12.1",
- "p3-dft 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=54069b1)",
- "p3-field 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=54069b1)",
- "p3-matrix 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=54069b1)",
- "p3-symmetric 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=54069b1)",
- "p3-util 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=54069b1)",
+ "p3-dft 0.1.3-succinct",
+ "p3-field 0.1.3-succinct",
+ "p3-matrix 0.1.3-succinct",
+ "p3-symmetric 0.1.3-succinct",
+ "p3-util 0.1.3-succinct",
  "rand 0.8.5",
 ]
 
 [[package]]
 name = "p3-merkle-tree"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a#3b5265f9d5af36534a46caebf0617595cfb42c5a"
+version = "0.1.3-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af46b41cba75d483ec8a553cbab1d2d794935ae3403d75394acfa4fb2c977cce"
 dependencies = [
  "itertools 0.12.1",
- "p3-commit 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-field 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-matrix 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-maybe-rayon 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-symmetric 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-util 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
+ "p3-commit",
+ "p3-field 0.1.3-succinct",
+ "p3-matrix 0.1.3-succinct",
+ "p3-maybe-rayon 0.1.3-succinct",
+ "p3-symmetric 0.1.3-succinct",
+ "p3-util 0.1.3-succinct",
  "serde",
  "tracing",
 ]
@@ -2914,33 +2400,22 @@ version = "0.1.0"
 source = "git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f#3b5265f9d5af36534a46caebf0617595cfb42c5a"
 dependencies = [
  "gcd",
- "p3-field 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
- "p3-mds 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
- "p3-symmetric 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
+ "p3-field 0.1.0",
+ "p3-mds 0.1.0",
+ "p3-symmetric 0.1.0",
  "rand 0.8.5",
 ]
 
 [[package]]
 name = "p3-poseidon2"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a#3b5265f9d5af36534a46caebf0617595cfb42c5a"
+version = "0.1.3-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adaba6f14c197203530e233badce0ca1126ba3bf3c9ff766505b497bdad0bee1"
 dependencies = [
  "gcd",
- "p3-field 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-mds 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-symmetric 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "rand 0.8.5",
-]
-
-[[package]]
-name = "p3-poseidon2"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=54069b1#54069b141e6f22a045d34edb91eb404decbfbd09"
-dependencies = [
- "gcd",
- "p3-field 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=54069b1)",
- "p3-mds 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=54069b1)",
- "p3-symmetric 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=54069b1)",
+ "p3-field 0.1.3-succinct",
+ "p3-mds 0.1.3-succinct",
+ "p3-symmetric 0.1.3-succinct",
  "rand 0.8.5",
 ]
 
@@ -2950,46 +2425,41 @@ version = "0.1.0"
 source = "git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f#3b5265f9d5af36534a46caebf0617595cfb42c5a"
 dependencies = [
  "itertools 0.12.1",
- "p3-field 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
+ "p3-field 0.1.0",
  "serde",
 ]
 
 [[package]]
 name = "p3-symmetric"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a#3b5265f9d5af36534a46caebf0617595cfb42c5a"
+version = "0.1.3-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57ecc4282566eb14f48be7707f6745c4dff6be664984d59ec0fb1849cd82b5c2"
 dependencies = [
  "itertools 0.12.1",
- "p3-field 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "serde",
-]
-
-[[package]]
-name = "p3-symmetric"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=54069b1#54069b141e6f22a045d34edb91eb404decbfbd09"
-dependencies = [
- "itertools 0.12.1",
- "p3-field 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=54069b1)",
+ "p3-field 0.1.3-succinct",
  "serde",
 ]
 
 [[package]]
 name = "p3-uni-stark"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a#3b5265f9d5af36534a46caebf0617595cfb42c5a"
+version = "0.1.3-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1af5c038b22b058bf1d49fb1ea3dd6c240a3e46c3278fde5c444e0034f7ffe37"
 dependencies = [
  "itertools 0.12.1",
  "p3-air",
- "p3-challenger 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-commit 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-dft 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-field 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-matrix 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-maybe-rayon 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-util 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
+ "p3-challenger 0.1.3-succinct",
+ "p3-commit",
+ "p3-dft 0.1.3-succinct",
+ "p3-field 0.1.3-succinct",
+ "p3-matrix 0.1.3-succinct",
+ "p3-maybe-rayon 0.1.3-succinct",
+ "p3-util 0.1.3-succinct",
+ "postcard",
  "serde",
  "tracing",
+ "tracing-forest",
+ "tracing-subscriber 0.3.18",
 ]
 
 [[package]]
@@ -3002,16 +2472,9 @@ dependencies = [
 
 [[package]]
 name = "p3-util"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a#3b5265f9d5af36534a46caebf0617595cfb42c5a"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "p3-util"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=54069b1#54069b141e6f22a045d34edb91eb404decbfbd09"
+version = "0.1.3-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79f3fef0e00d9d7246385e758c4cd39b4efcbbcea31752471491ab502631385e"
 dependencies = [
  "serde",
 ]
@@ -3122,32 +2585,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
-name = "percent-encoding"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
-
-[[package]]
-name = "pin-project"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3170,12 +2607,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pkg-config"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
-
-[[package]]
 name = "platforms"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3186,19 +2617,13 @@ name = "plonky3_poseidon2_benchmark"
 version = "0.0.1"
 dependencies = [
  "ff 0.13.0",
- "p3-bn254-fr 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=54069b1)",
- "p3-field 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=54069b1)",
- "p3-poseidon2 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=54069b1)",
- "p3-symmetric 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=54069b1)",
+ "p3-bn254-fr",
+ "p3-field 0.1.3-succinct",
+ "p3-poseidon2 0.1.3-succinct",
+ "p3-symmetric 0.1.3-succinct",
  "tachyon_rs",
  "zkhash 0.2.0 (git+https://github.com/HorizenLabs/poseidon2.git?rev=bb476b9)",
 ]
-
-[[package]]
-name = "portable-atomic"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
 
 [[package]]
 name = "poseidon"
@@ -3207,6 +2632,17 @@ source = "git+https://github.com/scroll-tech/poseidon.git?branch=main#5787dd3d2c
 dependencies = [
  "halo2curves",
  "subtle",
+]
+
+[[package]]
+name = "postcard"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55c51ee6c0db07e68448e336cf8ea4131a620edefebf9893e759b2d793420f8"
+dependencies = [
+ "cobs",
+ "embedded-io",
+ "serde",
 ]
 
 [[package]]
@@ -3257,6 +2693,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -3385,7 +2830,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -3444,55 +2889,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
-name = "reqwest"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
-dependencies = [
- "base64",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-tls",
- "hyper-util",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "native-tls",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls",
- "rustls-pemfile",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "system-configuration",
- "tokio",
- "tokio-native-tls",
- "tokio-rustls",
- "tokio-util",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-streams",
- "web-sys",
- "webpki-roots",
- "winreg",
-]
-
-[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3503,24 +2899,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ring"
-version = "0.17.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
-dependencies = [
- "cc",
- "cfg-if 1.0.0",
- "getrandom",
- "libc",
- "spin 0.9.8",
- "untrusted",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rrs-lib"
+name = "rrs-succinct"
 version = "0.1.0"
-source = "git+https://github.com/GregAC/rrs.git?branch=main#b23afc16b4e6a1fb5c4a73eb1e337e9400816507"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3372685893a9f67d18e98e792d690017287fd17379a83d798d958e517d380fa9"
 dependencies = [
  "downcast-rs",
  "num_enum",
@@ -3554,52 +2936,11 @@ version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rustls"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
-dependencies = [
- "log",
- "ring",
- "rustls-pki-types",
- "rustls-webpki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
-dependencies = [
- "base64",
- "rustls-pki-types",
-]
-
-[[package]]
-name = "rustls-pki-types"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.102.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
 ]
 
 [[package]]
@@ -3648,15 +2989,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schannel"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
-dependencies = [
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3683,29 +3015,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "security-framework"
-version = "2.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
-dependencies = [
- "bitflags 2.5.0",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "semver"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3713,9 +3022,9 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.203"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
 dependencies = [
  "serde_derive",
 ]
@@ -3731,9 +3040,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.203"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3742,32 +3051,21 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.117"
+version = "1.0.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+checksum = "4ab380d7d9f22ef3f21ad3e6c1ebe8e4fc7a2000ccba2e4d71fc96f15b2cb609"
 dependencies = [
  "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "serde_with"
-version = "3.8.1"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad483d2ab0149d5a5ebcd9972a3852711e0153d863bf5a5d0391d28883c4a20"
+checksum = "69cecfa94848272156ea67b2b1a53f20fc7bc638c4a46d2f8abde08f05f4b857"
 dependencies = [
  "base64",
  "chrono",
@@ -3783,9 +3081,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.8.1"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65569b702f41443e8bc8bbb1c5779bd0450bbe723b56198980e80ec45780bce2"
+checksum = "a8fee4991ef4f274617a51ad4af30519438dacb2f56ac773b08a1922ff743350"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -3867,15 +3165,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3917,56 +3206,49 @@ dependencies = [
 ]
 
 [[package]]
-name = "socket2"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "sp1-core"
-version = "0.1.0"
-source = "git+https://github.com/kroma-network/sp1.git?rev=353bf42#353bf429877bfeeeddb722b5a1e0c4c59881668f"
+version = "1.0.1"
+source = "git+https://github.com/kroma-network/sp1.git?rev=dd032eb#dd032eb23949828d244d1ad1f1569aa78155837c"
 dependencies = [
  "anyhow",
  "arrayref",
  "bincode",
  "blake3",
+ "bytemuck",
  "cfg-if 1.0.0",
  "curve25519-dalek",
  "elf",
  "elliptic-curve",
- "generic-array 1.0.0",
+ "generic-array 1.1.0",
+ "hashbrown 0.14.5",
  "hex",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "k256",
  "log",
  "nohash-hasher",
  "num",
- "num-bigint 0.4.5",
+ "num-bigint 0.4.6",
  "num_cpus",
  "p3-air",
- "p3-baby-bear 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
+ "p3-baby-bear 0.1.3-succinct",
  "p3-blake3",
- "p3-challenger 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-commit 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-dft 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-field 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-fri 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
+ "p3-challenger 0.1.3-succinct",
+ "p3-commit",
+ "p3-dft 0.1.3-succinct",
+ "p3-field 0.1.3-succinct",
+ "p3-fri",
  "p3-keccak",
  "p3-keccak-air",
- "p3-matrix 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-maybe-rayon 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
+ "p3-matrix 0.1.3-succinct",
+ "p3-maybe-rayon 0.1.3-succinct",
  "p3-merkle-tree",
- "p3-poseidon2 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-symmetric 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
+ "p3-poseidon2 0.1.3-succinct",
+ "p3-symmetric 0.1.3-succinct",
  "p3-uni-stark",
- "p3-util 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
+ "p3-util 0.1.3-succinct",
+ "rand 0.8.5",
  "rayon-scan",
- "rrs-lib",
+ "rrs-succinct",
  "serde",
  "serde_with",
  "size",
@@ -3986,8 +3268,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-derive"
-version = "0.1.0"
-source = "git+https://github.com/kroma-network/sp1.git?rev=353bf42#353bf429877bfeeeddb722b5a1e0c4c59881668f"
+version = "1.0.1"
+source = "git+https://github.com/kroma-network/sp1.git?rev=dd032eb#dd032eb23949828d244d1ad1f1569aa78155837c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3996,44 +3278,39 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "0.1.0"
-source = "git+https://github.com/kroma-network/sp1.git?rev=353bf42#353bf429877bfeeeddb722b5a1e0c4c59881668f"
+version = "1.0.1"
+source = "git+https://github.com/kroma-network/sp1.git?rev=dd032eb#dd032eb23949828d244d1ad1f1569aa78155837c"
 dependencies = [
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "lazy_static",
- "p3-baby-bear 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-field 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-poseidon2 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-symmetric 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
+ "p3-baby-bear 0.1.3-succinct",
+ "p3-field 0.1.3-succinct",
+ "p3-poseidon2 0.1.3-succinct",
+ "p3-symmetric 0.1.3-succinct",
 ]
 
 [[package]]
 name = "sp1-prover"
-version = "0.1.0"
-source = "git+https://github.com/kroma-network/sp1.git?rev=353bf42#353bf429877bfeeeddb722b5a1e0c4c59881668f"
+version = "1.0.1"
+source = "git+https://github.com/kroma-network/sp1.git?rev=dd032eb#dd032eb23949828d244d1ad1f1569aa78155837c"
 dependencies = [
  "anyhow",
- "backtrace",
  "bincode",
  "clap",
  "dirs",
- "futures 0.3.30",
  "hex",
- "indicatif",
- "itertools 0.12.1",
- "num-bigint 0.4.5",
- "p3-baby-bear 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-bn254-fr 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-challenger 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-commit 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-field 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
+ "itertools 0.13.0",
+ "num-bigint 0.4.6",
+ "oneshot",
+ "p3-baby-bear 0.1.3-succinct",
+ "p3-bn254-fr",
+ "p3-challenger 0.1.3-succinct",
+ "p3-commit",
+ "p3-field 0.1.3-succinct",
  "rayon",
- "reqwest",
  "serde",
  "serde_json",
  "serial_test",
- "sha2",
- "size",
  "sp1-core",
  "sp1-primitives",
  "sp1-recursion-circuit",
@@ -4044,26 +3321,25 @@ dependencies = [
  "subtle-encoding",
  "tempfile",
  "thiserror",
- "tokio",
  "tracing",
  "tracing-subscriber 0.3.18",
 ]
 
 [[package]]
 name = "sp1-recursion-circuit"
-version = "0.1.0"
-source = "git+https://github.com/kroma-network/sp1.git?rev=353bf42#353bf429877bfeeeddb722b5a1e0c4c59881668f"
+version = "1.0.1"
+source = "git+https://github.com/kroma-network/sp1.git?rev=dd032eb#dd032eb23949828d244d1ad1f1569aa78155837c"
 dependencies = [
  "bincode",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "p3-air",
- "p3-baby-bear 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-bn254-fr 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-commit 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-field 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-fri 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-matrix 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-util 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
+ "p3-baby-bear 0.1.3-succinct",
+ "p3-bn254-fr",
+ "p3-commit",
+ "p3-field 0.1.3-succinct",
+ "p3-fri",
+ "p3-matrix 0.1.3-succinct",
+ "p3-util 0.1.3-succinct",
  "serde",
  "sp1-core",
  "sp1-recursion-compiler",
@@ -4074,23 +3350,24 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-compiler"
-version = "0.1.0"
-source = "git+https://github.com/kroma-network/sp1.git?rev=353bf42#353bf429877bfeeeddb722b5a1e0c4c59881668f"
+version = "1.0.1"
+source = "git+https://github.com/kroma-network/sp1.git?rev=dd032eb#dd032eb23949828d244d1ad1f1569aa78155837c"
 dependencies = [
  "backtrace",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "p3-air",
- "p3-baby-bear 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-bn254-fr 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-commit 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-field 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-fri 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-matrix 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-poseidon2 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-symmetric 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-util 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
+ "p3-baby-bear 0.1.3-succinct",
+ "p3-bn254-fr",
+ "p3-commit",
+ "p3-field 0.1.3-succinct",
+ "p3-fri",
+ "p3-matrix 0.1.3-succinct",
+ "p3-poseidon2 0.1.3-succinct",
+ "p3-symmetric 0.1.3-succinct",
+ "p3-util 0.1.3-succinct",
  "serde",
  "sp1-core",
+ "sp1-primitives",
  "sp1-recursion-core",
  "sp1-recursion-derive",
  "tracing",
@@ -4098,27 +3375,29 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-core"
-version = "0.1.0"
-source = "git+https://github.com/kroma-network/sp1.git?rev=353bf42#353bf429877bfeeeddb722b5a1e0c4c59881668f"
+version = "1.0.1"
+source = "git+https://github.com/kroma-network/sp1.git?rev=dd032eb#dd032eb23949828d244d1ad1f1569aa78155837c"
 dependencies = [
  "arrayref",
  "backtrace",
  "ff 0.13.0",
  "hashbrown 0.14.5",
- "itertools 0.12.1",
+ "itertools 0.13.0",
+ "num_cpus",
  "p3-air",
- "p3-baby-bear 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-bn254-fr 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-challenger 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-commit 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-dft 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-field 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-fri 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-matrix 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-maybe-rayon 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
+ "p3-baby-bear 0.1.3-succinct",
+ "p3-bn254-fr",
+ "p3-challenger 0.1.3-succinct",
+ "p3-commit",
+ "p3-dft 0.1.3-succinct",
+ "p3-field 0.1.3-succinct",
+ "p3-fri",
+ "p3-matrix 0.1.3-succinct",
+ "p3-maybe-rayon 0.1.3-succinct",
  "p3-merkle-tree",
- "p3-poseidon2 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-symmetric 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
+ "p3-poseidon2 0.1.3-succinct",
+ "p3-symmetric 0.1.3-succinct",
+ "p3-util 0.1.3-succinct",
  "serde",
  "serde_with",
  "sp1-core",
@@ -4126,13 +3405,13 @@ dependencies = [
  "sp1-primitives",
  "static_assertions",
  "tracing",
- "zkhash 0.2.0 (git+https://github.com/HorizenLabs/poseidon2)",
+ "zkhash 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sp1-recursion-derive"
-version = "0.1.0"
-source = "git+https://github.com/kroma-network/sp1.git?rev=353bf42#353bf429877bfeeeddb722b5a1e0c4c59881668f"
+version = "1.0.1"
+source = "git+https://github.com/kroma-network/sp1.git?rev=dd032eb#dd032eb23949828d244d1ad1f1569aa78155837c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4141,55 +3420,57 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-ffi"
-version = "0.1.0"
-source = "git+https://github.com/kroma-network/sp1.git?rev=353bf42#353bf429877bfeeeddb722b5a1e0c4c59881668f"
+version = "1.0.1"
+source = "git+https://github.com/kroma-network/sp1.git?rev=dd032eb#dd032eb23949828d244d1ad1f1569aa78155837c"
 dependencies = [
+ "anyhow",
+ "bincode",
  "bindgen",
  "cc",
  "cfg-if 1.0.0",
+ "hex",
  "log",
- "num-bigint 0.4.5",
- "p3-baby-bear 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-field 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
+ "num-bigint 0.4.6",
+ "p3-baby-bear 0.1.3-succinct",
+ "p3-field 0.1.3-succinct",
+ "p3-symmetric 0.1.3-succinct",
  "rand 0.8.5",
  "serde",
  "serde_json",
+ "sha2",
+ "sp1-core",
  "sp1-recursion-compiler",
  "tempfile",
 ]
 
 [[package]]
 name = "sp1-recursion-program"
-version = "0.1.0"
-source = "git+https://github.com/kroma-network/sp1.git?rev=353bf42#353bf429877bfeeeddb722b5a1e0c4c59881668f"
+version = "1.0.1"
+source = "git+https://github.com/kroma-network/sp1.git?rev=dd032eb#dd032eb23949828d244d1ad1f1569aa78155837c"
 dependencies = [
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "p3-air",
- "p3-baby-bear 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-challenger 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-commit 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-dft 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-field 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-fri 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-matrix 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-maybe-rayon 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
+ "p3-baby-bear 0.1.3-succinct",
+ "p3-challenger 0.1.3-succinct",
+ "p3-commit",
+ "p3-dft 0.1.3-succinct",
+ "p3-field 0.1.3-succinct",
+ "p3-fri",
+ "p3-matrix 0.1.3-succinct",
+ "p3-maybe-rayon 0.1.3-succinct",
  "p3-merkle-tree",
- "p3-poseidon2 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-symmetric 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
- "p3-util 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=3b5265f9d5af36534a46caebf0617595cfb42c5a)",
+ "p3-poseidon2 0.1.3-succinct",
+ "p3-symmetric 0.1.3-succinct",
+ "p3-util 0.1.3-succinct",
  "rand 0.8.5",
  "serde",
  "sp1-core",
+ "sp1-primitives",
  "sp1-recursion-compiler",
  "sp1-recursion-core",
+ "stacker",
  "tracing",
 ]
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
@@ -4205,6 +3486,19 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "stacker"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce"
+dependencies = [
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "psm",
+ "winapi",
 ]
 
 [[package]]
@@ -4276,33 +3570,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "tachyon_halo2"
 version = "0.0.1"
 dependencies = [
@@ -4312,7 +3579,7 @@ dependencies = [
  "halo2_proofs 1.1.0 (git+https://github.com/kroma-network/halo2.git?rev=28ceefb)",
  "halo2curves",
  "log",
- "num-bigint 0.4.5",
+ "num-bigint 0.4.6",
  "rand_chacha",
  "rand_core 0.6.4",
  "rand_xorshift",
@@ -4325,11 +3592,11 @@ name = "tachyon_plonky3"
 version = "0.0.1"
 dependencies = [
  "cxx",
- "p3-baby-bear 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
- "p3-challenger 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
- "p3-field 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
- "p3-poseidon2 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
- "p3-symmetric 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
+ "p3-baby-bear 0.1.0",
+ "p3-challenger 0.1.0",
+ "p3-field 0.1.0",
+ "p3-poseidon2 0.1.0",
+ "p3-symmetric 0.1.0",
  "tachyon_rs",
  "zkhash 0.2.0 (git+https://github.com/HorizenLabs/poseidon2)",
 ]
@@ -4347,14 +3614,14 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "cxx",
- "p3-challenger 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
- "p3-commit 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
- "p3-dft 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
- "p3-field 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
- "p3-fri 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
- "p3-matrix 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
- "p3-maybe-rayon 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
- "p3-util 0.1.0 (git+https://github.com/kroma-network/Plonky3.git?rev=3b5265f)",
+ "p3-challenger 0.1.3-succinct",
+ "p3-commit",
+ "p3-dft 0.1.3-succinct",
+ "p3-field 0.1.3-succinct",
+ "p3-fri",
+ "p3-matrix 0.1.3-succinct",
+ "p3-maybe-rayon 0.1.3-succinct",
+ "p3-util 0.1.3-succinct",
  "sp1-core",
  "sp1-prover",
  "tachyon_rs",
@@ -4458,85 +3725,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
-name = "tokio"
-version = "1.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
-dependencies = [
- "backtrace",
- "bytes",
- "libc",
- "mio",
- "num_cpus",
- "parking_lot",
- "pin-project-lite",
- "signal-hook-registry",
- "socket2",
- "tokio-macros",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
-dependencies = [
- "rustls",
- "rustls-pki-types",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "toml_datetime"
 version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4563,33 +3751,6 @@ dependencies = [
  "toml_datetime",
  "winnow",
 ]
-
-[[package]]
-name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project",
- "pin-project-lite",
- "tokio",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-layer"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
-
-[[package]]
-name = "tower-service"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
@@ -4675,60 +3836,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "try-lock"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
-dependencies = [
- "tinyvec",
-]
-
-[[package]]
-name = "unicode-width"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
-
-[[package]]
-name = "untrusted"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "url"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
-dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
-]
 
 [[package]]
 name = "utf8parse"
@@ -4743,25 +3860,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "want"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
-dependencies = [
- "try-lock",
-]
 
 [[package]]
 name = "wasi"
@@ -4795,18 +3897,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
-dependencies = [
- "cfg-if 1.0.0",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4836,29 +3926,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
-name = "wasm-streams"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "web-sys"
-version = "0.3.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4866,15 +3933,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -5069,16 +4127,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winreg"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
-dependencies = [
- "cfg-if 1.0.0",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5130,9 +4178,36 @@ dependencies = [
 [[package]]
 name = "zkhash"
 version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4352d1081da6922701401cdd4cbf29a2723feb4cfabb5771f6fee8e9276da1c7"
+dependencies = [
+ "ark-ff",
+ "ark-std 0.4.0",
+ "bitvec",
+ "blake2",
+ "bls12_381",
+ "byteorder",
+ "cfg-if 1.0.0",
+ "group 0.12.1",
+ "group 0.13.0",
+ "halo2",
+ "hex",
+ "jubjub",
+ "lazy_static",
+ "pasta_curves 0.5.1",
+ "rand 0.8.5",
+ "serde",
+ "sha2",
+ "sha3 0.10.8",
+ "subtle",
+]
+
+[[package]]
+name = "zkhash"
+version = "0.2.0"
 source = "git+https://github.com/HorizenLabs/poseidon2.git?rev=bb476b9#bb476b9ca38198cf5092487283c8b8c5d4317c4e"
 dependencies = [
- "ark-ff 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ark-ff",
  "ark-std 0.4.0",
  "bitvec",
  "blake2",
@@ -5158,7 +4233,7 @@ name = "zkhash"
 version = "0.2.0"
 source = "git+https://github.com/HorizenLabs/poseidon2#bb476b9ca38198cf5092487283c8b8c5d4317c4e"
 dependencies = [
- "ark-ff 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ark-ff",
  "ark-std 0.4.0",
  "bitvec",
  "blake2",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -31,9 +31,7 @@ rules_rust_dependencies()
 
 rust_register_toolchains(
     edition = "2021",
-    versions = [
-        "1.77.1",
-    ],
+    versions = ["nightly/2024-04-17"],
 )
 
 load("@rules_rust//crate_universe:repositories.bzl", "crate_universe_dependencies")
@@ -45,15 +43,8 @@ load("@rules_rust//crate_universe:defs.bzl", "crate", "crates_repository")
 crates_repository(
     name = "crate_index",
     annotations = {
-        "ring": [crate.annotation(
-            build_script_env = {
-                "CARGO_MANIFEST_LINKS": "ring_core_0_17_8",
-            },
-        )],
         "sp1-prover": [crate.annotation(
-            data = [
-                "src/fibonacci/program/elf/riscv32im-succinct-zkvm-elf",
-            ],
+            data = ["elf/riscv32im-succinct-zkvm-elf"],
         )],
     },
     cargo_lockfile = "//:Cargo.lock",
@@ -87,6 +78,7 @@ crates_repository(
             version = "0.3.9",
         ),
     },
+    rust_version = "nightly/2024-04-17",
 )
 
 load(

--- a/benchmark/fft/arkworks/Cargo.toml
+++ b/benchmark/fft/arkworks/Cargo.toml
@@ -17,6 +17,6 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ark-test-curves = { git = "https://github.com/kroma-network/algebra.git", rev = "53f396c" }
+ark-bn254 = { git = "https://github.com/arkworks-rs/curves.git", tag = "v0.4.0-alpha.2" }
 ark-poly = { version = "0.4.2", features = ["parallel"] }
 tachyon_rs = { path = "../../../tachyon/rs" }

--- a/benchmark/fft/arkworks/src/lib.rs
+++ b/benchmark/fft/arkworks/src/lib.rs
@@ -1,5 +1,5 @@
+use ark_bn254::Fr;
 use ark_poly::domain::{EvaluationDomain, Radix2EvaluationDomain};
-use ark_test_curves::bn254::Fr;
 use std::{mem, slice, time::Instant};
 use tachyon_rs::math::elliptic_curves::bn::bn254::Fr as CppFr;
 

--- a/benchmark/fft/fft_benchmark.cc
+++ b/benchmark/fft/fft_benchmark.cc
@@ -84,47 +84,80 @@ void Run(const FFTConfig& config) {
   std::cout << "Generating evaluation domain and random polys..." << std::endl;
   std::vector<std::unique_ptr<Domain>> domains = base::Map(
       degrees, [](size_t degree) { return Domain::Create(degree + 1); });
+  std::vector<std::unique_ptr<Domain>> halo2_domains;
+  for (const FFTConfig::Vendor vendor : config.vendors()) {
+    if (vendor == FFTConfig::Vendor::kBellman ||
+        vendor == FFTConfig::Vendor::kHalo2) {
+      math::halo2::ScopedSubgroupGeneratorOverrider scoped_overrider;
+      halo2_domains = base::Map(
+          degrees, [](size_t degree) { return Domain::Create(degree + 1); });
+      break;
+    }
+  }
   std::vector<PolyOrEvals> polys = base::Map(
       degrees, [](size_t degree) { return PolyOrEvals::Random(degree); });
   std::cout << "Generation completed" << std::endl;
 
   FFTRunner<Domain, PolyOrEvals> runner(&reporter);
-  runner.SetInputs(&polys, std::move(domains));
+  runner.set_polys(polys);
 
   std::vector<RetPoly> results;
+  std::vector<RetPoly> halo2_results;
   if constexpr (std::is_same_v<PolyOrEvals, typename Domain::Evals>) {
+    runner.set_domains(absl::MakeSpan(domains));
     runner.Run(tachyon_bn254_univariate_evaluation_domain_ifft_inplace, degrees,
-               &results);
+               &results, true);
+    if (!halo2_domains.empty()) {
+      runner.set_domains(absl::MakeSpan(halo2_domains));
+      runner.Run(tachyon_bn254_univariate_evaluation_domain_ifft_inplace,
+                 degrees, &halo2_results, false);
+    }
     for (const FFTConfig::Vendor vendor : config.vendors()) {
       std::vector<RetPoly> results_vendor;
       if (vendor == FFTConfig::Vendor::kArkworks) {
+        runner.set_domains(absl::MakeSpan(domains));
         runner.RunExternal(run_ifft_arkworks, config.exponents(),
                            &results_vendor);
+        CheckResults(config.check_results(), results, results_vendor);
       } else if (vendor == FFTConfig::Vendor::kBellman) {
+        runner.set_domains(absl::MakeSpan(halo2_domains));
         runner.RunExternal(run_ifft_bellman, config.exponents(),
                            &results_vendor);
+        CheckResults(config.check_results(), halo2_results, results_vendor);
       } else if (vendor == FFTConfig::Vendor::kHalo2) {
+        runner.set_domains(absl::MakeSpan(halo2_domains));
         runner.RunExternal(run_ifft_halo2, config.exponents(), &results_vendor);
+        CheckResults(config.check_results(), halo2_results, results_vendor);
       }
-      CheckResults(config.check_results(), results, results_vendor);
     }
     // NOLINTNEXTLINE(readability/braces)
   } else if constexpr (std::is_same_v<PolyOrEvals,
                                       typename Domain::DensePoly>) {
+    runner.set_domains(absl::MakeSpan(domains));
     runner.Run(tachyon_bn254_univariate_evaluation_domain_fft_inplace, degrees,
-               &results);
+               &results, true);
+    if (!halo2_domains.empty()) {
+      runner.set_domains(absl::MakeSpan(halo2_domains));
+      runner.Run(tachyon_bn254_univariate_evaluation_domain_fft_inplace,
+                 degrees, &halo2_results, false);
+    }
     for (const FFTConfig::Vendor vendor : config.vendors()) {
       std::vector<RetPoly> results_vendor;
       if (vendor == FFTConfig::Vendor::kArkworks) {
+        runner.set_domains(absl::MakeSpan(domains));
         runner.RunExternal(run_fft_arkworks, config.exponents(),
                            &results_vendor);
+        CheckResults(config.check_results(), results, results_vendor);
       } else if (vendor == FFTConfig::Vendor::kBellman) {
+        runner.set_domains(absl::MakeSpan(halo2_domains));
         runner.RunExternal(run_fft_bellman, config.exponents(),
                            &results_vendor);
+        CheckResults(config.check_results(), halo2_results, results_vendor);
       } else if (vendor == FFTConfig::Vendor::kHalo2) {
+        runner.set_domains(absl::MakeSpan(halo2_domains));
         runner.RunExternal(run_fft_halo2, config.exponents(), &results_vendor);
+        CheckResults(config.check_results(), halo2_results, results_vendor);
       }
-      CheckResults(config.check_results(), results, results_vendor);
     }
   }
 
@@ -139,7 +172,6 @@ int RealMain(int argc, char** argv) {
   using Evals = Domain::Evals;
 
   Field::Init();
-  math::halo2::OverrideSubgroupGenerator();
 
   FFTConfig config;
   FFTConfig::Options options;

--- a/benchmark/poseidon2/plonky3/Cargo.toml
+++ b/benchmark/poseidon2/plonky3/Cargo.toml
@@ -17,9 +17,9 @@ publish = false
 
 [dependencies]
 ff = { version = "0.13", features = ["derive", "derive_bits"] }
-p3-bn254-fr = { git = "https://github.com/Plonky3/Plonky3.git", rev = "54069b1" }
-p3-field = { git = "https://github.com/Plonky3/Plonky3.git", rev = "54069b1" }
-p3-poseidon2 = { git = "https://github.com/Plonky3/Plonky3.git", rev = "54069b1" }
-p3-symmetric = { git = "https://github.com/Plonky3/Plonky3.git", rev = "54069b1" }
+p3-bn254-fr = "0.1.3-succinct"
+p3-field = "0.1.3-succinct"
+p3-poseidon2 = "0.1.3-succinct"
+p3-symmetric = "0.1.3-succinct"
 zkhash = { git = "https://github.com/HorizenLabs/poseidon2.git", rev = "bb476b9" }
 tachyon_rs = { path = "../../../tachyon/rs" }

--- a/docs/how_to_use/how_to_build.md
+++ b/docs/how_to_use/how_to_build.md
@@ -227,6 +227,14 @@ For example, add the following to `.bazelrc.user` to build rust on linux:
 build --build_tag_filters -objc,-cuda
 ```
 
+### Build Rust code
+
+Since the current toolchain is using the nightly channel, the following build flag is needed. Add this to your `.bazelrc.user`.
+
+```
+build --@rules_rust//rust/toolchain/channel=nightly
+```
+
 ### Build SP1 Rust code
 
 Since [scale-info](https://crates.io/crates/scale-info) needs a `CARGO` environment variable, add this to your `.bazelrc.user`.

--- a/tachyon/rs/src/math/finite_fields/mod.rs
+++ b/tachyon/rs/src/math/finite_fields/mod.rs
@@ -7,14 +7,14 @@ use zeroize::Zeroize;
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash, Zeroize)]
 pub struct PrimeField<const N: usize>(pub BigInt<N>);
 
-#[repr(C, align(32))]
+#[repr(C)]
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash, Zeroize)]
 pub struct Fq2<PrimeField> {
     pub c0: PrimeField,
     pub c1: PrimeField,
 }
 
-#[repr(C, align(32))]
+#[repr(C)]
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash, Zeroize)]
 pub struct Fq6<Fq2> {
     pub c0: Fq2,
@@ -22,7 +22,7 @@ pub struct Fq6<Fq2> {
     pub c2: Fq2,
 }
 
-#[repr(C, align(32))]
+#[repr(C)]
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash, Zeroize)]
 pub struct Fq12<Fq6> {
     pub c0: Fq6,

--- a/tachyon/rs/src/math/geometry/mod.rs
+++ b/tachyon/rs/src/math/geometry/mod.rs
@@ -1,6 +1,6 @@
 use zeroize::Zeroize;
 
-#[repr(C, align(32))]
+#[repr(C)]
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash, Zeroize)]
 pub struct Point2<T> {
     pub x: T,

--- a/vendors/halo2/Cargo.toml
+++ b/vendors/halo2/Cargo.toml
@@ -18,7 +18,7 @@ publish = false
 cxx = "1.0"
 digest = "0.10.3"
 ff = "0.13"
-log = "0.4.17"
+log = "0.4.22"
 num-bigint = { version = "0.4", features = ["rand"] }
 halo2_proofs = { git = "https://github.com/kroma-network/halo2.git", rev = "28ceefb" }
 halo2curves = { version = "0.1.0", features = ["derive_serde"] }

--- a/vendors/sp1/Cargo.toml
+++ b/vendors/sp1/Cargo.toml
@@ -17,18 +17,16 @@ publish = false
 [dependencies]
 anyhow = "1.0.83"
 cxx = "1.0"
-p3-challenger = { git = "https://github.com/kroma-network/Plonky3.git", rev = "3b5265f" }
-p3-commit = { git = "https://github.com/kroma-network/Plonky3.git", rev = "3b5265f" }
-p3-dft = { git = "https://github.com/kroma-network/Plonky3.git", rev = "3b5265f" }
-p3-field = { git = "https://github.com/kroma-network/Plonky3.git", rev = "3b5265f" }
-p3-fri = { git = "https://github.com/kroma-network/Plonky3.git", rev = "3b5265f" }
-p3-matrix = { git = "https://github.com/kroma-network/Plonky3.git", rev = "3b5265f" }
-p3-maybe-rayon = { git = "https://github.com/kroma-network/Plonky3.git", rev = "3b5265f", features = [
-  "parallel",
-] }
-p3-util = { git = "https://github.com/kroma-network/Plonky3.git", rev = "3b5265f" }
-sp1-core = { git = "https://github.com/kroma-network/sp1.git", rev = "353bf42" }
-sp1-prover = { git = "https://github.com/kroma-network/sp1.git", rev = "353bf42" }
+p3-challenger = "0.1.3-succinct"
+p3-commit = "0.1.3-succinct"
+p3-dft = "0.1.3-succinct"
+p3-field = "0.1.3-succinct"
+p3-fri = "0.1.3-succinct"
+p3-matrix = "0.1.3-succinct"
+p3-maybe-rayon = "0.1.3-succinct"
+p3-util = "0.1.3-succinct"
+sp1-core = { git = "https://github.com/kroma-network/sp1.git", rev = "dd032eb" }
+sp1-prover = { git = "https://github.com/kroma-network/sp1.git", rev = "dd032eb" }
 tachyon_rs = { path = "../../tachyon/rs" }
 
 [dev-dependencies]

--- a/vendors/sp1/src/lib.rs
+++ b/vendors/sp1/src/lib.rs
@@ -4,22 +4,25 @@ pub mod sp1;
 mod test {
     use anyhow::Result;
     use sp1_core::io::SP1Stdin;
-    use sp1_core::utils::setup_logger;
-    use sp1_prover::SP1Prover;
+    use sp1_core::{runtime::SP1Context, utils::setup_logger};
+    use sp1_prover::{components::DefaultProverComponents, SP1Prover};
 
     #[test]
     // This causes an stack overflow error on debug mode.
     #[cfg(not(debug_assertions))]
     fn test_e2e() -> Result<()> {
+        use sp1_core::utils::SP1ProverOpts;
+
         setup_logger();
         let elf = include_bytes!("tests/fibonacci/elf/riscv32im-succinct-zkvm-elf");
 
-        let prover = SP1Prover::new();
+        let prover = SP1Prover::<DefaultProverComponents>::new();
 
         let (pk, vk) = prover.setup(elf);
 
         let stdin = SP1Stdin::new();
-        let core_proof = prover.prove_core(&pk, &stdin)?;
+        let core_proof =
+            prover.prove_core(&pk, &stdin, SP1ProverOpts::default(), SP1Context::default())?;
 
         prover.verify(&core_proof.proof, &vk)?;
 


### PR DESCRIPTION
In this PR, `sp1-prover` was updated to version v1.0.1, along with a batch update of the associated packages.

[FYI] Some dependencies of arkworks have changed, but the benchmark results for Poseidon, Poseidon2, FFT and MSM remain unchanged.