### PR TITLE
test: optimize openmp test

### DIFF
--- a/bazel/tachyon_cc.bzl
+++ b/bazel/tachyon_cc.bzl
@@ -92,6 +92,11 @@ def tachyon_openmp_linkopts():
 def tachyon_linkopts():
     return tachyon_openmp_linkopts()
 
+def tachyon_openmp_num_threads_env(n):
+    return if_has_openmp({
+        "OMP_NUM_THREADS": "{}".format(n),
+    }, {})
+
 def tachyon_cc_library(
         name,
         copts = [],

--- a/tachyon/c/zk/plonk/halo2/BUILD.bazel
+++ b/tachyon/c/zk/plonk/halo2/BUILD.bazel
@@ -3,6 +3,7 @@ load(
     "tachyon_cc_binary",
     "tachyon_cc_library",
     "tachyon_cc_unittest",
+    "tachyon_openmp_num_threads_env",
 )
 
 package(default_visibility = ["//visibility:public"])
@@ -291,7 +292,7 @@ tachyon_cc_unittest(
         "bn254_prover_unittest.cc",
         "bn254_transcript_unittest.cc",
     ],
-    tags = ["exclusive"],
+    env = tachyon_openmp_num_threads_env(4),
     deps = [
         ":bn254_prover",
         "//tachyon/c/crypto/random:rng",

--- a/tachyon/c/zk/plonk/halo2/bn254_prover_unittest.cc
+++ b/tachyon/c/zk/plonk/halo2/bn254_prover_unittest.cc
@@ -135,6 +135,13 @@ TEST_P(ProverTest, Constructor) {
 }
 
 TEST_P(ProverTest, Getters) {
+  Param param = GetParam();
+  if (param.ls_type != TACHYON_HALO2_HALO2_LS ||
+      param.transcript_type != TACHYON_HALO2_BLAKE2B_TRANSCRIPT) {
+    GTEST_SKIP()
+        << "Getters test is not related to ls_type and transcript_type";
+  }
+
   EXPECT_EQ(tachyon_halo2_bn254_prover_get_k(prover_), k_);
   EXPECT_EQ(tachyon_halo2_bn254_prover_get_n(prover_), size_t{1} << k_);
   tachyon_bn254_blinder* blinder =
@@ -178,6 +185,11 @@ TEST_P(ProverTest, Getters) {
 }
 
 TEST_P(ProverTest, Commit) {
+  Param param = GetParam();
+  if (param.transcript_type != TACHYON_HALO2_BLAKE2B_TRANSCRIPT) {
+    GTEST_SKIP() << "Commit test is not related to transcript type";
+  }
+
   using Poly =
       math::UnivariateDensePolynomial<math::bn254::Fr, c::math::kMaxDegree>;
   Poly poly = Poly::Random(5);
@@ -233,6 +245,11 @@ TEST_P(ProverTest, Commit) {
 }
 
 TEST_P(ProverTest, CommitLagrange) {
+  Param param = GetParam();
+  if (param.transcript_type != TACHYON_HALO2_BLAKE2B_TRANSCRIPT) {
+    GTEST_SKIP() << "CommitLagrange test is not related to transcript type";
+  }
+
   using Evals =
       math::UnivariateEvaluations<math::bn254::Fr, c::math::kMaxDegree>;
   Evals evals = Evals::Random(5);
@@ -289,6 +306,11 @@ TEST_P(ProverTest, CommitLagrange) {
 }
 
 TEST_P(ProverTest, BatchCommit) {
+  Param param = GetParam();
+  if (param.transcript_type != TACHYON_HALO2_BLAKE2B_TRANSCRIPT) {
+    GTEST_SKIP() << "BatchCommit test is not related to transcript type";
+  }
+
   using Poly =
       math::UnivariateDensePolynomial<math::bn254::Fr, c::math::kMaxDegree>;
   std::vector<Poly> polys =
@@ -352,6 +374,12 @@ TEST_P(ProverTest, BatchCommit) {
 }
 
 TEST_P(ProverTest, BatchCommitLagrange) {
+  Param param = GetParam();
+  if (param.transcript_type != TACHYON_HALO2_BLAKE2B_TRANSCRIPT) {
+    GTEST_SKIP()
+        << "BatchCommitLagrange test is not related to transcript type";
+  }
+
   using Evals =
       math::UnivariateEvaluations<math::bn254::Fr, c::math::kMaxDegree>;
   std::vector<Evals> evals_vec =
@@ -452,12 +480,23 @@ void SetRngTestImpl(tachyon_halo2_bn254_prover* prover, uint8_t rng_type) {
 }
 
 TEST_P(ProverTest, SetRng) {
+  Param param = GetParam();
+  if (param.ls_type != TACHYON_HALO2_HALO2_LS ||
+      param.transcript_type != TACHYON_HALO2_BLAKE2B_TRANSCRIPT) {
+    GTEST_SKIP() << "SetRng test is not related to ls_type and transcript_type";
+  }
+
   SetRngTestImpl<crypto::XORShiftRNG>(prover_, TACHYON_RNG_XOR_SHIFT);
   SetRngTestImpl<crypto::ChaCha20RNG>(prover_, TACHYON_RNG_CHA_CHA20);
 }
 
 TEST_P(ProverTest, SetTranscript) {
-  uint8_t transcript_type = GetParam().transcript_type;
+  Param param = GetParam();
+  if (param.ls_type != TACHYON_HALO2_HALO2_LS) {
+    GTEST_SKIP() << "SetRng test is not related to ls_type";
+  }
+
+  uint8_t transcript_type = param.transcript_type;
 
   tachyon_halo2_bn254_transcript_writer* transcript =
       tachyon_halo2_bn254_transcript_writer_create(transcript_type);

--- a/tachyon/math/polynomials/univariate/BUILD.bazel
+++ b/tachyon/math/polynomials/univariate/BUILD.bazel
@@ -1,5 +1,10 @@
 load("//bazel:tachyon.bzl", "if_gpu_is_configured")
-load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_unittest")
+load(
+    "//bazel:tachyon_cc.bzl",
+    "tachyon_cc_library",
+    "tachyon_cc_unittest",
+    "tachyon_openmp_num_threads_env",
+)
 
 package(default_visibility = ["//visibility:public"])
 
@@ -163,7 +168,7 @@ tachyon_cc_unittest(
         "univariate_evaluations_unittest.cc",
         "univariate_sparse_polynomial_unittest.cc",
     ],
-    tags = ["exclusive"],
+    env = tachyon_openmp_num_threads_env(4),
     deps = [
         ":lagrange_interpolation",
         ":mixed_radix_evaluation_domain",

--- a/tachyon/zk/plonk/examples/BUILD.bazel
+++ b/tachyon/zk/plonk/examples/BUILD.bazel
@@ -1,4 +1,9 @@
-load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_unittest")
+load(
+    "//bazel:tachyon_cc.bzl",
+    "tachyon_cc_library",
+    "tachyon_cc_unittest",
+    "tachyon_openmp_num_threads_env",
+)
 
 package(default_visibility = ["//visibility:public"])
 
@@ -141,7 +146,7 @@ tachyon_cc_library(
 tachyon_cc_unittest(
     name = "multi_lookup_circuit_test",
     srcs = ["multi_lookup_circuit_test.cc"],
-    tags = ["exclusive"],
+    env = tachyon_openmp_num_threads_env(4),
     deps = COMMON_TEST_DEPS + [
         ":multi_lookup_circuit",
         ":multi_lookup_circuit_test_data",
@@ -151,7 +156,7 @@ tachyon_cc_unittest(
 tachyon_cc_unittest(
     name = "shuffle_circuit_test",
     srcs = ["shuffle_circuit_test.cc"],
-    tags = ["exclusive"],
+    env = tachyon_openmp_num_threads_env(4),
     deps = COMMON_TEST_DEPS + [
         ":shuffle_circuit",
         ":shuffle_circuit_test_data",
@@ -161,7 +166,7 @@ tachyon_cc_unittest(
 tachyon_cc_unittest(
     name = "shuffle_api_circuit_test",
     srcs = ["shuffle_api_circuit_test.cc"],
-    tags = ["exclusive"],
+    env = tachyon_openmp_num_threads_env(4),
     deps = COMMON_TEST_DEPS + [
         ":shuffle_api_circuit",
         ":shuffle_api_circuit_test_data",
@@ -171,7 +176,7 @@ tachyon_cc_unittest(
 tachyon_cc_unittest(
     name = "simple_circuit_test",
     srcs = ["simple_circuit_test.cc"],
-    tags = ["exclusive"],
+    env = tachyon_openmp_num_threads_env(4),
     deps = COMMON_TEST_DEPS + [
         ":simple_circuit",
         ":simple_circuit_test_data",
@@ -181,7 +186,7 @@ tachyon_cc_unittest(
 tachyon_cc_unittest(
     name = "simple_lookup_circuit_test",
     srcs = ["simple_lookup_circuit_test.cc"],
-    tags = ["exclusive"],
+    env = tachyon_openmp_num_threads_env(4),
     deps = COMMON_TEST_DEPS + [
         ":simple_lookup_circuit",
         ":simple_lookup_circuit_test_data",

--- a/tachyon/zk/plonk/examples/fibonacci/BUILD.bazel
+++ b/tachyon/zk/plonk/examples/fibonacci/BUILD.bazel
@@ -1,4 +1,9 @@
-load("//bazel:tachyon_cc.bzl", "tachyon_cc_library", "tachyon_cc_unittest")
+load(
+    "//bazel:tachyon_cc.bzl",
+    "tachyon_cc_library",
+    "tachyon_cc_unittest",
+    "tachyon_openmp_num_threads_env",
+)
 
 package(default_visibility = ["//visibility:public"])
 
@@ -70,7 +75,7 @@ tachyon_cc_unittest(
     name = "fibonacci1_circuit_test",
     testonly = True,
     srcs = ["fibonacci1_circuit_test.cc"],
-    tags = ["exclusive"],
+    env = tachyon_openmp_num_threads_env(4),
     deps = COMMON_TEST_DEPS + [
         "fibonacci1_circuit_test_data",
         ":fibonacci1_circuit",
@@ -81,7 +86,7 @@ tachyon_cc_unittest(
     name = "fibonacci2_circuit_test",
     testonly = True,
     srcs = ["fibonacci2_circuit_test.cc"],
-    tags = ["exclusive"],
+    env = tachyon_openmp_num_threads_env(4),
     deps = COMMON_TEST_DEPS + [
         "fibonacci2_circuit_test_data",
         ":fibonacci2_circuit",
@@ -92,7 +97,7 @@ tachyon_cc_unittest(
     name = "fibonacci3_circuit_test",
     testonly = True,
     srcs = ["fibonacci3_circuit_test.cc"],
-    tags = ["exclusive"],
+    env = tachyon_openmp_num_threads_env(4),
     deps = COMMON_TEST_DEPS + [
         "fibonacci3_circuit_test_data",
         ":fibonacci3_circuit",


### PR DESCRIPTION
# Description

#498 introduced an `exclusive` tag that caused some tests to run sequentially, which slowed down the test times. This PR improves the situation by limiting the number of threads to 4. This change increases the likelihood of passing the unit tests and reduces the overall test time.

See https://bazel.build/reference/be/common-definitions#common.tags.
