### PR TITLE
perf: compute twiddle cache just once per degree

### DIFF
--- a/tachyon/math/circle/BUILD.bazel
+++ b/tachyon/math/circle/BUILD.bazel
@@ -21,6 +21,7 @@ tachyon_cc_library(
         ":circle_traits_forward",
         "//tachyon/math/geometry:affine_point",
         "//tachyon/math/geometry:curve_type",
+        "@com_google_absl//absl/base",
     ],
 )
 

--- a/tachyon/math/circle/circle.h
+++ b/tachyon/math/circle/circle.h
@@ -1,6 +1,8 @@
 #ifndef TACHYON_MATH_CIRCLE_CIRCLE_H_
 #define TACHYON_MATH_CIRCLE_CIRCLE_H_
 
+#include "absl/base/call_once.h"
+
 #include "tachyon/math/circle/circle_traits_forward.h"
 #include "tachyon/math/geometry/affine_point.h"
 #include "tachyon/math/geometry/curve_type.h"
@@ -21,10 +23,13 @@ class Circle {
   constexpr static CurveType kType = CurveType::kCircle;
 
   static void Init() {
-    BaseField::Init();
-    ScalarField::Init();
+    static absl::once_flag once;
+    absl::call_once(once, []() {
+      BaseField::Init();
+      ScalarField::Init();
 
-    Config::Init();
+      Config::Init();
+    });
   }
 
   constexpr static bool IsOnCircle(const AffinePoint& point) {

--- a/tachyon/math/circle/generator/build_defs.bzl
+++ b/tachyon/math/circle/generator/build_defs.bzl
@@ -98,6 +98,7 @@ def generate_circle_points(
             scalar_field_dep,
             "//tachyon/math/circle:affine_point",
             "//tachyon/math/circle:circle",
+            "@com_google_absl//absl/base",
         ],
         **kwargs
     )

--- a/tachyon/math/circle/generator/cpu.h.tpl
+++ b/tachyon/math/circle/generator/cpu.h.tpl
@@ -1,4 +1,6 @@
 // clang-format off
+#include "absl/base/call_once.h"
+
 #include "tachyon/base/logging.h"
 #include "tachyon/math/circle/affine_point.h"
 #include "tachyon/math/circle/circle.h"
@@ -19,6 +21,12 @@ class %{class}CircleConfig {
   static Point2<BaseField> kGenerator;
 
   static void Init() {
+    static absl::once_flag once;
+    absl::call_once(once, &%{class}CircleConfig::DoInit);
+  }
+
+ private:
+  static void DoInit() {
 %{x_init}
 %{y_init}
     VLOG(1) << "%{namespace}::%{class} initialized";

--- a/tachyon/math/elliptic_curves/bls12/generator/build_defs.bzl
+++ b/tachyon/math/elliptic_curves/bls12/generator/build_defs.bzl
@@ -89,6 +89,7 @@ def generate_bls12_curves(
             "//tachyon/base:logging",
             "//tachyon/math/elliptic_curves/bls12:bls12_curve",
             "//tachyon/math/elliptic_curves/pairing:twist_type",
+            "@com_google_absl//absl/base",
         ],
         **kwargs
     )

--- a/tachyon/math/elliptic_curves/bls12/generator/curve.h.tpl
+++ b/tachyon/math/elliptic_curves/bls12/generator/curve.h.tpl
@@ -1,4 +1,6 @@
 // clang-format off
+#include "absl/base/call_once.h"
+
 #include "tachyon/base/logging.h"
 #include "tachyon/math/elliptic_curves/bls12/bls12_curve.h"
 #include "tachyon/math/elliptic_curves/pairing/twist_type.h"
@@ -28,9 +30,12 @@ class %{class}Config {
   using G2Curve = _G2Curve;
 
   static void Init() {
-    G1Curve::Init();
-    G2Curve::Init();
-    VLOG(1) << "%{namespace}::%{class} initialized";
+    static absl::once_flag once;
+    absl::call_once(once, [] {
+      G1Curve::Init();
+      G2Curve::Init();
+      VLOG(1) << "%{namespace}::%{class} initialized";
+    });
   }
 };
 

--- a/tachyon/math/elliptic_curves/bn/generator/build_defs.bzl
+++ b/tachyon/math/elliptic_curves/bn/generator/build_defs.bzl
@@ -101,6 +101,7 @@ def generate_bn_curves(
             "//tachyon/base:logging",
             "//tachyon/math/elliptic_curves/bn:bn_curve",
             "//tachyon/math/elliptic_curves/pairing:twist_type",
+            "@com_google_absl//absl/base",
         ],
         **kwargs
     )

--- a/tachyon/math/elliptic_curves/bn/generator/curve.h.tpl
+++ b/tachyon/math/elliptic_curves/bn/generator/curve.h.tpl
@@ -1,4 +1,6 @@
 // clang-format off
+#include "absl/base/call_once.h"
+
 #include "tachyon/base/logging.h"
 #include "tachyon/math/elliptic_curves/bn/bn_curve.h"
 #include "tachyon/math/elliptic_curves/pairing/twist_type.h"
@@ -35,6 +37,12 @@ class %{class}Config {
   static Fq2 kTwistMulByQY;
 
   static void Init() {
+    static absl::once_flag once;
+    absl::call_once(once, &%{class}Config::DoInit);
+  }
+
+ private:
+  static void DoInit() {
     // TODO(chokobole): This line below is needed by |GenerateInitExtField()|.
     // Later, I want GenerateInitExtField() to accept BasePrimeField as an argument.
     using BasePrimeField = Fq;

--- a/tachyon/math/elliptic_curves/pairing/BUILD.bazel
+++ b/tachyon/math/elliptic_curves/pairing/BUILD.bazel
@@ -41,6 +41,7 @@ tachyon_cc_library(
     deps = [
         ":ell_coeff",
         ":twist_type",
+        "@com_google_absl//absl/base",
     ],
 )
 

--- a/tachyon/math/elliptic_curves/pairing/pairing_friendly_curve.h
+++ b/tachyon/math/elliptic_curves/pairing/pairing_friendly_curve.h
@@ -3,6 +3,8 @@
 
 #include <vector>
 
+#include "absl/base/call_once.h"
+
 #include "tachyon/math/elliptic_curves/pairing/ell_coeff.h"
 #include "tachyon/math/elliptic_curves/pairing/twist_type.h"
 
@@ -19,8 +21,11 @@ class PairingFriendlyCurve {
   using G1AffinePoint = typename G1Curve::AffinePoint;
 
   static void Init() {
-    Config::Init();
-    Fp12::Init();
+    static absl::once_flag once;
+    absl::call_once(once, []() {
+      Config::Init();
+      Fp12::Init();
+    });
   }
 
  protected:

--- a/tachyon/math/elliptic_curves/short_weierstrass/BUILD.bazel
+++ b/tachyon/math/elliptic_curves/short_weierstrass/BUILD.bazel
@@ -48,6 +48,7 @@ tachyon_cc_library(
         "//tachyon/math/geometry:jacobian_point",
         "//tachyon/math/geometry:point_conversions",
         "//tachyon/math/geometry:projective_point",
+        "@com_google_absl//absl/base",
     ],
 )
 

--- a/tachyon/math/elliptic_curves/short_weierstrass/generator/build_defs.bzl
+++ b/tachyon/math/elliptic_curves/short_weierstrass/generator/build_defs.bzl
@@ -142,6 +142,7 @@ def generate_ec_points(
             scalar_field_dep,
             "//tachyon/math/elliptic_curves/short_weierstrass:points",
             "//tachyon/math/elliptic_curves/short_weierstrass:sw_curve",
+            "@com_google_absl//absl/base",
         ],
         **kwargs
     )

--- a/tachyon/math/elliptic_curves/short_weierstrass/generator/cpu.h.tpl
+++ b/tachyon/math/elliptic_curves/short_weierstrass/generator/cpu.h.tpl
@@ -1,4 +1,6 @@
 // clang-format off
+#include "absl/base/call_once.h"
+
 #include "tachyon/base/logging.h"
 #include "%{base_field_hdr}"
 #include "%{scalar_field_hdr}"
@@ -40,6 +42,16 @@ class %{class}CurveConfig {
   static mpz_class kGLVCoeffs[4];
 
   static void Init() {
+    static absl::once_flag once;
+    absl::call_once(once, &%{class}CurveConfig::DoInit);
+  }
+
+  constexpr static BaseField MulByA(const BaseField& v) {
+%{mul_by_a_code}
+  }
+
+ private:
+  static void DoInit() {
 %{a_init}
 %{b_init}
 %{x_init}
@@ -50,10 +62,6 @@ class %{class}CurveConfig {
 %{lambda_init_code}
 %{glv_coeffs_init_code}
     VLOG(1) << "%{namespace}::%{class} initialized";
-  }
-
-  constexpr static BaseField MulByA(const BaseField& v) {
-%{mul_by_a_code}
   }
 };
 

--- a/tachyon/math/elliptic_curves/short_weierstrass/sw_curve.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/sw_curve.h
@@ -3,6 +3,8 @@
 
 #include <utility>
 
+#include "absl/base/call_once.h"
+
 #include "tachyon/math/elliptic_curves/short_weierstrass/sw_curve_traits_forward.h"
 #include "tachyon/math/geometry/affine_point.h"
 #include "tachyon/math/geometry/curve_type.h"
@@ -35,10 +37,13 @@ class SWCurve {
   constexpr static CurveType kType = CurveType::kShortWeierstrass;
 
   static void Init() {
-    BaseField::Init();
-    ScalarField::Init();
+    static absl::once_flag once;
+    absl::call_once(once, []() {
+      BaseField::Init();
+      ScalarField::Init();
 
-    Config::Init();
+      Config::Init();
+    });
   }
 
   // Attempts to construct an affine point given an |x| coordinate. The

--- a/tachyon/math/elliptic_curves/short_weierstrass/test/BUILD.bazel
+++ b/tachyon/math/elliptic_curves/short_weierstrass/test/BUILD.bazel
@@ -10,5 +10,6 @@ tachyon_cc_library(
         "//tachyon/math/elliptic_curves/short_weierstrass:points",
         "//tachyon/math/elliptic_curves/short_weierstrass:sw_curve",
         "//tachyon/math/finite_fields/test:gf7",
+        "@com_google_absl//absl/base",
     ],
 )

--- a/tachyon/math/elliptic_curves/short_weierstrass/test/sw_curve_config.h
+++ b/tachyon/math/elliptic_curves/short_weierstrass/test/sw_curve_config.h
@@ -1,6 +1,8 @@
 #ifndef TACHYON_MATH_ELLIPTIC_CURVES_SHORT_WEIERSTRASS_TEST_SW_CURVE_CONFIG_H_
 #define TACHYON_MATH_ELLIPTIC_CURVES_SHORT_WEIERSTRASS_TEST_SW_CURVE_CONFIG_H_
 
+#include "absl/base/call_once.h"
+
 #include "tachyon/math/elliptic_curves/short_weierstrass/affine_point.h"
 #include "tachyon/math/elliptic_curves/short_weierstrass/jacobian_point.h"
 #include "tachyon/math/elliptic_curves/short_weierstrass/point_xyzz.h"
@@ -33,10 +35,13 @@ class SWCurveConfig {
   static Point2<BaseField> kGenerator;
 
   static void Init() {
-    kA = BaseField::Zero();
-    kB = BaseField(5);
-    kGenerator.x = BaseField(5);
-    kGenerator.y = BaseField(5);
+    static absl::once_flag once;
+    absl::call_once(once, []() {
+      kA = BaseField::Zero();
+      kB = BaseField(5);
+      kGenerator.x = BaseField(5);
+      kGenerator.y = BaseField(5);
+    });
   }
 };
 

--- a/tachyon/math/finite_fields/BUILD.bazel
+++ b/tachyon/math/finite_fields/BUILD.bazel
@@ -84,6 +84,7 @@ tachyon_cc_library(
     deps = [
         ":extension_field_traits_forward",
         ":quadratic_extension_field",
+        "@com_google_absl//absl/base",
     ],
 )
 
@@ -94,6 +95,7 @@ tachyon_cc_library(
         ":cubic_extension_field",
         ":extension_field_traits_forward",
         "//tachyon/math/base/gmp:gmp_util",
+        "@com_google_absl//absl/base",
     ],
 )
 
@@ -105,6 +107,7 @@ tachyon_cc_library(
         ":quadratic_extension_field",
         ":quartic_extension_field",
         "//tachyon/math/base/gmp:gmp_util",
+        "@com_google_absl//absl/base",
     ],
 )
 
@@ -116,6 +119,7 @@ tachyon_cc_library(
         ":extension_field_traits_forward",
         ":quadratic_extension_field",
         "//tachyon/math/base/gmp:gmp_util",
+        "@com_google_absl//absl/base",
     ],
 )
 
