### PR TITLE
ci: reduce cache storage usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Cleanup Cache
+        if: github.event.pull_request.merged == true
+        run: |
+          # get the ref key
+          ref_key="refs/pull/${{ github.event.pull_request.number }}/merge"
+
+          # delete cache
+          gh cache list --ref $ref_key --limit 100 | cut -f 1 | xargs -n1 gh cache delete
+        continue-on-error: true
+
       - name: Set up Bazel
         uses: bazel-contrib/setup-bazel@0.8.5
         with:
@@ -37,9 +47,9 @@ jobs:
           # Share a single build cache between workflows.
           disk-cache: ${{ matrix.os }}-${{ matrix.build_flag }}-${{ matrix.openmp }}
           # Share repository cache between workflows.
-          repository-cache: true
-          # Enable external repositories caches
-          external-cache: true
+          repository-cache: false
+          # Cache external repositories
+          external-cache: false
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cleanup Cache
         if: github.event.pull_request.merged == true
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -118,7 +118,7 @@ jobs:
           git fetch --all
 
       - name: Setup Python for cpplint
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10.12"
 


### PR DESCRIPTION
# Description

GitHub cache storage is limited to 10GB but it looks like [we can exceed it easily](https://github.com/kroma-network/tachyon/actions/caches) when working on multiple branches.
Exceeding the storage limit may result in unwanted deletion of caches (i.e main branch caches). It even went up to 20GB+ at some point so I had to clean them up with a script. So with this PR, we try to minimize our cache storage usage while keeping build/test time low.