### PR TITLE
feat(math): add `TwoInv` constant

### DIFF
--- a/tachyon/crypto/commitments/fri/fri.h
+++ b/tachyon/crypto/commitments/fri/fri.h
@@ -128,7 +128,6 @@ class FRI final
     F beta;
     F evaluation;
     F evaluation_sym;
-    F two_inv = unwrap(F(2).Inverse());
     for (uint32_t i = 0; i < num_layers; ++i) {
       BinaryMerkleTreeStorage<F>* layer = storage_->GetLayer(i);
       BinaryMerkleTree<F, F, MaxDegree + 1> tree(layer, hasher_);
@@ -171,7 +170,7 @@ class FRI final
         evaluation *= (F::One() + beta);
         evaluation_sym *= (F::One() - beta);
         evaluation += evaluation_sym;
-        evaluation *= two_inv;
+        evaluation *= F::TwoInv();
 
         if (evaluation != proof.evaluations[i]) {
           LOG(ERROR)
@@ -191,7 +190,7 @@ class FRI final
     evaluation *= (F::One() + beta);
     evaluation_sym *= (F::One() - beta);
     evaluation += evaluation_sym;
-    evaluation *= two_inv;
+    evaluation *= F::TwoInv();
 
     if (!reader->ReadFromProof(&root)) return false;
     if (root != evaluation) {

--- a/tachyon/crypto/commitments/fri/two_adic_fri_config.h
+++ b/tachyon/crypto/commitments/fri/two_adic_fri_config.h
@@ -44,10 +44,7 @@ std::vector<ExtF> FoldMatrix(const ExtF& beta,
   F w;
   CHECK(F::GetRootOfUnity(1 << (base::bits::CheckedLog2(rows) + 1), &w));
   ExtF w_inv = ExtF(unwrap(w.Inverse()));
-  // TODO(ashjeong): implement a field function |TwoInv()| as the inverse of 2
-  // is computed often.
-  ExtF one_half = ExtF(unwrap(F(2).Inverse()));
-  ExtF half_beta = beta * one_half;
+  ExtF half_beta = beta * ExtF::TwoInv();
 
   // β/2 times successive powers of gᵢₙᵥ
   std::vector<ExtF> powers =
@@ -57,7 +54,8 @@ std::vector<ExtF> FoldMatrix(const ExtF& beta,
   OMP_PARALLEL_FOR(size_t r = 0; r < rows; ++r) {
     const ExtF& lo = mat(r, 0);
     const ExtF& hi = mat(r, 1);
-    ret[r] = (one_half + powers[r]) * lo + (one_half - powers[r]) * hi;
+    ret[r] =
+        (ExtF::TwoInv() + powers[r]) * lo + (ExtF::TwoInv() - powers[r]) * hi;
   }
   return ret;
 }

--- a/tachyon/math/base/rational_field.h
+++ b/tachyon/math/base/rational_field.h
@@ -38,6 +38,8 @@ class RationalField : public Field<RationalField<F>> {
     return RationalField(F::MinusOne());
   }
 
+  constexpr static RationalField TwoInv() { return RationalField(F::TwoInv()); }
+
   constexpr static RationalField Random() {
     F denominator = F::Random();
     while (denominator.IsZero()) {

--- a/tachyon/math/base/rational_field_unittest.cc
+++ b/tachyon/math/base/rational_field_unittest.cc
@@ -38,6 +38,11 @@ TEST_F(RationalFieldTest, MinusOne) {
   EXPECT_TRUE(R(GF7(4), GF7(3)).IsMinusOne());
 }
 
+TEST_F(RationalFieldTest, TwoInv) {
+  EXPECT_TRUE((R::TwoInv() * R(GF7(2), GF7::One())).IsOne());
+  EXPECT_FALSE((R::TwoInv() * R::One()).IsOne());
+}
+
 TEST_F(RationalFieldTest, Random) {
   bool success = false;
   R r = R::Random();

--- a/tachyon/math/elliptic_curves/bls12/g2_prepared.h
+++ b/tachyon/math/elliptic_curves/bls12/g2_prepared.h
@@ -35,8 +35,6 @@ class G2Prepared : public G2PreparedBase<BLS12CurveConfig> {
     if (q.IsZero()) {
       return {};
     } else {
-      Fp two_inv = unwrap(Fp(2).Inverse());
-
       EllCoeffs<Fp2> ell_coeffs;
       size_t size = Config::kXLimbNums * 64;
       // NOTE(chokobole): A bit array consists of elements from [0, 1].
@@ -51,7 +49,7 @@ class G2Prepared : public G2PreparedBase<BLS12CurveConfig> {
       ++it;
       auto end = BitIteratorBE<BigInt<Config::kXLimbNums>>::end(&Config::kX);
       while (it != end) {
-        ell_coeffs.push_back(r.DoubleInPlace(two_inv));
+        ell_coeffs.push_back(r.DoubleInPlace(Fp::TwoInv()));
         if (*it) {
           ell_coeffs.push_back(r.AddInPlace(q));
         }

--- a/tachyon/math/elliptic_curves/bn/g2_prepared.h
+++ b/tachyon/math/elliptic_curves/bn/g2_prepared.h
@@ -44,10 +44,9 @@ class G2Prepared : public G2PreparedBase<BNCurveConfig> {
 
       G2AffinePoint neg_q = -q;
 
-      Fp two_inv = unwrap(Fp(2).Inverse());
       // NOTE(chokobole): skip the fist.
       for (size_t i = size - 2; i != SIZE_MAX; --i) {
-        ell_coeffs.push_back(r.DoubleInPlace(two_inv));
+        ell_coeffs.push_back(r.DoubleInPlace(Fp::TwoInv()));
 
         switch (Config::kAteLoopCount[i]) {
           case 1:

--- a/tachyon/math/finite_fields/BUILD.bazel
+++ b/tachyon/math/finite_fields/BUILD.bazel
@@ -356,6 +356,7 @@ tachyon_cc_unittest(
         "//tachyon/math/finite_fields/baby_bear",
         "//tachyon/math/finite_fields/baby_bear:baby_bear4",
         "//tachyon/math/finite_fields/baby_bear:packed_baby_bear4",
+        "//tachyon/math/finite_fields/baby_bear/internal:packed_baby_bear",
         "//tachyon/math/finite_fields/binary_fields",
         "//tachyon/math/finite_fields/goldilocks",
         "//tachyon/math/finite_fields/koala_bear",

--- a/tachyon/math/finite_fields/baby_bear/internal/packed_baby_bear_avx2.cc
+++ b/tachyon/math/finite_fields/baby_bear/internal/packed_baby_bear_avx2.cc
@@ -18,6 +18,7 @@ __m256i kInv;
 __m256i kZero;
 __m256i kOne;
 __m256i kMinusOne;
+__m256i kTwoInv;
 
 __m256i ToVector(const PackedBabyBearAVX2& packed) {
   return _mm256_loadu_si256(
@@ -56,6 +57,7 @@ void PackedBabyBearAVX2::Init() {
   kZero = _mm256_set1_epi32(0);
   kOne = _mm256_set1_epi32(BabyBear::Config::kOne);
   kMinusOne = _mm256_set1_epi32(BabyBear::Config::kMinusOne);
+  kTwoInv = _mm256_set1_epi32(BabyBear::Config::kTwoInv);
 }
 
 // static
@@ -68,6 +70,9 @@ PackedBabyBearAVX2 PackedBabyBearAVX2::One() { return FromVector(kOne); }
 PackedBabyBearAVX2 PackedBabyBearAVX2::MinusOne() {
   return FromVector(kMinusOne);
 }
+
+// static
+PackedBabyBearAVX2 PackedBabyBearAVX2::TwoInv() { return FromVector(kTwoInv); }
 
 // static
 PackedBabyBearAVX2 PackedBabyBearAVX2::Broadcast(const PrimeField& value) {

--- a/tachyon/math/finite_fields/baby_bear/internal/packed_baby_bear_avx2.h
+++ b/tachyon/math/finite_fields/baby_bear/internal/packed_baby_bear_avx2.h
@@ -46,6 +46,8 @@ class TACHYON_EXPORT PackedBabyBearAVX2 final
 
   static PackedBabyBearAVX2 MinusOne();
 
+  static PackedBabyBearAVX2 TwoInv();
+
   static PackedBabyBearAVX2 Broadcast(const PrimeField& value);
 
   // AdditiveSemigroup methods

--- a/tachyon/math/finite_fields/baby_bear/internal/packed_baby_bear_avx512.cc
+++ b/tachyon/math/finite_fields/baby_bear/internal/packed_baby_bear_avx512.cc
@@ -20,6 +20,7 @@ __m512i kInv;
 __m512i kZero;
 __m512i kOne;
 __m512i kMinusOne;
+__m512i kTwoInv;
 
 __m512i ToVector(const PackedBabyBearAVX512& packed) {
   return _mm512_loadu_si512(packed.values().data());
@@ -56,6 +57,7 @@ void PackedBabyBearAVX512::Init() {
   kZero = _mm512_set1_epi32(0);
   kOne = _mm512_set1_epi32(BabyBear::Config::kOne);
   kMinusOne = _mm512_set1_epi32(BabyBear::Config::kMinusOne);
+  kTwoInv = _mm512_set1_epi32(BabyBear::Config::kTwoInv);
 }
 
 // static
@@ -67,6 +69,11 @@ PackedBabyBearAVX512 PackedBabyBearAVX512::One() { return FromVector(kOne); }
 // static
 PackedBabyBearAVX512 PackedBabyBearAVX512::MinusOne() {
   return FromVector(kMinusOne);
+}
+
+// static
+PackedBabyBearAVX512 PackedBabyBearAVX512::TwoInv() {
+  return FromVector(kTwoInv);
 }
 
 // static

--- a/tachyon/math/finite_fields/baby_bear/internal/packed_baby_bear_avx512.h
+++ b/tachyon/math/finite_fields/baby_bear/internal/packed_baby_bear_avx512.h
@@ -46,6 +46,8 @@ class TACHYON_EXPORT PackedBabyBearAVX512 final
 
   static PackedBabyBearAVX512 MinusOne();
 
+  static PackedBabyBearAVX512 TwoInv();
+
   static PackedBabyBearAVX512 Broadcast(const PrimeField& value);
 
   // AdditiveSemigroup methods

--- a/tachyon/math/finite_fields/baby_bear/internal/packed_baby_bear_neon.cc
+++ b/tachyon/math/finite_fields/baby_bear/internal/packed_baby_bear_neon.cc
@@ -18,6 +18,7 @@ uint32x4_t kInv;
 uint32x4_t kZero;
 uint32x4_t kOne;
 uint32x4_t kMinusOne;
+uint32x4_t kTwoInv;
 
 uint32x4_t ToVector(const PackedBabyBearNeon& packed) {
   return vld1q_u32(reinterpret_cast<const uint32_t*>(packed.values().data()));
@@ -58,6 +59,7 @@ void PackedBabyBearNeon::Init() {
   kZero = vdupq_n_u32(0);
   kOne = vdupq_n_u32(BabyBear::Config::kOne);
   kMinusOne = vdupq_n_u32(BabyBear::Config::kMinusOne);
+  kTwoInv = vdupq_n_u32(BabyBear::Config::kTwoInv);
 }
 
 // static
@@ -70,6 +72,9 @@ PackedBabyBearNeon PackedBabyBearNeon::One() { return FromVector(kOne); }
 PackedBabyBearNeon PackedBabyBearNeon::MinusOne() {
   return FromVector(kMinusOne);
 }
+
+// static
+PackedBabyBearNeon PackedBabyBearNeon::TwoInv() { return FromVector(kTwoInv); }
 
 // static
 PackedBabyBearNeon PackedBabyBearNeon::Broadcast(const PrimeField& value) {

--- a/tachyon/math/finite_fields/baby_bear/internal/packed_baby_bear_neon.h
+++ b/tachyon/math/finite_fields/baby_bear/internal/packed_baby_bear_neon.h
@@ -46,6 +46,8 @@ class TACHYON_EXPORT PackedBabyBearNeon final
 
   static PackedBabyBearNeon MinusOne();
 
+  static PackedBabyBearNeon TwoInv();
+
   static PackedBabyBearNeon Broadcast(const PrimeField& value);
 
   // AdditiveSemigroup methods

--- a/tachyon/math/finite_fields/binary_fields/binary_field.h
+++ b/tachyon/math/finite_fields/binary_fields/binary_field.h
@@ -50,15 +50,13 @@ class BinaryField final : public FiniteField<BinaryField<_Config>> {
 
   constexpr BinaryField() = default;
   template <typename T, std::enable_if_t<std::is_integral_v<T>>* = nullptr>
-  constexpr explicit BinaryField(T value) {
+  constexpr explicit BinaryField(T value) : value_(value) {
     if constexpr (kBits <= 64) {
       DCHECK(base::IsValueInRangeForNumericType<Type>(value));
       DCHECK_LE(static_cast<Type>(value), GetMax());
-      value_ = static_cast<Type>(value);
-    } else {
-      value_[0] = value;
     }
   }
+
   constexpr explicit BinaryField(BigInt<1> value) : BinaryField(value[0]) {
     static_assert(kBits <= 64);
   }
@@ -73,6 +71,7 @@ class BinaryField final : public FiniteField<BinaryField<_Config>> {
   constexpr static BinaryField Zero() { return BinaryField(); }
   constexpr static BinaryField One() { return BinaryField(1); }
   constexpr static BinaryField MinusOne() { return One(); }
+  constexpr static BinaryField TwoInv() { return *BinaryField(2).Inverse(); }
 
   static BinaryField Random() {
     if constexpr (kBits <= 64) {

--- a/tachyon/math/finite_fields/binary_fields/binary_fields_unittest.cc
+++ b/tachyon/math/finite_fields/binary_fields/binary_fields_unittest.cc
@@ -65,6 +65,21 @@ TYPED_TEST(BinaryFieldsTest, MinusOne) {
   EXPECT_TRUE(BinaryField::One().IsMinusOne());
 }
 
+TYPED_TEST(BinaryFieldsTest, TwoInv) {
+  using BinaryField = TypeParam;
+
+  if constexpr (BinaryField::Config::kModulusBits > 2) {
+    // NOTE(ashjeong): This |constexpr| variable is created since
+    // |BinaryField::TwoInv()| is a true |constexpr| function unlike other
+    // |TwoInv()| functions in unittests of other field types.
+    constexpr BinaryField kTwoInv = BinaryField::TwoInv();
+    EXPECT_TRUE((kTwoInv * BinaryField(2)).IsOne());
+    EXPECT_FALSE((kTwoInv * BinaryField::One()).IsOne());
+  } else {
+    GTEST_SKIP() << "Modulus is too small";
+  }
+}
+
 TYPED_TEST(BinaryFieldsTest, BigIntConversion) {
   using BinaryField = TypeParam;
   BinaryField r = BinaryField::Random();

--- a/tachyon/math/finite_fields/cubic_extension_field.h
+++ b/tachyon/math/finite_fields/cubic_extension_field.h
@@ -57,6 +57,10 @@ class CubicExtensionField : public CyclotomicMultiplicativeSubgroup<Derived>,
     return {BaseField::MinusOne(), BaseField::Zero(), BaseField::Zero()};
   }
 
+  constexpr static Derived TwoInv() {
+    return {BaseField::TwoInv(), BaseField::Zero(), BaseField::Zero()};
+  }
+
   static Derived Random() {
     return {BaseField::Random(), BaseField::Random(), BaseField::Random()};
   }

--- a/tachyon/math/finite_fields/cubic_extension_field_unittest.cc
+++ b/tachyon/math/finite_fields/cubic_extension_field_unittest.cc
@@ -33,6 +33,11 @@ TEST_F(CubicExtensionFieldTest, MinusOne) {
   EXPECT_TRUE(GF7_3::MinusOne().IsMinusOne());
 }
 
+TEST_F(CubicExtensionFieldTest, TwoInv) {
+  EXPECT_TRUE((GF7_3::TwoInv() * GF7_3(GF7(2))).IsOne());
+  EXPECT_FALSE((GF7_3::TwoInv() * GF7_3::One()).IsOne());
+}
+
 TEST_F(CubicExtensionFieldTest, Random) {
   bool success = false;
   GF7_3 r = GF7_3::Random();

--- a/tachyon/math/finite_fields/generator/prime_field_generator/prime_field_config.h.tpl
+++ b/tachyon/math/finite_fields/generator/prime_field_generator/prime_field_config.h.tpl
@@ -62,6 +62,10 @@ class TACHYON_EXPORT %{class}Config {
     %{minus_one}
   });
 
+  constexpr static BigInt<%{n}> kTwoInv = BigInt<%{n}>({
+    %{two_inv}
+  });
+  
   constexpr static bool kHasTwoAdicRootOfUnity = %{has_two_adic_root_of_unity};
 
   constexpr static bool kHasLargeSubgroupRootOfUnity = %{has_large_subgroup_root_of_unity};

--- a/tachyon/math/finite_fields/generator/prime_field_generator/prime_field_generator.cc
+++ b/tachyon/math/finite_fields/generator/prime_field_generator/prime_field_generator.cc
@@ -215,13 +215,18 @@ int GenerationConfig::GenerateConfigHdr() const {
   replacements["%{inverse32}"] = base::NumberToString(modulus_info.inverse32);
 
   replacements["%{use_montgomery}"] = base::BoolToString(use_montgomery);
+  mpz_class two(2);
+  mpz_class two_inv;
+  mpz_invert(two_inv.get_mpz_t(), two.get_mpz_t(), m.get_mpz_t());
   if (use_montgomery) {
     replacements["%{one}"] = math::MpzClassToMontString(mpz_class(1), m);
     replacements["%{minus_one}"] =
         math::MpzClassToMontString(m - mpz_class(1), m);
+    replacements["%{two_inv}"] = math::MpzClassToMontString(two_inv, m);
   } else {
     replacements["%{one}"] = "1";
     replacements["%{minus_one}"] = math::MpzClassToString(m - mpz_class(1));
+    replacements["%{two_inv}"] = math::MpzClassToString(two_inv);
   }
 
   std::string tpl_content;

--- a/tachyon/math/finite_fields/generator/prime_field_generator/prime_field_x86.h.tpl
+++ b/tachyon/math/finite_fields/generator/prime_field_generator/prime_field_x86.h.tpl
@@ -71,6 +71,12 @@ class PrimeField<_Config, std::enable_if_t<_Config::%{asm_flag}>> final
     return ret;
   }
 
+  constexpr static PrimeField TwoInv() {
+    PrimeField ret{};
+    ret.value_ = Config::kTwoInv;
+    return ret;
+  }
+
   static PrimeField Random() {
     return PrimeField(BigInt<N>::Random(Config::kModulus));
   }

--- a/tachyon/math/finite_fields/generator/prime_field_generator/small_prime_field_config.h.tpl
+++ b/tachyon/math/finite_fields/generator/prime_field_generator/small_prime_field_config.h.tpl
@@ -26,6 +26,7 @@ class TACHYON_EXPORT %{class}Config {
 
   constexpr static uint32_t kOne = %{one};
   constexpr static uint32_t kMinusOne = %{minus_one};
+  constexpr static uint32_t kTwoInv = %{two_inv};
 
   constexpr static bool kHasTwoAdicRootOfUnity = %{has_two_adic_root_of_unity};
 

--- a/tachyon/math/finite_fields/goldilocks/internal/BUILD.bazel
+++ b/tachyon/math/finite_fields/goldilocks/internal/BUILD.bazel
@@ -50,6 +50,7 @@ tachyon_cc_library(
     deps = if_x86_64([
         ":goldilocks_config",
         "//tachyon/base:random",
+        "//tachyon/base:optional",
         "//tachyon/base/strings:string_number_conversions",
         "//tachyon/base/strings:string_util",
         "//tachyon/math/finite_fields:prime_field_base",

--- a/tachyon/math/finite_fields/goldilocks/internal/goldilocks_prime_field_x86_special.cc
+++ b/tachyon/math/finite_fields/goldilocks/internal/goldilocks_prime_field_x86_special.cc
@@ -6,6 +6,7 @@
 
 #include "third_party/goldilocks/include/goldilocks_base_field.hpp"
 
+#include "tachyon/base/optional.h"
 #include "tachyon/base/random.h"
 #include "tachyon/base/strings/string_number_conversions.h"
 #include "tachyon/base/strings/string_util.h"
@@ -34,6 +35,16 @@ CLASS CLASS::MinusOne() {
   return PrimeField::FromMontgomery(Config::kMinusOne[0]);
 #else
   return PrimeField(Config::kModulus[0] - 1);
+#endif
+}
+
+// static
+template <typename Config>
+CLASS CLASS::TwoInv() {
+#if USE_MONTGOMERY == 1
+  return PrimeField::FromMontgomery(Config::kTwoInv[0]);
+#else
+  return unwrap(PrimeField(2).Inverse());
 #endif
 }
 

--- a/tachyon/math/finite_fields/goldilocks/internal/goldilocks_prime_field_x86_special.h
+++ b/tachyon/math/finite_fields/goldilocks/internal/goldilocks_prime_field_x86_special.h
@@ -39,6 +39,7 @@ class PrimeField<_Config, std::enable_if_t<_Config::kIsTachyonMathGoldilocks>>
   constexpr static PrimeField Zero() { return PrimeField(); }
   static PrimeField One();
   static PrimeField MinusOne();
+  static PrimeField TwoInv();
   static PrimeField Random();
 
   static std::optional<PrimeField> FromDecString(std::string_view str);

--- a/tachyon/math/finite_fields/koala_bear/internal/packed_koala_bear_avx2.cc
+++ b/tachyon/math/finite_fields/koala_bear/internal/packed_koala_bear_avx2.cc
@@ -18,6 +18,7 @@ __m256i kInv;
 __m256i kZero;
 __m256i kOne;
 __m256i kMinusOne;
+__m256i kTwoInv;
 
 __m256i ToVector(const PackedKoalaBearAVX2& packed) {
   return _mm256_loadu_si256(
@@ -56,6 +57,7 @@ void PackedKoalaBearAVX2::Init() {
   kZero = _mm256_set1_epi32(0);
   kOne = _mm256_set1_epi32(KoalaBear::Config::kOne);
   kMinusOne = _mm256_set1_epi32(KoalaBear::Config::kMinusOne);
+  kTwoInv = _mm256_set1_epi32(KoalaBear::Config::kTwoInv);
 }
 
 // static
@@ -67,6 +69,11 @@ PackedKoalaBearAVX2 PackedKoalaBearAVX2::One() { return FromVector(kOne); }
 // static
 PackedKoalaBearAVX2 PackedKoalaBearAVX2::MinusOne() {
   return FromVector(kMinusOne);
+}
+
+// static
+PackedKoalaBearAVX2 PackedKoalaBearAVX2::TwoInv() {
+  return FromVector(kTwoInv);
 }
 
 // static

--- a/tachyon/math/finite_fields/koala_bear/internal/packed_koala_bear_avx2.h
+++ b/tachyon/math/finite_fields/koala_bear/internal/packed_koala_bear_avx2.h
@@ -46,6 +46,8 @@ class TACHYON_EXPORT PackedKoalaBearAVX2 final
 
   static PackedKoalaBearAVX2 MinusOne();
 
+  static PackedKoalaBearAVX2 TwoInv();
+
   static PackedKoalaBearAVX2 Broadcast(const PrimeField& value);
 
   // AdditiveSemigroup methods

--- a/tachyon/math/finite_fields/koala_bear/internal/packed_koala_bear_avx512.cc
+++ b/tachyon/math/finite_fields/koala_bear/internal/packed_koala_bear_avx512.cc
@@ -56,6 +56,7 @@ void PackedKoalaBearAVX512::Init() {
   kInv = _mm512_set1_epi32(KoalaBear::Config::kInverse32);
   kZero = _mm512_set1_epi32(0);
   kOne = _mm512_set1_epi32(KoalaBear::Config::kOne);
+  kMinusOne = _mm512_set1_epi32(KoalaBear::Config::kMinusOne);
   kTwoInv = _mm512_set1_epi32(KoalaBear::Config::kTwoInv);
 }
 

--- a/tachyon/math/finite_fields/koala_bear/internal/packed_koala_bear_avx512.cc
+++ b/tachyon/math/finite_fields/koala_bear/internal/packed_koala_bear_avx512.cc
@@ -20,6 +20,7 @@ __m512i kInv;
 __m512i kZero;
 __m512i kOne;
 __m512i kMinusOne;
+__m512i kTwoInv;
 
 __m512i ToVector(const PackedKoalaBearAVX512& packed) {
   return _mm512_loadu_si512(packed.values().data());
@@ -55,6 +56,7 @@ void PackedKoalaBearAVX512::Init() {
   kInv = _mm512_set1_epi32(KoalaBear::Config::kInverse32);
   kZero = _mm512_set1_epi32(0);
   kOne = _mm512_set1_epi32(KoalaBear::Config::kOne);
+  kTwoInv = _mm512_set1_epi32(KoalaBear::Config::kTwoInv);
 }
 
 // static
@@ -68,6 +70,11 @@ PackedKoalaBearAVX512 PackedKoalaBearAVX512::One() { return FromVector(kOne); }
 // static
 PackedKoalaBearAVX512 PackedKoalaBearAVX512::MinusOne() {
   return FromVector(kMinusOne);
+}
+
+// static
+PackedKoalaBearAVX512 PackedKoalaBearAVX512::TwoInv() {
+  return FromVector(kTwoInv);
 }
 
 // static

--- a/tachyon/math/finite_fields/koala_bear/internal/packed_koala_bear_avx512.h
+++ b/tachyon/math/finite_fields/koala_bear/internal/packed_koala_bear_avx512.h
@@ -47,6 +47,8 @@ class TACHYON_EXPORT PackedKoalaBearAVX512 final
 
   static PackedKoalaBearAVX512 MinusOne();
 
+  static PackedKoalaBearAVX512 TwoInv();
+
   static PackedKoalaBearAVX512 Broadcast(const PrimeField& value);
 
   // AdditiveSemigroup methods

--- a/tachyon/math/finite_fields/koala_bear/internal/packed_koala_bear_neon.cc
+++ b/tachyon/math/finite_fields/koala_bear/internal/packed_koala_bear_neon.cc
@@ -18,6 +18,7 @@ uint32x4_t kInv;
 uint32x4_t kZero;
 uint32x4_t kOne;
 uint32x4_t kMinusOne;
+uint32x4_t kTwoInv;
 
 uint32x4_t ToVector(const PackedKoalaBearNeon& packed) {
   return vld1q_u32(reinterpret_cast<const uint32_t*>(packed.values().data()));
@@ -58,6 +59,7 @@ void PackedKoalaBearNeon::Init() {
   kZero = vdupq_n_u32(0);
   kOne = vdupq_n_u32(KoalaBear::Config::kOne);
   kMinusOne = vdupq_n_u32(KoalaBear::Config::kMinusOne);
+  kTwoInv = vdupq_n_u32(KoalaBear::Config::kTwoInv);
 }
 
 // static
@@ -69,6 +71,11 @@ PackedKoalaBearNeon PackedKoalaBearNeon::One() { return FromVector(kOne); }
 // static
 PackedKoalaBearNeon PackedKoalaBearNeon::MinusOne() {
   return FromVector(kMinusOne);
+}
+
+// static
+PackedKoalaBearNeon PackedKoalaBearNeon::TwoInv() {
+  return FromVector(kTwoInv);
 }
 
 // static

--- a/tachyon/math/finite_fields/koala_bear/internal/packed_koala_bear_neon.h
+++ b/tachyon/math/finite_fields/koala_bear/internal/packed_koala_bear_neon.h
@@ -46,6 +46,8 @@ class TACHYON_EXPORT PackedKoalaBearNeon final
 
   static PackedKoalaBearNeon MinusOne();
 
+  static PackedKoalaBearNeon TwoInv();
+
   static PackedKoalaBearNeon Broadcast(const PrimeField& value);
 
   // AdditiveSemigroup methods

--- a/tachyon/math/finite_fields/mersenne31/internal/packed_mersenne31_avx2.cc
+++ b/tachyon/math/finite_fields/mersenne31/internal/packed_mersenne31_avx2.cc
@@ -17,6 +17,7 @@ __m256i kP;
 __m256i kZero;
 __m256i kOne;
 __m256i kMinusOne;
+__m256i kTwoInv;
 
 __m256i ToVector(const PackedMersenne31AVX2& packed) {
   return _mm256_loadu_si256(
@@ -171,6 +172,7 @@ void PackedMersenne31AVX2::Init() {
   kZero = _mm256_set1_epi32(0);
   kOne = _mm256_set1_epi32(1);
   kMinusOne = _mm256_set1_epi32(Mersenne31::Config::kModulus - 1);
+  kTwoInv = _mm256_set1_epi32(Mersenne31::Config::kTwoInv);
 }
 
 // static
@@ -182,6 +184,11 @@ PackedMersenne31AVX2 PackedMersenne31AVX2::One() { return FromVector(kOne); }
 // static
 PackedMersenne31AVX2 PackedMersenne31AVX2::MinusOne() {
   return FromVector(kMinusOne);
+}
+
+// static
+PackedMersenne31AVX2 PackedMersenne31AVX2::TwoInv() {
+  return FromVector(kTwoInv);
 }
 
 // static

--- a/tachyon/math/finite_fields/mersenne31/internal/packed_mersenne31_avx2.h
+++ b/tachyon/math/finite_fields/mersenne31/internal/packed_mersenne31_avx2.h
@@ -46,6 +46,8 @@ class TACHYON_EXPORT PackedMersenne31AVX2 final
 
   static PackedMersenne31AVX2 MinusOne();
 
+  static PackedMersenne31AVX2 TwoInv();
+
   static PackedMersenne31AVX2 Broadcast(const PrimeField& value);
 
   // AdditiveSemigroup methods

--- a/tachyon/math/finite_fields/mersenne31/internal/packed_mersenne31_avx512.cc
+++ b/tachyon/math/finite_fields/mersenne31/internal/packed_mersenne31_avx512.cc
@@ -19,6 +19,7 @@ __m512i kP;
 __m512i kZero;
 __m512i kOne;
 __m512i kMinusOne;
+__m512i kTwoInv;
 
 __mmask16 kEvens = 0b0101010101010101;
 __mmask16 kOdds = 0b1010101010101010;
@@ -130,6 +131,7 @@ void PackedMersenne31AVX512::Init() {
   kZero = _mm512_set1_epi32(0);
   kOne = _mm512_set1_epi32(1);
   kMinusOne = _mm512_set1_epi32(Mersenne31::Config::kModulus - 1);
+  kTwoInv = _mm512_set1_epi32(Mersenne31::Config::kTwoInv);
 }
 
 // static
@@ -145,6 +147,11 @@ PackedMersenne31AVX512 PackedMersenne31AVX512::One() {
 // static
 PackedMersenne31AVX512 PackedMersenne31AVX512::MinusOne() {
   return FromVector(kMinusOne);
+}
+
+// static
+PackedMersenne31AVX512 PackedMersenne31AVX512::TwoInv() {
+  return FromVector(kTwoInv);
 }
 
 // static

--- a/tachyon/math/finite_fields/mersenne31/internal/packed_mersenne31_avx512.h
+++ b/tachyon/math/finite_fields/mersenne31/internal/packed_mersenne31_avx512.h
@@ -47,6 +47,8 @@ class TACHYON_EXPORT PackedMersenne31AVX512 final
 
   static PackedMersenne31AVX512 MinusOne();
 
+  static PackedMersenne31AVX512 TwoInv();
+
   static PackedMersenne31AVX512 Broadcast(const PrimeField& value);
 
   // AdditiveSemigroup methods

--- a/tachyon/math/finite_fields/mersenne31/internal/packed_mersenne31_neon.cc
+++ b/tachyon/math/finite_fields/mersenne31/internal/packed_mersenne31_neon.cc
@@ -17,6 +17,7 @@ uint32x4_t kP;
 uint32x4_t kZero;
 uint32x4_t kOne;
 uint32x4_t kMinusOne;
+uint32x4_t kTwoInv;
 
 uint32x4_t ToVector(const PackedMersenne31Neon& packed) {
   return vld1q_u32(reinterpret_cast<const uint32_t*>(packed.values().data()));
@@ -104,6 +105,7 @@ void PackedMersenne31Neon::Init() {
   kZero = vdupq_n_u32(0);
   kOne = vdupq_n_u32(1);
   kMinusOne = vdupq_n_u32(Mersenne31::Config::kModulus - 1);
+  kTwoInv = vdupq_n_u32(Mersenne31::Config::kTwoInv);
 }
 
 // static
@@ -115,6 +117,11 @@ PackedMersenne31Neon PackedMersenne31Neon::One() { return FromVector(kOne); }
 // static
 PackedMersenne31Neon PackedMersenne31Neon::MinusOne() {
   return FromVector(kMinusOne);
+}
+
+// static
+PackedMersenne31Neon PackedMersenne31Neon::TwoInv() {
+  return FromVector(kTwoInv);
 }
 
 // static

--- a/tachyon/math/finite_fields/mersenne31/internal/packed_mersenne31_neon.h
+++ b/tachyon/math/finite_fields/mersenne31/internal/packed_mersenne31_neon.h
@@ -46,6 +46,8 @@ class TACHYON_EXPORT PackedMersenne31Neon final
 
   static PackedMersenne31Neon MinusOne();
 
+  static PackedMersenne31Neon TwoInv();
+
   static PackedMersenne31Neon Broadcast(const PrimeField& value);
 
   // AdditiveSemigroup methods

--- a/tachyon/math/finite_fields/packed_prime_field_unittest.cc
+++ b/tachyon/math/finite_fields/packed_prime_field_unittest.cc
@@ -2,6 +2,7 @@
 #include "gtest/gtest.h"
 
 #include "tachyon/build/build_config.h"
+#include "tachyon/math/finite_fields/baby_bear/internal/packed_baby_bear.h"
 #include "tachyon/math/finite_fields/packed_field_traits_forward.h"
 #include "tachyon/math/finite_fields/test/finite_field_test.h"
 
@@ -74,6 +75,17 @@ TYPED_TEST(PackedPrimeFieldTest, MinusOne) {
     EXPECT_TRUE(one[i].IsMinusOne());
   }
   EXPECT_FALSE(PackedPrimeField::Random().IsMinusOne());
+}
+
+TYPED_TEST(PackedPrimeFieldTest, TwoInv) {
+  using PackedPrimeField = TypeParam;
+  using PrimeField = typename PackedFieldTraits<PackedPrimeField>::Field;
+  PackedPrimeField two_inv = PackedPrimeField::TwoInv();
+  EXPECT_TRUE((two_inv * PackedPrimeField(2)).IsOne());
+  EXPECT_FALSE((two_inv * PackedPrimeField::One()).IsOne());
+  for (size_t i = 0; i < PackedPrimeField::N; ++i) {
+    EXPECT_TRUE((two_inv[i] * PrimeField(2)).IsOne());
+  }
 }
 
 TYPED_TEST(PackedPrimeFieldTest, Broadcast) {

--- a/tachyon/math/finite_fields/prime_field_fallback.h
+++ b/tachyon/math/finite_fields/prime_field_fallback.h
@@ -76,6 +76,12 @@ class PrimeField<_Config, std::enable_if_t<!_Config::kUseAsm &&
     return ret;
   }
 
+  constexpr static PrimeField TwoInv() {
+    PrimeField ret{};
+    ret.value_ = Config::kTwoInv;
+    return ret;
+  }
+
   static PrimeField Random() {
     return PrimeField(BigInt<N>::Random(Config::kModulus));
   }

--- a/tachyon/math/finite_fields/prime_field_generator_unittest.cc
+++ b/tachyon/math/finite_fields/prime_field_generator_unittest.cc
@@ -73,6 +73,12 @@ TYPED_TEST(PrimeFieldGeneratorTest, MinusOne) {
   EXPECT_FALSE(PrimeField::One().IsMinusOne());
 }
 
+TYPED_TEST(PrimeFieldGeneratorTest, TwoInv) {
+  using PrimeField = TypeParam;
+  EXPECT_TRUE((PrimeField::TwoInv() * PrimeField(2)).IsOne());
+  EXPECT_FALSE((PrimeField::TwoInv() * PrimeField::One()).IsOne());
+}
+
 TYPED_TEST(PrimeFieldGeneratorTest, BigIntConversion) {
   using PrimeField = TypeParam;
   PrimeField r = PrimeField::Random();

--- a/tachyon/math/finite_fields/prime_field_gpu_debug.h
+++ b/tachyon/math/finite_fields/prime_field_gpu_debug.h
@@ -68,6 +68,12 @@ class PrimeFieldGpuDebug final
     return ret;
   }
 
+  constexpr static PrimeFieldGpuDebug TwoInv() {
+    PrimeFieldGpuDebug ret{};
+    ret.value_ = Config::kTwoInv;
+    return ret;
+  }
+
   static PrimeFieldGpuDebug Random() {
     PrimeFieldGpuDebug ret{};
     ret.value_ = PrimeField<Config>::Random().value();

--- a/tachyon/math/finite_fields/prime_field_unittest.cc
+++ b/tachyon/math/finite_fields/prime_field_unittest.cc
@@ -65,6 +65,13 @@ TYPED_TEST(PrimeFieldTest, MinusOne) {
   EXPECT_FALSE(F::One().IsMinusOne());
 }
 
+TYPED_TEST(PrimeFieldTest, TwoInv) {
+  using F = TypeParam;
+
+  EXPECT_TRUE((F::TwoInv() * F(2)).IsOne());
+  EXPECT_FALSE((F::TwoInv() * F(1)).IsOne());
+}
+
 TYPED_TEST(PrimeFieldTest, BigIntConversion) {
   using F = TypeParam;
 

--- a/tachyon/math/finite_fields/quadratic_extension_field.h
+++ b/tachyon/math/finite_fields/quadratic_extension_field.h
@@ -57,6 +57,10 @@ class QuadraticExtensionField
     return {BaseField::MinusOne(), BaseField::Zero()};
   }
 
+  constexpr static Derived TwoInv() {
+    return {BaseField::TwoInv(), BaseField::Zero()};
+  }
+
   static Derived Random() { return {BaseField::Random(), BaseField::Random()}; }
 
   // TODO(chokobole): Should be generalized for packed extension field.

--- a/tachyon/math/finite_fields/quadratic_extension_field_unittest.cc
+++ b/tachyon/math/finite_fields/quadratic_extension_field_unittest.cc
@@ -34,6 +34,11 @@ TEST_F(QuadraticExtensionFieldTest, MinusOne) {
   EXPECT_FALSE(GF7_2::One().IsMinusOne());
 }
 
+TEST_F(QuadraticExtensionFieldTest, TwoInv) {
+  EXPECT_TRUE((GF7_2::TwoInv() * GF7_2(GF7(2))).IsOne());
+  EXPECT_FALSE((GF7_2::TwoInv() * GF7_2::One()).IsOne());
+}
+
 TEST_F(QuadraticExtensionFieldTest, Random) {
   bool success = false;
   GF7_2 r = GF7_2::Random();

--- a/tachyon/math/finite_fields/quartic_extension_field.h
+++ b/tachyon/math/finite_fields/quartic_extension_field.h
@@ -65,6 +65,11 @@ class QuarticExtensionField : public CyclotomicMultiplicativeSubgroup<Derived>,
             BaseField::Zero()};
   }
 
+  constexpr static Derived TwoInv() {
+    return {BaseField::TwoInv(), BaseField::Zero(), BaseField::Zero(),
+            BaseField::Zero()};
+  }
+
   static Derived Random() {
     return {BaseField::Random(), BaseField::Random(), BaseField::Random(),
             BaseField::Random()};
@@ -102,7 +107,6 @@ class QuarticExtensionField : public CyclotomicMultiplicativeSubgroup<Derived>,
   ConstIterator end() const { return {static_cast<const Derived&>(*this), 4}; }
 
   static void Init() {
-    kInv2 = *BaseField(2).Inverse();
     kInv3 = *BaseField(3).Inverse();
     kInv4 = *BaseField(4).Inverse();
     kInv6 = *BaseField(6).Inverse();
@@ -112,7 +116,7 @@ class QuarticExtensionField : public CyclotomicMultiplicativeSubgroup<Derived>,
     kInv30 = *BaseField(30).Inverse();
     kInv120 = *BaseField(120).Inverse();
     kNeg5 = -BaseField(5);
-    kNegInv2 = -kInv2;
+    kNegInv2 = -BaseField::TwoInv();
     kNegInv3 = -kInv3;
     kNegInv4 = -kInv4;
     kNegInv6 = -kInv6;
@@ -593,7 +597,6 @@ class QuarticExtensionField : public CyclotomicMultiplicativeSubgroup<Derived>,
   BaseField c2_;
   BaseField c3_;
 
-  static BaseField kInv2;
   static BaseField kInv3;
   static BaseField kInv4;
   static BaseField kInv6;
@@ -617,7 +620,6 @@ class QuarticExtensionField : public CyclotomicMultiplicativeSubgroup<Derived>,
   typename QuarticExtensionField<Derived>::BaseField \
       QuarticExtensionField<Derived>::name
 
-ADD_STATIC_MEMBER(kInv2);
 ADD_STATIC_MEMBER(kInv3);
 ADD_STATIC_MEMBER(kInv4);
 ADD_STATIC_MEMBER(kInv6);

--- a/tachyon/math/finite_fields/quartic_extension_field_unittest.cc
+++ b/tachyon/math/finite_fields/quartic_extension_field_unittest.cc
@@ -43,6 +43,14 @@ TYPED_TEST(QuarticExtensionFieldTest, MinusOne) {
   EXPECT_FALSE(F4::One().IsMinusOne());
 }
 
+TYPED_TEST(QuarticExtensionFieldTest, TwoInv) {
+  using F4 = TypeParam;
+  using F = typename ExtensionFieldTraits<F4>::BaseField;
+
+  EXPECT_TRUE((F4::TwoInv() * F4(F(2))).IsOne());
+  EXPECT_FALSE((F4::TwoInv() * F4::One()).IsOne());
+}
+
 TYPED_TEST(QuarticExtensionFieldTest, Random) {
   using F4 = TypeParam;
 

--- a/tachyon/math/finite_fields/small_prime_field.h
+++ b/tachyon/math/finite_fields/small_prime_field.h
@@ -56,6 +56,7 @@ class PrimeField<_Config, std::enable_if_t<(_Config::kModulusBits <= 32) &&
   constexpr static PrimeField MinusOne() {
     return PrimeField(GetModulus() - 1);
   }
+  constexpr static PrimeField TwoInv() { return PrimeField(Config::kTwoInv); }
 
   static PrimeField Random() {
     return PrimeField(

--- a/tachyon/math/finite_fields/small_prime_field_mont.h
+++ b/tachyon/math/finite_fields/small_prime_field_mont.h
@@ -63,6 +63,12 @@ class PrimeField<_Config, std::enable_if_t<(_Config::kModulusBits <= 32) &&
     return ret;
   }
 
+  constexpr static PrimeField TwoInv() {
+    PrimeField ret{};
+    ret.value_ = Config::kTwoInv;
+    return ret;
+  }
+
   static PrimeField Random() {
     return PrimeField(
         base::Uniform(base::Range<uint32_t>::Until(GetModulus())));


### PR DESCRIPTION
This PR generates the inverse of two for every field as a constant, removing the repetitive use of `F(2).Inverse()` across multiple functions. 