@@ -126,6 +130,7 @@ tachyon_cc_library(
         ":extension_field_traits_forward",
         ":quadratic_extension_field",
         "//tachyon/math/base/gmp:gmp_util",
+        "@com_google_absl//absl/base",
     ],
 )
 
@@ -209,6 +214,7 @@ tachyon_cc_library(
         "//tachyon/math/base:arithmetics",
         "//tachyon/math/base:byinverter",
         "//tachyon/math/base/gmp:gmp_util",
+        "@com_google_absl//absl/base",
         "@com_google_googletest//:gtest_prod",
     ],
 )
@@ -221,6 +227,7 @@ tachyon_cc_library(
         ":modulus",
         ":prime_field_base",
         "//tachyon/math/finite_fields/kernels:carry_chain",
+        "@com_google_absl//absl/base",
     ],
 )
 
@@ -281,6 +288,7 @@ tachyon_cc_library(
         ":extension_field_base",
         "//tachyon/base/buffer:copyable",
         "//tachyon/base/json",
+        "@com_google_absl//absl/base",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/types:span",
     ],
@@ -297,6 +305,7 @@ tachyon_cc_library(
         "//tachyon/base/strings:string_util",
         "//tachyon/build:build_config",
         "//tachyon/math/base:egcd",
+        "@com_google_absl//absl/base",
     ],
 )
 
@@ -310,6 +319,7 @@ tachyon_cc_library(
         "//tachyon/base/strings:string_number_conversions",
         "//tachyon/base/strings:string_util",
         "//tachyon/build:build_config",
+        "@com_google_absl//absl/base",
     ],
 )
 

--- a/tachyon/math/finite_fields/binary_fields/BUILD.bazel
+++ b/tachyon/math/finite_fields/binary_fields/BUILD.bazel
@@ -42,6 +42,7 @@ tachyon_cc_library(
         "//tachyon/base/strings:string_util",
         "//tachyon/build:build_config",
         "//tachyon/math/finite_fields:finite_field",
+        "@com_google_absl//absl/base",
     ],
 )
 

--- a/tachyon/math/finite_fields/binary_fields/binary_field.h
+++ b/tachyon/math/finite_fields/binary_fields/binary_field.h
@@ -14,6 +14,8 @@
 #include <tuple>
 #include <type_traits>
 
+#include "absl/base/call_once.h"
+
 #include "tachyon/base/logging.h"
 #include "tachyon/base/numerics/safe_conversions.h"
 #include "tachyon/base/random.h"
@@ -145,8 +147,11 @@ class BinaryField final : public FiniteField<BinaryField<_Config>> {
   }
 
   static void Init() {
-    Config::Init();
-    VLOG(1) << Config::kName << " initialized";
+    static absl::once_flag once;
+    absl::call_once(once, []() {
+      Config::Init();
+      VLOG(1) << Config::kName << " initialized";
+    });
   }
 
   constexpr value_type value() const { return value_; }

--- a/tachyon/math/finite_fields/fp12.h
+++ b/tachyon/math/finite_fields/fp12.h
@@ -9,6 +9,8 @@
 #include <type_traits>
 #include <utility>
 
+#include "absl/base/call_once.h"
+
 #include "tachyon/math/base/gmp/gmp_util.h"
 #include "tachyon/math/finite_fields/extension_field_traits_forward.h"
 #include "tachyon/math/finite_fields/quadratic_extension_field.h"
