### PR TITLE
perf: optimize fft batch

### DIFF
--- a/tachyon/crypto/commitments/fri/two_adic_fri_config.h
+++ b/tachyon/crypto/commitments/fri/two_adic_fri_config.h
@@ -63,7 +63,7 @@ std::vector<ExtF> FoldMatrix(const ExtF& beta,
 
 // NOTE(ashjeong): |arity| is subject to change in the future
 template <typename ExtF>
-ExtF FoldRow(size_t index, size_t log_num_rows, const ExtF& beta,
+ExtF FoldRow(size_t index, uint32_t log_num_rows, const ExtF& beta,
              const std::vector<ExtF>& evals) {
   using F = typename math::ExtensionFieldTraits<ExtF>::BaseField;
   const size_t kArity = 2;

--- a/tachyon/crypto/commitments/fri/two_adic_fri_pcs.h
+++ b/tachyon/crypto/commitments/fri/two_adic_fri_pcs.h
@@ -204,7 +204,7 @@ class TwoAdicFriPCS {
     // Batch combination challenge
     const ExtF alpha = challenger.template SampleExtElement<ExtF>();
     VLOG(2) << "FRI(alpha): " << alpha.ToHexString(true);
-    size_t log_global_max_num_rows =
+    uint32_t log_global_max_num_rows =
         proof.commit_phase_commits.size() + fri_.log_blowup;
     return TwoAdicFriPCSVerify(
         fri_, proof, challenger,

--- a/tachyon/crypto/commitments/fri/two_adic_fri_pcs.h
+++ b/tachyon/crypto/commitments/fri/two_adic_fri_pcs.h
@@ -287,7 +287,7 @@ class TwoAdicFriPCS {
   absl::flat_hash_map<ExtF, std::vector<ExtF>> ComputeInverseDenominators(
       const std::vector<absl::Span<const math::RowMajorMatrix<F>>>&
           matrices_by_round,
-      const std::vector<Points>& points_by_round, const F& coset_shift) {
+      const std::vector<Points>& points_by_round, F coset_shift) {
     size_t num_rounds = matrices_by_round.size();
 
     absl::flat_hash_map<ExtF, uint32_t> max_log_num_rows_for_point;
@@ -327,7 +327,7 @@ class TwoAdicFriPCS {
       uint32_t log_num_rows = it->second;
       std::vector<ExtF> temp = base::Map(
           absl::MakeSpan(subgroup.data(), (size_t{1} << log_num_rows)),
-          [&point](const F& x) { return ExtF(x) - point; });
+          [&point](F x) { return ExtF(x) - point; });
       CHECK(ExtF::BatchInverseInPlace(temp));
       ret[point] = std::move(temp);
     }
@@ -338,7 +338,7 @@ class TwoAdicFriPCS {
   // https://hackmd.io/@vbuterin/barycentric_evaluation
   template <typename Derived>
   static std::vector<ExtF> InterpolateCoset(
-      const Eigen::MatrixBase<Derived>& coset_evals, const F& shift,
+      const Eigen::MatrixBase<Derived>& coset_evals, F shift,
       const ExtF& point) {
     size_t num_rows = static_cast<size_t>(coset_evals.rows());
     size_t num_cols = static_cast<size_t>(coset_evals.cols());

--- a/tachyon/crypto/commitments/merkle_tree/field_merkle_tree/field_merkle_tree_mmcs.h
+++ b/tachyon/crypto/commitments/merkle_tree/field_merkle_tree/field_merkle_tree_mmcs.h
@@ -105,15 +105,15 @@ class FieldMerkleTreeMMCS final
                                           std::vector<std::vector<F>>* openings,
                                           Proof* proof) const {
     size_t max_row_size = this->GetMaxRowSize(prover_data);
-    size_t log_max_row_size = base::bits::Log2Ceiling(max_row_size);
+    uint32_t log_max_row_size = base::bits::Log2Ceiling(max_row_size);
 
     // TODO(chokobole): Is it able to be parallelized?
     *openings = base::Map(
         prover_data.leaves(),
         [log_max_row_size, index](const math::RowMajorMatrix<F>& matrix) {
-          size_t log_row_size =
+          uint32_t log_row_size =
               base::bits::Log2Ceiling(static_cast<size_t>(matrix.rows()));
-          size_t bits_reduced = log_max_row_size - log_row_size;
+          uint32_t bits_reduced = log_max_row_size - log_row_size;
           size_t reduced_index = index >> bits_reduced;
           return base::CreateVector(matrix.cols(),
                                     [reduced_index, &matrix](size_t col) {

--- a/tachyon/math/base/semigroups.h
+++ b/tachyon/math/base/semigroups.h
@@ -224,7 +224,7 @@ class MultiplicativeSemigroup {
   constexpr static std::vector<MulResult> GetBitRevIndexSuccessivePowers(
       size_t size, const G& generator, const G& c = G::One()) {
     std::vector<MulResult> ret(size);
-    size_t log_size = base::bits::CheckedLog2(size);
+    uint32_t log_size = base::bits::CheckedLog2(size);
     base::Parallelize(
         ret, [log_size, &generator, &c, &ret](
                  absl::Span<G> chunk, size_t chunk_offset, size_t chunk_size) {
@@ -248,7 +248,7 @@ class MultiplicativeSemigroup {
   constexpr static std::vector<MulResult> GetBitRevIndexSuccessivePowersSerial(
       size_t size, const G& generator, const G& c = G::One()) {
     std::vector<MulResult> ret(size);
-    size_t log_size = base::bits::CheckedLog2(size);
+    uint32_t log_size = base::bits::CheckedLog2(size);
     MulResult pow = c.IsOne() ? G::One() : c;
     for (size_t idx = 0; idx < size - 1; ++idx) {
       ret[base::bits::ReverseBitsLen(idx, log_size)] = pow;

--- a/tachyon/math/elliptic_curves/msm/algorithms/icicle/icicle_msm_utils.cc
+++ b/tachyon/math/elliptic_curves/msm/algorithms/icicle/icicle_msm_utils.cc
@@ -16,7 +16,7 @@ size_t DetermineMsmDivisionsForMemory(size_t scalar_t_mem_size,
   size_t free_memory =
       device::gpu::GpuMemLimitInfo(device::gpu::MemoryUsage::kHigh);
   size_t shift = 0;
-  size_t log_msm_size = base::bits::Log2Ceiling(msm_size);
+  uint32_t log_msm_size = base::bits::Log2Ceiling(msm_size);
 
   for (size_t number_of_divisions = 0; number_of_divisions < log_msm_size;
        ++number_of_divisions) {

--- a/tachyon/math/finite_fields/prime_field_fallback.h
+++ b/tachyon/math/finite_fields/prime_field_fallback.h
@@ -168,11 +168,11 @@ class PrimeField<_Config, std::enable_if_t<!_Config::kUseAsm &&
   constexpr const uint64_t& operator[](size_t i) const { return value_[i]; }
 
   constexpr bool operator==(const PrimeField& other) const {
-    return ToBigInt() == other.ToBigInt();
+    return value_ == other.value_;
   }
 
   constexpr bool operator!=(const PrimeField& other) const {
-    return ToBigInt() != other.ToBigInt();
+    return value_ != other.value_;
   }
 
   constexpr bool operator<(const PrimeField& other) const {

--- a/tachyon/math/finite_fields/prime_field_gpu_debug.h
+++ b/tachyon/math/finite_fields/prime_field_gpu_debug.h
@@ -157,11 +157,11 @@ class PrimeFieldGpuDebug final
   constexpr const uint64_t& operator[](size_t i) const { return value_[i]; }
 
   constexpr bool operator==(const PrimeFieldGpuDebug& other) const {
-    return ToBigInt() == other.ToBigInt();
+    return value_ == other.value_;
   }
 
   constexpr bool operator!=(const PrimeFieldGpuDebug& other) const {
-    return ToBigInt() != other.ToBigInt();
+    return value_ != other.value_;
   }
 
   constexpr bool operator<(const PrimeFieldGpuDebug& other) const {

--- a/tachyon/math/matrix/matrix_utils.h
+++ b/tachyon/math/matrix/matrix_utils.h
@@ -52,31 +52,6 @@ MakeCirculant(const Eigen::MatrixBase<ArgType>& arg) {
                                  CirculantFunctor<ArgType>(arg.derived()));
 }
 
-// Packs a given row of a matrix. Results in a vector of packed fields and a
-// vector of remaining values if the number of cols is not a factor of the
-// packed field size.
-//
-// NOTE(ashjeong): |PackRowHorizontally| currently only
-// supports row-major matrices.
-template <typename PackedField, typename PrimeField, typename Expr,
-          int BlockRows, int BlockCols, bool InnerPanel>
-std::vector<PackedField*> PackRowHorizontally(
-    Eigen::Block<Expr, BlockRows, BlockCols, InnerPanel>& matrix_row,
-    std::vector<PrimeField*>& remaining_values) {
-  size_t num_packed = matrix_row.cols() / PackedField::N;
-  size_t remaining_start_idx = num_packed * PackedField::N;
-  remaining_values =
-      base::CreateVector(matrix_row.cols() - remaining_start_idx,
-                         [remaining_start_idx, &matrix_row](size_t col) {
-                           return reinterpret_cast<PrimeField*>(
-                               matrix_row.data() + remaining_start_idx + col);
-                         });
-  return base::CreateVector(num_packed, [&matrix_row](size_t col) {
-    return reinterpret_cast<PackedField*>(matrix_row.data() +
-                                          PackedField::N * col);
-  });
-}
-
 // Creates a vector of packed fields for a given matrix row. If the length
 // of the row is not a multiple of |PackedField::N|, the last |PackedField|
 // element populates leftover values with |F::Zero()|.

--- a/tachyon/math/matrix/matrix_utils_unittest.cc
+++ b/tachyon/math/matrix/matrix_utils_unittest.cc
@@ -21,45 +21,6 @@ TEST_F(MatrixUtilsTest, Circulant) {
 
 class MatrixPackingTest : public FiniteFieldTest<PackedBabyBear> {};
 
-TEST_F(MatrixPackingTest, PackRowHorizontally) {
-  constexpr size_t N = PackedBabyBear::N;
-  constexpr size_t R = 3;
-
-  {
-    RowMajorMatrix<BabyBear> matrix =
-        RowMajorMatrix<BabyBear>::Random(2 * N, 2 * N);
-    auto mat_row = matrix.row(R);
-    std::vector<BabyBear*> remaining_values;
-    std::vector<PackedBabyBear*> packed_values =
-        PackRowHorizontally<PackedBabyBear>(mat_row, remaining_values);
-    ASSERT_TRUE(remaining_values.empty());
-    ASSERT_EQ(packed_values.size(), 2);
-    for (size_t i = 0; i < packed_values.size(); ++i) {
-      for (size_t j = 0; j < N; ++j) {
-        EXPECT_EQ((*packed_values[i])[j], matrix(R, i * N + j));
-      }
-    }
-  }
-  {
-    RowMajorMatrix<BabyBear> matrix =
-        RowMajorMatrix<BabyBear>::Random(2 * N - 1, 2 * N - 1);
-    auto mat_row = matrix.row(R);
-    std::vector<BabyBear*> remaining_values;
-    std::vector<PackedBabyBear*> packed_values =
-        PackRowHorizontally<PackedBabyBear>(mat_row, remaining_values);
-    ASSERT_EQ(remaining_values.size(), N - 1);
-    ASSERT_EQ(packed_values.size(), 1);
-    for (size_t i = 0; i < remaining_values.size(); ++i) {
-      EXPECT_EQ(*remaining_values[i], matrix(R, packed_values.size() * N + i));
-    }
-    for (size_t i = 0; i < packed_values.size(); ++i) {
-      for (size_t j = 0; j < N; ++j) {
-        EXPECT_EQ((*packed_values[i])[j], matrix(R, i * N + j));
-      }
-    }
-  }
-}
-
 TEST_F(MatrixPackingTest, PackRowVerticallyWithPrimeField) {
   constexpr size_t N = PackedBabyBear::N;
   constexpr size_t R = 3;

--- a/tachyon/math/polynomials/univariate/evaluations_utils.h
+++ b/tachyon/math/polynomials/univariate/evaluations_utils.h
@@ -29,7 +29,7 @@ std::vector<F> SwapBitRevElements(const std::vector<F>& vals) {
 //     element at index 4(100) are swapped.
 template <typename Container>
 void SwapBitRevElementsInPlace(Container& container, size_t size,
-                               size_t log_len) {
+                               uint32_t log_len) {
   TRACE_EVENT("Utils", "SwapBitRevElementsInPlace");
   if (size <= 1) return;
   OMP_PARALLEL_FOR(size_t idx = 1; idx < size; ++idx) {

--- a/tachyon/math/polynomials/univariate/radix2_evaluation_domain.h
+++ b/tachyon/math/polynomials/univariate/radix2_evaluation_domain.h
@@ -331,7 +331,7 @@ class Radix2EvaluationDomain : public UnivariateEvaluationDomain<F, MaxDegree>,
       packed_inv_roots_vec_[1].resize(vec_largest_size);
       rev_roots_vec_ = SwapBitRevElements(largest);
       rev_inv_roots_vec_ = SwapBitRevElements(largest_inv);
-      for (size_t i = 0; i < vec_largest_size; ++i) {
+      OMP_PARALLEL_FOR(size_t i = 0; i < vec_largest_size; ++i) {
         packed_roots_vec_[0][i] = PackedPrimeField::Broadcast(largest[i]);
         packed_inv_roots_vec_[0][i] =
             PackedPrimeField::Broadcast(largest_inv[i]);

--- a/tachyon/math/polynomials/univariate/radix2_evaluation_domain.h
+++ b/tachyon/math/polynomials/univariate/radix2_evaluation_domain.h
@@ -467,7 +467,7 @@ class Radix2EvaluationDomain : public UnivariateEvaluationDomain<F, MaxDegree>,
       for (size_t i = 0; i < half_block_size; ++i) {
         size_t lo = block_start + i;
         size_t hi = lo + half_block_size;
-        const F& twiddle =
+        F twiddle =
             rev ? twiddles[block_start / block_size] : twiddles[i << layer_rev];
         const PackedPrimeField& packed_twiddle =
             rev ? packed_twiddles[block_start / block_size]
@@ -479,7 +479,7 @@ class Radix2EvaluationDomain : public UnivariateEvaluationDomain<F, MaxDegree>,
 
   CONSTEXPR_IF_NOT_OPENMP void ApplyButterflyToRows(
       Eigen::Block<RowMajorMatrix<F>>& mat, size_t row_1, size_t row_2,
-      const F& twiddle, const PackedPrimeField& packed_twiddle) {
+      F twiddle, const PackedPrimeField& packed_twiddle) {
     TRACE_EVENT("EvaluationDomain", "ApplyButterflyToRows");
     if constexpr (F::Config::kModulusBits > 32) {
       NOTREACHED();

--- a/tachyon/math/polynomials/univariate/radix2_evaluation_domain.h
+++ b/tachyon/math/polynomials/univariate/radix2_evaluation_domain.h
@@ -399,10 +399,8 @@ class Radix2EvaluationDomain : public UnivariateEvaluationDomain<F, MaxDegree>,
     size_t chunk_rows = size_t{1} << mid_;
 
     // max block size: 2^|mid_|
-    // TODO(ashjeong): benchmark between |OMP_PARALLEL_FOR| here vs
-    // |OMP_PARALLEL_NESTED_FOR| in |RunDitLayers|
-    for (size_t block_start = 0; block_start < this->size_;
-         block_start += chunk_rows) {
+    OMP_PARALLEL_FOR(size_t block_start = 0; block_start < this->size_;
+                     block_start += chunk_rows) {
       size_t cur_chunk_rows = std::min(chunk_rows, this->size_ - block_start);
       Eigen::Block<RowMajorMatrix<F>> submat =
           mat.block(block_start, 0, cur_chunk_rows, cols);
@@ -428,10 +426,8 @@ class Radix2EvaluationDomain : public UnivariateEvaluationDomain<F, MaxDegree>,
 
     TRACE_EVENT("Subtask", "RunDitLayersLoop");
     // max block size: 2^(|this->log_size_of_group_| - |mid_|)
-    // TODO(ashjeong): benchmark between |OMP_PARALLEL_FOR| here vs
-    // |OMP_PARALLEL_NESTED_FOR| in |RunDitLayers|
-    for (size_t block_start = 0; block_start < this->size_;
-         block_start += chunk_rows) {
+    OMP_PARALLEL_FOR(size_t block_start = 0; block_start < this->size_;
+                     block_start += chunk_rows) {
       size_t thread = block_start / chunk_rows;
       size_t cur_chunk_rows = std::min(chunk_rows, this->size_ - block_start);
       Eigen::Block<RowMajorMatrix<F>> submat =
@@ -462,8 +458,8 @@ class Radix2EvaluationDomain : public UnivariateEvaluationDomain<F, MaxDegree>,
     size_t sub_rows = static_cast<size_t>(submat.rows());
     DCHECK_GE(sub_rows, block_size);
 
-    OMP_PARALLEL_NESTED_FOR(size_t block_start = 0; block_start < sub_rows;
-                            block_start += block_size) {
+    for (size_t block_start = 0; block_start < sub_rows;
+         block_start += block_size) {
       for (size_t i = 0; i < half_block_size; ++i) {
         size_t lo = block_start + i;
         size_t hi = lo + half_block_size;

--- a/tachyon/math/polynomials/univariate/radix2_evaluation_domain.h
+++ b/tachyon/math/polynomials/univariate/radix2_evaluation_domain.h
@@ -99,7 +99,7 @@ class Radix2EvaluationDomain : public UnivariateEvaluationDomain<F, MaxDegree>,
       NOTREACHED();
     }
     CHECK_EQ(this->size_, static_cast<size_t>(mat.rows()));
-    size_t log_n = this->log_size_of_group_;
+    uint32_t log_n = this->log_size_of_group_;
     mid_ = log_n / 2;
 
     // The first half looks like a normal DIT.
@@ -120,7 +120,7 @@ class Radix2EvaluationDomain : public UnivariateEvaluationDomain<F, MaxDegree>,
       NOTREACHED();
     }
     CHECK_EQ(this->size_, static_cast<size_t>(mat.rows()));
-    size_t log_n = this->log_size_of_group_;
+    uint32_t log_n = this->log_size_of_group_;
     mid_ = log_n / 2;
 
     // The first half looks like a normal DIT.
@@ -409,7 +409,7 @@ class Radix2EvaluationDomain : public UnivariateEvaluationDomain<F, MaxDegree>,
       size_t cur_chunk_rows = std::min(chunk_rows, this->size_ - block_start);
       Eigen::Block<RowMajorMatrix<F>> submat =
           mat.block(block_start, 0, cur_chunk_rows, cols);
-      for (size_t layer = 0; layer < mid_; ++layer) {
+      for (uint32_t layer = 0; layer < mid_; ++layer) {
         RunDitLayers(submat, layer, absl::MakeSpan(twiddles),
                      absl::MakeSpan(packed_twiddles_rev), false);
       }
@@ -440,7 +440,7 @@ class Radix2EvaluationDomain : public UnivariateEvaluationDomain<F, MaxDegree>,
         size_t cur_chunk_rows = std::min(chunk_rows, this->size_ - block_start);
         Eigen::Block<RowMajorMatrix<F>> submat =
             mat.block(block_start, 0, cur_chunk_rows, cols);
-        for (size_t layer = mid_; layer < this->log_size_of_group_; ++layer) {
+        for (uint32_t layer = mid_; layer < this->log_size_of_group_; ++layer) {
           size_t first_block = thread << (layer - mid_);
           RunDitLayers(submat, layer,
                        absl::MakeSpan(twiddles_rev.data() + first_block,
@@ -454,14 +454,14 @@ class Radix2EvaluationDomain : public UnivariateEvaluationDomain<F, MaxDegree>,
   }
 
   CONSTEXPR_IF_NOT_OPENMP void RunDitLayers(
-      Eigen::Block<RowMajorMatrix<F>>& submat, size_t layer,
+      Eigen::Block<RowMajorMatrix<F>>& submat, uint32_t layer,
       const absl::Span<const F>& twiddles,
       const absl::Span<const PackedPrimeField>& packed_twiddles, bool rev) {
     TRACE_EVENT("EvaluationDomain", "RunDitLayers");
     if constexpr (F::Config::kModulusBits > 32) {
       NOTREACHED();
     }
-    size_t layer_rev = this->log_size_of_group_ - 1 - layer;
+    uint32_t layer_rev = this->log_size_of_group_ - 1 - layer;
     size_t half_block_size = size_t{1} << (rev ? layer_rev : layer);
     size_t block_size = half_block_size * 2;
     size_t sub_rows = static_cast<size_t>(submat.rows());
@@ -515,7 +515,7 @@ class Radix2EvaluationDomain : public UnivariateEvaluationDomain<F, MaxDegree>,
     }
   }
 
-  size_t mid_ = 0;
+  uint32_t mid_ = 0;
   // For small prime fields
   std::vector<F> rev_roots_vec_;
   std::vector<F> rev_inv_roots_vec_;

--- a/tachyon/math/polynomials/univariate/radix2_evaluation_domain.h
+++ b/tachyon/math/polynomials/univariate/radix2_evaluation_domain.h
@@ -502,14 +502,14 @@ class Radix2EvaluationDomain : public UnivariateEvaluationDomain<F, MaxDegree>,
     {
       TRACE_EVENT("Subtask", "ButterflyOMPLoop");
       OMP_PARALLEL_FOR(size_t i = 0; i < shorts_1.size(); ++i) {
-        UnivariateEvaluationDomain<F, MaxDegree>::template ButterflyFnOutIn<
-            PackedPrimeField>(*shorts_1[i], *shorts_2[i], packed_twiddle);
+        UnivariateEvaluationDomain<F, MaxDegree>::template ButterflyFnOutIn(
+            *shorts_1[i], *shorts_2[i], packed_twiddle);
       }
     }
     {
       TRACE_EVENT("Subtask", "ButterflyLoop");
       for (size_t i = 0; i < suffix_1.size(); ++i) {
-        UnivariateEvaluationDomain<F, MaxDegree>::template ButterflyFnOutIn<F>(
+        UnivariateEvaluationDomain<F, MaxDegree>::template ButterflyFnOutIn(
             *suffix_1[i], *suffix_2[i], twiddle);
       }
     }

--- a/tachyon/math/polynomials/univariate/radix2_evaluation_domain.h
+++ b/tachyon/math/polynomials/univariate/radix2_evaluation_domain.h
@@ -455,8 +455,8 @@ class Radix2EvaluationDomain : public UnivariateEvaluationDomain<F, MaxDegree>,
 
   CONSTEXPR_IF_NOT_OPENMP void RunDitLayers(
       Eigen::Block<RowMajorMatrix<F>>& submat, uint32_t layer,
-      const absl::Span<const F>& twiddles,
-      const absl::Span<const PackedPrimeField>& packed_twiddles, bool rev) {
+      absl::Span<const F> twiddles,
+      absl::Span<const PackedPrimeField> packed_twiddles, bool rev) {
     TRACE_EVENT("EvaluationDomain", "RunDitLayers");
     if constexpr (F::Config::kModulusBits > 32) {
       NOTREACHED();

--- a/tachyon/math/polynomials/univariate/radix2_evaluation_domain.h
+++ b/tachyon/math/polynomials/univariate/radix2_evaluation_domain.h
@@ -480,29 +480,24 @@ class Radix2EvaluationDomain : public UnivariateEvaluationDomain<F, MaxDegree>,
     if constexpr (F::Config::kModulusBits > 32) {
       NOTREACHED();
     }
-    std::vector<F*> suffix_1;
-    std::vector<F*> suffix_2;
-
     auto row_1_block = mat.row(row_1);
-    std::vector<PackedPrimeField*> shorts_1 =
-        PackRowHorizontally<PackedPrimeField>(row_1_block, suffix_1);
     auto row_2_block = mat.row(row_2);
-    std::vector<PackedPrimeField*> shorts_2 =
-        PackRowHorizontally<PackedPrimeField>(row_2_block, suffix_2);
 
-    {
-      TRACE_EVENT("Subtask", "ButterflyOMPLoop");
-      OMP_PARALLEL_FOR(size_t i = 0; i < shorts_1.size(); ++i) {
-        UnivariateEvaluationDomain<F, MaxDegree>::template ButterflyFnOutIn(
-            *shorts_1[i], *shorts_2[i], packed_twiddle);
-      }
+    for (size_t i = 0; i < row_1_block.cols() / PackedPrimeField::N; ++i) {
+      UnivariateEvaluationDomain<F, MaxDegree>::template ButterflyFnOutIn(
+          *reinterpret_cast<PackedPrimeField*>(
+              &row_1_block.data()[PackedPrimeField::N * i]),
+          *reinterpret_cast<PackedPrimeField*>(
+              &row_2_block.data()[PackedPrimeField::N * i]),
+          packed_twiddle);
     }
-    {
-      TRACE_EVENT("Subtask", "ButterflyLoop");
-      for (size_t i = 0; i < suffix_1.size(); ++i) {
-        UnivariateEvaluationDomain<F, MaxDegree>::template ButterflyFnOutIn(
-            *suffix_1[i], *suffix_2[i], twiddle);
-      }
+    size_t remaining_start_idx =
+        row_1_block.cols() / PackedPrimeField::N * PackedPrimeField::N;
+    for (size_t i = remaining_start_idx;
+         i < static_cast<size_t>(row_1_block.cols()); ++i) {
+      UnivariateEvaluationDomain<F, MaxDegree>::template ButterflyFnOutIn(
+          *reinterpret_cast<F*>(&row_1_block.data()[i]),
+          *reinterpret_cast<F*>(&row_2_block.data()[i]), twiddle);
     }
   }
 

--- a/tachyon/math/polynomials/univariate/radix2_evaluation_domain_unittest.cc
+++ b/tachyon/math/polynomials/univariate/radix2_evaluation_domain_unittest.cc
@@ -25,7 +25,7 @@ TYPED_TEST_SUITE(Radix2EvaluationDomainTest, PrimeFieldTypes);
 
 TYPED_TEST(Radix2EvaluationDomainTest, FFTBatch) {
   using F = TypeParam;
-  for (size_t log_r = 0; log_r < 5; ++log_r) {
+  for (uint32_t log_r = 0; log_r < 5; ++log_r) {
     RowMajorMatrix<F> expected =
         RowMajorMatrix<F>::Random(size_t{1} << log_r, 3);
     RowMajorMatrix<F> result = expected;
@@ -40,7 +40,7 @@ TYPED_TEST(Radix2EvaluationDomainTest, FFTBatch) {
 
 TYPED_TEST(Radix2EvaluationDomainTest, CosetLDEBatch) {
   using F = TypeParam;
-  for (size_t log_r = 0; log_r < 5; ++log_r) {
+  for (uint32_t log_r = 0; log_r < 5; ++log_r) {
     RowMajorMatrix<F> expected =
         RowMajorMatrix<F>::Random(size_t{1} << log_r, 3);
     RowMajorMatrix<F> result = expected;

--- a/tachyon/math/polynomials/univariate/two_adic_subgroup.h
+++ b/tachyon/math/polynomials/univariate/two_adic_subgroup.h
@@ -39,7 +39,7 @@ class TwoAdicSubgroup {
   // Compute the "coset DFT" of each column in |mat|. This can be viewed as
   // interpolation onto a coset of a multiplicative subgroup, rather than the
   // subgroup itself.
-  void CosetFFTBatch(RowMajorMatrix<F>& mat, const F& shift) {
+  void CosetFFTBatch(RowMajorMatrix<F>& mat, F shift) {
     static_assert(F::Config::kModulusBits <= 32);
     // Observe that
     // yᵢ = ∑ⱼ cⱼ (s gⁱ)ʲ
@@ -68,8 +68,7 @@ class TwoAdicSubgroup {
 
   // Compute the low-degree extension of each column in |mat| onto a coset of
   // a larger subgroup.
-  void CosetLDEBatch(RowMajorMatrix<F>& mat, size_t added_bits,
-                     const F& shift) {
+  void CosetLDEBatch(RowMajorMatrix<F>& mat, size_t added_bits, F shift) {
     static_assert(F::Config::kModulusBits <= 32);
     IFFTBatch(mat);
     Eigen::Index rows = mat.rows();

--- a/tachyon/math/polynomials/univariate/univariate_evaluation_domain.h
+++ b/tachyon/math/polynomials/univariate/univariate_evaluation_domain.h
@@ -58,9 +58,9 @@ class UnivariateEvaluationDomain : public EvaluationDomain<F, MaxDegree> {
     size_inv_ = unwrap(size_as_field_element_.Inverse());
 
     // Compute the generator for the multiplicative subgroup.
-    // It should be the 2^|log_size_of_group_| root of unity.
+    // It should be the |size_|-th root of unity.
     CHECK(F::GetRootOfUnity(size_, &group_gen_));
-    // Check that it is indeed the 2^(log_size_of_group) root of unity.
+    // Check that it is indeed the |size_|-th root of unity.
     DCHECK_EQ(group_gen_.Pow(size_), F::One());
     group_gen_inv_ = unwrap(group_gen_.Inverse());
 #if TACHYON_CUDA

--- a/tachyon/math/polynomials/univariate/univariate_evaluation_domain_unittest.cc
+++ b/tachyon/math/polynomials/univariate/univariate_evaluation_domain_unittest.cc
@@ -90,11 +90,11 @@ TYPED_TEST(UnivariateEvaluationDomainTest, FilterPolynomial) {
   using DensePoly = typename Domain::DensePoly;
 
   if constexpr (std::is_same_v<F, bls12_381::Fr>) {
-    for (size_t log_domain_size = 1; log_domain_size < 4; ++log_domain_size) {
+    for (uint32_t log_domain_size = 1; log_domain_size < 4; ++log_domain_size) {
       size_t domain_size = size_t{1} << log_domain_size;
       std::unique_ptr<Domain> domain = Domain::Create(domain_size);
-      for (size_t log_subdomain_size = 1; log_subdomain_size <= log_domain_size;
-           ++log_subdomain_size) {
+      for (uint32_t log_subdomain_size = 1;
+           log_subdomain_size <= log_domain_size; ++log_subdomain_size) {
         size_t subdomain_size = size_t{1} << log_subdomain_size;
         std::unique_ptr<Domain> subdomain = Domain::Create(subdomain_size);
 
@@ -263,7 +263,7 @@ TYPED_TEST(UnivariateEvaluationDomainTest, FFTCorrectness) {
   const size_t kLogDegree = 5;
   const size_t kDegree = (size_t{1} << kLogDegree) - 1;
   DensePoly rand_poly = DensePoly::Random(kDegree);
-  for (size_t log_domain_size = kLogDegree; log_domain_size < kLogDegree + 2;
+  for (uint32_t log_domain_size = kLogDegree; log_domain_size < kLogDegree + 2;
        ++log_domain_size) {
     size_t domain_size = size_t{1} << log_domain_size;
     this->TestDomains(

--- a/tachyon/zk/air/plonky3/base/two_adic_multiplicative_coset.h
+++ b/tachyon/zk/air/plonky3/base/two_adic_multiplicative_coset.h
@@ -26,7 +26,7 @@ class TwoAdicMultiplicativeCoset {
  public:
   constexpr TwoAdicMultiplicativeCoset() = default;
 
-  TwoAdicMultiplicativeCoset(size_t log_n, const F& shift) {
+  TwoAdicMultiplicativeCoset(uint32_t log_n, const F& shift) {
     domain_.reset(static_cast<math::Radix2EvaluationDomain<F>*>(
         math::Radix2EvaluationDomain<F>::Create(size_t{1} << log_n)
             ->GetCoset(shift)
@@ -88,7 +88,7 @@ class TwoAdicMultiplicativeCoset {
     CHECK_EQ(domain_->offset(), F::One());
     CHECK_NE(coset_shift, F::One());
     CHECK_GE(domain_->log_size_of_group(), coset.domain()->log_size_of_group());
-    size_t rate_bits =
+    uint32_t rate_bits =
         coset.domain()->log_size_of_group() - domain_->log_size_of_group();
     F s_pow_n = coset_shift.ExpPowOfTwo(domain_->log_size_of_group());
 

--- a/tachyon/zk/air/plonky3/base/two_adic_multiplicative_coset.h
+++ b/tachyon/zk/air/plonky3/base/two_adic_multiplicative_coset.h
@@ -110,7 +110,8 @@ class TwoAdicMultiplicativeCoset {
           CHECK(F::BatchInverseInPlaceSerial(inv_denoms_inv_zeroifier_chunk));
         });
 
-    F coset_i = domain_->group_gen().Pow(domain_->size() - 1);
+    F coset_i = domain_->group_gen().ExpPowOfTwo(domain_->log_size_of_group()) *
+                domain_->group_gen_inv();
 
     size_t sz = coset.domain()->size();
     std::vector<F> first_row(sz);

--- a/tachyon/zk/air/plonky3/base/two_adic_multiplicative_coset.h
+++ b/tachyon/zk/air/plonky3/base/two_adic_multiplicative_coset.h
@@ -26,7 +26,7 @@ class TwoAdicMultiplicativeCoset {
  public:
   constexpr TwoAdicMultiplicativeCoset() = default;
 
-  TwoAdicMultiplicativeCoset(uint32_t log_n, const F& shift) {
+  TwoAdicMultiplicativeCoset(uint32_t log_n, F shift) {
     domain_.reset(static_cast<math::Radix2EvaluationDomain<F>*>(
         math::Radix2EvaluationDomain<F>::Create(size_t{1} << log_n)
             ->GetCoset(shift)
@@ -83,7 +83,7 @@ class TwoAdicMultiplicativeCoset {
 
   LagrangeSelectors<std::vector<F>> GetSelectorsOnCoset(
       const TwoAdicMultiplicativeCoset& coset) const {
-    const F& coset_shift = coset.domain()->offset();
+    F coset_shift = coset.domain()->offset();
 
     CHECK_EQ(domain_->offset(), F::One());
     CHECK_NE(coset_shift, F::One());

--- a/tachyon/zk/plonk/halo2/prover.h
+++ b/tachyon/zk/plonk/halo2/prover.h
@@ -339,7 +339,7 @@ class Prover : public ProverBase<typename _PS::PCS> {
         proving_key.verifying_key().constraint_system();
 
     const F& x = permutation_opening_point_set.x;
-    F x_n = x.Pow(this->pcs_.N());
+    F x_n = x.ExpPowOfTwo(this->pcs_.K());
     vanishing_prover.BatchEvaluate(this, constraint_system, poly_tables, x,
                                    x_n);
     PermutationProver<Poly, Evals>::EvaluateProvingKey(

--- a/tachyon/zk/plonk/halo2/verifier.h
+++ b/tachyon/zk/plonk/halo2/verifier.h
@@ -142,7 +142,7 @@ class Verifier : public VerifierBase<typename _PS::PCS> {
     proof.x_prev = Rotation::Prev().RotateOmega(this->domain(), proof.x);
     proof.x_last =
         Rotation(-(blinding_factors + 1)).RotateOmega(this->domain(), proof.x);
-    proof.x_n = proof.x.Pow(this->pcs_.N());
+    proof.x_n = proof.x.ExpPowOfTwo(this->pcs_.K());
   }
 
   bool ValidateInstanceColumnsVec(

--- a/tachyon/zk/plonk/vanishing/vanishing_utils.h
+++ b/tachyon/zk/plonk/vanishing/vanishing_utils.h
@@ -80,8 +80,9 @@ ExtendedEvals& DivideByVanishingPolyInPlace(
                                    << (extended_domain->log_size_of_group() -
                                        domain->log_size_of_group());
   // |coset_gen_pow_n| = w'ⁿ where w' is generator of extended domain.
-  const F coset_gen_pow_n = extended_domain->group_gen().Pow(domain->size());
-  const F zeta_pow_n = zeta.Pow(domain->size());
+  const F coset_gen_pow_n =
+      extended_domain->group_gen().ExpPowOfTwo(domain->log_size_of_group());
+  const F zeta_pow_n = zeta.ExpPowOfTwo(domain->log_size_of_group());
   std::vector<F> t_evaluations(kTEvaluationsSize);
   // |t_evaluations| = [ζⁿ - 1, ζⁿ * w'ⁿ - 1, ζⁿ * w'²ⁿ - 1, ...]
   base::Parallelize(t_evaluations, [&coset_gen_pow_n, &zeta_pow_n](


### PR DESCRIPTION
# Description

PR #515 introduces an FFT batch benchmark. Initially, the results were not as expected, but after some optimizations, they improved. However, there's still potential for further enhancements. Given that our implementation precomputes twiddles, we would expect even better performance. We need to investigate this further to understand the underlying reasons and explore additional optimizations.