### PR TITLE
perf(math): unset require initialization

### DIFF
--- a/tachyon/math/finite_fields/baby_bear/internal/packed_baby_bear.h
+++ b/tachyon/math/finite_fields/baby_bear/internal/packed_baby_bear.h
@@ -52,7 +52,7 @@ struct NumTraits<tachyon::math::PackedBabyBear>
     IsField = 1,
     IsSigned = 0,
     IsComplex = 0,
-    RequireInitialization = 1,
+    RequireInitialization = 0,
     ReadCost = tachyon::math::CostCalculator<PrimeField>::ComputeReadCost() * N,
     AddCost = tachyon::math::CostCalculator<PrimeField>::ComputeAddCost() * N,
     MulCost = tachyon::math::CostCalculator<PrimeField>::ComputeMulCost() * N,

--- a/tachyon/math/finite_fields/finite_field_traits.h
+++ b/tachyon/math/finite_fields/finite_field_traits.h
@@ -131,7 +131,7 @@ struct NumTraits<
     IsField = 1,
     IsSigned = 0,
     IsComplex = 0,
-    RequireInitialization = 1,
+    RequireInitialization = 0,
     ReadCost =
         tachyon::math::CostCalculator<BasePrimeField>::ComputeReadCost() *
         kDegreeOverBasePrimeField,

--- a/tachyon/math/finite_fields/koala_bear/internal/packed_koala_bear.h
+++ b/tachyon/math/finite_fields/koala_bear/internal/packed_koala_bear.h
@@ -52,7 +52,7 @@ struct NumTraits<tachyon::math::PackedKoalaBear>
     IsField = 1,
     IsSigned = 0,
     IsComplex = 0,
-    RequireInitialization = 1,
+    RequireInitialization = 0,
     ReadCost = tachyon::math::CostCalculator<PrimeField>::ComputeReadCost() * N,
     AddCost = tachyon::math::CostCalculator<PrimeField>::ComputeAddCost() * N,
     MulCost = tachyon::math::CostCalculator<PrimeField>::ComputeMulCost() * N,

--- a/tachyon/math/finite_fields/mersenne31/internal/packed_mersenne31.h
+++ b/tachyon/math/finite_fields/mersenne31/internal/packed_mersenne31.h
@@ -52,7 +52,7 @@ struct NumTraits<tachyon::math::PackedMersenne31>
     IsField = 1,
     IsSigned = 0,
     IsComplex = 0,
-    RequireInitialization = 1,
+    RequireInitialization = 0,
     ReadCost = tachyon::math::CostCalculator<PrimeField>::ComputeReadCost() * N,
     AddCost = tachyon::math::CostCalculator<PrimeField>::ComputeAddCost() * N,
     MulCost = tachyon::math::CostCalculator<PrimeField>::ComputeMulCost() * N,

--- a/tachyon/math/matrix/gmp_num_traits.h
+++ b/tachyon/math/matrix/gmp_num_traits.h
@@ -12,7 +12,7 @@ struct NumTraits<mpz_class> : GenericNumTraits<mpz_class> {
     IsInteger = 1,
     IsSigned = 1,
     IsComplex = 0,
-    RequireInitialization = 1,
+    RequireInitialization = 0,
     // NOTE(chokobole): I just used the same values defined at
     // https://eigen.tuxfamily.org/dox/TopicCustomizing_CustomScalar.html.
     ReadCost = 6,

--- a/tachyon/math/matrix/prime_field_num_traits.h
+++ b/tachyon/math/matrix/prime_field_num_traits.h
@@ -46,7 +46,7 @@ struct NumTraits<
     IsField = 1,
     IsSigned = 0,
     IsComplex = 0,
-    RequireInitialization = 1,
+    RequireInitialization = 0,
     ReadCost = tachyon::math::CostCalculator<F>::ComputeReadCost(),
     AddCost = tachyon::math::CostCalculator<F>::ComputeAddCost(),
     MulCost = tachyon::math::CostCalculator<F>::ComputeMulCost(),


### PR DESCRIPTION
# Description

If `RequireInitialization` is 1, constructors and destructors are called redundantly.

See https://gitlab.com/libeigen/eigen/-/blob/ab31094/Eigen/src/Core/util/Memory.h#L479-485.