@@ -37,110 +39,8 @@ class Fp12 final : public QuadraticExtensionField<Fp12<Config>> {
   constexpr static uint32_t kDegreeOverBasePrimeField = 12;
 
   static void Init() {
-    using BaseFieldConfig = typename BaseField::Config;
-    // x⁶ = q = |BaseFieldConfig::kNonResidue|
-
-    Config::Init();
-
-    // αᴾ = (α₀ + α₁x)ᴾ
-    //    = α₀ᴾ + α₁ᴾxᴾ
-    //    = α₀ᴾ + α₁ᴾxᴾ⁻¹x
-    //    = α₀ᴾ + α₁ᴾ(x⁶)^((P - 1) / 6) * x
-    //    = α₀ᴾ + α₁ᴾωx, where ω is a sextic root of unity.
-
-    using UnpackedBasePrimeField = MaybeUnpack<BasePrimeField>;
-
-    constexpr size_t N = UnpackedBasePrimeField::kLimbNums;
-    // m₁ = P
-    mpz_class m1;
-    if constexpr (UnpackedBasePrimeField::Config::kModulusBits <= 32) {
-      m1 = mpz_class(UnpackedBasePrimeField::Config::kModulus);
-    } else {
-      gmp::WriteLimbs(UnpackedBasePrimeField::Config::kModulus.limbs, N, &m1);
-    }
-
-#define SET_M(d, d_prev) mpz_class m##d = m##d_prev * m1
-
-    // m₂ = m₁ * P = P²
-    SET_M(2, 1);
-    // m₃ = m₂ * P = P³
-    SET_M(3, 2);
-    // m₄ = m₃ * P = P⁴
-    SET_M(4, 3);
-    // m₅ = m₄ * P = P⁵
-    SET_M(5, 4);
-    // m₆ = m₅ * P = P⁶
-    SET_M(6, 5);
-    // m₇ = m₆ * P = P⁷
-    SET_M(7, 6);
-    // m₈ = m₇ * P = P⁸
-    SET_M(8, 7);
-    // m₉ = m₈ * P = P⁹
-    SET_M(9, 8);
-    // m₁₀ = m₉ * P = P¹⁰
-    SET_M(10, 9);
-    // m₁₁ = m₁₀ * P = P¹¹
-    SET_M(11, 10);
-
-#undef SET_M
-
-#define SET_EXP_GMP(d) mpz_class exp##d##_gmp = (m##d - 1) / mpz_class(6)
-
-    // exp₁ = (m₁ - 1) / 6 = (P¹ - 1) / 6
-    SET_EXP_GMP(1);
-    // exp₂ = (m₂ - 1) / 6 = (P² - 1) / 6
-    SET_EXP_GMP(2);
-    // exp₃ = (m₃ - 1) / 6 = (P³ - 1) / 6
-    SET_EXP_GMP(3);
-    // exp₄ = (m₄ - 1) / 6 = (P⁴ - 1) / 6
-    SET_EXP_GMP(4);
-    // exp₅ = (m₅ - 1) / 6 = (P⁵ - 1) / 6
-    SET_EXP_GMP(5);
-    // exp₆ = (m₅ - 1) / 6 = (P⁶ - 1) / 6
-    SET_EXP_GMP(6);
-    // exp₇ = (m₆ - 1) / 6 = (P⁷ - 1) / 6
-    SET_EXP_GMP(7);
-    // exp₈ = (m₇ - 1) / 6 = (P⁸ - 1) / 6
-    SET_EXP_GMP(8);
-    // exp₉ = (m₈ - 1) / 6 = (P⁹ - 1) / 6
-    SET_EXP_GMP(9);
-    // exp₁₀ = (m₉ - 1) / 6 = (P¹⁰ - 1) / 6
-    SET_EXP_GMP(10);
-    // exp₁₁ = (m₁₀ - 1) / 6 = (P¹¹ - 1) / 6
-    SET_EXP_GMP(11);
-
-#undef SET_EXP_GMP
-
-    // |kFrobeniusCoeffs[0]| = q^((P⁰ - 1) / 6)
-    Config::kFrobeniusCoeffs[0] = FrobeniusCoefficient::One();
-#define SET_FROBENIUS_COEFF(d)                \
-  BigInt<d * N> exp##d;                       \
-  gmp::CopyLimbs(exp##d##_gmp, exp##d.limbs); \
-  Config::kFrobeniusCoeffs[d] = BaseFieldConfig::kNonResidue.Pow(exp##d)
-    // |kFrobeniusCoeffs[1]| = q^(exp₁) = q^((P¹ - 1) / 6)
-    SET_FROBENIUS_COEFF(1);
-    // |kFrobeniusCoeffs[2]| = q^(exp₂) = q^((P² - 1) / 6)
-    SET_FROBENIUS_COEFF(2);
-    // |kFrobeniusCoeffs[3]| = q^(exp₃) = q^((P³ - 1) / 6)
-    SET_FROBENIUS_COEFF(3);
-    // |kFrobeniusCoeffs[4]| = q^(exp₄) = q^((P⁴ - 1) / 6)
-    SET_FROBENIUS_COEFF(4);
-    // |kFrobeniusCoeffs[5]| = q^(exp₅) = q^((P⁵ - 1) / 6)
-    SET_FROBENIUS_COEFF(5);
-    // |kFrobeniusCoeffs[6]| = q^(exp₆) = q^((P⁶ - 1) / 6)
-    SET_FROBENIUS_COEFF(6);
-    // |kFrobeniusCoeffs[7]| = q^(exp₇) = q^((P⁷ - 1) / 6)
-    SET_FROBENIUS_COEFF(7);
-    // |kFrobeniusCoeffs[8]| = q^(exp₈) = q^((P⁸ - 1) / 6)
-    SET_FROBENIUS_COEFF(8);
-    // |kFrobeniusCoeffs[9]| = q^(exp₉) = q^((P⁹ - 1) / 6)
-    SET_FROBENIUS_COEFF(9);
-    // |kFrobeniusCoeffs[10]| = q^(exp₁₀) = q^((P¹⁰ - 1) / 6)
-    SET_FROBENIUS_COEFF(10);
-    // |kFrobeniusCoeffs[11]| = q^(exp₁₁) = q^((P¹¹ - 1) / 6)
-    SET_FROBENIUS_COEFF(11);
-
-#undef SET_FROBENIUS_COEFF
+    static absl::once_flag once;
+    absl::call_once(once, &Fp12::DoInit);
   }
 
   // CyclotomicMultiplicativeSubgroup methods
@@ -360,6 +260,114 @@ class Fp12 final : public QuadraticExtensionField<Fp12<Config>> {
         b = a.Square();
       }
     }
+  }
+
+ private:
+  static void DoInit() {
+    using BaseFieldConfig = typename BaseField::Config;
+    // x⁶ = q = |BaseFieldConfig::kNonResidue|
+
+    Config::Init();
+
+    // αᴾ = (α₀ + α₁x)ᴾ
+    //    = α₀ᴾ + α₁ᴾxᴾ
+    //    = α₀ᴾ + α₁ᴾxᴾ⁻¹x
+    //    = α₀ᴾ + α₁ᴾ(x⁶)^((P - 1) / 6) * x
+    //    = α₀ᴾ + α₁ᴾωx, where ω is a sextic root of unity.
+
+    using UnpackedBasePrimeField = MaybeUnpack<BasePrimeField>;
+
+    constexpr size_t N = UnpackedBasePrimeField::kLimbNums;
+    // m₁ = P
+    mpz_class m1;
+    if constexpr (UnpackedBasePrimeField::Config::kModulusBits <= 32) {
+      m1 = mpz_class(UnpackedBasePrimeField::Config::kModulus);
+    } else {
+      gmp::WriteLimbs(UnpackedBasePrimeField::Config::kModulus.limbs, N, &m1);
+    }
+
+#define SET_M(d, d_prev) mpz_class m##d = m##d_prev * m1
+
+    // m₂ = m₁ * P = P²
+    SET_M(2, 1);
+    // m₃ = m₂ * P = P³
+    SET_M(3, 2);
+    // m₄ = m₃ * P = P⁴
+    SET_M(4, 3);
+    // m₅ = m₄ * P = P⁵
+    SET_M(5, 4);
+    // m₆ = m₅ * P = P⁶
+    SET_M(6, 5);
+    // m₇ = m₆ * P = P⁷
+    SET_M(7, 6);
+    // m₈ = m₇ * P = P⁸
+    SET_M(8, 7);
+    // m₉ = m₈ * P = P⁹
+    SET_M(9, 8);
+    // m₁₀ = m₉ * P = P¹⁰
+    SET_M(10, 9);
+    // m₁₁ = m₁₀ * P = P¹¹
+    SET_M(11, 10);
+
+#undef SET_M
+
+#define SET_EXP_GMP(d) mpz_class exp##d##_gmp = (m##d - 1) / mpz_class(6)
+
+    // exp₁ = (m₁ - 1) / 6 = (P¹ - 1) / 6
+    SET_EXP_GMP(1);
+    // exp₂ = (m₂ - 1) / 6 = (P² - 1) / 6
+    SET_EXP_GMP(2);
+    // exp₃ = (m₃ - 1) / 6 = (P³ - 1) / 6
+    SET_EXP_GMP(3);
+    // exp₄ = (m₄ - 1) / 6 = (P⁴ - 1) / 6
+    SET_EXP_GMP(4);
+    // exp₅ = (m₅ - 1) / 6 = (P⁵ - 1) / 6
+    SET_EXP_GMP(5);
+    // exp₆ = (m₅ - 1) / 6 = (P⁶ - 1) / 6
+    SET_EXP_GMP(6);
+    // exp₇ = (m₆ - 1) / 6 = (P⁷ - 1) / 6
+    SET_EXP_GMP(7);
+    // exp₈ = (m₇ - 1) / 6 = (P⁸ - 1) / 6
+    SET_EXP_GMP(8);
+    // exp₉ = (m₈ - 1) / 6 = (P⁹ - 1) / 6
+    SET_EXP_GMP(9);
+    // exp₁₀ = (m₉ - 1) / 6 = (P¹⁰ - 1) / 6
+    SET_EXP_GMP(10);
+    // exp₁₁ = (m₁₀ - 1) / 6 = (P¹¹ - 1) / 6
+    SET_EXP_GMP(11);
+
+#undef SET_EXP_GMP
+
+    // |kFrobeniusCoeffs[0]| = q^((P⁰ - 1) / 6)
+    Config::kFrobeniusCoeffs[0] = FrobeniusCoefficient::One();
+#define SET_FROBENIUS_COEFF(d)                \
+  BigInt<d * N> exp##d;                       \
+  gmp::CopyLimbs(exp##d##_gmp, exp##d.limbs); \
+  Config::kFrobeniusCoeffs[d] = BaseFieldConfig::kNonResidue.Pow(exp##d)
+    // |kFrobeniusCoeffs[1]| = q^(exp₁) = q^((P¹ - 1) / 6)
+    SET_FROBENIUS_COEFF(1);
+    // |kFrobeniusCoeffs[2]| = q^(exp₂) = q^((P² - 1) / 6)
+    SET_FROBENIUS_COEFF(2);
+    // |kFrobeniusCoeffs[3]| = q^(exp₃) = q^((P³ - 1) / 6)
+    SET_FROBENIUS_COEFF(3);
+    // |kFrobeniusCoeffs[4]| = q^(exp₄) = q^((P⁴ - 1) / 6)
+    SET_FROBENIUS_COEFF(4);
+    // |kFrobeniusCoeffs[5]| = q^(exp₅) = q^((P⁵ - 1) / 6)
+    SET_FROBENIUS_COEFF(5);
+    // |kFrobeniusCoeffs[6]| = q^(exp₆) = q^((P⁶ - 1) / 6)
+    SET_FROBENIUS_COEFF(6);
+    // |kFrobeniusCoeffs[7]| = q^(exp₇) = q^((P⁷ - 1) / 6)
+    SET_FROBENIUS_COEFF(7);
+    // |kFrobeniusCoeffs[8]| = q^(exp₈) = q^((P⁸ - 1) / 6)
+    SET_FROBENIUS_COEFF(8);
+    // |kFrobeniusCoeffs[9]| = q^(exp₉) = q^((P⁹ - 1) / 6)
+    SET_FROBENIUS_COEFF(9);
+    // |kFrobeniusCoeffs[10]| = q^(exp₁₀) = q^((P¹⁰ - 1) / 6)
+    SET_FROBENIUS_COEFF(10);
+    // |kFrobeniusCoeffs[11]| = q^(exp₁₁) = q^((P¹¹ - 1) / 6)
+    SET_FROBENIUS_COEFF(11);
+
+#undef SET_FROBENIUS_COEFF
   }
 };
 

--- a/tachyon/math/finite_fields/fp2.h
+++ b/tachyon/math/finite_fields/fp2.h
@@ -6,6 +6,8 @@
 #ifndef TACHYON_MATH_FINITE_FIELDS_FP2_H_
 #define TACHYON_MATH_FINITE_FIELDS_FP2_H_
 
+#include "absl/base/call_once.h"
+
 #include "tachyon/math/finite_fields/extension_field_traits_forward.h"
 #include "tachyon/math/finite_fields/quadratic_extension_field.h"
 
@@ -30,6 +32,12 @@ class Fp2 final : public QuadraticExtensionField<Fp2<Config>> {
   constexpr static uint32_t kDegreeOverBasePrimeField = 2;
 
   static void Init() {
+    static absl::once_flag once;
+    absl::call_once(once, &Fp2::DoInit);
+  }
+
+ private:
+  static void DoInit() {
     Config::Init();
 
     // αᴾ = (α₀ + α₁x)ᴾ

--- a/tachyon/math/finite_fields/fp3.h
+++ b/tachyon/math/finite_fields/fp3.h
@@ -8,6 +8,8 @@
 
 #include <type_traits>
 
+#include "absl/base/call_once.h"
+
 #include "tachyon/math/base/gmp/gmp_util.h"
 #include "tachyon/math/finite_fields/cubic_extension_field.h"
 #include "tachyon/math/finite_fields/extension_field_traits_forward.h"
@@ -33,6 +35,12 @@ class Fp3 final : public CubicExtensionField<Fp3<Config>> {
   constexpr static uint32_t kDegreeOverBasePrimeField = 3;
 
   static void Init() {
+    static absl::once_flag once;
+    absl::call_once(once, &Fp3::DoInit);
+  }
+
+ private:
+  static void DoInit() {
     Config::Init();
     // x³ = q = |Config::kNonResidue|
 

--- a/tachyon/math/finite_fields/fp4.h
+++ b/tachyon/math/finite_fields/fp4.h
@@ -8,6 +8,8 @@
 
 #include <type_traits>
 
+#include "absl/base/call_once.h"
+
 #include "tachyon/math/base/gmp/gmp_util.h"
 #include "tachyon/math/finite_fields/extension_field_traits_forward.h"
 #include "tachyon/math/finite_fields/quadratic_extension_field.h"
@@ -35,6 +37,12 @@ class Fp4<Config, std::enable_if_t<Config::kDegreeOverBaseField == 2>> final
   constexpr static uint32_t kDegreeOverBasePrimeField = 4;
 
   static void Init() {
+    static absl::once_flag once;
+    absl::call_once(once, &Fp4::DoInit);
+  }
+
+ private:
+  static void DoInit() {
     using BaseFieldConfig = typename BaseField::Config;
     // x⁴ = q = |BaseFieldConfig::kNonResidue|
 
@@ -116,6 +124,12 @@ class Fp4<Config, std::enable_if_t<Config::kDegreeOverBaseField == 4>> final
   constexpr static uint32_t kDegreeOverBasePrimeField = 4;
 
   static void Init() {
+    static absl::once_flag once;
+    absl::call_once(once, &Fp4::DoInit);
+  }
+
+ private:
+  static void DoInit() {
     Config::Init();
     QuarticExtensionField<Fp4<Config>>::Init();
     // x⁴ = q = |Config::kNonResidue|

--- a/tachyon/math/finite_fields/generator/ext_field_generator/BUILD.bazel
+++ b/tachyon/math/finite_fields/generator/ext_field_generator/BUILD.bazel
@@ -13,6 +13,7 @@ tachyon_cc_binary(
         "//tachyon/base/strings:string_number_conversions",
         "//tachyon/build:cc_writer",
         "//tachyon/math/finite_fields/generator:generator_util",
+        "@com_google_absl//absl/base",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/strings",
     ],

--- a/tachyon/math/finite_fields/generator/ext_field_generator/fp.h.tpl
+++ b/tachyon/math/finite_fields/generator/ext_field_generator/fp.h.tpl
@@ -1,4 +1,6 @@
 // clang-format off
+#include "absl/base/call_once.h"
+
 #include "tachyon/base/logging.h"
 #include "tachyon/math/finite_fields/fp%{degree}.h"
 #include "%{base_field_hdr}"
@@ -31,6 +33,12 @@ class %{class}Config {
   }
 
   static void Init() {
+    static absl::once_flag once;
+    absl::call_once(once, %{class}Config::DoInit);
+  }
+
+ private:
+  static void DoInit() {
     BaseField::Init();
 %{init_code}
     VLOG(1) << "%{namespace}::%{class} initialized";

--- a/tachyon/math/finite_fields/generator/prime_field_generator/build_defs.bzl
+++ b/tachyon/math/finite_fields/generator/prime_field_generator/build_defs.bzl
@@ -200,6 +200,7 @@ def _do_generate_prime_fields(
         "//tachyon:export",
         "//tachyon/build:build_config",
         "//tachyon/math/base:big_int",
+        "@com_google_absl//absl/base",
     ]
 
     tachyon_cc_library(
@@ -297,12 +298,14 @@ def _do_generate_prime_fields(
                     ":{}_fail".format(name),
                     "//tachyon/math/base:byinverter",
                     "//tachyon/math/finite_fields:prime_field_base",
+                    "@com_google_absl//absl/base",
                 ],
                 "@kroma_network_tachyon//:macos_x86_64": [
                     ":{}_object".format(name),
                     ":{}_fail".format(name),
                     "//tachyon/math/base:byinverter",
                     "//tachyon/math/finite_fields:prime_field_base",
+                    "@com_google_absl//absl/base",
                 ],
                 "//conditions:default": ["//tachyon/math/finite_fields:prime_field_fallback"],
             }),

--- a/tachyon/math/finite_fields/generator/prime_field_generator/prime_field_config.h.tpl
+++ b/tachyon/math/finite_fields/generator/prime_field_generator/prime_field_config.h.tpl
@@ -1,4 +1,6 @@
 // clang-format off
+#include "absl/base/call_once.h"
+
 #include "tachyon/export.h"
 #include "tachyon/build/build_config.h"
 #include "tachyon/math/base/big_int.h"
@@ -83,6 +85,12 @@ class TACHYON_EXPORT %{class}Config {
 %{endif kHasTwoAdicRootOfUnity}
 
   static void Init() {
+    static absl::once_flag once;
+    absl::call_once(once, &%{class}Config::DoInit);
+  }
+
+ private:
+  static void DoInit() {
 %{if kHasTwoAdicRootOfUnity}
     kSubgroupGenerator = BigInt<%{n}>({
       %{subgroup_generator}

--- a/tachyon/math/finite_fields/generator/prime_field_generator/prime_field_x86.h.tpl
+++ b/tachyon/math/finite_fields/generator/prime_field_generator/prime_field_x86.h.tpl
@@ -6,6 +6,8 @@
 #include <string>
 #include <optional>
 
+#include "absl/base/call_once.h"
+
 #include "tachyon/math/base/big_int.h"
 #include "tachyon/math/base/gmp/gmp_util.h"
 #include "tachyon/math/finite_fields/prime_field_base.h"
@@ -117,8 +119,11 @@ class PrimeField<_Config, std::enable_if_t<_Config::%{asm_flag}>> final
   }
 
   static void Init() {
-    Config::Init();
-    VLOG(1) << Config::kName << " initialized";
+    static absl::once_flag once;
+    absl::call_once(once, []() {
+      Config::Init();
+      VLOG(1) << Config::kName << " initialized";
+    });
   }
 
   const value_type& value() const { return value_; }

--- a/tachyon/math/finite_fields/generator/prime_field_generator/small_prime_field_config.h.tpl
+++ b/tachyon/math/finite_fields/generator/prime_field_generator/small_prime_field_config.h.tpl
@@ -1,6 +1,8 @@
 // clang-format off
 #include <stdint.h>
 
+#include "absl/base/call_once.h"
+
 #include "tachyon/export.h"
 #include "tachyon/build/build_config.h"
 #include "tachyon/math/base/big_int.h"
@@ -39,10 +41,13 @@ class TACHYON_EXPORT %{class}Config {
 %{endif kHasTwoAdicRootOfUnity}
 
   static void Init() {
+    static absl::once_flag once;
+    absl::call_once(once, []() {
 %{if kHasTwoAdicRootOfUnity}
-    kSubgroupGenerator = %{subgroup_generator};
-    kTwoAdicRootOfUnity = %{two_adic_root_of_unity};
+      kSubgroupGenerator = %{subgroup_generator};
+      kTwoAdicRootOfUnity = %{two_adic_root_of_unity};
 %{endif kHasTwoAdicRootOfUnity}
+    });
   }
 
   constexpr static uint32_t AddMod(uint32_t a, uint32_t b) {

--- a/tachyon/math/finite_fields/goldilocks/internal/BUILD.bazel
+++ b/tachyon/math/finite_fields/goldilocks/internal/BUILD.bazel
@@ -54,6 +54,7 @@ tachyon_cc_library(
         "//tachyon/base/strings:string_number_conversions",
         "//tachyon/base/strings:string_util",
         "//tachyon/math/finite_fields:prime_field_base",
+        "@com_google_absl//absl/base",
         "@goldilocks//:base_field",
     ]),
 )

--- a/tachyon/math/finite_fields/goldilocks/internal/goldilocks_prime_field_x86_special.h
+++ b/tachyon/math/finite_fields/goldilocks/internal/goldilocks_prime_field_x86_special.h
@@ -7,6 +7,8 @@
 #include <optional>
 #include <string>
 
+#include "absl/base/call_once.h"
+
 #include "tachyon/math/finite_fields/goldilocks/internal/goldilocks_config.h"
 #include "tachyon/math/finite_fields/prime_field_base.h"
 
@@ -50,8 +52,11 @@ class PrimeField<_Config, std::enable_if_t<_Config::kIsTachyonMathGoldilocks>>
 #endif
 
   static void Init() {
-    Config::Init();
-    VLOG(1) << Config::kName << " initialized";
+    static absl::once_flag once;
+    absl::call_once(once, []() {
+      Config::Init();
+      VLOG(1) << Config::kName << " initialized";
+    });
   }
 
   // NOTE(chokobole): To be consistent with `PrimeField<F>` defined in

--- a/tachyon/math/finite_fields/prime_field_fallback.h
+++ b/tachyon/math/finite_fields/prime_field_fallback.h
@@ -13,6 +13,7 @@
 #include <string>
 #include <utility>
 
+#include "absl/base/call_once.h"
 #include "gtest/gtest_prod.h"
 
 #include "tachyon/base/logging.h"
@@ -124,8 +125,11 @@ class PrimeField<_Config, std::enable_if_t<!_Config::kUseAsm &&
   }
 
   static void Init() {
-    Config::Init();
-    VLOG(1) << Config::kName << " initialized";
+    static absl::once_flag once;
+    absl::call_once(once, []() {
+      Config::Init();
+      VLOG(1) << Config::kName << " initialized";
+    });
   }
 
   const value_type& value() const { return value_; }

--- a/tachyon/math/finite_fields/prime_field_gpu.h
+++ b/tachyon/math/finite_fields/prime_field_gpu.h
@@ -13,6 +13,8 @@
 #include <string>
 #include <utility>
 
+#include "absl/base/call_once.h"
+
 #if TACHYON_CUDA
 #include "third_party/gpus/cuda/include/cuda_runtime.h"
 #endif
@@ -107,8 +109,11 @@ class PrimeFieldGpu final : public PrimeFieldBase<PrimeFieldGpu<_Config>> {
   }
 
   static void Init() {
-    Config::Init();
-    VLOG(1) << Config::kName << " initialized";
+    static absl::once_flag once;
+    absl::call_once(once, []() {
+      Config::Init();
+      VLOG(1) << Config::kName << " initialized";
+    });
   }
 
   constexpr const value_type& value() const { return value_; }

--- a/tachyon/math/finite_fields/quartic_extension_field.h
+++ b/tachyon/math/finite_fields/quartic_extension_field.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <utility>
 
+#include "absl/base/call_once.h"
 #include "absl/strings/substitute.h"
 #include "absl/types/span.h"
 
@@ -107,22 +108,25 @@ class QuarticExtensionField : public CyclotomicMultiplicativeSubgroup<Derived>,
   ConstIterator end() const { return {static_cast<const Derived&>(*this), 4}; }
 
   static void Init() {
-    kInv3 = *BaseField(3).Inverse();
-    kInv4 = *BaseField(4).Inverse();
-    kInv6 = *BaseField(6).Inverse();
-    kInv12 = *BaseField(12).Inverse();
-    kInv20 = *BaseField(20).Inverse();
-    kInv24 = *BaseField(24).Inverse();
-    kInv30 = *BaseField(30).Inverse();
-    kInv120 = *BaseField(120).Inverse();
-    kNeg5 = -BaseField(5);
-    kNegInv2 = -BaseField::TwoInv();
-    kNegInv3 = -kInv3;
-    kNegInv4 = -kInv4;
-    kNegInv6 = -kInv6;
-    kNegInv12 = -kInv12;
-    kNegInv24 = -kInv24;
-    kNegInv120 = -kInv120;
+    static absl::once_flag once;
+    absl::call_once(once, []() {
+      kInv3 = *BaseField(3).Inverse();
+      kInv4 = *BaseField(4).Inverse();
+      kInv6 = *BaseField(6).Inverse();
+      kInv12 = *BaseField(12).Inverse();
+      kInv20 = *BaseField(20).Inverse();
+      kInv24 = *BaseField(24).Inverse();
+      kInv30 = *BaseField(30).Inverse();
+      kInv120 = *BaseField(120).Inverse();
+      kNeg5 = -BaseField(5);
+      kNegInv2 = -BaseField::TwoInv();
+      kNegInv3 = -kInv3;
+      kNegInv4 = -kInv4;
+      kNegInv6 = -kInv6;
+      kNegInv12 = -kInv12;
+      kNegInv24 = -kInv24;
+      kNegInv120 = -kInv120;
+    });
   }
 
   constexpr bool IsZero() const {

--- a/tachyon/math/finite_fields/small_prime_field.h
+++ b/tachyon/math/finite_fields/small_prime_field.h
@@ -12,6 +12,8 @@
 #include <optional>
 #include <string>
 
+#include "absl/base/call_once.h"
+
 #include "tachyon/base/logging.h"
 #include "tachyon/base/random.h"
 #include "tachyon/base/strings/string_number_conversions.h"
@@ -87,8 +89,11 @@ class PrimeField<_Config, std::enable_if_t<(_Config::kModulusBits <= 32) &&
   }
 
   static void Init() {
-    Config::Init();
-    VLOG(1) << Config::kName << " initialized";
+    static absl::once_flag once;
+    absl::call_once(once, []() {
+      Config::Init();
+      VLOG(1) << Config::kName << " initialized";
+    });
   }
 
   constexpr value_type value() const { return value_; }

--- a/tachyon/math/finite_fields/small_prime_field_mont.h
+++ b/tachyon/math/finite_fields/small_prime_field_mont.h
@@ -12,6 +12,8 @@
 #include <optional>
 #include <string>
 
+#include "absl/base/call_once.h"
+
 #include "tachyon/base/logging.h"
 #include "tachyon/base/random.h"
 #include "tachyon/base/strings/string_number_conversions.h"
@@ -104,8 +106,11 @@ class PrimeField<_Config, std::enable_if_t<(_Config::kModulusBits <= 32) &&
   }
 
   static void Init() {
-    Config::Init();
-    VLOG(1) << Config::kName << " initialized";
+    static absl::once_flag once;
+    absl::call_once(once, []() {
+      Config::Init();
+      VLOG(1) << Config::kName << " initialized";
+    });
   }
 
   constexpr value_type value() const { return value_; }

--- a/tachyon/math/polynomials/univariate/BUILD.bazel
+++ b/tachyon/math/polynomials/univariate/BUILD.bazel
@@ -67,6 +67,7 @@ tachyon_cc_library(
     hdrs = ["radix2_evaluation_domain.h"],
     deps = [
         ":evaluations_utils",
+        ":radix2_twiddle_cache",
         ":two_adic_subgroup",
         ":univariate_evaluation_domain",
         "//tachyon/base:bits",
@@ -81,6 +82,19 @@ tachyon_cc_library(
         "@com_google_absl//absl/types:span",
         "@com_google_googletest//:gtest_prod",
         "@eigen_archive//:eigen3",
+    ],
+)
+
+tachyon_cc_library(
+    name = "radix2_twiddle_cache",
+    hdrs = ["radix2_twiddle_cache.h"],
+    deps = [
+        "//tachyon/base:no_destructor",
+        "//tachyon/base:openmp_util",
+        "//tachyon/base:profiler",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/synchronization",
     ],
 )
 

--- a/tachyon/math/polynomials/univariate/radix2_evaluation_domain.h
+++ b/tachyon/math/polynomials/univariate/radix2_evaluation_domain.h
@@ -41,6 +41,7 @@
 #include "tachyon/math/matrix/matrix_types.h"
 #include "tachyon/math/matrix/matrix_utils.h"
 #include "tachyon/math/polynomials/univariate/evaluations_utils.h"
+#include "tachyon/math/polynomials/univariate/radix2_twiddle_cache.h"
 #include "tachyon/math/polynomials/univariate/two_adic_subgroup.h"
 #include "tachyon/math/polynomials/univariate/univariate_evaluation_domain.h"
 #include "tachyon/math/polynomials/univariate/univariate_polynomial.h"
@@ -82,7 +83,8 @@ class Radix2EvaluationDomain
   static std::unique_ptr<Radix2EvaluationDomain> Create(size_t num_coeffs) {
     auto ret = absl::WrapUnique(new Radix2EvaluationDomain(
         absl::bit_ceil(num_coeffs), base::bits::SafeLog2Ceiling(num_coeffs)));
-    ret->PrepareRootsVecCache(/*packed_vec_only=*/false);
+    ret->cache_ =
+        Radix2TwiddleCache<F>::GetItem(ret.get(), /*packed_vec_only=*/false);
     return ret;
   }
 
@@ -100,17 +102,19 @@ class Radix2EvaluationDomain
     if constexpr (F::Config::kModulusBits > 32) {
       NOTREACHED();
     }
-    CHECK_GT(roots_vec_.size(), size_t{0});
-    CHECK_GT(packed_roots_vec_.size(), size_t{0});
+    CHECK_GT(cache_->roots_vec.size(), size_t{0});
+    CHECK_GT(cache_->packed_roots_vec.size(), size_t{0});
     CHECK_EQ(this->size_, static_cast<size_t>(mat.rows()));
 
     // The first half looks like a normal DIT.
     ReverseMatrixIndexBits(mat);
-    RunParallelRowChunks(mat, roots_vec_.back(), packed_roots_vec_[0]);
+    RunParallelRowChunks(mat, cache_->roots_vec.back(),
+                         cache_->packed_roots_vec[0]);
 
     // For the second half, we flip the DIT, working in bit-reversed order.
     ReverseMatrixIndexBits(mat);
-    RunParallelRowChunksReversed(mat, rev_roots_vec_, packed_roots_vec_[1]);
+    RunParallelRowChunksReversed(mat, cache_->rev_roots_vec,
+                                 cache_->packed_roots_vec[1]);
     ReverseMatrixIndexBits(mat);
   }
 
@@ -121,18 +125,19 @@ class Radix2EvaluationDomain
     if constexpr (F::Config::kModulusBits > 32) {
       NOTREACHED();
     }
-    CHECK_GT(roots_vec_.size(), size_t{0});
-    CHECK_GT(packed_roots_vec_.size(), size_t{0});
+    CHECK_GT(cache_->roots_vec.size(), size_t{0});
+    CHECK_GT(cache_->packed_roots_vec.size(), size_t{0});
     CHECK_EQ(this->size_, static_cast<size_t>(mat.rows()));
 
     // The first half looks like a normal DIT.
     ReverseMatrixIndexBits(mat);
-    RunParallelRowChunks(mat, inv_roots_vec_[0], packed_inv_roots_vec_[0]);
+    RunParallelRowChunks(mat, cache_->inv_roots_vec[0],
+                         cache_->packed_inv_roots_vec[0]);
 
     // For the second half, we flip the DIT, working in bit-reversed order.
     ReverseMatrixIndexBits(mat);
-    RunParallelRowChunksReversed(mat, rev_inv_roots_vec_,
-                                 packed_inv_roots_vec_[1]);
+    RunParallelRowChunksReversed(mat, cache_->rev_inv_roots_vec,
+                                 cache_->packed_inv_roots_vec[1]);
     // We skip the final bit-reversal, since the next FFT expects bit-reversed
     // input.
 
@@ -161,16 +166,17 @@ class Radix2EvaluationDomain
     uint32_t log_size_of_group = base::bits::CheckedLog2(rows);
     auto domain =
         absl::WrapUnique(new Radix2EvaluationDomain(rows, log_size_of_group));
-    domain->PrepareRootsVecCache(/*packed_vec_only=*/true);
+    domain->cache_ =
+        Radix2TwiddleCache<F>::GetItem(domain.get(), /*packed_vec_only=*/true);
 
     // The first half looks like a normal DIT.
-    domain->RunParallelRowChunks(ret, domain->roots_vec_.back(),
-                                 domain->packed_roots_vec_[0]);
+    domain->RunParallelRowChunks(ret, domain->cache_->roots_vec.back(),
+                                 domain->cache_->packed_roots_vec[0]);
 
     // For the second half, we flip the DIT, working in bit-reversed order.
     ReverseMatrixIndexBits(ret);
-    domain->RunParallelRowChunksReversed(ret, domain->rev_roots_vec_,
-                                         domain->packed_roots_vec_[1]);
+    domain->RunParallelRowChunksReversed(ret, domain->cache_->rev_roots_vec,
+                                         domain->cache_->packed_roots_vec[1]);
     ReverseMatrixIndexBits(ret);
     return ret;
   }
@@ -290,91 +296,12 @@ class Radix2EvaluationDomain
     }
   }
 
-  // clang-format off
-  // Precompute |roots_vec_| and |inv_roots_vec_| for |OutInHelper()| and |InOutHelper()|.
-  // Here is an example where |this->size_| equals 32.
-  // |roots_vec_| = [
-  //   [1],
-  //   [1, ω⁸],
-  //   [1, ω⁴, ω⁸, ω¹²],
-  //   [1, ω², ω⁴, ω⁶, ω⁸, ω¹⁰, ω¹², ω¹⁴],
-  //   [1, ω, ω², ω³, ω⁴, ω⁵, ω⁶, ω⁷, ω⁸, ω⁹, ω¹⁰, ω¹¹, ω¹², ω¹³, ω¹⁴, ω¹⁵],
-  // ]
-  // |inv_roots_vec_| = [
-  //   [1, ω⁻¹, ω⁻², ω⁻³, ω⁻⁴, ω⁻⁵, ω⁻⁶, ω⁻⁷, ω⁻⁸, ω⁻⁹, ω⁻¹⁰, ω⁻¹¹, ω⁻¹², ω⁻¹³, ω⁻¹⁴, ω⁻¹⁵],
-  //   [1, ω⁻², ω⁻⁴, ω⁻⁶, ω⁻⁸, ω⁻¹⁰, ω⁻¹², ω⁻¹⁴],
-  //   [1, ω⁻⁴, ω⁻⁸, ω⁻¹²],
-  //   [1, ω⁻⁸],
-  //   [1],
-  // ]
-  // clang-format on
-  CONSTEXPR_IF_NOT_OPENMP void PrepareRootsVecCache(bool packed_vec_only) {
-    TRACE_EVENT("EvaluationDomain", "PrepareRootsVecCache");
-    if (this->log_size_of_group_ == 0) return;
-
-    roots_vec_.resize(this->log_size_of_group_);
-    inv_roots_vec_.resize(this->log_size_of_group_);
-
-    size_t vec_largest_size = this->size_ / 2;
-
-    // Compute biggest vector of |roots_vec_| and |inv_roots_vec_| first.
-    std::vector<F> largest =
-        this->GetRootsOfUnity(vec_largest_size, this->group_gen_);
-    std::vector<F> largest_inv =
-        this->GetRootsOfUnity(vec_largest_size, this->group_gen_inv_);
-
-    if constexpr (F::Config::kModulusBits <= 32) {
-      TRACE_EVENT("Subtask", "PreparePackedVec");
-      packed_roots_vec_.resize(2);
-      packed_inv_roots_vec_.resize(2);
-      packed_roots_vec_[0].resize(vec_largest_size);
-      packed_inv_roots_vec_[0].resize(vec_largest_size);
-      packed_roots_vec_[1].resize(vec_largest_size);
-      packed_inv_roots_vec_[1].resize(vec_largest_size);
-      rev_roots_vec_ = SwapBitRevElements(largest);
-      rev_inv_roots_vec_ = SwapBitRevElements(largest_inv);
-      OMP_PARALLEL_FOR(size_t i = 0; i < vec_largest_size; ++i) {
-        packed_roots_vec_[0][i] = PackedPrimeField::Broadcast(largest[i]);
-        packed_inv_roots_vec_[0][i] =
-            PackedPrimeField::Broadcast(largest_inv[i]);
-        packed_roots_vec_[1][i] =
-            PackedPrimeField::Broadcast(rev_roots_vec_[i]);
-        packed_inv_roots_vec_[1][i] =
-            PackedPrimeField::Broadcast(rev_inv_roots_vec_[i]);
-      }
-    }
-
-    TRACE_EVENT("Subtask", "PrepareRootsVec");
-
-    roots_vec_[this->log_size_of_group_ - 1] = std::move(largest);
-    inv_roots_vec_[0] = std::move(largest_inv);
-
-    if (packed_vec_only) return;
-
-    // Prepare space in each vector for the others.
-    size_t size = this->size_ / 2;
-    for (size_t i = 1; i < this->log_size_of_group_; ++i) {
-      size /= 2;
-      roots_vec_[this->log_size_of_group_ - i - 1].resize(size);
-      inv_roots_vec_[i].resize(size);
-    }
-
-    // Assign every element based on the biggest vector.
-    OMP_PARALLEL_FOR(size_t i = 1; i < this->log_size_of_group_; ++i) {
-      for (size_t j = 0; j < this->size_ / std::pow(2, i + 1); ++j) {
-        size_t k = std::pow(2, i) * j;
-        roots_vec_[this->log_size_of_group_ - i - 1][j] = roots_vec_.back()[k];
-        inv_roots_vec_[i][j] = inv_roots_vec_.front()[k];
-      }
-    }
-  }
-
   CONSTEXPR_IF_NOT_OPENMP void InOutHelper(DensePoly& poly) const {
     TRACE_EVENT("EvaluationDomain", "InOutHelper");
     size_t gap = poly.coefficients_.coefficients_.size() / 2;
     size_t idx = 0;
     while (gap > 0) {
-      ApplyButterfly<FFTOrder::kInOut>(poly, inv_roots_vec_[idx++], gap);
+      ApplyButterfly<FFTOrder::kInOut>(poly, cache_->inv_roots_vec[idx++], gap);
       gap /= 2;
     }
   }
@@ -385,7 +312,7 @@ class Radix2EvaluationDomain
     size_t gap = start_gap;
     size_t idx = base::bits::SafeLog2Ceiling(start_gap);
     while (gap < evals.evaluations_.size()) {
-      ApplyButterfly<FFTOrder::kOutIn>(evals, roots_vec_[idx++], gap);
+      ApplyButterfly<FFTOrder::kOutIn>(evals, cache_->roots_vec[idx++], gap);
       gap *= 2;
     }
   }
@@ -510,14 +437,7 @@ class Radix2EvaluationDomain
     }
   }
 
-  // For small prime fields
-  std::vector<F> rev_roots_vec_;
-  std::vector<F> rev_inv_roots_vec_;
-  std::vector<std::vector<PackedPrimeField>> packed_roots_vec_;
-  std::vector<std::vector<PackedPrimeField>> packed_inv_roots_vec_;
-  // For all finite fields
-  std::vector<std::vector<F>> roots_vec_;
-  std::vector<std::vector<F>> inv_roots_vec_;
+  typename Radix2TwiddleCache<F>::Item* cache_ = nullptr;
 };
 
 template <typename F, size_t MaxDegree>

--- a/tachyon/math/polynomials/univariate/radix2_evaluation_domain.h
+++ b/tachyon/math/polynomials/univariate/radix2_evaluation_domain.h
@@ -293,14 +293,14 @@ class Radix2EvaluationDomain
   // clang-format off
   // Precompute |roots_vec_| and |inv_roots_vec_| for |OutInHelper()| and |InOutHelper()|.
   // Here is an example where |this->size_| equals 32.
-  // |root_vec_| = [
+  // |roots_vec_| = [
   //   [1],
   //   [1, ω⁸],
   //   [1, ω⁴, ω⁸, ω¹²],
   //   [1, ω², ω⁴, ω⁶, ω⁸, ω¹⁰, ω¹², ω¹⁴],
   //   [1, ω, ω², ω³, ω⁴, ω⁵, ω⁶, ω⁷, ω⁸, ω⁹, ω¹⁰, ω¹¹, ω¹², ω¹³, ω¹⁴, ω¹⁵],
   // ]
-  // |inv_root_vec_| = [
+  // |inv_roots_vec_| = [
   //   [1, ω⁻¹, ω⁻², ω⁻³, ω⁻⁴, ω⁻⁵, ω⁻⁶, ω⁻⁷, ω⁻⁸, ω⁻⁹, ω⁻¹⁰, ω⁻¹¹, ω⁻¹², ω⁻¹³, ω⁻¹⁴, ω⁻¹⁵],
   //   [1, ω⁻², ω⁻⁴, ω⁻⁶, ω⁻⁸, ω⁻¹⁰, ω⁻¹², ω⁻¹⁴],
   //   [1, ω⁻⁴, ω⁻⁸, ω⁻¹²],
@@ -317,7 +317,7 @@ class Radix2EvaluationDomain
 
     size_t vec_largest_size = this->size_ / 2;
 
-    // Compute biggest vector of |root_vec_| and |inv_root_vec_| first.
+    // Compute biggest vector of |roots_vec_| and |inv_roots_vec_| first.
     std::vector<F> largest =
         this->GetRootsOfUnity(vec_largest_size, this->group_gen_);
     std::vector<F> largest_inv =

--- a/tachyon/math/polynomials/univariate/radix2_twiddle_cache.h
+++ b/tachyon/math/polynomials/univariate/radix2_twiddle_cache.h
@@ -1,0 +1,147 @@
+#ifndef TACHYON_MATH_POLYNOMIALS_UNIVARIATE_RADIX2_TWIDDLE_CACHE_H_
+#define TACHYON_MATH_POLYNOMIALS_UNIVARIATE_RADIX2_TWIDDLE_CACHE_H_
+
+#include <stddef.h>
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "absl/base/thread_annotations.h"
+#include "absl/container/flat_hash_map.h"
+#include "absl/synchronization/mutex.h"
+
+#include "tachyon/base/no_destructor.h"
+#include "tachyon/base/openmp_util.h"
+#include "tachyon/base/profiler.h"
+
+namespace tachyon::math {
+
+template <typename F>
+class Radix2TwiddleCache {
+ public:
+  using PackedPrimeField =
+      // NOLINTNEXTLINE(whitespace/operators)
+      std::conditional_t<F::Config::kModulusBits <= 32,
+                         typename PackedFieldTraits<F>::PackedField, F>;
+
+  struct Item {
+    // For small prime fields
+    std::vector<F> rev_roots_vec;
+    std::vector<F> rev_inv_roots_vec;
+    std::vector<std::vector<PackedPrimeField>> packed_roots_vec;
+    std::vector<std::vector<PackedPrimeField>> packed_inv_roots_vec;
+    // For all finite fields
+    std::vector<std::vector<F>> roots_vec;
+    std::vector<std::vector<F>> inv_roots_vec;
+    bool packed_vec_only;
+
+    // clang-format off
+    // Precompute |roots_vec| and |inv_roots_vec| for |OutInHelper()| and |InOutHelper()|.
+    // Here is an example where |domain->size()| equals 32.
+    // |roots_vec| = [
+    //   [1],
+    //   [1, ω⁸],
+    //   [1, ω⁴, ω⁸, ω¹²],
+    //   [1, ω², ω⁴, ω⁶, ω⁸, ω¹⁰, ω¹², ω¹⁴],
+    //   [1, ω, ω², ω³, ω⁴, ω⁵, ω⁶, ω⁷, ω⁸, ω⁹, ω¹⁰, ω¹¹, ω¹², ω¹³, ω¹⁴, ω¹⁵],
+    // ]
+    // |inv_roots_vec| = [
+    //   [1, ω⁻¹, ω⁻², ω⁻³, ω⁻⁴, ω⁻⁵, ω⁻⁶, ω⁻⁷, ω⁻⁸, ω⁻⁹, ω⁻¹⁰, ω⁻¹¹, ω⁻¹², ω⁻¹³, ω⁻¹⁴, ω⁻¹⁵],
+    //   [1, ω⁻², ω⁻⁴, ω⁻⁶, ω⁻⁸, ω⁻¹⁰, ω⁻¹², ω⁻¹⁴],
+    //   [1, ω⁻⁴, ω⁻⁸, ω⁻¹²],
+    //   [1, ω⁻⁸],
+    //   [1],
+    // ]
+    // clang-format on
+    template <typename Domain>
+    Item(const Domain* domain, bool packed_vec_only) {
+      TRACE_EVENT("Utils", "Radix2TwiddleCache<F>::Item::Init");
+      if (domain->log_size_of_group() == 0) return;
+
+      this->packed_vec_only = packed_vec_only;
+
+      roots_vec.resize(domain->log_size_of_group());
+      inv_roots_vec.resize(domain->log_size_of_group());
+
+      size_t vec_largest_size = domain->size() / 2;
+
+      // Compute biggest vector of |roots_vec_| and |inv_roots_vec_| first.
+      std::vector<F> largest =
+          Domain::GetRootsOfUnity(vec_largest_size, domain->group_gen());
+      std::vector<F> largest_inv =
+          Domain::GetRootsOfUnity(vec_largest_size, domain->group_gen_inv());
+
+      if constexpr (F::Config::kModulusBits <= 32) {
+        TRACE_EVENT("Subtask", "PreparePackedVec");
+        packed_roots_vec.resize(2);
+        packed_inv_roots_vec.resize(2);
+        packed_roots_vec[0].resize(vec_largest_size);
+        packed_inv_roots_vec[0].resize(vec_largest_size);
+        packed_roots_vec[1].resize(vec_largest_size);
+        packed_inv_roots_vec[1].resize(vec_largest_size);
+        rev_roots_vec = SwapBitRevElements(largest);
+        rev_inv_roots_vec = SwapBitRevElements(largest_inv);
+        OMP_PARALLEL_FOR(size_t i = 0; i < vec_largest_size; ++i) {
+          packed_roots_vec[0][i] = PackedPrimeField::Broadcast(largest[i]);
+          packed_inv_roots_vec[0][i] =
+              PackedPrimeField::Broadcast(largest_inv[i]);
+          packed_roots_vec[1][i] =
+              PackedPrimeField::Broadcast(rev_roots_vec[i]);
+          packed_inv_roots_vec[1][i] =
+              PackedPrimeField::Broadcast(rev_inv_roots_vec[i]);
+        }
+      }
+
+      TRACE_EVENT("Subtask", "PrepareRootsVec");
+
+      roots_vec[domain->log_size_of_group() - 1] = std::move(largest);
+      inv_roots_vec[0] = std::move(largest_inv);
+
+      if (packed_vec_only) return;
+
+      // Prepare space in each vector for the others.
+      size_t size = domain->size() / 2;
+      for (size_t i = 1; i < domain->log_size_of_group(); ++i) {
+        size /= 2;
+        roots_vec[domain->log_size_of_group() - i - 1].resize(size);
+        inv_roots_vec[i].resize(size);
+      }
+
+      // Assign every element based on the biggest vector.
+      OMP_PARALLEL_FOR(size_t i = 1; i < domain->log_size_of_group(); ++i) {
+        size_t pow2_i = size_t{1} << i;
+        for (size_t j = 0; j < domain->size() / (pow2_i << 1); ++j) {
+          size_t k = pow2_i * j;
+          roots_vec[domain->log_size_of_group() - i - 1][j] =
+              roots_vec.back()[k];
+          inv_roots_vec[i][j] = inv_roots_vec.front()[k];
+        }
+      }
+    }
+  };
+
+  template <typename Domain>
+  static Item* GetItem(const Domain* domain, bool packed_vec_only) {
+    static base::NoDestructor<Radix2TwiddleCache> twiddle_cache;
+
+    absl::MutexLock lock(&twiddle_cache->mutex_);
+    auto it = twiddle_cache->items_.find(domain->size());
+    if (it == twiddle_cache->items_.end() ||
+        (it->second->packed_vec_only && !packed_vec_only)) {
+      it = twiddle_cache->items_.insert(
+          it, std::make_pair(domain->size(),
+                             std::make_unique<Item>(domain, packed_vec_only)));
+    }
+    return it->second.get();
+  }
+
+ private:
+  absl::Mutex mutex_;
+  absl::flat_hash_map<size_t, std::unique_ptr<Item>> items_
+      ABSL_GUARDED_BY(mutex_);
+};
+
+}  // namespace tachyon::math
+
+#endif  // TACHYON_MATH_POLYNOMIALS_UNIVARIATE_RADIX2_TWIDDLE_CACHE_H_

--- a/tachyon/math/polynomials/univariate/univariate_evaluation_domain.h
+++ b/tachyon/math/polynomials/univariate/univariate_evaluation_domain.h
@@ -236,7 +236,7 @@ class UnivariateEvaluationDomain : public EvaluationDomain<F, MaxDegree> {
   // Computes the first |size| roots of unity for the entire domain.
   // e.g. for the domain [1, g, g², ..., gⁿ⁻¹}] and |size| = n / 2, it
   // computes [1, g, g², ..., g^{(n / 2) - 1}]
-  constexpr std::vector<F> GetRootsOfUnity(size_t size, const F& root) const {
+  constexpr static std::vector<F> GetRootsOfUnity(size_t size, const F& root) {
     return F::GetSuccessivePowers(size, root);
   }
 

--- a/tachyon/math/polynomials/univariate/univariate_evaluation_domain_unittest.cc
+++ b/tachyon/math/polynomials/univariate/univariate_evaluation_domain_unittest.cc
@@ -311,7 +311,7 @@ TYPED_TEST(UnivariateEvaluationDomainTest, RootsOfUnity) {
   for (size_t coeffs = 0; coeffs < kNumCoeffs; ++coeffs) {
     std::unique_ptr<Domain> domain = Domain::Create(coeffs);
     std::vector<F> actual_roots =
-        domain->GetRootsOfUnity(domain->size(), domain->group_gen());
+        Domain::GetRootsOfUnity(domain->size(), domain->group_gen());
     for (const F& value : actual_roots) {
       EXPECT_TRUE(domain->EvaluateVanishingPolynomial(value).IsZero());
     }

--- a/tachyon/zk/plonk/permutation/unpermuted_table.h
+++ b/tachyon/zk/plonk/permutation/unpermuted_table.h
@@ -57,7 +57,7 @@ class UnpermutedTable {
                                    const Domain* domain) {
     // The ω is gᵀ with order 2ˢ where modulus = 2ˢ * T + 1.
     std::vector<F> omega_powers =
-        domain->GetRootsOfUnity(rows, domain->group_gen());
+        Domain::GetRootsOfUnity(rows, domain->group_gen());
 
     // The δ is g^2ˢ with order T where modulus = 2ˢ * T + 1.
     F delta = GetDelta<F>();

--- a/tachyon/zk/plonk/permutation/unpermuted_table_unittest.cc
+++ b/tachyon/zk/plonk/permutation/unpermuted_table_unittest.cc
@@ -45,7 +45,7 @@ class UnpermutedTableTest : public math::FiniteFieldTest<F> {
 
 TEST_F(UnpermutedTableTest, Construct) {
   const F& omega = domain_->group_gen();
-  std::vector<F> omega_powers = domain_->GetRootsOfUnity(kRows, omega);
+  std::vector<F> omega_powers = Domain::GetRootsOfUnity(kRows, omega);
 
   const F delta = GetDelta<F>();
   for (size_t i = 1; i < kCols; ++i) {
@@ -59,7 +59,7 @@ TEST_F(UnpermutedTableTest, Construct) {
 TEST_F(UnpermutedTableTest, GetColumns) {
   const F& omega = domain_->group_gen();
   const F delta = GetDelta<F>();
-  std::vector<F> omega_powers = domain_->GetRootsOfUnity(kRows, omega);
+  std::vector<F> omega_powers = Domain::GetRootsOfUnity(kRows, omega);
   for (F& omega_power : omega_powers) {
     omega_power *= delta;
   }


### PR DESCRIPTION
# Description

This PR optimizes `Radix2EvaluationDomain` by introducing `TwiddleCache<F>`. 

This has 2 benefits:

- **Eliminating Vector Copying**: When creating a coset using `GetCoset()`, the vectors are no longer copied.
- **Optimized TwoAdicMultiplicativeCoset Creation**: A new domain is still created in `TwoAdicMultiplicativeCoset` even when the domain size remains the same. Additionally, the post-creation copying of vectors has been removed

```c++
  TwoAdicMultiplicativeCoset(uint32_t log_n, F shift) {
    domain_.reset(static_cast<math::Radix2EvaluationDomain<F>*>(
        math::Radix2EvaluationDomain<F>::Create(size_t{1} << log_n)
            ->GetCoset(shift)
            .release()));
  }
```

I pushed a commit with the same branch name of #530 by chance, I couldn't reopen it..
