### PR TITLE
feat: enable rust binding for `TwoAdicFriPcs::Verify()`

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "a9fbed09c049bf53d1422ae2fb19a3cea5955abe3cd56efe8444f998567af7ee",
+  "checksum": "b3816f6bd5dd0bec76c601bd49e3d4f7141a37c95eca3443b1d49dbb7182742d",
   "crates": {
     "addchain 0.2.0": {
       "name": "addchain",
@@ -18176,6 +18176,10 @@
             {
               "id": "cxx 1.0.122",
               "target": "cxx"
+            },
+            {
+              "id": "itertools 0.13.0",
+              "target": "itertools"
             },
             {
               "id": "p3-baby-bear 0.1.3-succinct",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3528,6 +3528,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "cxx",
+ "itertools 0.13.0",
  "p3-baby-bear",
  "p3-challenger",
  "p3-commit",

--- a/tachyon/c/crypto/commitments/fri/two_adic_fri_impl.h
+++ b/tachyon/c/crypto/commitments/fri/two_adic_fri_impl.h
@@ -54,7 +54,7 @@ class TwoAdicFRIImpl
   void CreateOpeningProof(
       const std::vector<std::unique_ptr<ProverData>>& prover_data_by_round_in,
       const OpeningPoints& points_by_round, Challenger& challenger,
-      OpenedValues* opened_values_by_round, FRIProof* proof) {
+      OpenedValues* opened_values_by_round, FRIProof* proof) const {
     auto& prover_data_by_round =
         const_cast<std::vector<std::unique_ptr<ProverData>>&>(
             prover_data_by_round_in);

--- a/tachyon/c/zk/air/sp1/BUILD.bazel
+++ b/tachyon/c/zk/air/sp1/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 filegroup(
     name = "sp1_hdrs",
     srcs = [
+        "baby_bear_poseidon2_commitment_vec.h",
         "baby_bear_poseidon2_constants.h",
         "baby_bear_poseidon2_domains.h",
         "baby_bear_poseidon2_duplex_challenger.h",
@@ -20,6 +21,21 @@ filegroup(
 tachyon_cc_library(
     name = "baby_bear_poseidon2_constants",
     hdrs = ["baby_bear_poseidon2_constants.h"],
+)
+
+tachyon_cc_library(
+    name = "baby_bear_poseidon2_commitment_vec",
+    srcs = ["baby_bear_poseidon2_commitment_vec.cc"],
+    hdrs = [
+        "baby_bear_poseidon2_commitment_vec.h",
+        "baby_bear_poseidon2_commitment_vec_type_traits.h",
+    ],
+    deps = [
+        ":baby_bear_poseidon2_constants",
+        "//tachyon/c:export",
+        "//tachyon/c/base:type_traits_forward",
+        "//tachyon/c/math/finite_fields/baby_bear",
+    ],
 )
 
 tachyon_cc_library(

--- a/tachyon/c/zk/air/sp1/BUILD.bazel
+++ b/tachyon/c/zk/air/sp1/BUILD.bazel
@@ -6,6 +6,7 @@ filegroup(
     name = "sp1_hdrs",
     srcs = [
         "baby_bear_poseidon2_constants.h",
+        "baby_bear_poseidon2_domains.h",
         "baby_bear_poseidon2_duplex_challenger.h",
         "baby_bear_poseidon2_field_merkle_tree.h",
         "baby_bear_poseidon2_field_merkle_tree_vec.h",
@@ -19,6 +20,21 @@ filegroup(
 tachyon_cc_library(
     name = "baby_bear_poseidon2_constants",
     hdrs = ["baby_bear_poseidon2_constants.h"],
+)
+
+tachyon_cc_library(
+    name = "baby_bear_poseidon2_domains",
+    srcs = ["baby_bear_poseidon2_domains.cc"],
+    hdrs = [
+        "baby_bear_poseidon2_domains.h",
+        "baby_bear_poseidon2_domains_type_traits.h",
+    ],
+    deps = [
+        "//tachyon/c:export",
+        "//tachyon/c/base:type_traits_forward",
+        "//tachyon/c/math/finite_fields/baby_bear",
+        "//tachyon/crypto/commitments/fri:two_adic_multiplicative_coset",
+    ],
 )
 
 tachyon_cc_library(

--- a/tachyon/c/zk/air/sp1/BUILD.bazel
+++ b/tachyon/c/zk/air/sp1/BUILD.bazel
@@ -148,7 +148,9 @@ tachyon_cc_library(
         "baby_bear_poseidon2_two_adic_fri_type_traits.h",
     ],
     deps = [
+        ":baby_bear_poseidon2_commitment_vec",
         ":baby_bear_poseidon2_constants",
+        ":baby_bear_poseidon2_domains",
         ":baby_bear_poseidon2_duplex_challenger",
         ":baby_bear_poseidon2_field_merkle_tree",
         ":baby_bear_poseidon2_field_merkle_tree_vec",

--- a/tachyon/c/zk/air/sp1/baby_bear_poseidon2_commitment_vec.cc
+++ b/tachyon/c/zk/air/sp1/baby_bear_poseidon2_commitment_vec.cc
@@ -1,0 +1,34 @@
+#include "tachyon/c/zk/air/sp1/baby_bear_poseidon2_commitment_vec.h"
+
+#include <string.h>
+
+#include <array>
+#include <vector>
+
+#include "tachyon/c/math/finite_fields/baby_bear/baby_bear_type_traits.h"
+#include "tachyon/c/zk/air/sp1/baby_bear_poseidon2_commitment_vec_type_traits.h"
+
+using namespace tachyon;
+
+using CommitmentVec = std::vector<
+    std::array<math::BabyBear, TACHYON_PLONKY3_BABY_BEAR_POSEIDON2_CHUNK>>;
+
+tachyon_sp1_baby_bear_poseidon2_commitment_vec*
+tachyon_sp1_baby_bear_poseidon2_commitment_vec_create(size_t rounds) {
+  return c::base::c_cast(new CommitmentVec(rounds));
+}
+
+void tachyon_sp1_baby_bear_poseidon2_commitment_vec_destroy(
+    tachyon_sp1_baby_bear_poseidon2_commitment_vec* commitment_vec) {
+  delete c::base::native_cast(commitment_vec);
+}
+
+void tachyon_sp1_baby_bear_poseidon2_commitment_vec_set(
+    tachyon_sp1_baby_bear_poseidon2_commitment_vec* commitment_vec,
+    size_t round, const tachyon_baby_bear* commitment) {
+  std::array<math::BabyBear, TACHYON_PLONKY3_BABY_BEAR_POSEIDON2_CHUNK>&
+      native_commitment = c::base::native_cast(*commitment_vec)[round];
+  for (size_t i = 0; i < TACHYON_PLONKY3_BABY_BEAR_POSEIDON2_CHUNK; ++i) {
+    native_commitment[i] = c::base::native_cast(commitment[i]);
+  }
+}

--- a/tachyon/c/zk/air/sp1/baby_bear_poseidon2_commitment_vec.h
+++ b/tachyon/c/zk/air/sp1/baby_bear_poseidon2_commitment_vec.h
@@ -1,0 +1,55 @@
+/**
+ * @file baby_bear_poseidon2_commitment_vec.h
+ * @brief Defines the interface for the commitment vector used within the
+ * SP1(BabyBear + Poseidon2) proof system.
+ */
+
+#ifndef TACHYON_C_ZK_AIR_SP1_BABY_BEAR_POSEIDON2_COMMITMENT_VEC_H_
+#define TACHYON_C_ZK_AIR_SP1_BABY_BEAR_POSEIDON2_COMMITMENT_VEC_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "tachyon/c/export.h"
+#include "tachyon/c/math/finite_fields/baby_bear/baby_bear.h"
+
+struct tachyon_sp1_baby_bear_poseidon2_commitment_vec {};
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Creates a new commitment vector.
+ *
+ * @param rounds The number of rounds.
+ * @return A pointer to the newly created commitment vector.
+ */
+TACHYON_C_EXPORT
+tachyon_sp1_baby_bear_poseidon2_commitment_vec*
+tachyon_sp1_baby_bear_poseidon2_commitment_vec_create(size_t rounds);
+
+/**
+ * @brief Destroys a commitment vector, freeing its resources.
+ *
+ * @param commitment_vec A pointer to the commitment vector to destroy.
+ */
+TACHYON_C_EXPORT void tachyon_sp1_baby_bear_poseidon2_commitment_vec_destroy(
+    tachyon_sp1_baby_bear_poseidon2_commitment_vec* commitment_vec);
+
+/**
+ * @brief Sets commitment.
+ *
+ * @param commitment_vec A pointer to the commitment vector.
+ * @param round The round index of the point.
+ * @param commitment A const pointer to the commitment.
+ */
+TACHYON_C_EXPORT void tachyon_sp1_baby_bear_poseidon2_commitment_vec_set(
+    tachyon_sp1_baby_bear_poseidon2_commitment_vec* commitment_vec,
+    size_t round, const tachyon_baby_bear* commitment);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // TACHYON_C_ZK_AIR_SP1_BABY_BEAR_POSEIDON2_COMMITMENT_VEC_H_

--- a/tachyon/c/zk/air/sp1/baby_bear_poseidon2_commitment_vec_type_traits.h
+++ b/tachyon/c/zk/air/sp1/baby_bear_poseidon2_commitment_vec_type_traits.h
@@ -1,0 +1,29 @@
+#ifndef TACHYON_C_ZK_AIR_SP1_BABY_BEAR_POSEIDON2_COMMITMENT_VEC_TYPE_TRAITS_H_
+#define TACHYON_C_ZK_AIR_SP1_BABY_BEAR_POSEIDON2_COMMITMENT_VEC_TYPE_TRAITS_H_
+
+#include <array>
+#include <vector>
+
+#include "tachyon/c/base/type_traits_forward.h"
+#include "tachyon/c/zk/air/sp1/baby_bear_poseidon2_commitment_vec.h"
+#include "tachyon/c/zk/air/sp1/baby_bear_poseidon2_constants.h"
+#include "tachyon/math/finite_fields/baby_bear/baby_bear.h"
+
+namespace tachyon::c::base {
+
+template <>
+struct TypeTraits<std::vector<std::array<
+    tachyon::math::BabyBear, TACHYON_PLONKY3_BABY_BEAR_POSEIDON2_CHUNK>>> {
+  using CType = tachyon_sp1_baby_bear_poseidon2_commitment_vec;
+};
+
+template <>
+struct TypeTraits<tachyon_sp1_baby_bear_poseidon2_commitment_vec> {
+  using NativeType =
+      std::vector<std::array<tachyon::math::BabyBear,
+                             TACHYON_PLONKY3_BABY_BEAR_POSEIDON2_CHUNK>>;
+};
+
+}  // namespace tachyon::c::base
+
+#endif  // TACHYON_C_ZK_AIR_SP1_BABY_BEAR_POSEIDON2_COMMITMENT_VEC_TYPE_TRAITS_H_

--- a/tachyon/c/zk/air/sp1/baby_bear_poseidon2_domains.cc
+++ b/tachyon/c/zk/air/sp1/baby_bear_poseidon2_domains.cc
@@ -1,0 +1,34 @@
+#include "tachyon/c/zk/air/sp1/baby_bear_poseidon2_domains.h"
+
+#include <vector>
+
+#include "tachyon/c/math/finite_fields/baby_bear/baby_bear_type_traits.h"
+#include "tachyon/c/zk/air/sp1/baby_bear_poseidon2_domains_type_traits.h"
+
+using namespace tachyon;
+
+using Domains = std::vector<
+    std::vector<crypto::TwoAdicMultiplicativeCoset<math::BabyBear>>>;
+
+tachyon_sp1_baby_bear_poseidon2_domains*
+tachyon_sp1_baby_bear_poseidon2_domains_create(size_t rounds) {
+  return c::base::c_cast(new Domains(rounds));
+}
+
+void tachyon_sp1_baby_bear_poseidon2_domains_destroy(
+    tachyon_sp1_baby_bear_poseidon2_domains* domains) {
+  delete c::base::native_cast(domains);
+}
+
+void tachyon_sp1_baby_bear_poseidon2_domains_allocate(
+    tachyon_sp1_baby_bear_poseidon2_domains* domains, size_t round,
+    size_t size) {
+  c::base::native_cast(*domains)[round].resize(size);
+}
+
+void tachyon_sp1_baby_bear_poseidon2_domains_set(
+    tachyon_sp1_baby_bear_poseidon2_domains* domains, size_t round, size_t idx,
+    uint32_t log_n, const tachyon_baby_bear* shift) {
+  c::base::native_cast(*domains)[round][idx] =
+      crypto::TwoAdicMultiplicativeCoset(log_n, c::base::native_cast(*shift));
+}

--- a/tachyon/c/zk/air/sp1/baby_bear_poseidon2_domains.h
+++ b/tachyon/c/zk/air/sp1/baby_bear_poseidon2_domains.h
@@ -1,0 +1,68 @@
+/**
+ * @file baby_bear_poseidon2_domains.h
+ * @brief Defines the interface for the set of domains used within the
+ * SP1(BabyBear + Poseidon2) proof system.
+ */
+
+#ifndef TACHYON_C_ZK_AIR_SP1_BABY_BEAR_POSEIDON2_DOMAINS_H_
+#define TACHYON_C_ZK_AIR_SP1_BABY_BEAR_POSEIDON2_DOMAINS_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "tachyon/c/export.h"
+#include "tachyon/c/math/finite_fields/baby_bear/baby_bear.h"
+
+struct tachyon_sp1_baby_bear_poseidon2_domains {};
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Creates a new set of domains.
+ *
+ * @param rounds The number of rounds.
+ * @return A pointer to the newly created domains.
+ */
+TACHYON_C_EXPORT
+tachyon_sp1_baby_bear_poseidon2_domains*
+tachyon_sp1_baby_bear_poseidon2_domains_create(size_t rounds);
+
+/**
+ * @brief Destroys a set of domains, freeing its resources.
+ *
+ * @param domains A pointer to the domains to destroy.
+ */
+TACHYON_C_EXPORT void tachyon_sp1_baby_bear_poseidon2_domains_destroy(
+    tachyon_sp1_baby_bear_poseidon2_domains* domains);
+
+/**
+ * @brief Allocates memory for the set of domains.
+ *
+ * @param domains A pointer to the set of domains.
+ * @param round The round.
+ * @param size The size of the domains.
+ */
+TACHYON_C_EXPORT void tachyon_sp1_baby_bear_poseidon2_domains_allocate(
+    tachyon_sp1_baby_bear_poseidon2_domains* domains, size_t round,
+    size_t size);
+
+/**
+ * @brief Sets up a domain.
+ *
+ * @param domains A pointer to the domains.
+ * @param round The round index of the point.
+ * @param idx The index of the domain.
+ * @param log_n The logarithmic of domain size.
+ * @param shift The shift value.
+ */
+TACHYON_C_EXPORT void tachyon_sp1_baby_bear_poseidon2_domains_set(
+    tachyon_sp1_baby_bear_poseidon2_domains* domains, size_t round, size_t idx,
+    uint32_t log_n, const tachyon_baby_bear* shift);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // TACHYON_C_ZK_AIR_SP1_BABY_BEAR_POSEIDON2_DOMAINS_H_

--- a/tachyon/c/zk/air/sp1/baby_bear_poseidon2_domains_type_traits.h
+++ b/tachyon/c/zk/air/sp1/baby_bear_poseidon2_domains_type_traits.h
@@ -1,0 +1,26 @@
+#ifndef TACHYON_C_ZK_AIR_SP1_BABY_BEAR_POSEIDON2_DOMAINS_TYPE_TRAITS_H_
+#define TACHYON_C_ZK_AIR_SP1_BABY_BEAR_POSEIDON2_DOMAINS_TYPE_TRAITS_H_
+
+#include <vector>
+
+#include "tachyon/c/base/type_traits_forward.h"
+#include "tachyon/c/zk/air/sp1/baby_bear_poseidon2_domains.h"
+#include "tachyon/crypto/commitments/fri/two_adic_multiplicative_coset.h"
+
+namespace tachyon::c::base {
+
+template <>
+struct TypeTraits<std::vector<std::vector<
+    tachyon::crypto::TwoAdicMultiplicativeCoset<tachyon::math::BabyBear>>>> {
+  using CType = tachyon_sp1_baby_bear_poseidon2_domains;
+};
+
+template <>
+struct TypeTraits<tachyon_sp1_baby_bear_poseidon2_domains> {
+  using NativeType = std::vector<std::vector<
+      tachyon::crypto::TwoAdicMultiplicativeCoset<tachyon::math::BabyBear>>>;
+};
+
+}  // namespace tachyon::c::base
+
+#endif  // TACHYON_C_ZK_AIR_SP1_BABY_BEAR_POSEIDON2_DOMAINS_TYPE_TRAITS_H_

--- a/tachyon/c/zk/air/sp1/baby_bear_poseidon2_opened_values.cc
+++ b/tachyon/c/zk/air/sp1/baby_bear_poseidon2_opened_values.cc
@@ -4,6 +4,7 @@
 
 #include "tachyon/base/auto_reset.h"
 #include "tachyon/base/buffer/buffer.h"
+#include "tachyon/c/math/finite_fields/baby_bear/baby_bear4_type_traits.h"
 #include "tachyon/c/zk/air/sp1/baby_bear_poseidon2_opened_values_type_traits.h"
 
 using namespace tachyon;
@@ -12,8 +13,8 @@ using OpenedValues =
     std::vector<std::vector<std::vector<std::vector<math::BabyBear4>>>>;
 
 tachyon_sp1_baby_bear_poseidon2_opened_values*
-tachyon_sp1_baby_bear_poseidon2_opened_values_create() {
-  return c::base::c_cast(new OpenedValues());
+tachyon_sp1_baby_bear_poseidon2_opened_values_create(size_t rounds) {
+  return c::base::c_cast(new OpenedValues(rounds));
 }
 
 tachyon_sp1_baby_bear_poseidon2_opened_values*
@@ -39,4 +40,33 @@ void tachyon_sp1_baby_bear_poseidon2_opened_values_serialize(
       &base::Copyable<math::BabyBear>::s_is_in_montgomery, true);
   base::Buffer buffer(data, *data_len);
   CHECK(buffer.Write(c::base::native_cast(*opened_values)));
+}
+
+void tachyon_sp1_baby_bear_poseidon2_opened_values_allocate_outer(
+    tachyon_sp1_baby_bear_poseidon2_opened_values* opened_values, size_t round,
+    size_t rows, size_t cols) {
+  std::vector<std::vector<std::vector<math::BabyBear4>>>& mat =
+      c::base::native_cast(*opened_values)[round];
+  mat.resize(rows);
+  for (size_t r = 0; r < rows; ++r) {
+    mat[r].resize(cols);
+  }
+}
+
+void tachyon_sp1_baby_bear_poseidon2_opened_values_allocate_inner(
+    tachyon_sp1_baby_bear_poseidon2_opened_values* opened_values, size_t round,
+    size_t r, size_t cols, size_t size) {
+  std::vector<std::vector<std::vector<math::BabyBear4>>>& mat =
+      c::base::native_cast(*opened_values)[round];
+  std::vector<std::vector<math::BabyBear4>>& row = mat[r];
+  for (size_t c = 0; c < cols; ++c) {
+    row[c].resize(size);
+  }
+}
+
+void tachyon_sp1_baby_bear_poseidon2_opened_values_set(
+    tachyon_sp1_baby_bear_poseidon2_opened_values* opened_values, size_t round,
+    size_t row, size_t col, size_t idx, const tachyon_baby_bear4* value) {
+  c::base::native_cast(*opened_values)[round][row][col][idx] =
+      c::base::native_cast(*value);
 }

--- a/tachyon/c/zk/air/sp1/baby_bear_poseidon2_opened_values.h
+++ b/tachyon/c/zk/air/sp1/baby_bear_poseidon2_opened_values.h
@@ -22,10 +22,11 @@ extern "C" {
 /**
  * @brief Creates a new set of opened values.
  *
+ * @param rounds The number of rounds.
  * @return A pointer to the newly created set of opened values.
  */
 TACHYON_C_EXPORT tachyon_sp1_baby_bear_poseidon2_opened_values*
-tachyon_sp1_baby_bear_poseidon2_opened_values_create();
+tachyon_sp1_baby_bear_poseidon2_opened_values_create(size_t rounds);
 
 /**
  * @brief Clones an existing set of opened values.
@@ -58,6 +59,47 @@ TACHYON_C_EXPORT void tachyon_sp1_baby_bear_poseidon2_opened_values_destroy(
 TACHYON_C_EXPORT void tachyon_sp1_baby_bear_poseidon2_opened_values_serialize(
     const tachyon_sp1_baby_bear_poseidon2_opened_values* opened_values,
     uint8_t* data, size_t* data_len);
+
+/**
+ * @brief Allocates outer memory for the set of opened values.
+ *
+ * @param opened_values A pointer to the set of opened values.
+ * @param round The round index of the point.
+ * @param rows The number of rows.
+ * @param cols The number of columns.
+ */
+TACHYON_C_EXPORT void
+tachyon_sp1_baby_bear_poseidon2_opened_values_allocate_outer(
+    tachyon_sp1_baby_bear_poseidon2_opened_values* opened_values, size_t round,
+    size_t rows, size_t cols);
+
+/**
+ * @brief Allocates inner memory for the set of opened values.
+ *
+ * @param opened_values A pointer to the set of opened values.
+ * @param round The round index of the point.
+ * @param row The row index of the value.
+ * @param cols The number of columns.
+ * @param size The size of the values.
+ */
+TACHYON_C_EXPORT void
+tachyon_sp1_baby_bear_poseidon2_opened_values_allocate_inner(
+    tachyon_sp1_baby_bear_poseidon2_opened_values* opened_values, size_t round,
+    size_t row, size_t cols, size_t size);
+
+/**
+ * @brief Sets value.
+ *
+ * @param opened_values A pointer to the set of opened values.
+ * @param round The round index of the point.
+ * @param row The row index of the value.
+ * @param col The column index of the value.
+ * @param idx The index of the value.
+ * @param value A const pointer to the value.
+ */
+TACHYON_C_EXPORT void tachyon_sp1_baby_bear_poseidon2_opened_values_set(
+    tachyon_sp1_baby_bear_poseidon2_opened_values* opened_values, size_t round,
+    size_t row, size_t col, size_t idx, const tachyon_baby_bear4* value);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/tachyon/c/zk/air/sp1/baby_bear_poseidon2_two_adic_fri.cc
+++ b/tachyon/c/zk/air/sp1/baby_bear_poseidon2_two_adic_fri.cc
@@ -5,6 +5,8 @@
 #include "tachyon/c/math/finite_fields/baby_bear/baby_bear4_type_traits.h"
 #include "tachyon/c/math/finite_fields/baby_bear/baby_bear_type_traits.h"
 #include "tachyon/c/math/matrix/baby_bear_row_major_matrix_type_traits.h"
+#include "tachyon/c/zk/air/sp1/baby_bear_poseidon2_commitment_vec_type_traits.h"
+#include "tachyon/c/zk/air/sp1/baby_bear_poseidon2_domains_type_traits.h"
 #include "tachyon/c/zk/air/sp1/baby_bear_poseidon2_duplex_challenger_type_traits.h"
 #include "tachyon/c/zk/air/sp1/baby_bear_poseidon2_field_merkle_tree_type_traits.h"
 #include "tachyon/c/zk/air/sp1/baby_bear_poseidon2_field_merkle_tree_vec_type_traits.h"
@@ -144,4 +146,20 @@ void tachyon_sp1_baby_bear_poseidon2_two_adic_fri_open(
       c::base::native_cast(
           reinterpret_cast<tachyon_sp1_baby_bear_poseidon2_fri_proof*>(
               *proof)));
+}
+
+bool tachyon_sp1_baby_bear_poseidon2_two_adic_fri_verify(
+    const tachyon_sp1_baby_bear_poseidon2_two_adic_fri* pcs,
+    const tachyon_sp1_baby_bear_poseidon2_commitment_vec* commitments_by_round,
+    const tachyon_sp1_baby_bear_poseidon2_domains* domains_by_round,
+    const tachyon_sp1_baby_bear_poseidon2_opening_points* points_by_round,
+    const tachyon_sp1_baby_bear_poseidon2_opened_values* opened_values_by_round,
+    const tachyon_sp1_baby_bear_poseidon2_fri_proof* proof,
+    tachyon_sp1_baby_bear_poseidon2_duplex_challenger* challenger) {
+  return c::base::native_cast(pcs)->VerifyOpeningProof(
+      c::base::native_cast(*commitments_by_round),
+      c::base::native_cast(*domains_by_round),
+      c::base::native_cast(*points_by_round),
+      c::base::native_cast(*opened_values_by_round),
+      c::base::native_cast(*proof), c::base::native_cast(*challenger));
 }

--- a/tachyon/c/zk/air/sp1/baby_bear_poseidon2_two_adic_fri.cc
+++ b/tachyon/c/zk/air/sp1/baby_bear_poseidon2_two_adic_fri.cc
@@ -128,7 +128,7 @@ void tachyon_sp1_baby_bear_poseidon2_two_adic_fri_commit(
 }
 
 void tachyon_sp1_baby_bear_poseidon2_two_adic_fri_open(
-    tachyon_sp1_baby_bear_poseidon2_two_adic_fri* pcs,
+    const tachyon_sp1_baby_bear_poseidon2_two_adic_fri* pcs,
     const tachyon_sp1_baby_bear_poseidon2_field_merkle_tree_vec*
         prover_data_by_round,
     const tachyon_sp1_baby_bear_poseidon2_opening_points* points_by_round,

--- a/tachyon/c/zk/air/sp1/baby_bear_poseidon2_two_adic_fri.h
+++ b/tachyon/c/zk/air/sp1/baby_bear_poseidon2_two_adic_fri.h
@@ -95,7 +95,7 @@ TACHYON_C_EXPORT void tachyon_sp1_baby_bear_poseidon2_two_adic_fri_commit(
 /**
  * @brief Creates an opening proof with prover data and points.
  *
- * @param pcs A pointer to the two adic fri pcs.
+ * @param pcs A const pointer to the two adic fri pcs.
  * @param prover_data_by_round A const pointer to the field merkle tree vector.
  * @param points_by_round A const pointer to the opening points.
  * @param challenger A pointer to the duplex challenger.
@@ -103,7 +103,7 @@ TACHYON_C_EXPORT void tachyon_sp1_baby_bear_poseidon2_two_adic_fri_commit(
  * @param proof A pointer to store the fri proof.
  */
 TACHYON_C_EXPORT void tachyon_sp1_baby_bear_poseidon2_two_adic_fri_open(
-    tachyon_sp1_baby_bear_poseidon2_two_adic_fri* pcs,
+    const tachyon_sp1_baby_bear_poseidon2_two_adic_fri* pcs,
     const tachyon_sp1_baby_bear_poseidon2_field_merkle_tree_vec*
         prover_data_by_round,
     const tachyon_sp1_baby_bear_poseidon2_opening_points* points_by_round,

--- a/tachyon/c/zk/air/sp1/baby_bear_poseidon2_two_adic_fri.h
+++ b/tachyon/c/zk/air/sp1/baby_bear_poseidon2_two_adic_fri.h
@@ -13,7 +13,9 @@
 #include "tachyon/c/export.h"
 #include "tachyon/c/math/finite_fields/baby_bear/baby_bear4.h"
 #include "tachyon/c/math/matrix/baby_bear_row_major_matrix.h"
+#include "tachyon/c/zk/air/sp1/baby_bear_poseidon2_commitment_vec.h"
 #include "tachyon/c/zk/air/sp1/baby_bear_poseidon2_constants.h"
+#include "tachyon/c/zk/air/sp1/baby_bear_poseidon2_domains.h"
 #include "tachyon/c/zk/air/sp1/baby_bear_poseidon2_duplex_challenger.h"
 #include "tachyon/c/zk/air/sp1/baby_bear_poseidon2_field_merkle_tree.h"
 #include "tachyon/c/zk/air/sp1/baby_bear_poseidon2_field_merkle_tree_vec.h"
@@ -110,6 +112,27 @@ TACHYON_C_EXPORT void tachyon_sp1_baby_bear_poseidon2_two_adic_fri_open(
     tachyon_sp1_baby_bear_poseidon2_duplex_challenger* challenger,
     tachyon_sp1_baby_bear_poseidon2_opened_values** opened_values,
     tachyon_sp1_baby_bear_poseidon2_fri_proof** proof);
+
+/**
+ * @brief Verifies an opening proof with commitments.
+ *
+ * @param pcs A const pointer to the two adic fri pcs.
+ * @param commitments_by_round A const pointer to the commitment vector.
+ * @param domains_by_round A const pointer to the domains.
+ * @param prover_data_by_round A const pointer to the field merkle tree vector.
+ * @param points_by_round A const pointer to the opening points.
+ * @param opened_values_by_round A const pointer to the opened values.
+ * @param proof A const pointer to the fri proof.
+ * @param challenger A pointer to the duplex challenger.
+ */
+TACHYON_C_EXPORT bool tachyon_sp1_baby_bear_poseidon2_two_adic_fri_verify(
+    const tachyon_sp1_baby_bear_poseidon2_two_adic_fri* pcs,
+    const tachyon_sp1_baby_bear_poseidon2_commitment_vec* commitments_by_round,
+    const tachyon_sp1_baby_bear_poseidon2_domains* domains_by_round,
+    const tachyon_sp1_baby_bear_poseidon2_opening_points* points_by_round,
+    const tachyon_sp1_baby_bear_poseidon2_opened_values* opened_values_by_round,
+    const tachyon_sp1_baby_bear_poseidon2_fri_proof* proof,
+    tachyon_sp1_baby_bear_poseidon2_duplex_challenger* challenger);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/tachyon/c/zk/air/sp1/baby_bear_poseidon2_two_adic_fri_unittest.cc
+++ b/tachyon/c/zk/air/sp1/baby_bear_poseidon2_two_adic_fri_unittest.cc
@@ -5,9 +5,12 @@
 
 #include "gtest/gtest.h"
 
+#include "tachyon/base/bits.h"
 #include "tachyon/c/math/finite_fields/baby_bear/baby_bear4_type_traits.h"
 #include "tachyon/c/math/finite_fields/baby_bear/baby_bear_type_traits.h"
 #include "tachyon/c/math/matrix/baby_bear_row_major_matrix_type_traits.h"
+#include "tachyon/c/zk/air/sp1/baby_bear_poseidon2_commitment_vec_type_traits.h"
+#include "tachyon/c/zk/air/sp1/baby_bear_poseidon2_domains_type_traits.h"
 #include "tachyon/c/zk/air/sp1/baby_bear_poseidon2_duplex_challenger_type_traits.h"
 #include "tachyon/c/zk/air/sp1/baby_bear_poseidon2_fri_proof_type_traits.h"
 #include "tachyon/c/zk/air/sp1/baby_bear_poseidon2_opened_values_type_traits.h"
@@ -24,16 +27,22 @@ using MMCS = c::zk::air::plonky3::baby_bear::MMCS;
 using Coset = c::zk::air::plonky3::baby_bear::Coset;
 using PCS = c::zk::air::plonky3::baby_bear::PCS;
 
+constexpr size_t kRounds = 1;
+
 class TwoAdicFRITest : public testing::Test {
  public:
   void SetUp() override {
     pcs_ = tachyon_sp1_baby_bear_poseidon2_two_adic_fri_create(1, 10, 8);
     prover_data_vec_ =
         tachyon_sp1_baby_bear_poseidon2_field_merkle_tree_vec_create();
-    opening_points_ = tachyon_sp1_baby_bear_poseidon2_opening_points_create(1);
+    opening_points_ =
+        tachyon_sp1_baby_bear_poseidon2_opening_points_create(kRounds);
     challenger_ = tachyon_sp1_baby_bear_poseidon2_duplex_challenger_create();
     opened_values_ = tachyon_sp1_baby_bear_poseidon2_opened_values_create();
     proof_ = tachyon_sp1_baby_bear_poseidon2_fri_proof_create();
+    commitment_vec_ =
+        tachyon_sp1_baby_bear_poseidon2_commitment_vec_create(kRounds);
+    domains_ = tachyon_sp1_baby_bear_poseidon2_domains_create(kRounds);
   }
 
   void TearDown() override {
@@ -44,6 +53,8 @@ class TwoAdicFRITest : public testing::Test {
     tachyon_sp1_baby_bear_poseidon2_duplex_challenger_destroy(challenger_);
     tachyon_sp1_baby_bear_poseidon2_opened_values_destroy(opened_values_);
     tachyon_sp1_baby_bear_poseidon2_fri_proof_destroy(proof_);
+    tachyon_sp1_baby_bear_poseidon2_commitment_vec_destroy(commitment_vec_);
+    tachyon_sp1_baby_bear_poseidon2_domains_destroy(domains_);
   }
 
  protected:
@@ -54,6 +65,8 @@ class TwoAdicFRITest : public testing::Test {
   tachyon_sp1_baby_bear_poseidon2_duplex_challenger* challenger_ = nullptr;
   tachyon_sp1_baby_bear_poseidon2_opened_values* opened_values_ = nullptr;
   tachyon_sp1_baby_bear_poseidon2_fri_proof* proof_ = nullptr;
+  tachyon_sp1_baby_bear_poseidon2_commitment_vec* commitment_vec_ = nullptr;
+  tachyon_sp1_baby_bear_poseidon2_domains* domains_ = nullptr;
 };
 
 }  // namespace
@@ -118,11 +131,26 @@ TEST_F(TwoAdicFRITest, APIs) {
           opening_points_, 0, r, c, c::base::c_cast(&point));
     }
   }
+
+  tachyon_sp1_baby_bear_poseidon2_duplex_challenger* another_challenger =
+      tachyon_sp1_baby_bear_poseidon2_duplex_challenger_clone(challenger_);
   tachyon_sp1_baby_bear_poseidon2_two_adic_fri_open(
       pcs_, prover_data_vec_, opening_points_, challenger_, &opened_values_,
       &proof_);
 
+  tachyon_sp1_baby_bear_poseidon2_commitment_vec_set(commitment_vec_, 0,
+                                                     commitment);
+  tachyon_sp1_baby_bear_poseidon2_domains_allocate(domains_, 0, 1);
+  tachyon_sp1_baby_bear_poseidon2_domains_set(
+      domains_, 0, 0, base::bits::CheckedLog2(kRowsForInput),
+      c::base::c_cast(&shift));
+
+  ASSERT_TRUE(tachyon_sp1_baby_bear_poseidon2_two_adic_fri_verify(
+      pcs_, commitment_vec_, domains_, opening_points_, opened_values_, proof_,
+      another_challenger));
+
   tachyon_sp1_baby_bear_poseidon2_two_adic_fri_destroy(another_pcs);
+  tachyon_sp1_baby_bear_poseidon2_duplex_challenger_destroy(another_challenger);
 }
 
 }  // namespace tachyon

--- a/tachyon/c/zk/air/sp1/baby_bear_poseidon2_two_adic_fri_unittest.cc
+++ b/tachyon/c/zk/air/sp1/baby_bear_poseidon2_two_adic_fri_unittest.cc
@@ -38,7 +38,7 @@ class TwoAdicFRITest : public testing::Test {
     opening_points_ =
         tachyon_sp1_baby_bear_poseidon2_opening_points_create(kRounds);
     challenger_ = tachyon_sp1_baby_bear_poseidon2_duplex_challenger_create();
-    opened_values_ = tachyon_sp1_baby_bear_poseidon2_opened_values_create();
+    opened_values_ = tachyon_sp1_baby_bear_poseidon2_opened_values_create(0);
     proof_ = tachyon_sp1_baby_bear_poseidon2_fri_proof_create();
     commitment_vec_ =
         tachyon_sp1_baby_bear_poseidon2_commitment_vec_create(kRounds);

--- a/tachyon/crypto/commitments/fri/prove.h
+++ b/tachyon/crypto/commitments/fri/prove.h
@@ -21,7 +21,7 @@ namespace tachyon::crypto::fri {
 
 template <typename PCS, typename ExtF, typename ChallengeMMCS,
           typename Challenger>
-CommitPhaseResult<PCS> CommitPhase(FRIConfig<ChallengeMMCS>& config,
+CommitPhaseResult<PCS> CommitPhase(const FRIConfig<ChallengeMMCS>& config,
                                    std::vector<std::vector<ExtF>>&& inputs,
                                    Challenger& challenger) {
   // NOTE(ashjeong): This is empirically determined in case the size of the for
@@ -93,7 +93,7 @@ CommitPhaseResult<PCS> CommitPhase(FRIConfig<ChallengeMMCS>& config,
 
 template <typename PCS, typename ChallengeMMCS = typename PCS::ChallengeMMCS>
 std::vector<CommitPhaseProofStep<PCS>> AnswerQuery(
-    size_t index, FRIConfig<ChallengeMMCS>& config,
+    size_t index, const FRIConfig<ChallengeMMCS>& config,
     const std::vector<typename ChallengeMMCS::ProverData>&
         commit_phase_commits) {
   return base::CreateVector(
@@ -120,7 +120,7 @@ std::vector<CommitPhaseProofStep<PCS>> AnswerQuery(
 template <typename PCS, typename ExtF, typename ChallengeMMCS,
           typename Challenger, typename OpenInputCallback,
           typename F = typename math::ExtensionFieldTraits<ExtF>::BaseField>
-FRIProof<PCS> Prove(FRIConfig<ChallengeMMCS>& config,
+FRIProof<PCS> Prove(const FRIConfig<ChallengeMMCS>& config,
                     std::vector<std::vector<ExtF>>&& inputs,
                     Challenger& challenger, OpenInputCallback open_input) {
   using QueryProof = QueryProof<PCS>;

--- a/tachyon/crypto/commitments/fri/two_adic_fri.h
+++ b/tachyon/crypto/commitments/fri/two_adic_fri.h
@@ -383,14 +383,14 @@ class TwoAdicFRI {
 
     std::vector<std::vector<ExtF>> sums = base::ParallelizeMap(
         num_rows,
-        [num_cols, &w, &point, &shift, &coset_evals](
+        [num_cols, shift, w, &point, &coset_evals](
             size_t chunk_actual_size, size_t chunk_offset, size_t chunk_size) {
           size_t row_start = chunk_offset * chunk_size;
           F pow = w.Pow(row_start);
           std::vector<ExtF> sum_tracker(num_cols, ExtF::Zero());
           ExtF shifted_pow(shift * pow);
           std::vector<ExtF> diff_invs = base::CreateVector(
-              chunk_actual_size, [&point, &shifted_pow, &w](size_t i) {
+              chunk_actual_size, [w, &point, &shifted_pow](size_t i) {
                 ExtF temp = point - shifted_pow;
                 shifted_pow *= w;
                 return temp;

--- a/tachyon/crypto/commitments/fri/two_adic_fri.h
+++ b/tachyon/crypto/commitments/fri/two_adic_fri.h
@@ -274,7 +274,7 @@ class TwoAdicFRI {
               for (size_t i = 0; i < cur_points.size(); ++i) {
                 const ExtF& z = cur_points[i];
                 const std::vector<ExtF>& ps_at_z = cur_values[i];
-                CHECK_EQ(ps_at_z.size(), opened_values_in[i].size());
+                CHECK_EQ(ps_at_z.size(), cur_values_in.size());
                 for (size_t j = 0; j < ps_at_z.size(); ++j) {
                   ExtF quotient = unwrap((ExtF(cur_values_in[j]) - ps_at_z[j]) /
                                          (ExtF(x) - z));

--- a/tachyon/crypto/commitments/fri/two_adic_fri.h
+++ b/tachyon/crypto/commitments/fri/two_adic_fri.h
@@ -238,9 +238,8 @@ class TwoAdicFRI {
             std::vector<math::Dimensions> batch_dims = base::CreateVector(
                 vals_size, [this, round, &batch_max_num_rows,
                             &domains_by_round](size_t batch_idx) {
-                  const Domain& mat_domain = domains_by_round[round][batch_idx];
-                  size_t num_rows = mat_domain.domain()->size()
-                                    << fri_.log_blowup;
+                  const Domain& domain = domains_by_round[round][batch_idx];
+                  size_t num_rows = domain.domain()->size() << fri_.log_blowup;
                   batch_max_num_rows = std::max(batch_max_num_rows, num_rows);
                   return math::Dimensions{0, num_rows};
                 });
@@ -255,11 +254,11 @@ class TwoAdicFRI {
                                            input_proof[round].opening_proof));
 
             for (size_t batch_idx = 0; batch_idx < vals_size; ++batch_idx) {
-              const Domain& mat_domain = domains_by_round[round][batch_idx];
+              const Domain& domain = domains_by_round[round][batch_idx];
               const std::vector<std::tuple<ExtF, std::vector<ExtF>>>&
                   mat_points_and_values = claim[batch_idx];
               uint32_t log_num_rows =
-                  mat_domain.domain()->log_size_of_group() + fri_.log_blowup;
+                  domain.domain()->log_size_of_group() + fri_.log_blowup;
               uint32_t bits_reduced = log_global_max_num_rows - log_num_rows;
               uint32_t rev_reduced_index = base::bits::ReverseBitsLen(
                   index >> bits_reduced, log_num_rows);

--- a/tachyon/crypto/commitments/fri/two_adic_fri.h
+++ b/tachyon/crypto/commitments/fri/two_adic_fri.h
@@ -91,7 +91,7 @@ class TwoAdicFRI {
   [[nodiscard]] bool CreateOpeningProof(
       const std::vector<ProverData>& prover_data_by_round,
       const OpeningPoints& points_by_round, Challenger& challenger,
-      OpenedValues* openings, FRIProof* proof) {
+      OpenedValues* opened_values_out, FRIProof* proof) {
     TRACE_EVENT("ProofGeneration", "TwoAdicFRI::CreateOpeningProof");
     ExtF alpha = challenger.template SampleExtElement<ExtF>();
     VLOG(2) << "FRI(alpha): " << alpha.ToHexString(true);
@@ -208,7 +208,7 @@ class TwoAdicFRI {
 
           return ret;
         });
-    *openings = std::move(opened_values);
+    *opened_values_out = std::move(opened_values);
     *proof = std::move(fri_proof);
     return true;
   }

--- a/tachyon/crypto/commitments/fri/two_adic_fri.h
+++ b/tachyon/crypto/commitments/fri/two_adic_fri.h
@@ -211,7 +211,7 @@ class TwoAdicFRI {
       const std::vector<std::vector<Domain>>& domains_by_round,
       const OpeningPoints& points_by_round,
       const OpenedValues& opened_values_by_round, const FRIProof& proof,
-      Challenger& challenger) {
+      Challenger& challenger) const {
     TRACE_EVENT("ProofVerification", "TwoAdicFRI::VerifyOpeningProof");
     // Batch combination challenge
     const ExtF alpha = challenger.template SampleExtElement<ExtF>();

--- a/tachyon/crypto/commitments/fri/two_adic_fri.h
+++ b/tachyon/crypto/commitments/fri/two_adic_fri.h
@@ -89,7 +89,7 @@ class TwoAdicFRI {
   [[nodiscard]] bool CreateOpeningProof(
       const std::vector<ProverData>& prover_data_by_round,
       const OpeningPoints& points_by_round, Challenger& challenger,
-      OpenedValues* opened_values_out, FRIProof* proof) {
+      OpenedValues* opened_values_out, FRIProof* proof) const {
     TRACE_EVENT("ProofGeneration", "TwoAdicFRI::CreateOpeningProof");
     ExtF alpha = challenger.template SampleExtElement<ExtF>();
     VLOG(2) << "FRI(alpha): " << alpha.ToHexString(true);

--- a/tachyon/crypto/commitments/fri/two_adic_fri.h
+++ b/tachyon/crypto/commitments/fri/two_adic_fri.h
@@ -185,11 +185,12 @@ class TwoAdicFRI {
       }
     }
 
-    FRIProof fri_proof = fri::Prove<TwoAdicFRI>(
+    *opened_values_out = std::move(opened_values);
+    *proof = fri::Prove<TwoAdicFRI>(
         fri_, std::move(fri_input), challenger,
         [this, log_global_max_num_rows, &prover_data_by_round](size_t index) {
           size_t num_rounds = prover_data_by_round.size();
-          std::vector<BatchOpening<TwoAdicFRI>> ret = base::CreateVector(
+          return base::CreateVector(
               num_rounds, [this, log_global_max_num_rows, index,
                            &prover_data_by_round](size_t round) {
                 Proof proof;
@@ -205,11 +206,7 @@ class TwoAdicFRI {
                 return BatchOpening<TwoAdicFRI>{std::move(openings),
                                                 std::move(proof)};
               });
-
-          return ret;
         });
-    *opened_values_out = std::move(opened_values);
-    *proof = std::move(fri_proof);
     return true;
   }
 

--- a/tachyon/crypto/commitments/fri/two_adic_fri.h
+++ b/tachyon/crypto/commitments/fri/two_adic_fri.h
@@ -57,8 +57,7 @@ class TwoAdicFRI {
   using OpeningPointsForRound = std::vector<std::vector<ExtF>>;
   using OpeningPoints = std::vector<OpeningPointsForRound>;
 
-  using OpenedValuesForMat = std::vector<std::vector<ExtF>>;
-  using OpenedValuesForRound = std::vector<OpenedValuesForMat>;
+  using OpenedValuesForRound = std::vector<std::vector<std::vector<ExtF>>>;
   using OpenedValues = std::vector<OpenedValuesForRound>;
 
   TwoAdicFRI() = default;
@@ -138,9 +137,8 @@ class TwoAdicFRI {
         std::vector<ExtF>& reduced_opening_for_log_num_rows =
             reduced_openings[log_num_rows];
         CHECK_EQ(reduced_opening_for_log_num_rows.size(), num_rows);
-        // TODO(ashjeong): Determine if using a matrix is a better fit for
-        // |opened_values_for_mat|.
-        OpenedValuesForMat opened_values_for_mat = base::CreateVector(
+        // TODO(ashjeong): Determine if using a matrix is a better fit.
+        opened_values_for_round[matrix_idx] = base::CreateVector(
             points[matrix_idx].size(),
             [this, matrix_idx, num_rows, num_cols, log_num_rows, &points, &mat,
              &alpha, &num_reduced, &inv_denoms,
@@ -173,7 +171,6 @@ class TwoAdicFRI {
               num_reduced[log_num_rows] += num_cols;
               return ys;
             });
-        opened_values_for_round[matrix_idx] = std::move(opened_values_for_mat);
       }
       opened_values[round] = std::move(opened_values_for_round);
     }

--- a/tachyon/crypto/commitments/fri/two_adic_fri_unittest.cc
+++ b/tachyon/crypto/commitments/fri/two_adic_fri_unittest.cc
@@ -86,7 +86,6 @@ class TwoAdicFRITest : public testing::Test {
     using OpenedValues =
         std::vector<std::vector<std::vector<std::vector<ExtF>>>>;
     using Proof = FRIProof<MyPCS>;
-    using Claims = std::vector<std::tuple<ExtF, std::vector<ExtF>>>;
 
     size_t num_rounds = log_degrees_by_round.size();
     std::vector<std::vector<Domain>> domains_by_round(num_rounds);
@@ -116,11 +115,12 @@ class TwoAdicFRITest : public testing::Test {
       points_by_round[round] = std::vector<std::vector<ExtF>>(
           log_degrees_by_round[round].size(), {zeta});
     }
-    OpenedValues openings;
+    OpenedValues opened_values_by_round;
     Proof proof;
     ASSERT_TRUE(pcs_.CreateOpeningProof(data_by_round, points_by_round,
-                                        p_challenger, &openings, &proof));
-    ASSERT_EQ(openings.size(), num_rounds);
+                                        p_challenger, &opened_values_by_round,
+                                        &proof));
+    ASSERT_EQ(opened_values_by_round.size(), num_rounds);
 
     // Verify the proof
     Challenger v_challenger = challenger_;
@@ -128,16 +128,9 @@ class TwoAdicFRITest : public testing::Test {
     ExtF verifier_zeta = v_challenger.template SampleExtElement<ExtF>();
     ASSERT_EQ(verifier_zeta, zeta);
 
-    std::vector<std::vector<Claims>> claims_by_round = base::CreateVector(
-        num_rounds, [&domains_by_round, &zeta, &openings](size_t round) {
-          return base::CreateVector(
-              domains_by_round[round].size(),
-              [round, &zeta, &openings](size_t i) {
-                return Claims{std::make_tuple(zeta, openings[round][i][0])};
-              });
-        });
     ASSERT_TRUE(pcs_.VerifyOpeningProof(commits_by_round, domains_by_round,
-                                        claims_by_round, proof, v_challenger));
+                                        points_by_round, opened_values_by_round,
+                                        proof, v_challenger));
   }
 
  protected:

--- a/tachyon/crypto/commitments/merkle_tree/field_merkle_tree/extension_field_merkle_tree_mmcs.h
+++ b/tachyon/crypto/commitments/merkle_tree/field_merkle_tree/extension_field_merkle_tree_mmcs.h
@@ -36,7 +36,7 @@ class ExtensionFieldMerkleTreeMMCS final
 
   [[nodiscard]] bool DoCommit(
       std::vector<math::RowMajorMatrix<ExtensionField>>&& matrices,
-      Commitment* commitment, ProverData* prover_data) {
+      Commitment* commitment, ProverData* prover_data) const {
     return inner_.Commit(std::move(matrices), commitment, prover_data);
   }
 

--- a/tachyon/crypto/commitments/merkle_tree/field_merkle_tree/field_merkle_tree_mmcs.h
+++ b/tachyon/crypto/commitments/merkle_tree/field_merkle_tree/field_merkle_tree_mmcs.h
@@ -87,7 +87,8 @@ class FieldMerkleTreeMMCS final
   };
 
   [[nodiscard]] bool DoCommit(std::vector<math::RowMajorMatrix<F>>&& matrices,
-                              Commitment* commitment, ProverData* prover_data) {
+                              Commitment* commitment,
+                              ProverData* prover_data) const {
     TRACE_EVENT("ProofGeneration", "FieldMerkleTreeMMCS::DoCommit");
     *prover_data =
         FieldMerkleTree<F, N>::Build(hasher_, packed_hasher_, compressor_,

--- a/tachyon/crypto/commitments/mixed_matrix_commitment_scheme.h
+++ b/tachyon/crypto/commitments/mixed_matrix_commitment_scheme.h
@@ -35,14 +35,16 @@ class MixedMatrixCommitmentScheme {
   }
 
   [[nodiscard]] bool Commit(math::RowMajorMatrix<Field>&& matrix,
-                            Commitment* commitment, ProverData* prover_data) {
+                            Commitment* commitment,
+                            ProverData* prover_data) const {
     return Commit(std::vector<math::RowMajorMatrix<Field>>{std::move(matrix)},
                   commitment, prover_data);
   }
 
   [[nodiscard]] bool Commit(std::vector<math::RowMajorMatrix<Field>>&& matrices,
-                            Commitment* commitment, ProverData* prover_data) {
-    Derived* derived = static_cast<Derived*>(this);
+                            Commitment* commitment,
+                            ProverData* prover_data) const {
+    const Derived* derived = static_cast<const Derived*>(this);
     return derived->DoCommit(std::move(matrices), commitment, prover_data);
   }
 

--- a/tachyon/math/polynomials/univariate/naive_batch_fft.h
+++ b/tachyon/math/polynomials/univariate/naive_batch_fft.h
@@ -97,8 +97,8 @@ class NaiveBatchFFT : public TwoAdicSubgroup<NaiveBatchFFT<F>> {
     // is first replaced by cⱼ s.
     size_t rows = mat.rows();
     base::Parallelize(
-        rows, [&mat, &shift](Eigen::Index len, Eigen::Index chunk_offset,
-                             Eigen::Index chunk_size) {
+        rows, [shift, &mat](Eigen::Index len, Eigen::Index chunk_offset,
+                            Eigen::Index chunk_size) {
           Eigen::Index start = chunk_offset * chunk_size;
           F weight = shift.Pow(start);
           // NOTE: It is not possible to have empty chunk so this is safe

--- a/tachyon/math/polynomials/univariate/radix2_evaluation_domain.h
+++ b/tachyon/math/polynomials/univariate/radix2_evaluation_domain.h
@@ -140,9 +140,9 @@ class Radix2EvaluationDomain
     // - divide by number of rows (since we're doing an inverse DFT)
     // - multiply by powers of the coset shift (see default coset LDE impl for
     // an explanation)
-    base::Parallelize(this->size_, [this, &mat, &shift](size_t len,
-                                                        size_t chunk_offset,
-                                                        size_t chunk_size) {
+    base::Parallelize(this->size_, [this, shift, &mat](size_t len,
+                                                       size_t chunk_offset,
+                                                       size_t chunk_size) {
       // Reverse bits because |mat| is encoded in bit-reversed order
       size_t start = chunk_offset * chunk_size;
       F weight = this->size_inv_ * shift.Pow(start);

--- a/vendors/sp1/BUILD.bazel
+++ b/vendors/sp1/BUILD.bazel
@@ -14,9 +14,12 @@ tachyon_rust_library(
     crate_features = FEATURES,
     proc_macro_deps = all_crate_deps(proc_macro = True),
     deps = all_crate_deps(normal = True) + [
+        ":baby_bear_poseidon2_commitment_vec",
         ":baby_bear_poseidon2_cxx_bridge",
+        ":baby_bear_poseidon2_domains",
         ":baby_bear_poseidon2_duplex_challenger",
         ":baby_bear_poseidon2_fri_proof",
+        ":baby_bear_poseidon2_opened_values",
         ":baby_bear_poseidon2_opening_points",
         ":baby_bear_poseidon2_opening_proof",
         ":baby_bear_poseidon2_prover_data",
@@ -66,8 +69,11 @@ rust_cxx_bridge(
 tachyon_cc_library(
     name = "baby_bear_poseidon2_api_hdrs",
     hdrs = [
+        "include/baby_bear_poseidon2_commitment_vec.h",
+        "include/baby_bear_poseidon2_domains.h",
         "include/baby_bear_poseidon2_duplex_challenger.h",
         "include/baby_bear_poseidon2_fri_proof.h",
+        "include/baby_bear_poseidon2_opened_values.h",
         "include/baby_bear_poseidon2_opening_points.h",
         "include/baby_bear_poseidon2_opening_proof.h",
         "include/baby_bear_poseidon2_prover_data.h",
@@ -78,6 +84,24 @@ tachyon_cc_library(
         "//tachyon/c/zk/air/sp1:baby_bear_poseidon2_duplex_challenger",
         "//tachyon/c/zk/air/sp1:baby_bear_poseidon2_two_adic_fri",
         "@cxx.rs//:core",
+    ],
+)
+
+tachyon_cc_library(
+    name = "baby_bear_poseidon2_commitment_vec",
+    srcs = ["src/baby_bear_poseidon2_commitment_vec.cc"],
+    deps = [
+        ":baby_bear_poseidon2_api_hdrs",
+        ":baby_bear_poseidon2_cxx_bridge/include",
+    ],
+)
+
+tachyon_cc_library(
+    name = "baby_bear_poseidon2_domains",
+    srcs = ["src/baby_bear_poseidon2_domains.cc"],
+    deps = [
+        ":baby_bear_poseidon2_api_hdrs",
+        ":baby_bear_poseidon2_cxx_bridge/include",
     ],
 )
 
@@ -93,6 +117,15 @@ tachyon_cc_library(
 tachyon_cc_library(
     name = "baby_bear_poseidon2_fri_proof",
     srcs = ["src/baby_bear_poseidon2_fri_proof.cc"],
+    deps = [
+        ":baby_bear_poseidon2_api_hdrs",
+        ":baby_bear_poseidon2_cxx_bridge/include",
+    ],
+)
+
+tachyon_cc_library(
+    name = "baby_bear_poseidon2_opened_values",
+    srcs = ["src/baby_bear_poseidon2_opened_values.cc"],
     deps = [
         ":baby_bear_poseidon2_api_hdrs",
         ":baby_bear_poseidon2_cxx_bridge/include",

--- a/vendors/sp1/Cargo.toml
+++ b/vendors/sp1/Cargo.toml
@@ -17,6 +17,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.83"
 cxx = "1.0"
+itertools = "0.13.0"
 p3-baby-bear = "0.1.3-succinct"
 p3-challenger = "0.1.3-succinct"
 p3-commit = "0.1.3-succinct"

--- a/vendors/sp1/include/baby_bear_poseidon2_commitment_vec.h
+++ b/vendors/sp1/include/baby_bear_poseidon2_commitment_vec.h
@@ -1,0 +1,39 @@
+#ifndef VENDORS_SP1_INCLUDE_BABY_BEAR_POSEIDON2_COMMITMENT_VEC_H_
+#define VENDORS_SP1_INCLUDE_BABY_BEAR_POSEIDON2_COMMITMENT_VEC_H_
+
+#include <stddef.h>
+
+#include <memory>
+
+#include "rust/cxx.h"
+
+#include "tachyon/c/zk/air/sp1/baby_bear_poseidon2_commitment_vec.h"
+
+namespace tachyon::sp1_api::baby_bear_poseidon2 {
+
+struct TachyonBabyBear;
+
+class CommitmentVec {
+ public:
+  explicit CommitmentVec(
+      tachyon_sp1_baby_bear_poseidon2_commitment_vec* commitment_vec)
+      : commitment_vec_(commitment_vec) {}
+  CommitmentVec(const CommitmentVec& other) = delete;
+  CommitmentVec& operator=(const CommitmentVec& other) = delete;
+  ~CommitmentVec();
+
+  const tachyon_sp1_baby_bear_poseidon2_commitment_vec* commitment_vec() const {
+    return commitment_vec_;
+  }
+
+  void set(size_t round, rust::Slice<const TachyonBabyBear> commitment);
+
+ private:
+  tachyon_sp1_baby_bear_poseidon2_commitment_vec* commitment_vec_;
+};
+
+std::unique_ptr<CommitmentVec> new_commitment_vec(size_t rounds);
+
+}  // namespace tachyon::sp1_api::baby_bear_poseidon2
+
+#endif  // VENDORS_SP1_INCLUDE_BABY_BEAR_POSEIDON2_COMMITMENT_VEC_H_

--- a/vendors/sp1/include/baby_bear_poseidon2_domains.h
+++ b/vendors/sp1/include/baby_bear_poseidon2_domains.h
@@ -1,0 +1,41 @@
+#ifndef VENDORS_SP1_INCLUDE_BABY_BEAR_POSEIDON2_DOMAINS_H_
+#define VENDORS_SP1_INCLUDE_BABY_BEAR_POSEIDON2_DOMAINS_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <memory>
+
+#include "rust/cxx.h"
+
+#include "tachyon/c/zk/air/sp1/baby_bear_poseidon2_domains.h"
+
+namespace tachyon::sp1_api::baby_bear_poseidon2 {
+
+struct TachyonBabyBear;
+
+class Domains {
+ public:
+  explicit Domains(tachyon_sp1_baby_bear_poseidon2_domains* domains)
+      : domains_(domains) {}
+  Domains(const Domains& other) = delete;
+  Domains& operator=(const Domains& other) = delete;
+  ~Domains();
+
+  const tachyon_sp1_baby_bear_poseidon2_domains* domains() const {
+    return domains_;
+  }
+
+  void allocate(size_t round, size_t size);
+  void set(size_t round, size_t idx, uint32_t log_n,
+           const TachyonBabyBear& shift);
+
+ private:
+  tachyon_sp1_baby_bear_poseidon2_domains* domains_;
+};
+
+std::unique_ptr<Domains> new_domains(size_t rounds);
+
+}  // namespace tachyon::sp1_api::baby_bear_poseidon2
+
+#endif  // VENDORS_SP1_INCLUDE_BABY_BEAR_POSEIDON2_DOMAINS_H_

--- a/vendors/sp1/include/baby_bear_poseidon2_fri_proof.h
+++ b/vendors/sp1/include/baby_bear_poseidon2_fri_proof.h
@@ -17,6 +17,10 @@ class FriProof {
   FriProof& operator=(const FriProof& other) = delete;
   ~FriProof();
 
+  const tachyon_sp1_baby_bear_poseidon2_fri_proof* proof() const {
+    return proof_;
+  }
+
   std::unique_ptr<FriProof> clone() const;
 
  private:

--- a/vendors/sp1/include/baby_bear_poseidon2_opened_values.h
+++ b/vendors/sp1/include/baby_bear_poseidon2_opened_values.h
@@ -1,0 +1,42 @@
+#ifndef VENDORS_SP1_INCLUDE_BABY_BEAR_POSEIDON2_OPENED_VALUES_H_
+#define VENDORS_SP1_INCLUDE_BABY_BEAR_POSEIDON2_OPENED_VALUES_H_
+
+#include <stddef.h>
+
+#include <memory>
+
+#include "rust/cxx.h"
+
+#include "tachyon/c/zk/air/sp1/baby_bear_poseidon2_opened_values.h"
+
+namespace tachyon::sp1_api::baby_bear_poseidon2 {
+
+struct TachyonBabyBear4;
+
+class OpenedValues {
+ public:
+  explicit OpenedValues(
+      tachyon_sp1_baby_bear_poseidon2_opened_values* opened_values)
+      : opened_values_(opened_values) {}
+  OpenedValues(const OpenedValues& other) = delete;
+  OpenedValues& operator=(const OpenedValues& other) = delete;
+  ~OpenedValues();
+
+  const tachyon_sp1_baby_bear_poseidon2_opened_values* opened_values() const {
+    return opened_values_;
+  }
+
+  void allocate_outer(size_t round, size_t rows, size_t cols);
+  void allocate_inner(size_t round, size_t row, size_t cols, size_t size);
+  void set(size_t round, size_t row, size_t col, size_t idx,
+           const TachyonBabyBear4& value);
+
+ private:
+  tachyon_sp1_baby_bear_poseidon2_opened_values* opened_values_;
+};
+
+std::unique_ptr<OpenedValues> new_opened_values(size_t rounds);
+
+}  // namespace tachyon::sp1_api::baby_bear_poseidon2
+
+#endif  // VENDORS_SP1_INCLUDE_BABY_BEAR_POSEIDON2_OPENED_VALUES_H_

--- a/vendors/sp1/include/baby_bear_poseidon2_two_adic_fri_pcs.h
+++ b/vendors/sp1/include/baby_bear_poseidon2_two_adic_fri_pcs.h
@@ -12,12 +12,16 @@
 
 namespace tachyon::sp1_api::baby_bear_poseidon2 {
 
+class CommitmentVec;
 class CommitResult;
+class Domains;
 class DuplexChallenger;
+class FriProof;
 class OpeningPoints;
 class OpeningProof;
 class ProverData;
 class ProverDataVec;
+class OpenedValues;
 struct TachyonBabyBear;
 struct TachyonBabyBear4;
 
@@ -38,6 +42,10 @@ class TwoAdicFriPcs {
   std::unique_ptr<OpeningProof> do_open(const ProverDataVec& prover_data_vec,
                                         const OpeningPoints& opening_points,
                                         DuplexChallenger& challenger) const;
+  bool do_verify(const CommitmentVec& commitment_vec, const Domains& domains,
+                 const OpeningPoints& opening_points,
+                 const OpenedValues& opened_values, const FriProof& proof,
+                 DuplexChallenger& challenger) const;
 
  private:
   tachyon_sp1_baby_bear_poseidon2_two_adic_fri* pcs_;

--- a/vendors/sp1/src/baby_bear_poseidon2.rs
+++ b/vendors/sp1/src/baby_bear_poseidon2.rs
@@ -105,7 +105,7 @@ pub mod ffi {
 
         fn new_opening_points(rounds: usize) -> UniquePtr<OpeningPoints>;
         fn clone(&self) -> UniquePtr<OpeningPoints>;
-        fn allocate(self: Pin<&mut OpeningPoints>, rounds: usize, rows: usize, cols: usize);
+        fn allocate(self: Pin<&mut OpeningPoints>, round: usize, rows: usize, cols: usize);
         fn set(
             self: Pin<&mut OpeningPoints>,
             round: usize,

--- a/vendors/sp1/src/baby_bear_poseidon2.rs
+++ b/vendors/sp1/src/baby_bear_poseidon2.rs
@@ -2,7 +2,7 @@ use std::{fmt::Debug, io::Cursor, marker::PhantomData, pin::Pin};
 
 use p3_baby_bear::BabyBear;
 use p3_challenger::{CanObserve, CanSample, CanSampleBits, FieldChallenger, GrindingChallenger};
-use p3_commit::{Mmcs, OpenedValues, Pcs, PolynomialSpace, TwoAdicMultiplicativeCoset};
+use p3_commit::{Mmcs, Pcs, PolynomialSpace, TwoAdicMultiplicativeCoset};
 use p3_dft::TwoAdicSubgroupDft;
 use p3_field::{ExtensionField, Field, PackedField, PackedValue, PrimeField64, TwoAdicField};
 use p3_fri::{FriConfig, VerificationError};
@@ -31,6 +31,31 @@ pub mod ffi {
     }
 
     unsafe extern "C++" {
+        include!("vendors/sp1/include/baby_bear_poseidon2_commitment_vec.h");
+
+        type CommitmentVec;
+
+        fn new_commitment_vec(rounds: usize) -> UniquePtr<CommitmentVec>;
+        fn set(self: Pin<&mut CommitmentVec>, round: usize, commitment: &[TachyonBabyBear]);
+    }
+
+    unsafe extern "C++" {
+        include!("vendors/sp1/include/baby_bear_poseidon2_domains.h");
+
+        type Domains;
+
+        fn new_domains(rounds: usize) -> UniquePtr<Domains>;
+        fn allocate(self: Pin<&mut Domains>, round: usize, size: usize);
+        fn set(
+            self: Pin<&mut Domains>,
+            round: usize,
+            idx: usize,
+            log_n: u32,
+            shift: &TachyonBabyBear,
+        );
+    }
+
+    unsafe extern "C++" {
         include!("vendors/sp1/include/baby_bear_poseidon2_duplex_challenger.h");
 
         type DuplexChallenger;
@@ -47,6 +72,30 @@ pub mod ffi {
         type FriProof;
 
         fn clone(&self) -> UniquePtr<FriProof>;
+    }
+
+    unsafe extern "C++" {
+        include!("vendors/sp1/include/baby_bear_poseidon2_opened_values.h");
+
+        type OpenedValues;
+
+        fn new_opened_values(rounds: usize) -> UniquePtr<OpenedValues>;
+        fn allocate_outer(self: Pin<&mut OpenedValues>, round: usize, rows: usize, cols: usize);
+        fn allocate_inner(
+            self: Pin<&mut OpenedValues>,
+            round: usize,
+            row: usize,
+            cols: usize,
+            size: usize,
+        );
+        fn set(
+            self: Pin<&mut OpenedValues>,
+            round: usize,
+            row: usize,
+            col: usize,
+            idx: usize,
+            value: &TachyonBabyBear4,
+        );
     }
 
     unsafe extern "C++" {
@@ -117,6 +166,71 @@ pub mod ffi {
             opening_points: &OpeningPoints,
             challenger: Pin<&mut DuplexChallenger>,
         ) -> UniquePtr<OpeningProof>;
+        fn do_verify(
+            &self,
+            commitments: &CommitmentVec,
+            domains: &Domains,
+            opening_points: &OpeningPoints,
+            opened_values: &OpenedValues,
+            proof: &FriProof,
+            challenger: Pin<&mut DuplexChallenger>,
+        ) -> bool;
+    }
+}
+
+pub struct CommitmentVec<Val> {
+    inner: cxx::UniquePtr<ffi::CommitmentVec>,
+    _marker: PhantomData<Val>,
+}
+
+impl<Val> Debug for CommitmentVec<Val> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CommitmentVec").finish()
+    }
+}
+
+impl<Val> CommitmentVec<Val> {
+    pub fn new(inner: cxx::UniquePtr<ffi::CommitmentVec>) -> Self {
+        Self {
+            inner,
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn set(&mut self, round: usize, commitment: &[Val]) {
+        self.inner
+            .pin_mut()
+            .set(round, unsafe { std::mem::transmute(commitment) })
+    }
+}
+
+pub struct Domains<Val> {
+    inner: cxx::UniquePtr<ffi::Domains>,
+    _marker: PhantomData<Val>,
+}
+
+impl<Val> Debug for Domains<Val> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Domains").finish()
+    }
+}
+
+impl<Val> Domains<Val> {
+    pub fn new(inner: cxx::UniquePtr<ffi::Domains>) -> Self {
+        Self {
+            inner,
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn allocate(&mut self, round: usize, size: usize) {
+        self.inner.pin_mut().allocate(round, size)
+    }
+
+    pub fn set(&mut self, round: usize, idx: usize, log_n: u32, shift: Val) {
+        self.inner
+            .pin_mut()
+            .set(round, idx, log_n, unsafe { std::mem::transmute(&shift) })
     }
 }
 
@@ -312,6 +426,34 @@ impl FriProof {
     }
 }
 
+pub struct OpenedValues<Val> {
+    inner: cxx::UniquePtr<ffi::OpenedValues>,
+    _marker: PhantomData<Val>,
+}
+
+impl<Val> OpenedValues<Val> {
+    pub fn new(inner: cxx::UniquePtr<ffi::OpenedValues>) -> Self {
+        Self {
+            inner,
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn allocate_outer(&mut self, round: usize, rows: usize, cols: usize) {
+        self.inner.pin_mut().allocate_outer(round, rows, cols)
+    }
+
+    pub fn allocate_inner(&mut self, round: usize, row: usize, cols: usize, size: usize) {
+        self.inner.pin_mut().allocate_inner(round, row, cols, size)
+    }
+
+    pub fn set(&mut self, round: usize, row: usize, col: usize, idx: usize, value: &Val) {
+        self.inner
+            .pin_mut()
+            .set(round, row, col, idx, unsafe { std::mem::transmute(value) })
+    }
+}
+
 pub struct OpeningPoints<Val> {
     inner: cxx::UniquePtr<ffi::OpeningPoints>,
     _marker: PhantomData<Val>,
@@ -353,10 +495,10 @@ impl OpeningProof {
         Self { inner }
     }
 
-    pub fn serialize_to_opened_values<Challenge>(&self) -> OpenedValues<Challenge> {
+    pub fn serialize_to_opened_values<Challenge>(&self) -> p3_commit::OpenedValues<Challenge> {
         let buffer = self.inner.serialize_to_opened_values();
         let mut reader = Cursor::new(buffer);
-        let values = OpenedValues::<[u32; 4]>::read_from(&mut reader).unwrap();
+        let values = p3_commit::OpenedValues::<[u32; 4]>::read_from(&mut reader).unwrap();
         unsafe { std::mem::transmute(values) }
     }
 
@@ -501,6 +643,25 @@ where
             challenger,
         ))
     }
+
+    fn do_verify<Challenge>(
+        &self,
+        commitment_vec: &CommitmentVec<Val>,
+        domains: &Domains<Val>,
+        opening_points: &OpeningPoints<Challenge>,
+        opened_values: &OpenedValues<Challenge>,
+        proof: &FriProof,
+        challenger: Pin<&mut ffi::DuplexChallenger>,
+    ) -> bool {
+        self.inner.do_verify(
+            &commitment_vec.inner,
+            &domains.inner,
+            &opening_points.inner,
+            &opened_values.inner,
+            &proof.inner,
+            challenger,
+        )
+    }
 }
 
 impl<Val, Dft, InputMmcs, FriMmcs, Challenge, Challenger> Pcs<Challenge, Challenger>
@@ -578,7 +739,7 @@ where
             >,
         )>,
         challenger: &mut Challenger,
-    ) -> (OpenedValues<Challenge>, Self::Proof) {
+    ) -> (p3_commit::OpenedValues<Challenge>, Self::Proof) {
         let mut opening_points = OpeningPoints::new(ffi::new_opening_points(rounds.len()));
         for (round, (_, matrix)) in rounds.iter().enumerate() {
             opening_points.allocate(round, matrix.len(), matrix[0].len());
@@ -616,6 +777,37 @@ where
         proof: &Self::Proof,
         challenger: &mut Challenger,
     ) -> Result<(), Self::Error> {
-        todo!()
+        let mut commitment_vec = CommitmentVec::new(ffi::new_commitment_vec(rounds.len()));
+        let mut domains = Domains::<Val>::new(ffi::new_domains(rounds.len()));
+        let mut opening_points = OpeningPoints::new(ffi::new_opening_points(rounds.len()));
+        let mut opened_values = OpenedValues::new(ffi::new_opened_values(rounds.len()));
+        for (round, (commitment, matrix)) in rounds.iter().enumerate() {
+            commitment_vec.set(round, commitment.as_ref());
+            domains.allocate(round, matrix.len());
+            let claims = &matrix[0].1;
+            opening_points.allocate(round, matrix.len(), claims.len());
+            opened_values.allocate_outer(round, matrix.len(), claims.len());
+            for (row, (domain, claims)) in matrix.iter().enumerate() {
+                domains.set(round, row, domain.log_n as u32, domain.shift);
+                let values = &claims[0].1;
+                opened_values.allocate_inner(round, row, claims.len(), values.len());
+                for (col, (challenge, values)) in claims.iter().enumerate() {
+                    opening_points.set(round, row, col, challenge);
+                    for (idx, value) in values.iter().enumerate() {
+                        opened_values.set(round, row, col, idx, value);
+                    }
+                }
+            }
+        }
+        let succeeded = self.do_verify(
+            &commitment_vec,
+            &domains,
+            &opening_points,
+            &opened_values,
+            proof,
+            challenger.get_inner_pin_mut(),
+        );
+        assert!(succeeded);
+        Ok(())
     }
 }

--- a/vendors/sp1/src/baby_bear_poseidon2_commitment_vec.cc
+++ b/vendors/sp1/src/baby_bear_poseidon2_commitment_vec.cc
@@ -1,0 +1,21 @@
+#include "vendors/sp1/include/baby_bear_poseidon2_commitment_vec.h"
+
+namespace tachyon::sp1_api::baby_bear_poseidon2 {
+
+CommitmentVec::~CommitmentVec() {
+  tachyon_sp1_baby_bear_poseidon2_commitment_vec_destroy(commitment_vec_);
+}
+
+void CommitmentVec::set(size_t round,
+                        rust::Slice<const TachyonBabyBear> commitment) {
+  tachyon_sp1_baby_bear_poseidon2_commitment_vec_set(
+      commitment_vec_, round,
+      reinterpret_cast<const tachyon_baby_bear*>(commitment.data()));
+}
+
+std::unique_ptr<CommitmentVec> new_commitment_vec(size_t rounds) {
+  return std::make_unique<CommitmentVec>(
+      tachyon_sp1_baby_bear_poseidon2_commitment_vec_create(rounds));
+}
+
+}  // namespace tachyon::sp1_api::baby_bear_poseidon2

--- a/vendors/sp1/src/baby_bear_poseidon2_domains.cc
+++ b/vendors/sp1/src/baby_bear_poseidon2_domains.cc
@@ -1,0 +1,25 @@
+#include "vendors/sp1/include/baby_bear_poseidon2_domains.h"
+
+namespace tachyon::sp1_api::baby_bear_poseidon2 {
+
+Domains::~Domains() {
+  tachyon_sp1_baby_bear_poseidon2_domains_destroy(domains_);
+}
+
+void Domains::allocate(size_t round, size_t size) {
+  tachyon_sp1_baby_bear_poseidon2_domains_allocate(domains_, round, size);
+}
+
+void Domains::set(size_t round, size_t idx, uint32_t log_n,
+                  const TachyonBabyBear& shift) {
+  tachyon_sp1_baby_bear_poseidon2_domains_set(
+      domains_, round, idx, log_n,
+      reinterpret_cast<const tachyon_baby_bear*>(&shift));
+}
+
+std::unique_ptr<Domains> new_domains(size_t rounds) {
+  return std::make_unique<Domains>(
+      tachyon_sp1_baby_bear_poseidon2_domains_create(rounds));
+}
+
+}  // namespace tachyon::sp1_api::baby_bear_poseidon2

--- a/vendors/sp1/src/baby_bear_poseidon2_opened_values.cc
+++ b/vendors/sp1/src/baby_bear_poseidon2_opened_values.cc
@@ -1,0 +1,34 @@
+#include "vendors/sp1/include/baby_bear_poseidon2_opened_values.h"
+
+#include "vendors/sp1/src/baby_bear_poseidon2.rs.h"
+
+namespace tachyon::sp1_api::baby_bear_poseidon2 {
+
+OpenedValues::~OpenedValues() {
+  tachyon_sp1_baby_bear_poseidon2_opened_values_destroy(opened_values_);
+}
+
+void OpenedValues::allocate_outer(size_t round, size_t rows, size_t cols) {
+  tachyon_sp1_baby_bear_poseidon2_opened_values_allocate_outer(
+      opened_values_, round, rows, cols);
+}
+
+void OpenedValues::allocate_inner(size_t round, size_t row, size_t cols,
+                                  size_t size) {
+  tachyon_sp1_baby_bear_poseidon2_opened_values_allocate_inner(
+      opened_values_, round, row, cols, size);
+}
+
+void OpenedValues::set(size_t round, size_t row, size_t col, size_t idx,
+                       const TachyonBabyBear4& value) {
+  tachyon_sp1_baby_bear_poseidon2_opened_values_set(
+      opened_values_, round, row, col, idx,
+      reinterpret_cast<const tachyon_baby_bear4*>(&value));
+}
+
+std::unique_ptr<OpenedValues> new_opened_values(size_t rounds) {
+  return std::make_unique<OpenedValues>(
+      tachyon_sp1_baby_bear_poseidon2_opened_values_create(rounds));
+}
+
+}  // namespace tachyon::sp1_api::baby_bear_poseidon2

--- a/vendors/sp1/src/baby_bear_poseidon2_opening_proof.cc
+++ b/vendors/sp1/src/baby_bear_poseidon2_opening_proof.cc
@@ -7,7 +7,7 @@
 namespace tachyon::sp1_api::baby_bear_poseidon2 {
 
 OpeningProof::OpeningProof()
-    : opened_values_(tachyon_sp1_baby_bear_poseidon2_opened_values_create()),
+    : opened_values_(tachyon_sp1_baby_bear_poseidon2_opened_values_create(0)),
       proof_(tachyon_sp1_baby_bear_poseidon2_fri_proof_create()) {}
 
 OpeningProof::~OpeningProof() {

--- a/vendors/sp1/src/baby_bear_poseidon2_two_adic_fri_pcs.cc
+++ b/vendors/sp1/src/baby_bear_poseidon2_two_adic_fri_pcs.cc
@@ -47,10 +47,21 @@ std::unique_ptr<OpeningProof> TwoAdicFriPcs::do_open(
     DuplexChallenger& challenger) const {
   std::unique_ptr<OpeningProof> ret(new OpeningProof);
   tachyon_sp1_baby_bear_poseidon2_two_adic_fri_open(
-      pcs_,
-      prover_data_vec.tree_vec(), opening_points.opening_points(),
+      pcs_, prover_data_vec.tree_vec(), opening_points.opening_points(),
       challenger.challenger(), ret->opened_values_ptr(), ret->proof_ptr());
   return ret;
+}
+
+bool TwoAdicFriPcs::do_verify(const CommitmentVec& commitment_vec,
+                              const Domains& domains,
+                              const OpeningPoints& opening_points,
+                              const OpenedValues& opened_values,
+                              const FriProof& proof,
+                              DuplexChallenger& challenger) const {
+  return tachyon_sp1_baby_bear_poseidon2_two_adic_fri_verify(
+      pcs_, commitment_vec.commitment_vec(), domains.domains(),
+      opening_points.opening_points(), opened_values.opened_values(),
+      proof.proof(), challenger.challenger());
 }
 
 std::unique_ptr<TwoAdicFriPcs> new_two_adic_fri_pcs(size_t log_blowup,

--- a/vendors/sp1/src/baby_bear_poseidon2_two_adic_fri_pcs.cc
+++ b/vendors/sp1/src/baby_bear_poseidon2_two_adic_fri_pcs.cc
@@ -47,7 +47,7 @@ std::unique_ptr<OpeningProof> TwoAdicFriPcs::do_open(
     DuplexChallenger& challenger) const {
   std::unique_ptr<OpeningProof> ret(new OpeningProof);
   tachyon_sp1_baby_bear_poseidon2_two_adic_fri_open(
-      const_cast<tachyon_sp1_baby_bear_poseidon2_two_adic_fri*>(pcs_),
+      pcs_,
       prover_data_vec.tree_vec(), opening_points.opening_points(),
       challenger.challenger(), ret->opened_values_ptr(), ret->proof_ptr());
   return ret;


### PR DESCRIPTION
# Description

This PR enables rust binding for `TwoAdicFriPcs::Verify()`.