### PR TITLE
chore: fix naming and error messages

### DIFF
--- a/benchmark/ec/ec_double_benchmark_gpu.cc
+++ b/benchmark/ec/ec_double_benchmark_gpu.cc
@@ -32,11 +32,10 @@ void TestDoubleOnCPU(const std::vector<math::bn254::G1AffinePoint>& bases,
 gpuError_t LaunchDouble(const math::bn254::G1AffinePointGpu* x,
                         math::bn254::G1JacobianPointGpu* y, uint64_t count) {
   math::kernels::Double<<<(count - 1) / 32 + 1, 32>>>(x, y, count);
-  gpuError_t error = LOG_IF_GPU_LAST_ERROR("Failed to Double()");
-  return error == gpuSuccess
-             ? LOG_IF_GPU_ERROR(gpuDeviceSynchronize(),
-                                "Failed to gpuDeviceSynchronize")
-             : error;
+  gpuError_t error = LOG_IF_GPU_LAST_ERROR("Failed Double()");
+  return error == gpuSuccess ? LOG_IF_GPU_ERROR(gpuDeviceSynchronize(),
+                                                "Failed gpuDeviceSynchronize()")
+                             : error;
 }
 
 void TestDoubleOnGPU(math::bn254::G1AffinePointGpu* bases_cuda,
@@ -80,7 +79,7 @@ int RealMain(int argc, char** argv) {
     reporter.AddTime(i, interval.GetTimeDelta().InSecondsF());
   }
 
-  GPU_MUST_SUCCESS(gpuDeviceReset(), "Failed to gpuDeviceReset()");
+  GPU_MUST_SUCCESS(gpuDeviceReset(), "Failed gpuDeviceReset()");
   auto bases_cuda =
       gpu::GpuMemory<math::bn254::G1AffinePointGpu>::MallocManaged(
           max_point_num);

--- a/benchmark/ec/ec_double_benchmark_gpu.cc
+++ b/benchmark/ec/ec_double_benchmark_gpu.cc
@@ -79,7 +79,7 @@ int RealMain(int argc, char** argv) {
     reporter.AddTime(i, interval.GetTimeDelta().InSecondsF());
   }
 
-  GPU_MUST_SUCCESS(gpuDeviceReset(), "Failed gpuDeviceReset()");
+  GPU_MUST_SUCCEED(gpuDeviceReset(), "Failed gpuDeviceReset()");
   auto bases_cuda =
       gpu::GpuMemory<math::bn254::G1AffinePointGpu>::MallocManaged(
           max_point_num);

--- a/tachyon/c/math/elliptic_curves/msm/msm_gpu.h
+++ b/tachyon/c/math/elliptic_curves/msm/msm_gpu.h
@@ -56,7 +56,7 @@ struct MSMGpuApi {
                              {gpuMemLocationTypeDevice, 0}};
     mem_pool = tachyon::device::gpu::CreateMemPool(&props);
     uint64_t mem_pool_threshold = std::numeric_limits<uint64_t>::max();
-    GPU_MUST_SUCCESS(
+    GPU_MUST_SUCCEED(
         gpuMemPoolSetAttribute(mem_pool.get(), gpuMemPoolAttrReleaseThreshold,
                                &mem_pool_threshold),
         "Failed gpuMemPoolSetAttribute()");

--- a/tachyon/c/math/elliptic_curves/msm/msm_gpu.h
+++ b/tachyon/c/math/elliptic_curves/msm/msm_gpu.h
@@ -59,7 +59,7 @@ struct MSMGpuApi {
     GPU_MUST_SUCCESS(
         gpuMemPoolSetAttribute(mem_pool.get(), gpuMemPoolAttrReleaseThreshold,
                                &mem_pool_threshold),
-        "Failed to gpuMemPoolSetAttribute()");
+        "Failed gpuMemPoolSetAttribute()");
 
     stream = tachyon::device::gpu::CreateStream();
     msm.reset(new tachyon::math::VariableBaseMSMGpu<Point>(mem_pool.get(),

--- a/tachyon/device/gpu/cuda/cub_helper.h
+++ b/tachyon/device/gpu/cuda/cub_helper.h
@@ -14,7 +14,7 @@
           ::tachyon::device::gpu::GpuMemory<uint8_t>::Malloc(bytes); \
       std::ignore = storage;                                         \
     } else {                                                         \
-      GPU_LOG(ERROR, error) << "Failed to " #fn;                     \
+      GPU_LOG(ERROR, error) << "Failed " #fn;                        \
     }                                                                \
     error;                                                           \
   })
@@ -28,7 +28,7 @@
           ::tachyon::device::gpu::GpuMemory<uint8_t>::Malloc(bytes); \
       error = fn(storage.get(), bytes, __VA_ARGS__);                 \
     } else {                                                         \
-      GPU_LOG(ERROR, error) << "Failed to " #fn;                     \
+      GPU_LOG(ERROR, error) << "Failed " #fn;                        \
     }                                                                \
     error;                                                           \
   })
@@ -43,7 +43,7 @@
               bytes, pool, stream);                                        \
       std::ignore = storage;                                               \
     } else {                                                               \
-      GPU_LOG(ERROR, error) << "Failed to " #fn;                           \
+      GPU_LOG(ERROR, error) << "Failed " #fn;                              \
     }                                                                      \
     error;                                                                 \
   })
@@ -58,7 +58,7 @@
               bytes, pool, stream);                                        \
       error = fn(storage.get(), bytes, __VA_ARGS__);                       \
     } else {                                                               \
-      GPU_LOG(ERROR, error) << "Failed to " #fn;                           \
+      GPU_LOG(ERROR, error) << "Failed " #fn;                              \
     }                                                                      \
     error;                                                                 \
   })

--- a/tachyon/device/gpu/gpu_logging.h
+++ b/tachyon/device/gpu/gpu_logging.h
@@ -96,7 +96,7 @@ class TACHYON_EXPORT GpuLogMessage : public LogMessage {
     error;                                \
   })
 
