### PR TITLE
build: add openmp flags to goldilocks

### DIFF
--- a/bazel/tachyon_cc.bzl
+++ b/bazel/tachyon_cc.bzl
@@ -33,7 +33,7 @@ def tachyon_rtti(force_rtti):
 def tachyon_simd_copts():
     return if_linux_x86_64(["-msse3"])
 
-def tachyon_openmp():
+def tachyon_openmp_copts():
     return select({
         "@kroma_network_tachyon//:tachyon_has_openmp_on_macos": ["-Xclang -fopenmp"],
         "@kroma_network_tachyon//:tachyon_has_openmp": ["-fopenmp"],
@@ -41,7 +41,7 @@ def tachyon_openmp():
     })
 
 def tachyon_copts(safe_code = True):
-    return tachyon_warnings(safe_code) + tachyon_hide_symbols() + tachyon_simd_copts() + tachyon_openmp()
+    return tachyon_warnings(safe_code) + tachyon_hide_symbols() + tachyon_simd_copts() + tachyon_openmp_copts()
 
 def tachyon_cxxopts(safe_code = True, force_exceptions = False, force_rtti = False):
     return tachyon_copts(safe_code) + tachyon_exceptions(force_exceptions) + tachyon_rtti(force_rtti)

--- a/third_party/goldilocks/goldilocks.BUILD
+++ b/third_party/goldilocks/goldilocks.BUILD
@@ -1,4 +1,5 @@
 load("@kroma_network_tachyon//bazel:tachyon.bzl", "if_has_avx512")
+load("@kroma_network_tachyon//bazel:tachyon_cc.bzl", "tachyon_openmp_copts", "tachyon_openmp_linkopts")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 
 package(default_visibility = ["//visibility:public"])
@@ -19,7 +20,8 @@ cc_library(
     copts = if_has_avx512(
         ["-mavx512f"],
         ["-mavx2"],
-    ),
+    ) + tachyon_openmp_copts(),
+    linkopts = tachyon_openmp_linkopts(),
     defines = if_has_avx512(["__AVX512__"]),
     include_prefix = "third_party/goldilocks/include",
     includes = ["src"],


### PR DESCRIPTION
# Description

This PR adds `openmp` support for `goldilocks`.

Previously, we used to have a warning when building with openmp.
```
INFO: From Compiling src/goldilocks_base_field.cpp:
external/goldilocks/src/goldilocks_base_field.cpp:72: warning: ignoring '#pragma omp parallel' [-Wunknown-pragmas]
   72 | #pragma omp parallel for num_threads(num_threads_copy)
      | 
external/goldilocks/src/goldilocks_base_field.cpp:93: warning: ignoring '#pragma omp parallel' [-Wunknown-pragmas]
   93 | #pragma omp parallel for num_threads(num_threads_copy)
      |
```