-#define GPU_MUST_SUCCESS(x, msg)                  \
+#define GPU_MUST_SUCCEED(x, msg)                  \
   ({                                              \
     gpuError_t error = (x);                       \
     GPU_CHECK(error == gpuSuccess, error) << msg; \

--- a/tachyon/device/gpu/gpu_memory.cc
+++ b/tachyon/device/gpu/gpu_memory.cc
@@ -114,20 +114,20 @@ gpuError_t GpuMallocFromPoolAsync(void** ptr, size_t size, gpuMemPool_t pool,
 
 void GpuFreeMemory(gpuStream_t stream, void* ptr, GpuMemoryType type) {
   if (stream) {
-    GPU_MUST_SUCCESS(gpuFreeAsync(ptr, stream), "Failed to gpuFreeAsync()");
+    GPU_MUST_SUCCESS(gpuFreeAsync(ptr, stream), "Failed gpuFreeAsync()");
   } else {
     switch (type) {
       case GpuMemoryType::kUnregistered:
         NOTREACHED();
       case GpuMemoryType::kDevice:
-        GPU_MUST_SUCCESS(gpuFree(ptr), "Failed to gpuFree()");
+        GPU_MUST_SUCCESS(gpuFree(ptr), "Failed gpuFree()");
         break;
       case GpuMemoryType::kHost:
-        GPU_MUST_SUCCESS(gpuFreeHost(ptr), "Failed to gpuFreeHost()");
+        GPU_MUST_SUCCESS(gpuFreeHost(ptr), "Failed gpuFreeHost()");
         break;
 #if TACHYON_CUDA
       case GpuMemoryType::kUnified:
-        GPU_MUST_SUCCESS(gpuFree(ptr), "Failed to gpuFree()");
+        GPU_MUST_SUCCESS(gpuFree(ptr), "Failed gpuFree()");
         break;
 #endif
     }
@@ -168,7 +168,7 @@ size_t GpuMemLimitInfo(MemoryUsage type) {
 
   gpuError_t error = GpuMemGetInfo(&free_memory, &total_memory);
   if (error != gpuSuccess) {
-    GPU_LOG(ERROR, error) << "Failed to GpuMemGetInfo()";
+    GPU_LOG(ERROR, error) << "Failed GpuMemGetInfo()";
     return available_memory;
   }
 

--- a/tachyon/device/gpu/gpu_memory.cc
+++ b/tachyon/device/gpu/gpu_memory.cc
@@ -114,20 +114,20 @@ gpuError_t GpuMallocFromPoolAsync(void** ptr, size_t size, gpuMemPool_t pool,
 
 void GpuFreeMemory(gpuStream_t stream, void* ptr, GpuMemoryType type) {
   if (stream) {
-    GPU_MUST_SUCCESS(gpuFreeAsync(ptr, stream), "Failed gpuFreeAsync()");
+    GPU_MUST_SUCCEED(gpuFreeAsync(ptr, stream), "Failed gpuFreeAsync()");
   } else {
     switch (type) {
       case GpuMemoryType::kUnregistered:
         NOTREACHED();
       case GpuMemoryType::kDevice:
-        GPU_MUST_SUCCESS(gpuFree(ptr), "Failed gpuFree()");
+        GPU_MUST_SUCCEED(gpuFree(ptr), "Failed gpuFree()");
         break;
       case GpuMemoryType::kHost:
-        GPU_MUST_SUCCESS(gpuFreeHost(ptr), "Failed gpuFreeHost()");
+        GPU_MUST_SUCCEED(gpuFreeHost(ptr), "Failed gpuFreeHost()");
         break;
 #if TACHYON_CUDA
       case GpuMemoryType::kUnified:
-        GPU_MUST_SUCCESS(gpuFree(ptr), "Failed gpuFree()");
+        GPU_MUST_SUCCEED(gpuFree(ptr), "Failed gpuFree()");
         break;
 #endif
     }

--- a/tachyon/device/gpu/gpu_memory.h
+++ b/tachyon/device/gpu/gpu_memory.h
@@ -115,7 +115,7 @@ class GpuMemory {
     T* ptr = nullptr;
     GPU_MUST_SUCCESS(
         GpuMalloc(reinterpret_cast<void**>(&ptr), sizeof(T) * size),
-        "Failed to GpuMalloc()");
+        "Failed GpuMalloc()");
     return GpuMemory(ptr, size, GpuMemoryType::kDevice);
   }
 
@@ -123,7 +123,7 @@ class GpuMemory {
     T* ptr = nullptr;
     GPU_MUST_SUCCESS(
         GpuMallocHost(reinterpret_cast<void**>(&ptr), sizeof(T) * size),
-        "Failed to GpuMallocHost()");
+        "Failed GpuMallocHost()");
     return GpuMemory(ptr, size, GpuMemoryType::kHost);
   }
 
@@ -131,7 +131,7 @@ class GpuMemory {
   static GpuMemory MallocManaged(size_t size) {
     T* ptr = nullptr;
     GPU_MUST_SUCCESS(cudaMallocManaged(&ptr, sizeof(T) * size),
-                     "Failed to cudaMallocManaged()");
+                     "Failed cudaMallocManaged()");
     return GpuMemory(ptr, size, GpuMemoryType::kUnified);
   }
 #endif  // TACHYON_CUDA
@@ -141,7 +141,7 @@ class GpuMemory {
     T* ptr = nullptr;
     GPU_MUST_SUCCESS(GpuMallocFromPoolAsync(reinterpret_cast<void**>(&ptr),
                                             sizeof(T) * size, pool, stream),
-                     "Failed to GpuMallocFromPoolAsync()");
+                     "Failed GpuMallocFromPoolAsync()");
     return GpuMemory(ptr, size, GpuMemoryType::kDevice, stream);
   }
 
@@ -197,7 +197,7 @@ class GpuMemory {
   bool GetAttributes(gpuPointerAttributes* attributes) const {
     gpuError_t error = GpuPointerGetAttributes(attributes, ptr_);
     if (error != gpuSuccess) {
-      GPU_LOG(ERROR, error) << "Failed to GpuPointerGetAttributes()";
+      GPU_LOG(ERROR, error) << "Failed GpuPointerGetAttributes()";
       return false;
     }
     return true;
@@ -207,7 +207,7 @@ class GpuMemory {
     COMPUTE_FROM_AND_LEN(from, len);
     gpuError_t error = GpuMemset(ptr_ + from, value, sizeof(T) * len);
     if (error != gpuSuccess) {
-      GPU_LOG(ERROR, error) << "Failed to GpuMemset()";
+      GPU_LOG(ERROR, error) << "Failed GpuMemset()";
       return false;
     }
     return true;
@@ -219,7 +219,7 @@ class GpuMemory {
     gpuError_t error =
         GpuMemsetAsync(ptr_ + from, value, sizeof(T) * len, stream);
     if (error != gpuSuccess) {
-      GPU_LOG(ERROR, error) << "Failed to GpuMemsetAsync()";
+      GPU_LOG(ERROR, error) << "Failed GpuMemsetAsync()";
       return false;
     }
     return true;
@@ -232,7 +232,7 @@ class GpuMemory {
         GpuMemcpy(dst, ptr_ + from, sizeof(T) * len,
                   ComputeGpuMemcpyKind(memory_type_, dst_memory_type));
     if (error != gpuSuccess) {
-      GPU_LOG(ERROR, error) << "Failed to GpuMemcpy()";
+      GPU_LOG(ERROR, error) << "Failed GpuMemcpy()";
       return false;
     }
     return true;
@@ -251,7 +251,7 @@ class GpuMemory {
         dst, ptr_ + from, sizeof(T) * len,
         ComputeGpuMemcpyKind(memory_type_, dst_memory_type), stream);
     if (error != gpuSuccess) {
-      GPU_LOG(ERROR, error) << "Failed to GpuMemcpyAsync()";
+      GPU_LOG(ERROR, error) << "Failed GpuMemcpyAsync()";
       return false;
     }
     return true;
@@ -271,7 +271,7 @@ class GpuMemory {
         GpuMemcpy(ptr_ + from, src, sizeof(T) * len,
                   ComputeGpuMemcpyKind(src_memory_type, memory_type_));
     if (error != gpuSuccess) {
-      GPU_LOG(ERROR, error) << "Failed to GpuMemcpy()";
+      GPU_LOG(ERROR, error) << "Failed GpuMemcpy()";
       return false;
     }
     return true;
@@ -291,7 +291,7 @@ class GpuMemory {
         ptr_ + from, src, sizeof(T) * len,
         ComputeGpuMemcpyKind(src_memory_type, memory_type_), stream);
     if (error != gpuSuccess) {
-      GPU_LOG(ERROR, error) << "Failed to GpuMemcpyAsync()";
+      GPU_LOG(ERROR, error) << "Failed GpuMemcpyAsync()";
       return false;
     }
     return true;

--- a/tachyon/device/gpu/gpu_memory.h
+++ b/tachyon/device/gpu/gpu_memory.h
@@ -113,7 +113,7 @@ class GpuMemory {
  public:
   static GpuMemory Malloc(size_t size) {
     T* ptr = nullptr;
-    GPU_MUST_SUCCESS(
+    GPU_MUST_SUCCEED(
         GpuMalloc(reinterpret_cast<void**>(&ptr), sizeof(T) * size),
         "Failed GpuMalloc()");
     return GpuMemory(ptr, size, GpuMemoryType::kDevice);
@@ -121,7 +121,7 @@ class GpuMemory {
 
   static GpuMemory MallocHost(size_t size) {
     T* ptr = nullptr;
-    GPU_MUST_SUCCESS(
+    GPU_MUST_SUCCEED(
         GpuMallocHost(reinterpret_cast<void**>(&ptr), sizeof(T) * size),
         "Failed GpuMallocHost()");
     return GpuMemory(ptr, size, GpuMemoryType::kHost);
@@ -130,7 +130,7 @@ class GpuMemory {
 #if TACHYON_CUDA
   static GpuMemory MallocManaged(size_t size) {
     T* ptr = nullptr;
-    GPU_MUST_SUCCESS(cudaMallocManaged(&ptr, sizeof(T) * size),
+    GPU_MUST_SUCCEED(cudaMallocManaged(&ptr, sizeof(T) * size),
                      "Failed cudaMallocManaged()");
     return GpuMemory(ptr, size, GpuMemoryType::kUnified);
   }
@@ -139,7 +139,7 @@ class GpuMemory {
   static GpuMemory MallocFromPoolAsync(size_t size, gpuMemPool_t pool,
                                        gpuStream_t stream) {
     T* ptr = nullptr;
-    GPU_MUST_SUCCESS(GpuMallocFromPoolAsync(reinterpret_cast<void**>(&ptr),
+    GPU_MUST_SUCCEED(GpuMallocFromPoolAsync(reinterpret_cast<void**>(&ptr),
                                             sizeof(T) * size, pool, stream),
                      "Failed GpuMallocFromPoolAsync()");
     return GpuMemory(ptr, size, GpuMemoryType::kDevice, stream);

--- a/tachyon/device/gpu/gpu_memory_unittest.cc
+++ b/tachyon/device/gpu/gpu_memory_unittest.cc
@@ -45,7 +45,7 @@ TEST(GpuMemoryTest, Memset) {
   vec.resize(512);
   memory.CopyTo(vec.data(), GpuMemoryType::kHost);
 
-  GPU_MUST_SUCCESS(gpuDeviceSynchronize(), "");
+  GPU_MUST_SUCCEED(gpuDeviceSynchronize(), "");
 
   for (size_t i = 0; i < vec.size(); ++i) {
     if (i >= from && i < (from + len)) {
@@ -75,7 +75,7 @@ TEST(GpuMemoryTest, CopyFrom) {
       ASSERT_TRUE(memories[i].ToStdVector(&results[i]));
     }
 
-    GPU_MUST_SUCCESS(gpuDeviceSynchronize(), "");
+    GPU_MUST_SUCCEED(gpuDeviceSynchronize(), "");
     for (size_t i = 0; i < memories.size(); ++i) {
       EXPECT_EQ(results[i], host_memory);
     }
@@ -96,7 +96,7 @@ TEST(GpuMemoryTest, CopyFrom) {
       ASSERT_TRUE(memories[i].ToStdVector(&results[i]));
     }
 
-    GPU_MUST_SUCCESS(gpuDeviceSynchronize(), "");
+    GPU_MUST_SUCCEED(gpuDeviceSynchronize(), "");
     for (size_t i = 0; i < memories.size(); ++i) {
       EXPECT_EQ(results[i], unified_memory_view);
     }

--- a/tachyon/device/gpu/scoped_event.cc
+++ b/tachyon/device/gpu/scoped_event.cc
@@ -4,14 +4,14 @@ namespace tachyon::device::gpu {
 
 ScopedEvent CreateEvent() {
   gpuEvent_t event = nullptr;
-  GPU_MUST_SUCCESS(gpuEventCreate(&event), "Failed to gpuEventCreate()");
+  GPU_MUST_SUCCESS(gpuEventCreate(&event), "Failed gpuEventCreate()");
   return ScopedEvent(event);
 }
 
 ScopedEvent CreateEventWithFlags(unsigned int flags) {
   gpuEvent_t event = nullptr;
   GPU_MUST_SUCCESS(gpuEventCreateWithFlags(&event, flags),
-                   "Failed to gpuEventCreateWithFlags()");
+                   "Failed gpuEventCreateWithFlags()");
   return ScopedEvent(event);
 }
 

--- a/tachyon/device/gpu/scoped_event.cc
+++ b/tachyon/device/gpu/scoped_event.cc
@@ -4,13 +4,13 @@ namespace tachyon::device::gpu {
 
 ScopedEvent CreateEvent() {
   gpuEvent_t event = nullptr;
-  GPU_MUST_SUCCESS(gpuEventCreate(&event), "Failed gpuEventCreate()");
+  GPU_MUST_SUCCEED(gpuEventCreate(&event), "Failed gpuEventCreate()");
   return ScopedEvent(event);
 }
 
 ScopedEvent CreateEventWithFlags(unsigned int flags) {
   gpuEvent_t event = nullptr;
-  GPU_MUST_SUCCESS(gpuEventCreateWithFlags(&event, flags),
+  GPU_MUST_SUCCEED(gpuEventCreateWithFlags(&event, flags),
                    "Failed gpuEventCreateWithFlags()");
   return ScopedEvent(event);
 }

--- a/tachyon/device/gpu/scoped_event.h
+++ b/tachyon/device/gpu/scoped_event.h
@@ -11,7 +11,7 @@ namespace tachyon::device::gpu {
 
 struct TACHYON_EXPORT EventDestroyer {
   void operator()(gpuEvent_t event) const {
-    GPU_MUST_SUCCESS(gpuEventDestroy(event), "Failed gpuEventDestroy()");
+    GPU_MUST_SUCCEED(gpuEventDestroy(event), "Failed gpuEventDestroy()");
   }
 };
 

--- a/tachyon/device/gpu/scoped_event.h
+++ b/tachyon/device/gpu/scoped_event.h
@@ -11,7 +11,7 @@ namespace tachyon::device::gpu {
 
 struct TACHYON_EXPORT EventDestroyer {
   void operator()(gpuEvent_t event) const {
-    GPU_MUST_SUCCESS(gpuEventDestroy(event), "Failed to gpuEventDestroy()");
+    GPU_MUST_SUCCESS(gpuEventDestroy(event), "Failed gpuEventDestroy()");
   }
 };
 

--- a/tachyon/device/gpu/scoped_mem_pool.cc
+++ b/tachyon/device/gpu/scoped_mem_pool.cc
@@ -4,7 +4,7 @@ namespace tachyon::device::gpu {
 
 ScopedMemPool CreateMemPool(const gpuMemPoolProps* pool_props) {
   gpuMemPool_t mem_pool = nullptr;
-  GPU_MUST_SUCCESS(gpuMemPoolCreate(&mem_pool, pool_props),
+  GPU_MUST_SUCCEED(gpuMemPoolCreate(&mem_pool, pool_props),
                    "Failed gpuMemPoolCreate()");
   return ScopedMemPool(mem_pool);
 }

--- a/tachyon/device/gpu/scoped_mem_pool.cc
+++ b/tachyon/device/gpu/scoped_mem_pool.cc
@@ -5,7 +5,7 @@ namespace tachyon::device::gpu {
 ScopedMemPool CreateMemPool(const gpuMemPoolProps* pool_props) {
   gpuMemPool_t mem_pool = nullptr;
   GPU_MUST_SUCCESS(gpuMemPoolCreate(&mem_pool, pool_props),
-                   "Failed to gpuMemPoolCreate()");
+                   "Failed gpuMemPoolCreate()");
   return ScopedMemPool(mem_pool);
 }
 

--- a/tachyon/device/gpu/scoped_mem_pool.h
+++ b/tachyon/device/gpu/scoped_mem_pool.h
@@ -11,8 +11,7 @@ namespace tachyon::device::gpu {
 
 struct TACHYON_EXPORT MemPoolDestroyer {
   void operator()(gpuMemPool_t mem_pool) const {
-    GPU_MUST_SUCCESS(gpuMemPoolDestroy(mem_pool),
-                     "Failed to gpuMemPoolDestroy()");
+    GPU_MUST_SUCCESS(gpuMemPoolDestroy(mem_pool), "Failed gpuMemPoolDestroy()");
   }
 };
 

--- a/tachyon/device/gpu/scoped_mem_pool.h
+++ b/tachyon/device/gpu/scoped_mem_pool.h
@@ -11,7 +11,7 @@ namespace tachyon::device::gpu {
 
 struct TACHYON_EXPORT MemPoolDestroyer {
   void operator()(gpuMemPool_t mem_pool) const {
-    GPU_MUST_SUCCESS(gpuMemPoolDestroy(mem_pool), "Failed gpuMemPoolDestroy()");
+    GPU_MUST_SUCCEED(gpuMemPoolDestroy(mem_pool), "Failed gpuMemPoolDestroy()");
   }
 };
 

--- a/tachyon/device/gpu/scoped_stream.cc
+++ b/tachyon/device/gpu/scoped_stream.cc
@@ -4,14 +4,14 @@ namespace tachyon::device::gpu {
 
 ScopedStream CreateStream() {
   gpuStream_t event = nullptr;
-  GPU_MUST_SUCCESS(gpuStreamCreate(&event), "Failed to gpuStreamCreate()");
+  GPU_MUST_SUCCESS(gpuStreamCreate(&event), "Failed gpuStreamCreate()");
   return ScopedStream(event);
 }
 
 ScopedStream CreateStreamWithFlags(unsigned int flags) {
   gpuStream_t event = nullptr;
   GPU_MUST_SUCCESS(gpuStreamCreateWithFlags(&event, flags),
-                   "Failed to gpuStreamCreateWithFlags()");
+                   "Failed gpuStreamCreateWithFlags()");
   return ScopedStream(event);
 }
 

--- a/tachyon/device/gpu/scoped_stream.cc
+++ b/tachyon/device/gpu/scoped_stream.cc
@@ -4,13 +4,13 @@ namespace tachyon::device::gpu {
 
 ScopedStream CreateStream() {
   gpuStream_t event = nullptr;
-  GPU_MUST_SUCCESS(gpuStreamCreate(&event), "Failed gpuStreamCreate()");
+  GPU_MUST_SUCCEED(gpuStreamCreate(&event), "Failed gpuStreamCreate()");
   return ScopedStream(event);
 }
 
 ScopedStream CreateStreamWithFlags(unsigned int flags) {
   gpuStream_t event = nullptr;
-  GPU_MUST_SUCCESS(gpuStreamCreateWithFlags(&event, flags),
+  GPU_MUST_SUCCEED(gpuStreamCreateWithFlags(&event, flags),
                    "Failed gpuStreamCreateWithFlags()");
   return ScopedStream(event);
 }

--- a/tachyon/device/gpu/scoped_stream.h
+++ b/tachyon/device/gpu/scoped_stream.h
@@ -13,7 +13,7 @@ namespace tachyon::device::gpu {
 
 struct TACHYON_EXPORT StreamDestroyer {
   void operator()(gpuStream_t event) const {
-    GPU_MUST_SUCCESS(gpuStreamDestroy(event), "Failed to gpuStreamDestroy()");
+    GPU_MUST_SUCCESS(gpuStreamDestroy(event), "Failed gpuStreamDestroy()");
   }
 };
 

--- a/tachyon/device/gpu/scoped_stream.h
+++ b/tachyon/device/gpu/scoped_stream.h
@@ -13,7 +13,7 @@ namespace tachyon::device::gpu {
 
 struct TACHYON_EXPORT StreamDestroyer {
   void operator()(gpuStream_t event) const {
-    GPU_MUST_SUCCESS(gpuStreamDestroy(event), "Failed gpuStreamDestroy()");
+    GPU_MUST_SUCCEED(gpuStreamDestroy(event), "Failed gpuStreamDestroy()");
   }
 };
 

--- a/tachyon/math/elliptic_curves/msm/algorithms/icicle/icicle_msm_bls12_381_g1.cc
+++ b/tachyon/math/elliptic_curves/msm/algorithms/icicle/icicle_msm_bls12_381_g1.cc
@@ -59,7 +59,7 @@ bool IcicleMSM<bls12_381::G1AffinePoint>::Run(
         reinterpret_cast<const ::bls12_381::affine_t*>(&cpu_bases[start_idx]),
         data_size, *config_, &ret);
     if (error != gpuSuccess) {
-      GPU_LOG(ERROR, error) << "Failed to tachyon_bls12_381_g1_msm_cuda()";
+      GPU_LOG(ERROR, error) << "Failed tachyon_bls12_381_g1_msm_cuda()";
       return false;
     }
     final_value = final_value + ret;

--- a/tachyon/math/elliptic_curves/msm/algorithms/icicle/icicle_msm_bls12_381_g2.cc
+++ b/tachyon/math/elliptic_curves/msm/algorithms/icicle/icicle_msm_bls12_381_g2.cc
@@ -60,7 +60,7 @@ bool IcicleMSM<bls12_381::G2AffinePoint>::Run(
             &cpu_bases[start_idx]),
         data_size, *config_, &ret);
     if (error != gpuSuccess) {
-      GPU_LOG(ERROR, error) << "Failed to tachyon_bls12_381_g2_msm_cuda()";
+      GPU_LOG(ERROR, error) << "Failed tachyon_bls12_381_g2_msm_cuda()";
       return false;
     }
     final_value = final_value + ret;

--- a/tachyon/math/elliptic_curves/msm/algorithms/icicle/icicle_msm_bn254_g1.cc
+++ b/tachyon/math/elliptic_curves/msm/algorithms/icicle/icicle_msm_bn254_g1.cc
@@ -57,7 +57,7 @@ bool IcicleMSM<bn254::G1AffinePoint>::Run(
         reinterpret_cast<const ::bn254::affine_t*>(&cpu_bases[start_idx]),
         data_size, *config_, &ret);
     if (error != gpuSuccess) {
-      GPU_LOG(ERROR, error) << "Failed to tachyon_bn254_g1_msm_cuda()";
+      GPU_LOG(ERROR, error) << "Failed tachyon_bn254_g1_msm_cuda()";
       return false;
     }
     final_value = final_value + ret;

--- a/tachyon/math/elliptic_curves/msm/algorithms/icicle/icicle_msm_bn254_g2.cc
+++ b/tachyon/math/elliptic_curves/msm/algorithms/icicle/icicle_msm_bn254_g2.cc
@@ -57,7 +57,7 @@ bool IcicleMSM<bn254::G2AffinePoint>::Run(
         reinterpret_cast<const ::bn254::g2_affine_t*>(&cpu_bases[start_idx]),
         data_size, *config_, &ret);
     if (error != gpuSuccess) {
-      GPU_LOG(ERROR, error) << "Failed to tachyon_bn254_g2_msm_cuda()";
+      GPU_LOG(ERROR, error) << "Failed tachyon_bn254_g2_msm_cuda()";
       return false;
     }
     final_value = final_value + ret;

--- a/tachyon/math/elliptic_curves/msm/variable_base_msm_gpu_unittest.cc
+++ b/tachyon/math/elliptic_curves/msm/variable_base_msm_gpu_unittest.cc
@@ -34,7 +34,7 @@ class VariableMSMCorrectnessGpuTest : public testing::Test {
     expected_ = test_set_.answer.ToProjective();
   }
 
-  static void TearDownTestSuite() { GPU_MUST_SUCCESS(gpuDeviceReset(), ""); }
+  static void TearDownTestSuite() { GPU_MUST_SUCCEED(gpuDeviceReset(), ""); }
 
  protected:
   static VariableBaseMSMTestSet<Point> test_set_;

--- a/tachyon/math/elliptic_curves/short_weierstrass/affine_point_correctness_gpu_test.cc
+++ b/tachyon/math/elliptic_curves/short_weierstrass/affine_point_correctness_gpu_test.cc
@@ -42,7 +42,7 @@ class AffinePointCorrectnessGpuTest : public testing::Test {
   constexpr static size_t N = kThreadNum * 2;
 
   static void SetUpTestSuite() {
-    GPU_MUST_SUCCESS(gpuDeviceReset(), "");
+    GPU_MUST_SUCCEED(gpuDeviceReset(), "");
     xs_ = gpu::GpuMemory<bn254::G1AffinePointGpu>::MallocManaged(N);
     ys_ = gpu::GpuMemory<bn254::G1AffinePointGpu>::MallocManaged(N);
     affine_results_ = gpu::GpuMemory<bn254::G1AffinePointGpu>::MallocManaged(N);
@@ -75,7 +75,7 @@ class AffinePointCorrectnessGpuTest : public testing::Test {
     jacobian_results_.reset();
     bool_results_.reset();
 
-    GPU_MUST_SUCCESS(gpuDeviceReset(), "");
+    GPU_MUST_SUCCEED(gpuDeviceReset(), "");
 
     x_cpus_.clear();
     y_cpus_.clear();
@@ -112,7 +112,7 @@ std::vector<bn254::G1AffinePoint> AffinePointCorrectnessGpuTest::y_cpus_;
 }  // namespace
 
 TEST_F(AffinePointCorrectnessGpuTest, Add) {
-  GPU_MUST_SUCCESS(LaunchAdd(xs_.get(), ys_.get(), jacobian_results_.get(), N),
+  GPU_MUST_SUCCEED(LaunchAdd(xs_.get(), ys_.get(), jacobian_results_.get(), N),
                    "");
   for (size_t i = 0; i < N; ++i) {
     SCOPED_TRACE(
@@ -123,7 +123,7 @@ TEST_F(AffinePointCorrectnessGpuTest, Add) {
 }
 
 TEST_F(AffinePointCorrectnessGpuTest, Double) {
-  GPU_MUST_SUCCESS(LaunchDouble(xs_.get(), jacobian_results_.get(), N), "");
+  GPU_MUST_SUCCEED(LaunchDouble(xs_.get(), jacobian_results_.get(), N), "");
   for (size_t i = 0; i < N; ++i) {
     SCOPED_TRACE(absl::Substitute("a: $0", xs_[i].ToString()));
     auto result = ConvertPoint<bn254::G1JacobianPoint>(jacobian_results_[i]);
@@ -132,7 +132,7 @@ TEST_F(AffinePointCorrectnessGpuTest, Double) {
 }
 
 TEST_F(AffinePointCorrectnessGpuTest, Negate) {
-  GPU_MUST_SUCCESS(LaunchNegate(xs_.get(), affine_results_.get(), N), "");
+  GPU_MUST_SUCCEED(LaunchNegate(xs_.get(), affine_results_.get(), N), "");
   for (size_t i = 0; i < N; ++i) {
     SCOPED_TRACE(absl::Substitute("a: $0", xs_[i].ToString()));
     auto result = ConvertPoint<bn254::G1AffinePoint>(affine_results_[i]);
@@ -141,7 +141,7 @@ TEST_F(AffinePointCorrectnessGpuTest, Negate) {
 }
 
 TEST_F(AffinePointCorrectnessGpuTest, Eq) {
-  GPU_MUST_SUCCESS(LaunchEq(xs_.get(), xs_.get(), bool_results_.get(), N), "");
+  GPU_MUST_SUCCEED(LaunchEq(xs_.get(), xs_.get(), bool_results_.get(), N), "");
   for (size_t i = 0; i < N; ++i) {
     SCOPED_TRACE(
         absl::Substitute("a: $0, b: $1", xs_[i].ToString(), xs_[i].ToString()));
@@ -150,7 +150,7 @@ TEST_F(AffinePointCorrectnessGpuTest, Eq) {
 }
 
 TEST_F(AffinePointCorrectnessGpuTest, Ne) {
-  GPU_MUST_SUCCESS(LaunchNe(xs_.get(), ys_.get(), bool_results_.get(), N), "");
+  GPU_MUST_SUCCEED(LaunchNe(xs_.get(), ys_.get(), bool_results_.get(), N), "");
   for (size_t i = 0; i < N; ++i) {
     SCOPED_TRACE(
         absl::Substitute("a: $0, b: $1", xs_[i].ToString(), ys_[i].ToString()));

--- a/tachyon/math/elliptic_curves/short_weierstrass/non_affine_point_correctness_gpu_test.cc
+++ b/tachyon/math/elliptic_curves/short_weierstrass/non_affine_point_correctness_gpu_test.cc
@@ -61,7 +61,7 @@ class PointCorrectnessGpuTest : public testing::Test {
   constexpr static size_t N = kThreadNum * 2;
 
   static void SetUpTestSuite() {
-    GPU_MUST_SUCCESS(gpuDeviceReset(), "");
+    GPU_MUST_SUCCEED(gpuDeviceReset(), "");
     xs_ = gpu::GpuMemory<Actual>::MallocManaged(N);
     ys_ = gpu::GpuMemory<Actual>::MallocManaged(N);
     results_ = gpu::GpuMemory<Actual>::MallocManaged(N);
@@ -91,7 +91,7 @@ class PointCorrectnessGpuTest : public testing::Test {
     results_.reset();
     bool_results_.reset();
 
-    GPU_MUST_SUCCESS(gpuDeviceReset(), "");
+    GPU_MUST_SUCCEED(gpuDeviceReset(), "");
 
     x_cpus_.clear();
     y_cpus_.clear();
@@ -160,7 +160,7 @@ TYPED_TEST(PointCorrectnessGpuTest, Add) {
   using Expected = typename TypeParam::Expected;
   size_t N = PointCorrectnessGpuTest<TypeParam>::N;
 
-  GPU_MUST_SUCCESS(
+  GPU_MUST_SUCCEED(
       LaunchAdd(this->xs_.get(), this->ys_.get(), this->results_.get(), N), "");
   for (size_t i = 0; i < N; ++i) {
     SCOPED_TRACE(absl::Substitute("a: $0, b: $1", this->xs_[i].ToString(),
@@ -174,7 +174,7 @@ TYPED_TEST(PointCorrectnessGpuTest, Double) {
   using Expected = typename TypeParam::Expected;
   size_t N = PointCorrectnessGpuTest<TypeParam>::N;
 
-  GPU_MUST_SUCCESS(LaunchDouble(this->xs_.get(), this->results_.get(), N), "");
+  GPU_MUST_SUCCEED(LaunchDouble(this->xs_.get(), this->results_.get(), N), "");
   for (size_t i = 0; i < N; ++i) {
     SCOPED_TRACE(absl::Substitute("a: $0", this->xs_[i].ToString()));
     auto result = ConvertPoint<Expected>(this->results_[i]);
@@ -186,7 +186,7 @@ TYPED_TEST(PointCorrectnessGpuTest, Negate) {
   using Expected = typename TypeParam::Expected;
   size_t N = PointCorrectnessGpuTest<TypeParam>::N;
 
-  GPU_MUST_SUCCESS(LaunchNegate(this->xs_.get(), this->results_.get(), N), "");
+  GPU_MUST_SUCCEED(LaunchNegate(this->xs_.get(), this->results_.get(), N), "");
   for (size_t i = 0; i < N; ++i) {
     SCOPED_TRACE(absl::Substitute("a: $0", this->xs_[i].ToString()));
     auto result = ConvertPoint<Expected>(this->results_[i]);
@@ -197,7 +197,7 @@ TYPED_TEST(PointCorrectnessGpuTest, Negate) {
 TYPED_TEST(PointCorrectnessGpuTest, Eq) {
   size_t N = PointCorrectnessGpuTest<TypeParam>::N;
 
-  GPU_MUST_SUCCESS(
+  GPU_MUST_SUCCEED(
       LaunchEq(this->xs_.get(), this->xs_.get(), this->bool_results_.get(), N),
       "");
   for (size_t i = 0; i < N; ++i) {
@@ -210,7 +210,7 @@ TYPED_TEST(PointCorrectnessGpuTest, Eq) {
 TYPED_TEST(PointCorrectnessGpuTest, Ne) {
   size_t N = PointCorrectnessGpuTest<TypeParam>::N;
 
-  GPU_MUST_SUCCESS(
+  GPU_MUST_SUCCEED(
       LaunchNe(this->xs_.get(), this->ys_.get(), this->bool_results_.get(), N),
       "");
   for (size_t i = 0; i < N; ++i) {

--- a/tachyon/math/finite_fields/prime_field_correctness_gpu_test.cc
+++ b/tachyon/math/finite_fields/prime_field_correctness_gpu_test.cc
@@ -35,7 +35,7 @@ class PrimeFieldCorrectnessGpuTest : public FiniteFieldTest<bn254::Fq> {
   static void SetUpTestSuite() {
     FiniteFieldTest<bn254::Fq>::SetUpTestSuite();
 
-    GPU_MUST_SUCCESS(gpuDeviceReset(), "");
+    GPU_MUST_SUCCEED(gpuDeviceReset(), "");
     xs_ = gpu::GpuMemory<bn254::FqGpu>::MallocManaged(N);
     ys_ = gpu::GpuMemory<bn254::FqGpu>::MallocManaged(N);
     results_ = gpu::GpuMemory<bn254::FqGpu>::MallocManaged(N);
@@ -60,7 +60,7 @@ class PrimeFieldCorrectnessGpuTest : public FiniteFieldTest<bn254::Fq> {
     ys_.reset();
     results_.reset();
 
-    GPU_MUST_SUCCESS(gpuDeviceReset(), "");
+    GPU_MUST_SUCCEED(gpuDeviceReset(), "");
 
     x_cpus_.clear();
     y_cpus_.clear();
@@ -87,7 +87,7 @@ std::vector<bn254::Fq> PrimeFieldCorrectnessGpuTest::y_cpus_;
 }  // namespace
 
 #define RUN_OPERATION_TESTS(method)                                         \
-  GPU_MUST_SUCCESS(Launch##method(xs_.get(), ys_.get(), results_.get(), N), \
+  GPU_MUST_SUCCEED(Launch##method(xs_.get(), ys_.get(), results_.get(), N), \
                    "");                                                     \
   for (size_t i = 0; i < N; ++i)
 

--- a/tachyon/math/finite_fields/prime_field_gpu_unittest.cc
+++ b/tachyon/math/finite_fields/prime_field_gpu_unittest.cc
@@ -43,7 +43,7 @@ class PrimeFieldGpuTest : public FiniteFieldTest<GF7> {
   static void SetUpTestSuite() {
     FiniteFieldTest<GF7>::SetUpTestSuite();
 
-    GPU_MUST_SUCCESS(gpuDeviceReset(), "");
+    GPU_MUST_SUCCEED(gpuDeviceReset(), "");
     xs_ = gpu::GpuMemory<GF7Gpu>::MallocManaged(N);
     ys_ = gpu::GpuMemory<GF7Gpu>::MallocManaged(N);
     results_ = gpu::GpuMemory<GF7Gpu>::MallocManaged(N);
@@ -56,7 +56,7 @@ class PrimeFieldGpuTest : public FiniteFieldTest<GF7> {
     results_.reset();
     bool_results_.reset();
 
-    GPU_MUST_SUCCESS(gpuDeviceReset(), "");
+    GPU_MUST_SUCCEED(gpuDeviceReset(), "");
   }
 
   void SetUp() override {
@@ -86,7 +86,7 @@ gpu::GpuMemory<bool> PrimeFieldGpuTest::bool_results_;
     xs_[i] = GF7Gpu::FromBigInt(test.x.ToBigInt());                          \
     ys_[i] = GF7Gpu::FromBigInt(test.y.ToBigInt());                          \
   }                                                                          \
-  GPU_MUST_SUCCESS(                                                          \
+  GPU_MUST_SUCCEED(                                                          \
       Launch##method(xs_.get(), ys_.get(), results.get(), std::size(tests)), \
       "Failed " #method "()");                                               \
   for (size_t i = 0; i < std::size(tests); ++i)
@@ -194,7 +194,7 @@ TEST_F(PrimeFieldGpuTest, Eq) {
     ASSERT_EQ(xs_[i] == ys_[i], test.result);
   }
 
-  GPU_MUST_SUCCESS(
+  GPU_MUST_SUCCEED(
       LaunchEq(xs_.get(), ys_.get(), bool_results_.get(), std::size(tests)),
       "Failed Eq()");
   for (size_t i = 0; i < std::size(tests); ++i) {
@@ -220,7 +220,7 @@ TEST_F(PrimeFieldGpuTest, Ne) {
     ASSERT_EQ(xs_[i] != ys_[i], test.result);
   }
 
-  GPU_MUST_SUCCESS(
+  GPU_MUST_SUCCEED(
       LaunchNe(xs_.get(), ys_.get(), bool_results_.get(), std::size(tests)),
       "Failed Ne()");
   for (size_t i = 0; i < std::size(tests); ++i) {

--- a/tachyon/math/finite_fields/prime_field_gpu_unittest.cc
+++ b/tachyon/math/finite_fields/prime_field_gpu_unittest.cc
@@ -88,7 +88,7 @@ gpu::GpuMemory<bool> PrimeFieldGpuTest::bool_results_;
   }                                                                          \
   GPU_MUST_SUCCESS(                                                          \
       Launch##method(xs_.get(), ys_.get(), results.get(), std::size(tests)), \
-      "Failed to " #method "()");                                            \
+      "Failed " #method "()");                                               \
   for (size_t i = 0; i < std::size(tests); ++i)
 
 #define RUN_FIELD_OPERATION_TESTS(method) \
@@ -196,7 +196,7 @@ TEST_F(PrimeFieldGpuTest, Eq) {
 
   GPU_MUST_SUCCESS(
       LaunchEq(xs_.get(), ys_.get(), bool_results_.get(), std::size(tests)),
-      "Failed to Eq()");
+      "Failed Eq()");
   for (size_t i = 0; i < std::size(tests); ++i) {
     ASSERT_EQ(bool_results_[i], tests[i].result);
   }
@@ -222,7 +222,7 @@ TEST_F(PrimeFieldGpuTest, Ne) {
 
   GPU_MUST_SUCCESS(
       LaunchNe(xs_.get(), ys_.get(), bool_results_.get(), std::size(tests)),
-      "Failed to Ne()");
+      "Failed Ne()");
   for (size_t i = 0; i < std::size(tests); ++i) {
     ASSERT_EQ(bool_results_[i], tests[i].result);
   }

--- a/tachyon/math/polynomials/univariate/icicle/icicle_ntt_baby_bear.cc
+++ b/tachyon/math/polynomials/univariate/icicle/icicle_ntt_baby_bear.cc
@@ -46,7 +46,7 @@ bool IcicleNTT<BabyBear>::Init(const BabyBear& group_gen,
       reinterpret_cast<const ::babybear::scalar_t&>(group_gen_big_int), ctx,
       options.fast_twiddles_mode);
   if (error != gpuSuccess) {
-    GPU_LOG(ERROR, error) << "Failed to tachyon_babybear_initialize_domain()";
+    GPU_LOG(ERROR, error) << "Failed tachyon_babybear_initialize_domain()";
     return false;
   }
   VLOG(1) << "IcicleNTT is initialized";
@@ -93,7 +93,7 @@ bool IcicleNTT<BabyBear>::Run(::ntt::NttAlgorithm algorithm,
       reinterpret_cast<const ::babybear::scalar_t*>(inout), size, dir, config,
       reinterpret_cast<::babybear::scalar_t*>(inout));
   if (error != gpuSuccess) {
-    GPU_LOG(ERROR, error) << "Failed to tachyon_babybear_ntt_cuda()";
+    GPU_LOG(ERROR, error) << "Failed tachyon_babybear_ntt_cuda()";
     return false;
   }
   return true;
@@ -108,7 +108,7 @@ bool IcicleNTT<BabyBear>::Release() {
   ::device_context::DeviceContext ctx{stream_, /*device_id=*/0, mem_pool_};
   gpuError_t error = tachyon_babybear_release_domain(ctx);
   if (error != gpuSuccess) {
-    GPU_LOG(ERROR, error) << "Failed to tachyon_babybear_release_domain()";
+    GPU_LOG(ERROR, error) << "Failed tachyon_babybear_release_domain()";
     return false;
   }
   return true;

--- a/tachyon/math/polynomials/univariate/icicle/icicle_ntt_bls12_381.cc
+++ b/tachyon/math/polynomials/univariate/icicle/icicle_ntt_bls12_381.cc
@@ -46,7 +46,7 @@ bool IcicleNTT<bls12_381::Fr>::Init(const bls12_381::Fr& group_gen,
       reinterpret_cast<const ::bls12_381::scalar_t&>(group_gen_big_int), ctx,
       options.fast_twiddles_mode);
   if (error != gpuSuccess) {
-    GPU_LOG(ERROR, error) << "Failed to tachyon_bls12_381_initialize_domain()";
+    GPU_LOG(ERROR, error) << "Failed tachyon_bls12_381_initialize_domain()";
     return false;
   }
   VLOG(1) << "IcicleNTT is initialized";
@@ -93,7 +93,7 @@ bool IcicleNTT<bls12_381::Fr>::Run(::ntt::NttAlgorithm algorithm,
       reinterpret_cast<const ::bls12_381::scalar_t*>(inout), size, dir, config,
       reinterpret_cast<::bls12_381::scalar_t*>(inout));
   if (error != gpuSuccess) {
-    GPU_LOG(ERROR, error) << "Failed to tachyon_bls12_381_ntt_cuda()";
+    GPU_LOG(ERROR, error) << "Failed tachyon_bls12_381_ntt_cuda()";
     return false;
   }
   return true;
@@ -108,7 +108,7 @@ bool IcicleNTT<bls12_381::Fr>::Release() {
   ::device_context::DeviceContext ctx{stream_, /*device_id=*/0, mem_pool_};
   gpuError_t error = tachyon_bls12_381_release_domain(ctx);
   if (error != gpuSuccess) {
-    GPU_LOG(ERROR, error) << "Failed to tachyon_bls12_381_release_domain()";
+    GPU_LOG(ERROR, error) << "Failed tachyon_bls12_381_release_domain()";
     return false;
   }
   return true;

--- a/tachyon/math/polynomials/univariate/icicle/icicle_ntt_bn254.cc
+++ b/tachyon/math/polynomials/univariate/icicle/icicle_ntt_bn254.cc
@@ -45,7 +45,7 @@ bool IcicleNTT<bn254::Fr>::Init(const bn254::Fr& group_gen,
       reinterpret_cast<const ::bn254::scalar_t&>(group_gen_big_int), ctx,
       options.fast_twiddles_mode);
   if (error != gpuSuccess) {
-    GPU_LOG(ERROR, error) << "Failed to tachyon_bn254_initialize_domain()";
+    GPU_LOG(ERROR, error) << "Failed tachyon_bn254_initialize_domain()";
     return false;
   }
   VLOG(1) << "IcicleNTT is initialized";
@@ -93,7 +93,7 @@ bool IcicleNTT<bn254::Fr>::Run(::ntt::NttAlgorithm algorithm,
       reinterpret_cast<const ::bn254::scalar_t*>(inout), size, dir, config,
       reinterpret_cast<::bn254::scalar_t*>(inout));
   if (error != gpuSuccess) {
-    GPU_LOG(ERROR, error) << "Failed to tachyon_bn254_ntt_cuda()";
+    GPU_LOG(ERROR, error) << "Failed tachyon_bn254_ntt_cuda()";
     return false;
   }
   return true;
@@ -108,7 +108,7 @@ bool IcicleNTT<bn254::Fr>::Release() {
   ::device_context::DeviceContext ctx{stream_, /*device_id=*/0, mem_pool_};
   gpuError_t error = tachyon_bn254_release_domain(ctx);
   if (error != gpuSuccess) {
-    GPU_LOG(ERROR, error) << "Failed to tachyon_bn254_release_domain()";
+    GPU_LOG(ERROR, error) << "Failed tachyon_bn254_release_domain()";
     return false;
   }
   return true;

--- a/tachyon/math/test/launch_op_macros.h
+++ b/tachyon/math/test/launch_op_macros.h
@@ -4,17 +4,17 @@
 #include "tachyon/device/gpu/gpu_device_functions.h"
 #include "tachyon/device/gpu/gpu_logging.h"
 
-#define DEFINE_LAUNCH_UNARY_OP(thread_num, method, type, result_type)    \
-  gpuError_t Launch##method(const type* x, result_type* result,          \
-                            size_t count) {                              \
-    ::tachyon::math::kernels::                                           \
-        method<<<(count - 1) / thread_num + 1, thread_num>>>(x, result,  \
-                                                             count);     \
-    gpuError_t error = LOG_IF_GPU_LAST_ERROR("Failed to " #method "()"); \
-    return error == gpuSuccess                                           \
-               ? LOG_IF_GPU_ERROR(gpuDeviceSynchronize(),                \
-                                  "Failed to gpuDeviceSynchronize()")    \
-               : error;                                                  \
+#define DEFINE_LAUNCH_UNARY_OP(thread_num, method, type, result_type)   \
+  gpuError_t Launch##method(const type* x, result_type* result,         \
+                            size_t count) {                             \
+    ::tachyon::math::kernels::                                          \
+        method<<<(count - 1) / thread_num + 1, thread_num>>>(x, result, \
+                                                             count);    \
+    gpuError_t error = LOG_IF_GPU_LAST_ERROR("Failed " #method "()");   \
+    return error == gpuSuccess                                          \
+               ? LOG_IF_GPU_ERROR(gpuDeviceSynchronize(),               \
+                                  "Failed gpuDeviceSynchronize()")      \
+               : error;                                                 \
   }
 
 #define DEFINE_LAUNCH_BINARY_OP(thread_num, method, type, result_type)         \
@@ -23,10 +23,10 @@
     ::tachyon::math::kernels::                                                 \
         method<<<(count - 1) / thread_num + 1, thread_num>>>(x, y, result,     \
                                                              count);           \
-    gpuError_t error = LOG_IF_GPU_LAST_ERROR("Failed to " #method "()");       \
+    gpuError_t error = LOG_IF_GPU_LAST_ERROR("Failed " #method "()");          \
     return error == gpuSuccess                                                 \
                ? LOG_IF_GPU_ERROR(gpuDeviceSynchronize(),                      \
-                                  "Failed to gpuDeviceSynchronize()")          \
+                                  "Failed gpuDeviceSynchronize()")             \
                : error;                                                        \
   }
 

--- a/third_party/gpus/cuda_configure.bzl
+++ b/third_party/gpus/cuda_configure.bzl
@@ -657,7 +657,7 @@ def find_cuda_config(repository_ctx, script_path, cuda_libraries):
     """Returns CUDA config dictionary from running find_cuda_config.py"""
     exec_result = _exec_find_cuda_config(repository_ctx, script_path, cuda_libraries)
     if exec_result.return_code:
-        auto_configure_fail("Failed to run find_cuda_config.py: %s" % err_out(exec_result))
+        auto_configure_fail("Failed find_cuda_config.py: %s" % err_out(exec_result))
 
     # Parse the dict from stdout.
     return dict([tuple(x.split(": ")) for x in exec_result.stdout.splitlines()])

--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -381,7 +381,7 @@ def find_rocm_config(repository_ctx, script_path):
     """Returns ROCm config dictionary from running find_rocm_config.py"""
     exec_result = _exec_find_rocm_config(repository_ctx, script_path)
     if exec_result.return_code:
-        auto_configure_fail("Failed to run find_rocm_config.py: %s" % err_out(exec_result))
+        auto_configure_fail("Failed find_rocm_config.py: %s" % err_out(exec_result))
 
     # Parse the dict from stdout.
     return dict([tuple(x.split(": ")) for x in exec_result.stdout.splitlines()])

--- a/third_party/node_addon_api/install_node_addon_api.bzl
+++ b/third_party/node_addon_api/install_node_addon_api.bzl
@@ -15,17 +15,17 @@ def _install_node_addon_api_impl(repository_ctx):
     cmd = [bash_bin, "-c", "npm install"]
     result = repository_ctx.execute(cmd)
     if result.return_code != 0:
-        _fail("Failed to npm install: %s." % result.stderr)
+        _fail("Failed npm install: %s." % result.stderr)
 
     cmd = [bash_bin, "-c", "npx node-gyp install --devdir ."]
     result = repository_ctx.execute(cmd)
     if result.return_code != 0:
-        _fail("Failed to node-gyp install: %s." % result.stderr)
+        _fail("Failed node-gyp install: %s." % result.stderr)
 
     cmd = [bash_bin, "-c", "node --version"]
     result = repository_ctx.execute(cmd)
     if result.return_code != 0:
-        _fail("Failed to node --version: %s." % result.stderr)
+        _fail("Failed node --version: %s." % result.stderr)
 
     version = result.stdout.strip()
     if version.startswith("v"):


### PR DESCRIPTION
1. Fixes error messages concerning a function from `Failed to ...()` to `Failed ...()`
2. Renames `GPU_MUST_SUCCESS` to `GPU_MUST_SUCCEED` for better grammar.