### PR TITLE
feat: enable using rust allocated ldes

### DIFF
--- a/benchmark/fft_batch/fft_batch_runner.h
+++ b/benchmark/fft_batch/fft_batch_runner.h
@@ -38,10 +38,9 @@ class FFTBatchRunner {
     base::TimeTicks start = base::TimeTicks::Now();
     if (run_coset_lde) {
       const size_t kAddedBits = 1;
-      math::RowMajorMatrix<F> input_tmp = input;
       result =
           math::RowMajorMatrix<F>(input.rows() << kAddedBits, input.cols());
-      domain->CosetLDEBatch(input_tmp, kAddedBits,
+      domain->CosetLDEBatch(input, kAddedBits,
                             F::FromMontgomery(F::Config::kSubgroupGenerator),
                             result);
     } else {

--- a/benchmark/fft_batch/fft_batch_runner.h
+++ b/benchmark/fft_batch/fft_batch_runner.h
@@ -32,14 +32,20 @@ class FFTBatchRunner {
 
   math::RowMajorMatrix<F> Run(Vendor vendor, bool run_coset_lde,
                               const math::RowMajorMatrix<F>& input) {
-    math::RowMajorMatrix<F> result = input;
+    math::RowMajorMatrix<F> result;
     std::unique_ptr<Domain> domain =
         Domain::Create(static_cast<size_t>(input.rows()));
     base::TimeTicks start = base::TimeTicks::Now();
     if (run_coset_lde) {
-      result = result = domain->CosetLDEBatch(
-          result, 1, F::FromMontgomery(F::Config::kSubgroupGenerator));
+      const size_t kAddedBits = 1;
+      math::RowMajorMatrix<F> input_tmp = input;
+      result =
+          math::RowMajorMatrix<F>(input.rows() << kAddedBits, input.cols());
+      domain->CosetLDEBatch(input_tmp, kAddedBits,
+                            F::FromMontgomery(F::Config::kSubgroupGenerator),
+                            result);
     } else {
+      result = input;
       domain->FFTBatch(result);
     }
     reporter_.AddTime(vendor, base::TimeTicks::Now() - start);

--- a/benchmark/fri/fri_runner.h
+++ b/benchmark/fri/fri_runner.h
@@ -47,7 +47,7 @@ class FRIRunner {
   ExtF Run(Vendor vendor, const math::RowMajorMatrix<F>& input) {
     size_t max_degree = static_cast<size_t>(input.rows());
     std::vector<Commitment> commits_by_round(config_.round_num());
-    std::vector<ProverData> data_by_round(config_.round_num());
+    std::vector<std::unique_ptr<ProverData>> data_by_round(config_.round_num());
     std::vector<std::vector<Domain>> domains_by_round(config_.round_num());
     std::vector<std::vector<math::RowMajorMatrix<F>>> inner_polys_by_round(
         config_.round_num());
@@ -72,8 +72,9 @@ class FRIRunner {
 
     base::TimeTicks start = base::TimeTicks::Now();
     for (size_t round = 0; round < config_.round_num(); round++) {
+      data_by_round[round].reset(new ProverData());
       CHECK(pcs_.Commit(domains_by_round[round], inner_polys_by_round[round],
-                        &commits_by_round[round], &data_by_round[round]));
+                        &commits_by_round[round], data_by_round[round].get()));
     }
     p_challenger.ObserveContainer2D(commits_by_round);
     ExtF zeta = p_challenger.template SampleExtElement<ExtF>();

--- a/tachyon/c/crypto/commitments/fri/two_adic_fri_impl.h
+++ b/tachyon/c/crypto/commitments/fri/two_adic_fri_impl.h
@@ -33,10 +33,12 @@ class TwoAdicFRIImpl
   template <typename Derived>
   absl::Span<F> CosetLDEBatch(Eigen::MatrixBase<Derived>& matrix, F shift) {
     Domain coset = this->GetNaturalDomainForDegree(matrix.rows());
-    tachyon::math::RowMajorMatrix<F> mat = coset.domain()->CosetLDEBatch(
-        matrix, this->fri_.log_blowup, shift, /*reverse_at_last=*/false);
-    absl::Span<F> ret(mat.data(), mat.size());
-    ldes_.push_back(std::move(mat));
+    tachyon::math::RowMajorMatrix<F> lde(matrix.rows() << this->fri_.log_blowup,
+                                         matrix.cols());
+    coset.domain()->CosetLDEBatch(matrix, this->fri_.log_blowup, shift, lde,
+                                  /*reverse_at_last=*/false);
+    absl::Span<F> ret(lde.data(), lde.size());
+    ldes_.push_back(std::move(lde));
     return ret;
   }
 

--- a/tachyon/c/crypto/commitments/fri/two_adic_fri_impl.h
+++ b/tachyon/c/crypto/commitments/fri/two_adic_fri_impl.h
@@ -33,9 +33,9 @@ class TwoAdicFRIImpl
   template <typename Derived>
   absl::Span<F> CosetLDEBatch(Eigen::MatrixBase<Derived>&& matrix, F shift) {
     Domain coset = this->GetNaturalDomainForDegree(matrix.rows());
-    tachyon::math::RowMajorMatrix<F> lde(matrix.rows() << this->fri_.log_blowup,
-                                         matrix.cols());
-    coset.domain()->CosetLDEBatch(std::move(matrix), this->fri_.log_blowup,
+    tachyon::math::RowMajorMatrix<F> lde(
+        matrix.rows() << this->config_.log_blowup, matrix.cols());
+    coset.domain()->CosetLDEBatch(std::move(matrix), this->config_.log_blowup,
                                   shift, lde,
                                   /*reverse_at_last=*/false);
     absl::Span<F> ret(lde.data(), lde.size());

--- a/tachyon/c/crypto/commitments/fri/two_adic_fri_impl.h
+++ b/tachyon/c/crypto/commitments/fri/two_adic_fri_impl.h
@@ -54,25 +54,6 @@ class TwoAdicFRIImpl
     prover_data_by_round->push_back(std::move(prover_data));
   }
 
-  void CreateOpeningProof(
-      const std::vector<std::unique_ptr<ProverData>>& prover_data_by_round_in,
-      const OpeningPoints& points_by_round, Challenger& challenger,
-      OpenedValues* opened_values_by_round, FRIProof* proof) const {
-    auto& prover_data_by_round =
-        const_cast<std::vector<std::unique_ptr<ProverData>>&>(
-            prover_data_by_round_in);
-    std::vector<ProverData> prover_data_by_round_tmp = tachyon::base::Map(
-        prover_data_by_round, [](std::unique_ptr<ProverData>& prover_data) {
-          return ProverData(std::move(*prover_data));
-        });
-    CHECK(Base::CreateOpeningProof(prover_data_by_round_tmp, points_by_round,
-                                   challenger, opened_values_by_round, proof));
-    prover_data_by_round = tachyon::base::Map(
-        prover_data_by_round_tmp, [](ProverData& prover_data) {
-          return std::make_unique<ProverData>(std::move(prover_data));
-        });
-  }
-
  protected:
   std::vector<math::RowMajorMatrix<F>> ldes_;
 };

--- a/tachyon/c/crypto/commitments/fri/two_adic_fri_impl.h
+++ b/tachyon/c/crypto/commitments/fri/two_adic_fri_impl.h
@@ -31,11 +31,12 @@ class TwoAdicFRIImpl
   void AllocateLDEs(size_t size) { ldes_.reserve(size); }
 
   template <typename Derived>
-  absl::Span<F> CosetLDEBatch(Eigen::MatrixBase<Derived>& matrix, F shift) {
+  absl::Span<F> CosetLDEBatch(Eigen::MatrixBase<Derived>&& matrix, F shift) {
     Domain coset = this->GetNaturalDomainForDegree(matrix.rows());
     tachyon::math::RowMajorMatrix<F> lde(matrix.rows() << this->fri_.log_blowup,
                                          matrix.cols());
-    coset.domain()->CosetLDEBatch(matrix, this->fri_.log_blowup, shift, lde,
+    coset.domain()->CosetLDEBatch(std::move(matrix), this->fri_.log_blowup,
+                                  shift, lde,
                                   /*reverse_at_last=*/false);
     absl::Span<F> ret(lde.data(), lde.size());
     ldes_.push_back(std::move(lde));

--- a/tachyon/c/crypto/commitments/fri/two_adic_fri_impl.h
+++ b/tachyon/c/crypto/commitments/fri/two_adic_fri_impl.h
@@ -28,7 +28,7 @@ class TwoAdicFRIImpl
 
   using Base::Base;
 
-  void AllocateLDEs(size_t size) { this->ldes_.reserve(size); }
+  void AllocateLDEs(size_t size) { ldes_.reserve(size); }
 
   template <typename Derived>
   absl::Span<F> CosetLDEBatch(Eigen::MatrixBase<Derived>& matrix, F shift) {
@@ -36,7 +36,7 @@ class TwoAdicFRIImpl
     tachyon::math::RowMajorMatrix<F> mat = coset.domain()->CosetLDEBatch(
         matrix, this->fri_.log_blowup, shift, /*reverse_at_last=*/false);
     absl::Span<F> ret(mat.data(), mat.size());
-    this->ldes_.push_back(std::move(mat));
+    ldes_.push_back(std::move(mat));
     return ret;
   }
 

--- a/tachyon/c/crypto/commitments/fri/two_adic_fri_impl.h
+++ b/tachyon/c/crypto/commitments/fri/two_adic_fri_impl.h
@@ -45,7 +45,8 @@ class TwoAdicFRIImpl
   void Commit(Commitment* commitment, ProverData** prover_data_out,
               std::vector<std::unique_ptr<ProverData>>* prover_data_by_round) {
     std::unique_ptr<ProverData> prover_data(new ProverData);
-    CHECK(this->mmcs_.Commit(std::move(ldes_), commitment, prover_data.get()));
+    CHECK(this->mmcs_.CommitOwned(std::move(ldes_), commitment,
+                                  prover_data.get()));
     *prover_data_out = prover_data.get();
     prover_data_by_round->push_back(std::move(prover_data));
   }

--- a/tachyon/c/zk/air/sp1/baby_bear_poseidon2_field_merkle_tree_vec.cc
+++ b/tachyon/c/zk/air/sp1/baby_bear_poseidon2_field_merkle_tree_vec.cc
@@ -28,6 +28,6 @@ tachyon_sp1_baby_bear_poseidon2_field_merkle_tree_vec_clone(
 }
 
 void tachyon_sp1_baby_bear_poseidon2_field_merkle_tree_vec_destroy(
-    tachyon_sp1_baby_bear_poseidon2_field_merkle_tree_vec* tree) {
-  delete c::base::native_cast(tree);
+    tachyon_sp1_baby_bear_poseidon2_field_merkle_tree_vec* tree_vec) {
+  delete c::base::native_cast(tree_vec);
 }

--- a/tachyon/c/zk/air/sp1/baby_bear_poseidon2_two_adic_fri.cc
+++ b/tachyon/c/zk/air/sp1/baby_bear_poseidon2_two_adic_fri.cc
@@ -99,17 +99,20 @@ void tachyon_sp1_baby_bear_poseidon2_two_adic_fri_allocate_ldes(
   c::base::native_cast(pcs)->AllocateLDEs(size);
 }
 
-tachyon_baby_bear* tachyon_sp1_baby_bear_poseidon2_two_adic_fri_coset_lde_batch(
+void tachyon_sp1_baby_bear_poseidon2_two_adic_fri_coset_lde_batch(
     tachyon_sp1_baby_bear_poseidon2_two_adic_fri* pcs,
     tachyon_baby_bear* values, size_t rows, size_t cols,
-    tachyon_baby_bear shift, size_t* new_rows) {
+    tachyon_baby_bear* extended_values, tachyon_baby_bear shift) {
+  PCS* native_pcs = c::base::native_cast(pcs);
   Eigen::Map<math::RowMajorMatrix<F>> matrix(c::base::native_cast(values),
                                              static_cast<Eigen::Index>(rows),
                                              static_cast<Eigen::Index>(cols));
-  absl::Span<F> ret = c::base::native_cast(pcs)->CosetLDEBatch(
-      std::move(matrix), c::base::native_cast(shift));
-  *new_rows = ret.size() / cols;
-  return c::base::c_cast(ret.data());
+  Eigen::Map<math::RowMajorMatrix<F>> extended_matrix(
+      c::base::native_cast(extended_values),
+      static_cast<Eigen::Index>(rows) << (native_pcs->config().log_blowup),
+      static_cast<Eigen::Index>(cols));
+  native_pcs->CosetLDEBatch(std::move(matrix), c::base::native_cast(shift),
+                            extended_matrix);
 }
 
 void tachyon_sp1_baby_bear_poseidon2_two_adic_fri_commit(

--- a/tachyon/c/zk/air/sp1/baby_bear_poseidon2_two_adic_fri.cc
+++ b/tachyon/c/zk/air/sp1/baby_bear_poseidon2_two_adic_fri.cc
@@ -107,7 +107,7 @@ tachyon_baby_bear* tachyon_sp1_baby_bear_poseidon2_two_adic_fri_coset_lde_batch(
                                              static_cast<Eigen::Index>(rows),
                                              static_cast<Eigen::Index>(cols));
   absl::Span<F> ret = c::base::native_cast(pcs)->CosetLDEBatch(
-      matrix, c::base::native_cast(shift));
+      std::move(matrix), c::base::native_cast(shift));
   *new_rows = ret.size() / cols;
   return c::base::c_cast(ret.data());
 }

--- a/tachyon/c/zk/air/sp1/baby_bear_poseidon2_two_adic_fri.cc
+++ b/tachyon/c/zk/air/sp1/baby_bear_poseidon2_two_adic_fri.cc
@@ -131,7 +131,7 @@ void tachyon_sp1_baby_bear_poseidon2_two_adic_fri_open(
     tachyon_sp1_baby_bear_poseidon2_duplex_challenger* challenger,
     tachyon_sp1_baby_bear_poseidon2_opened_values** opened_values,
     tachyon_sp1_baby_bear_poseidon2_fri_proof** proof) {
-  c::base::native_cast(pcs)->CreateOpeningProof(
+  CHECK(c::base::native_cast(pcs)->CreateOpeningProof(
       c::base::native_cast(*prover_data_by_round),
       c::base::native_cast(*points_by_round), c::base::native_cast(*challenger),
       c::base::native_cast(
@@ -139,7 +139,7 @@ void tachyon_sp1_baby_bear_poseidon2_two_adic_fri_open(
               *opened_values)),
       c::base::native_cast(
           reinterpret_cast<tachyon_sp1_baby_bear_poseidon2_fri_proof*>(
-              *proof)));
+              *proof))));
 }
 
 bool tachyon_sp1_baby_bear_poseidon2_two_adic_fri_verify(

--- a/tachyon/c/zk/air/sp1/baby_bear_poseidon2_two_adic_fri.h
+++ b/tachyon/c/zk/air/sp1/baby_bear_poseidon2_two_adic_fri.h
@@ -68,16 +68,15 @@ tachyon_sp1_baby_bear_poseidon2_two_adic_fri_allocate_ldes(
  * @param values A pointer to the data of the baby bear row major matrix.
  * @param rows The number of rows.
  * @param cols The number of columns.
+ * @param extended_values A pointer to the data of the extended baby bear row
+ * major matrix.
  * @param shift The shift value.
- * @param new_rows The number of rows of the baby bear row major matrix.
- * @return A pointer to the data of the newly created baby bear row major
- * matrix.
  */
-TACHYON_C_EXPORT tachyon_baby_bear*
+TACHYON_C_EXPORT void
 tachyon_sp1_baby_bear_poseidon2_two_adic_fri_coset_lde_batch(
     tachyon_sp1_baby_bear_poseidon2_two_adic_fri* pcs,
     tachyon_baby_bear* values, size_t rows, size_t cols,
-    tachyon_baby_bear shift, size_t* new_rows);
+    tachyon_baby_bear* extended_values, tachyon_baby_bear shift);
 
 /**
  * @brief Commits to the mixed matrix created by

--- a/tachyon/crypto/commitments/fri/prove.h
+++ b/tachyon/crypto/commitments/fri/prove.h
@@ -56,7 +56,7 @@ CommitPhaseResult<PCS> CommitPhase(const FRIConfig<ChallengeMMCS>& config,
 
     Commitment commit;
     ProverData prover_data;
-    CHECK(config.mmcs.Commit(std::move(leaves), &commit, &prover_data));
+    CHECK(config.mmcs.CommitOwned(std::move(leaves), &commit, &prover_data));
     commits.push_back(std::move(commit));
     data.push_back(std::move(prover_data));
 

--- a/tachyon/crypto/commitments/fri/two_adic_fri.h
+++ b/tachyon/crypto/commitments/fri/two_adic_fri.h
@@ -96,13 +96,14 @@ class TwoAdicFRI {
     size_t num_rounds = prover_data_by_round.size();
 
     size_t global_max_num_rows = 0;
-    std::vector<absl::Span<const math::RowMajorMatrix<F>>> matrices_by_round =
-        base::Map(prover_data_by_round,
-                  [this, &global_max_num_rows](const ProverData& prover_data) {
-                    global_max_num_rows = std::max(
-                        global_max_num_rows, mmcs_.GetMaxRowSize(prover_data));
-                    return absl::MakeConstSpan(mmcs_.GetMatrices(prover_data));
-                  });
+    std::vector<absl::Span<const Eigen::Map<const math::RowMajorMatrix<F>>>>
+        matrices_by_round = base::Map(
+            prover_data_by_round,
+            [this, &global_max_num_rows](const ProverData& prover_data) {
+              global_max_num_rows = std::max(global_max_num_rows,
+                                             mmcs_.GetMaxRowSize(prover_data));
+              return absl::MakeConstSpan(mmcs_.GetMatrices(prover_data));
+            });
     uint32_t log_global_max_num_rows =
         base::bits::CheckedLog2(global_max_num_rows);
 
@@ -119,12 +120,13 @@ class TwoAdicFRI {
 
     OpenedValues opened_values(num_rounds);
     for (size_t round = 0; round < num_rounds; ++round) {
-      absl::Span<const math::RowMajorMatrix<F>> matrices =
+      absl::Span<const Eigen::Map<const math::RowMajorMatrix<F>>> matrices =
           matrices_by_round[round];
       const OpeningPointsForRound& points = points_by_round[round];
       OpenedValuesForRound opened_values_for_round(matrices.size());
       for (size_t matrix_idx = 0; matrix_idx < matrices.size(); ++matrix_idx) {
-        const math::RowMajorMatrix<F>& mat = matrices[matrix_idx];
+        const Eigen::Map<const math::RowMajorMatrix<F>>& mat =
+            matrices[matrix_idx];
         size_t num_rows = static_cast<size_t>(mat.rows());
         size_t num_cols = static_cast<size_t>(mat.cols());
         uint32_t log_num_rows = base::bits::CheckedLog2(num_rows);
@@ -313,8 +315,8 @@ class TwoAdicFRI {
 
   static absl::flat_hash_map<ExtF, std::vector<ExtF>>
   ComputeInverseDenominators(
-      const std::vector<absl::Span<const math::RowMajorMatrix<F>>>&
-          matrices_by_round,
+      const std::vector<absl::Span<
+          const Eigen::Map<const math::RowMajorMatrix<F>>>>& matrices_by_round,
       const OpeningPoints& points_by_round, F coset_shift) {
     TRACE_EVENT("Utils", "ComputeInverseDenominators");
     size_t num_rounds = matrices_by_round.size();
@@ -322,10 +324,10 @@ class TwoAdicFRI {
     absl::flat_hash_map<ExtF, uint32_t> max_log_num_rows_for_point;
     uint32_t max_log_num_rows = 0;
     for (size_t round = 0; round < num_rounds; ++round) {
-      absl::Span<const math::RowMajorMatrix<F>> matrices =
+      absl::Span<const Eigen::Map<const math::RowMajorMatrix<F>>> matrices =
           matrices_by_round[round];
       const OpeningPointsForRound& points = points_by_round[round];
-      for (const math::RowMajorMatrix<F>& matrix : matrices) {
+      for (const Eigen::Map<const math::RowMajorMatrix<F>>& matrix : matrices) {
         uint32_t log_num_rows =
             base::bits::CheckedLog2(static_cast<uint32_t>(matrix.rows()));
         max_log_num_rows = std::max(max_log_num_rows, log_num_rows);

--- a/tachyon/crypto/commitments/fri/two_adic_fri.h
+++ b/tachyon/crypto/commitments/fri/two_adic_fri.h
@@ -76,11 +76,16 @@ class TwoAdicFRI {
     TRACE_EVENT("ProofGeneration", "TwoAdicFRI::Commit");
     std::vector<math::RowMajorMatrix<F>> ldes =
         base::Map(cosets, [this, &matrices](size_t i, const Domain& coset) {
-          return coset.domain()->CosetLDEBatch(
-              matrices[i], fri_.log_blowup,
+          math::RowMajorMatrix<F>& mat = matrices[i];
+          CHECK_EQ(coset.domain()->size(), static_cast<size_t>(mat.rows()));
+          math::RowMajorMatrix<F> lde(mat.rows() << fri_.log_blowup,
+                                      mat.cols());
+          coset.domain()->CosetLDEBatch(
+              mat, fri_.log_blowup,
               F::FromMontgomery(F::Config::kSubgroupGenerator) *
                   coset.domain()->offset_inv(),
-              /*reverse_at_last=*/false);
+              lde, /*reverse_at_last=*/false);
+          return lde;
         });
     return mmcs_.CommitOwned(std::move(ldes), commitment, prover_data);
   }

--- a/tachyon/crypto/commitments/fri/two_adic_fri.h
+++ b/tachyon/crypto/commitments/fri/two_adic_fri.h
@@ -82,7 +82,7 @@ class TwoAdicFRI {
                   coset.domain()->offset_inv(),
               /*reverse_at_last=*/false);
         });
-    return mmcs_.Commit(std::move(ldes), commitment, prover_data);
+    return mmcs_.CommitOwned(std::move(ldes), commitment, prover_data);
   }
 
   [[nodiscard]] bool CreateOpeningProof(

--- a/tachyon/crypto/commitments/fri/two_adic_fri.h
+++ b/tachyon/crypto/commitments/fri/two_adic_fri.h
@@ -81,7 +81,7 @@ class TwoAdicFRI {
           math::RowMajorMatrix<F> lde(mat.rows() << fri_.log_blowup,
                                       mat.cols());
           coset.domain()->CosetLDEBatch(
-              mat, fri_.log_blowup,
+              std::move(mat), fri_.log_blowup,
               F::FromMontgomery(F::Config::kSubgroupGenerator) *
                   coset.domain()->offset_inv(),
               lde, /*reverse_at_last=*/false);

--- a/tachyon/crypto/commitments/fri/two_adic_fri.h
+++ b/tachyon/crypto/commitments/fri/two_adic_fri.h
@@ -66,6 +66,8 @@ class TwoAdicFRI {
   TwoAdicFRI(InputMMCS&& mmcs, FRIConfig<ChallengeMMCS>&& config)
       : mmcs_(std::move(mmcs)), config_(std::move(config)) {}
 
+  const FRIConfig<ChallengeMMCS>& config() const { return config_; }
+
   Domain GetNaturalDomainForDegree(size_t size) {
     uint32_t log_n = base::bits::CheckedLog2(size);
     return Domain(log_n, F::One());

--- a/tachyon/crypto/commitments/fri/two_adic_fri_unittest.cc
+++ b/tachyon/crypto/commitments/fri/two_adic_fri_unittest.cc
@@ -94,7 +94,7 @@ class TwoAdicFRITest : public testing::Test {
     size_t num_rounds = log_degrees_by_round.size();
     std::vector<std::vector<Domain>> domains_by_round(num_rounds);
     std::vector<Commitment> commits_by_round(num_rounds);
-    std::vector<ProverData> data_by_round(num_rounds);
+    std::vector<std::unique_ptr<ProverData>> data_by_round(num_rounds);
     Challenger p_challenger = challenger_;
     for (size_t round = 0; round < num_rounds; ++round) {
       const std::vector<uint32_t>& log_degrees = log_degrees_by_round[round];
@@ -107,8 +107,10 @@ class TwoAdicFRITest : public testing::Test {
         inner_domains[i] = pcs_.GetNaturalDomainForDegree(rows);
         inner_polys[i] = math::RowMajorMatrix<F>::Random(rows, cols);
       }
+      data_by_round[round].reset(new ProverData());
       ASSERT_TRUE(pcs_.Commit(inner_domains, inner_polys,
-                              &commits_by_round[round], &data_by_round[round]));
+                              &commits_by_round[round],
+                              data_by_round[round].get()));
       domains_by_round[round] = std::move(inner_domains);
     }
     p_challenger.ObserveContainer2D(commits_by_round);

--- a/tachyon/crypto/commitments/merkle_tree/field_merkle_tree/extension_field_merkle_tree_mmcs.h
+++ b/tachyon/crypto/commitments/merkle_tree/field_merkle_tree/extension_field_merkle_tree_mmcs.h
@@ -35,9 +35,16 @@ class ExtensionFieldMerkleTreeMMCS final
       ExtensionFieldMerkleTreeMMCS<ExtF, InnerMMCS>>;
 
   [[nodiscard]] bool DoCommit(
-      std::vector<math::RowMajorMatrix<ExtF>>&& matrices,
+      std::vector<Eigen::Map<const math::RowMajorMatrix<ExtF>>>&& matrices,
       Commitment* commitment, ProverData* prover_data) const {
     return inner_.Commit(std::move(matrices), commitment, prover_data);
+  }
+
+  [[nodiscard]] bool DoCommitOwned(
+      std::vector<math::RowMajorMatrix<ExtF>>&& owned_matrices,
+      Commitment* commitment, ProverData* prover_data) const {
+    return inner_.CommitOwned(std::move(owned_matrices), commitment,
+                              prover_data);
   }
 
   const std::vector<Eigen::Map<const math::RowMajorMatrix<ExtF>>>&

--- a/tachyon/crypto/commitments/merkle_tree/field_merkle_tree/extension_field_merkle_tree_mmcs.h
+++ b/tachyon/crypto/commitments/merkle_tree/field_merkle_tree/extension_field_merkle_tree_mmcs.h
@@ -40,8 +40,8 @@ class ExtensionFieldMerkleTreeMMCS final
     return inner_.Commit(std::move(matrices), commitment, prover_data);
   }
 
-  const std::vector<math::RowMajorMatrix<ExtensionField>>& DoGetMatrices(
-      const ProverData& prover_data) const {
+  const std::vector<Eigen::Map<const math::RowMajorMatrix<ExtensionField>>>&
+  DoGetMatrices(const ProverData& prover_data) const {
     return prover_data.leaves();
   }
 

--- a/tachyon/crypto/commitments/merkle_tree/field_merkle_tree/extension_field_merkle_tree_mmcs.h
+++ b/tachyon/crypto/commitments/merkle_tree/field_merkle_tree/extension_field_merkle_tree_mmcs.h
@@ -13,10 +13,10 @@
 
 namespace tachyon::crypto {
 
-template <typename ExtensionField, typename InnerMMCS>
+template <typename ExtF, typename InnerMMCS>
 class ExtensionFieldMerkleTreeMMCS final
     : public MixedMatrixCommitmentScheme<
-          ExtensionFieldMerkleTreeMMCS<ExtensionField, InnerMMCS>> {
+          ExtensionFieldMerkleTreeMMCS<ExtF, InnerMMCS>> {
  public:
   using Commitment =
       typename MixedMatrixCommitmentSchemeTraits<InnerMMCS>::Commitment;
@@ -32,29 +32,29 @@ class ExtensionFieldMerkleTreeMMCS final
 
  private:
   friend class MixedMatrixCommitmentScheme<
-      ExtensionFieldMerkleTreeMMCS<ExtensionField, InnerMMCS>>;
+      ExtensionFieldMerkleTreeMMCS<ExtF, InnerMMCS>>;
 
   [[nodiscard]] bool DoCommit(
-      std::vector<math::RowMajorMatrix<ExtensionField>>&& matrices,
+      std::vector<math::RowMajorMatrix<ExtF>>&& matrices,
       Commitment* commitment, ProverData* prover_data) const {
     return inner_.Commit(std::move(matrices), commitment, prover_data);
   }
 
-  const std::vector<Eigen::Map<const math::RowMajorMatrix<ExtensionField>>>&
+  const std::vector<Eigen::Map<const math::RowMajorMatrix<ExtF>>>&
   DoGetMatrices(const ProverData& prover_data) const {
     return prover_data.leaves();
   }
 
   [[nodiscard]] bool DoCreateOpeningProof(
       size_t index, const ProverData& prover_data,
-      std::vector<std::vector<ExtensionField>>* openings, Proof* proof) const {
+      std::vector<std::vector<ExtF>>* openings, Proof* proof) const {
     return inner_.CreateOpeningProof(index, prover_data, openings, proof);
   }
 
   [[nodiscard]] bool DoVerifyOpeningProof(
       const Commitment& commitment,
       absl::Span<const math::Dimensions> dimensions_list, size_t index,
-      absl::Span<const std::vector<ExtensionField>> opened_values,
+      absl::Span<const std::vector<ExtF>> opened_values,
       const Proof& proof) const {
     return inner_.VerifyOpeningProof(commitment, dimensions_list, index,
                                      opened_values, proof);
@@ -63,11 +63,11 @@ class ExtensionFieldMerkleTreeMMCS final
   InnerMMCS inner_;
 };
 
-template <typename ExtensionField, typename InnerMMCS>
+template <typename ExtF, typename InnerMMCS>
 struct MixedMatrixCommitmentSchemeTraits<
-    ExtensionFieldMerkleTreeMMCS<ExtensionField, InnerMMCS>> {
+    ExtensionFieldMerkleTreeMMCS<ExtF, InnerMMCS>> {
  public:
-  using Field = ExtensionField;
+  using Field = ExtF;
   using Commitment =
       typename MixedMatrixCommitmentSchemeTraits<InnerMMCS>::Commitment;
   using ProverData =

--- a/tachyon/crypto/commitments/merkle_tree/field_merkle_tree/extension_field_merkle_tree_mmcs_unittest.cc
+++ b/tachyon/crypto/commitments/merkle_tree/field_merkle_tree/extension_field_merkle_tree_mmcs_unittest.cc
@@ -100,8 +100,8 @@ TEST_F(ExtensionFieldMerkleTreeMMCSTest, CommitAndVerify) {
       std::move(ext_matrix)};
   std::array<F, kChunk> ext_commitment;
   ExtTree ext_prover_data;
-  ASSERT_TRUE(ext_mmcs_->Commit(std::move(ext_matrices), &ext_commitment,
-                                &ext_prover_data));
+  ASSERT_TRUE(ext_mmcs_->CommitOwned(std::move(ext_matrices), &ext_commitment,
+                                     &ext_prover_data));
 
   const InnerMMCS& inner_mmcs = ext_mmcs_->inner();
   MMCS mmcs(inner_mmcs.hasher(), inner_mmcs.packed_hasher(),
@@ -109,7 +109,7 @@ TEST_F(ExtensionFieldMerkleTreeMMCSTest, CommitAndVerify) {
   std::vector<math::RowMajorMatrix<F>> matrices = {std::move(matrix)};
   std::array<F, kChunk> commitment;
   Tree prover_data;
-  ASSERT_TRUE(mmcs.Commit(std::move(matrices), &commitment, &prover_data));
+  ASSERT_TRUE(mmcs.CommitOwned(std::move(matrices), &commitment, &prover_data));
 
   EXPECT_EQ(ext_commitment, commitment);
 

--- a/tachyon/crypto/commitments/merkle_tree/field_merkle_tree/field_merkle_tree_mmcs.h
+++ b/tachyon/crypto/commitments/merkle_tree/field_merkle_tree/field_merkle_tree_mmcs.h
@@ -98,7 +98,7 @@ class FieldMerkleTreeMMCS final
     return true;
   }
 
-  const std::vector<math::RowMajorMatrix<F>>& DoGetMatrices(
+  const std::vector<Eigen::Map<const math::RowMajorMatrix<F>>>& DoGetMatrices(
       const ProverData& prover_data) const {
     return prover_data.leaves();
   }
@@ -114,7 +114,8 @@ class FieldMerkleTreeMMCS final
     // TODO(chokobole): Is it able to be parallelized?
     *openings = base::Map(
         prover_data.leaves(),
-        [log_max_row_size, index](const math::RowMajorMatrix<F>& matrix) {
+        [log_max_row_size,
+         index](const Eigen::Map<const math::RowMajorMatrix<F>>& matrix) {
           uint32_t log_row_size =
               base::bits::Log2Ceiling(static_cast<size_t>(matrix.rows()));
           uint32_t bits_reduced = log_max_row_size - log_row_size;

--- a/tachyon/crypto/commitments/merkle_tree/field_merkle_tree/field_merkle_tree_mmcs.h
+++ b/tachyon/crypto/commitments/merkle_tree/field_merkle_tree/field_merkle_tree_mmcs.h
@@ -86,13 +86,25 @@ class FieldMerkleTreeMMCS final
     }
   };
 
-  [[nodiscard]] bool DoCommit(std::vector<math::RowMajorMatrix<F>>&& matrices,
-                              Commitment* commitment,
-                              ProverData* prover_data) const {
+  [[nodiscard]] bool DoCommit(
+      std::vector<Eigen::Map<const math::RowMajorMatrix<F>>>&& matrices,
+      Commitment* commitment, ProverData* prover_data) const {
     TRACE_EVENT("ProofGeneration", "FieldMerkleTreeMMCS::DoCommit");
     *prover_data =
         FieldMerkleTree<F, N>::Build(hasher_, packed_hasher_, compressor_,
                                      packed_compressor_, std::move(matrices));
+    *commitment = prover_data->GetRoot();
+
+    return true;
+  }
+
+  [[nodiscard]] bool DoCommitOwned(
+      std::vector<math::RowMajorMatrix<F>>&& owned_matrices,
+      Commitment* commitment, ProverData* prover_data) const {
+    TRACE_EVENT("ProofGeneration", "FieldMerkleTreeMMCS::DoCommitOwned");
+    *prover_data = FieldMerkleTree<F, N>::BuildOwned(
+        hasher_, packed_hasher_, compressor_, packed_compressor_,
+        std::move(owned_matrices));
     *commitment = prover_data->GetRoot();
 
     return true;

--- a/tachyon/crypto/commitments/merkle_tree/field_merkle_tree/field_merkle_tree_unittest.cc
+++ b/tachyon/crypto/commitments/merkle_tree/field_merkle_tree/field_merkle_tree_unittest.cc
@@ -72,8 +72,8 @@ TEST_F(FieldMerkleTreeTest, CommitSingle1x8) {
   };
   std::vector<math::RowMajorMatrix<F>> matrices = {matrix};
 
-  Tree tree = Tree::Build(hasher_, packed_hasher_, compressor_,
-                          packed_compressor_, std::move(matrices));
+  Tree tree = Tree::BuildOwned(hasher_, packed_hasher_, compressor_,
+                               packed_compressor_, std::move(matrices));
 
   auto h0_1 = compressor_.Compress(std::vector<std::array<F, kChunk>>{
       hasher_.Hash(std::vector<F>{matrix(0, 0)}),
@@ -103,8 +103,8 @@ TEST_F(FieldMerkleTreeTest, CommitSingle2x2) {
   };
   std::vector<math::RowMajorMatrix<F>> matrices = {matrix};
 
-  Tree tree = Tree::Build(hasher_, packed_hasher_, compressor_,
-                          packed_compressor_, std::move(matrices));
+  Tree tree = Tree::BuildOwned(hasher_, packed_hasher_, compressor_,
+                               packed_compressor_, std::move(matrices));
 
   auto expected = compressor_.Compress(std::vector<std::array<F, kChunk>>{
       hasher_.Hash(std::vector<F>{matrix(0, 0), matrix(0, 1)}),
@@ -120,8 +120,8 @@ TEST_F(FieldMerkleTreeTest, CommitSingle2x3) {
   };
   std::vector<math::RowMajorMatrix<F>> matrices = {matrix};
 
-  Tree tree = Tree::Build(hasher_, packed_hasher_, compressor_,
-                          packed_compressor_, std::move(matrices));
+  Tree tree = Tree::BuildOwned(hasher_, packed_hasher_, compressor_,
+                               packed_compressor_, std::move(matrices));
   std::array<F, kChunk> default_digest =
       base::CreateArray<kChunk>([]() { return F::Zero(); });
   auto h0_3 = compressor_.Compress(std::vector<std::array<F, kChunk>>{
@@ -147,8 +147,8 @@ TEST_F(FieldMerkleTreeTest, CommitMixed) {
   };
   std::vector<math::RowMajorMatrix<F>> matrices = {matrix, matrix2};
 
-  Tree tree = Tree::Build(hasher_, packed_hasher_, compressor_,
-                          packed_compressor_, std::move(matrices));
+  Tree tree = Tree::BuildOwned(hasher_, packed_hasher_, compressor_,
+                               packed_compressor_, std::move(matrices));
   std::array<F, kChunk> default_digest =
       base::CreateArray<kChunk>([]() { return F::Zero(); });
   auto h0_3 = compressor_.Compress(std::vector<std::array<F, kChunk>>{
@@ -175,12 +175,12 @@ TEST_F(FieldMerkleTreeTest, CommitEitherOrder) {
   math::RowMajorMatrix<F> matrix2 = math::RowMajorMatrix<F>::Random(2, 3);
 
   std::vector<math::RowMajorMatrix<F>> matrices = {matrix, matrix2};
-  Tree tree = Tree::Build(hasher_, packed_hasher_, compressor_,
-                          packed_compressor_, std::move(matrices));
+  Tree tree = Tree::BuildOwned(hasher_, packed_hasher_, compressor_,
+                               packed_compressor_, std::move(matrices));
 
   std::vector<math::RowMajorMatrix<F>> matrices2 = {matrix2, matrix};
-  Tree tree2 = Tree::Build(hasher_, packed_hasher_, compressor_,
-                           packed_compressor_, std::move(matrices2));
+  Tree tree2 = Tree::BuildOwned(hasher_, packed_hasher_, compressor_,
+                                packed_compressor_, std::move(matrices2));
   EXPECT_EQ(tree.GetRoot(), tree2.GetRoot());
 }
 

--- a/tachyon/crypto/commitments/merkle_tree/field_merkle_tree/field_merkle_tree_unittest.cc
+++ b/tachyon/crypto/commitments/merkle_tree/field_merkle_tree/field_merkle_tree_unittest.cc
@@ -178,7 +178,7 @@ TEST_F(FieldMerkleTreeTest, CommitEitherOrder) {
   Tree tree = Tree::Build(hasher_, packed_hasher_, compressor_,
                           packed_compressor_, std::move(matrices));
 
-  std::vector<math::RowMajorMatrix<F>> matrices2 = {matrix, matrix2};
+  std::vector<math::RowMajorMatrix<F>> matrices2 = {matrix2, matrix};
   Tree tree2 = Tree::Build(hasher_, packed_hasher_, compressor_,
                            packed_compressor_, std::move(matrices2));
   EXPECT_EQ(tree.GetRoot(), tree2.GetRoot());

--- a/tachyon/crypto/commitments/mixed_matrix_commitment_scheme.h
+++ b/tachyon/crypto/commitments/mixed_matrix_commitment_scheme.h
@@ -55,28 +55,30 @@ class MixedMatrixCommitmentScheme {
     return derived->DoCreateOpeningProof(index, prover_data, openings, proof);
   }
 
-  const std::vector<math::RowMajorMatrix<Field>>& GetMatrices(
+  const std::vector<Eigen::Map<const math::RowMajorMatrix<Field>>>& GetMatrices(
       const ProverData& prover_data) const {
     const Derived* derived = static_cast<const Derived*>(this);
     return derived->DoGetMatrices(prover_data);
   }
 
   std::vector<size_t> GetRowSizes() const {
-    return base::Map(GetMatrices(),
-                     [](const math::RowMajorMatrix<Field>& matrix) {
-                       return matrix.rows();
-                     });
+    return base::Map(
+        GetMatrices(),
+        [](const Eigen::Map<const math::RowMajorMatrix<Field>>& matrix) {
+          return matrix.rows();
+        });
   }
 
   size_t GetMaxRowSize(const ProverData& prover_data) const {
-    const std::vector<math::RowMajorMatrix<Field>>& matrices =
+    const std::vector<Eigen::Map<const math::RowMajorMatrix<Field>>>& matrices =
         GetMatrices(prover_data);
     if (matrices.empty()) return 0;
-    return std::max_element(matrices.begin(), matrices.end(),
-                            [](const math::RowMajorMatrix<Field>& a,
-                               const math::RowMajorMatrix<Field>& b) {
-                              return a.rows() < b.rows();
-                            })
+    return std::max_element(
+               matrices.begin(), matrices.end(),
+               [](const Eigen::Map<const math::RowMajorMatrix<Field>>& a,
+                  const Eigen::Map<const math::RowMajorMatrix<Field>>& b) {
+                 return a.rows() < b.rows();
+               })
         ->rows();
   }
 

--- a/tachyon/crypto/commitments/mixed_matrix_commitment_scheme.h
+++ b/tachyon/crypto/commitments/mixed_matrix_commitment_scheme.h
@@ -25,27 +25,63 @@ class MixedMatrixCommitmentScheme {
       typename MixedMatrixCommitmentSchemeTraits<Derived>::ProverData;
   using Proof = typename MixedMatrixCommitmentSchemeTraits<Derived>::Proof;
 
+  // NOTE: |Commit()| doesn't own the input data unlike |CommitOwned()|.
+  // This is created based on our usecase. |get_evaluations_on_domain()| returns
+  // a borrowed value with the same lifetime as the prover_data in |ProverData|.
+  // However, if the actual data is managed on the C++ side, then both Rust and
+  // C++ attempt to deallocate the memory once it goes out of scope. An
+  // alternative is using |std::mem::forget()| in Plonky3, but this needs
+  // additional modifications.
+  // See
+  // https://github.com/Plonky3/Plonky3/blob/2df15fd/fri/src/two_adic_pcs.rs#L177-L188.
   [[nodiscard]] bool Commit(const std::vector<Field>& vector,
                             Commitment* commitment, ProverData* prover_data) {
+    return Commit(
+        std::vector<Eigen::Map<const math::RowMajorMatrix<Field>>>{
+            Eigen::Map<const math::RowMajorMatrix<Field>>(vector.data(),
+                                                          vector.size(), 1)},
+        commitment, prover_data);
+  }
+
+  [[nodiscard]] bool Commit(
+      const Eigen::Map<const math::RowMajorMatrix<Field>>& matrix,
+      Commitment* commitment, ProverData* prover_data) const {
+    return Commit(
+        std::vector<Eigen::Map<const math::RowMajorMatrix<Field>>>{matrix},
+        commitment, prover_data);
+  }
+
+  [[nodiscard]] bool Commit(
+      std::vector<Eigen::Map<const math::RowMajorMatrix<Field>>>&& matrices,
+      Commitment* commitment, ProverData* prover_data) const {
+    const Derived* derived = static_cast<const Derived*>(this);
+    return derived->DoCommit(std::move(matrices), commitment, prover_data);
+  }
+
+  // NOTE: |CommitOwned()| own the input data unlike |Commit()|.
+  [[nodiscard]] bool CommitOwned(const std::vector<Field>& vector,
+                                 Commitment* commitment,
+                                 ProverData* prover_data) {
     math::RowMajorMatrix<Field> matrix(vector.size(), 1);
     OMP_PARALLEL_FOR(size_t i = 0; i < vector.size(); ++i) {
       matrix(i, 0) = vector[i];
     }
-    return Commit(std::move(matrix), commitment, prover_data);
+    return CommitOwned(std::move(matrix), commitment, prover_data);
   }
 
-  [[nodiscard]] bool Commit(math::RowMajorMatrix<Field>&& matrix,
-                            Commitment* commitment,
-                            ProverData* prover_data) const {
-    return Commit(std::vector<math::RowMajorMatrix<Field>>{std::move(matrix)},
-                  commitment, prover_data);
+  [[nodiscard]] bool CommitOwned(math::RowMajorMatrix<Field>&& matrix,
+                                 Commitment* commitment,
+                                 ProverData* prover_data) const {
+    return CommitOwned(
+        std::vector<math::RowMajorMatrix<Field>>{std::move(matrix)}, commitment,
+        prover_data);
   }
 
-  [[nodiscard]] bool Commit(std::vector<math::RowMajorMatrix<Field>>&& matrices,
-                            Commitment* commitment,
-                            ProverData* prover_data) const {
+  [[nodiscard]] bool CommitOwned(
+      std::vector<math::RowMajorMatrix<Field>>&& matrices,
+      Commitment* commitment, ProverData* prover_data) const {
     const Derived* derived = static_cast<const Derived*>(this);
-    return derived->DoCommit(std::move(matrices), commitment, prover_data);
+    return derived->DoCommitOwned(std::move(matrices), commitment, prover_data);
   }
 
   [[nodiscard]] bool CreateOpeningProof(

--- a/tachyon/math/matrix/matrix_utils.h
+++ b/tachyon/math/matrix/matrix_utils.h
@@ -213,6 +213,16 @@ std::vector<ExtField> DotExtPowers(const Eigen::MatrixBase<Derived>& mat,
   });
 }
 
+template <typename Derived>
+Eigen::Map<Derived> Map(Eigen::PlainObjectBase<Derived>& mat) {
+  return Eigen::Map<Derived>(mat.data(), mat.rows(), mat.cols());
+}
+
+template <typename Derived>
+Eigen::Map<const Derived> Map(const Eigen::PlainObjectBase<Derived>& mat) {
+  return Eigen::Map<const Derived>(mat.data(), mat.rows(), mat.cols());
+}
+
 }  // namespace tachyon::math
 
 #endif  // TACHYON_MATH_MATRIX_MATRIX_UTILS_H_

--- a/tachyon/math/matrix/matrix_utils.h
+++ b/tachyon/math/matrix/matrix_utils.h
@@ -107,32 +107,6 @@ std::vector<PackedField> PackRowVertically(
   }
 }
 
-// Expands a |Eigen::MatrixBase|'s rows from |rows| to |rows|^(|added_bits|),
-// moving values from row |i| to row |i|^(|added_bits|). All new entries are set
-// to |F::Zero()|.
-template <typename Derived, typename Scalar = typename Derived::Scalar>
-RowMajorMatrix<Scalar> ExpandInPlaceWithZeroPad(Eigen::MatrixBase<Derived>& mat,
-                                                size_t added_bits) {
-  if (added_bits == 0) {
-    return mat;
-  }
-
-  Eigen::Index new_rows = mat.rows() << added_bits;
-  Eigen::Index cols = mat.cols();
-
-  RowMajorMatrix<Scalar> padded(new_rows, cols);
-  Eigen::Index mask = (Eigen::Index{1} << added_bits) - 1;
-
-  OMP_PARALLEL_FOR(Eigen::Index row = 0; row < new_rows; ++row) {
-    if ((row & mask) == 0) {
-      padded.row(row) = mat.row(row >> added_bits);
-    } else {
-      padded.row(row).setZero();
-    }
-  }
-  return padded;
-}
-
 // Swaps rows of a |Eigen::MatrixBase| such that each row is changed to the row
 // accessed with the reversed bits of the current index. Crashes if the number
 // of rows is not a power of two.

--- a/tachyon/math/polynomials/univariate/naive_batch_fft.h
+++ b/tachyon/math/polynomials/univariate/naive_batch_fft.h
@@ -59,7 +59,14 @@ class NaiveBatchFFT : public TwoAdicSubgroup<NaiveBatchFFT<F>> {
   // Compute the low-degree extension of each column in |mat| onto a coset of
   // a larger subgroup and populate |out| with the result.
   template <typename Derived>
-  void CosetLDEBatch(Eigen::MatrixBase<Derived>& mat, size_t added_bits,
+  void CosetLDEBatch(const Eigen::MatrixBase<Derived>& mat, size_t added_bits,
+                     F shift, Eigen::MatrixBase<Derived>& out) const {
+    Derived mat_tmp = mat;
+    CosetLDEBatch(std::move(mat_tmp), added_bits, shift, out);
+  }
+
+  template <typename Derived>
+  void CosetLDEBatch(Eigen::MatrixBase<Derived>&& mat, size_t added_bits,
                      F shift, Eigen::MatrixBase<Derived>& out) const {
     if constexpr (F::Config::kModulusBits > 32) {
       NOTREACHED();

--- a/tachyon/math/polynomials/univariate/radix2_evaluation_domain.h
+++ b/tachyon/math/polynomials/univariate/radix2_evaluation_domain.h
@@ -118,18 +118,18 @@ class Radix2EvaluationDomain
     ReverseMatrixIndexBits(mat);
   }
 
-  template <typename Derived, typename Derived2>
+  template <typename Derived>
   CONSTEXPR_IF_NOT_OPENMP void CosetLDEBatch(
       const Eigen::MatrixBase<Derived>& mat, size_t added_bits, F shift,
-      Eigen::MatrixBase<Derived2>& out, bool reverse_at_last = true) const {
+      Eigen::MatrixBase<Derived>& out, bool reverse_at_last = true) const {
     Derived mat_tmp = mat;
     CosetLDEBatch(std::move(mat_tmp), added_bits, shift, out);
   }
 
-  template <typename Derived, typename Derived2>
+  template <typename Derived>
   CONSTEXPR_IF_NOT_OPENMP void CosetLDEBatch(
       Eigen::MatrixBase<Derived>&& mat, size_t added_bits, F shift,
-      Eigen::MatrixBase<Derived2>& out, bool reverse_at_last = true) const {
+      Eigen::MatrixBase<Derived>& out, bool reverse_at_last = true) const {
     TRACE_EVENT("EvaluationDomain", "Radix2EvaluationDomain::CosetLDEBatch");
     if constexpr (F::Config::kModulusBits > 32) {
       NOTREACHED();
@@ -456,10 +456,10 @@ class Radix2EvaluationDomain
   // moving values from row |i| to row |i|^(|added_bits|). All new entries are
   // set to |F::Zero()|.
   // Note that it crashes if the |added_bits| is zero.
-  template <typename Derived, typename Derived2>
+  template <typename Derived>
   CONSTEXPR_IF_NOT_OPENMP static void ExpandWithZeroPad(
       Eigen::MatrixBase<Derived>& mat, size_t added_bits,
-      Eigen::MatrixBase<Derived2>& out) {
+      Eigen::MatrixBase<Derived>& out) {
     CHECK_GT(added_bits, size_t{0});
 
     Eigen::Index new_rows = mat.rows() << added_bits;

--- a/tachyon/math/polynomials/univariate/radix2_evaluation_domain.h
+++ b/tachyon/math/polynomials/univariate/radix2_evaluation_domain.h
@@ -120,7 +120,15 @@ class Radix2EvaluationDomain
 
   template <typename Derived, typename Derived2>
   CONSTEXPR_IF_NOT_OPENMP void CosetLDEBatch(
-      Eigen::MatrixBase<Derived>& mat, size_t added_bits, F shift,
+      const Eigen::MatrixBase<Derived>& mat, size_t added_bits, F shift,
+      Eigen::MatrixBase<Derived2>& out, bool reverse_at_last = true) const {
+    Derived mat_tmp = mat;
+    CosetLDEBatch(std::move(mat_tmp), added_bits, shift, out);
+  }
+
+  template <typename Derived, typename Derived2>
+  CONSTEXPR_IF_NOT_OPENMP void CosetLDEBatch(
+      Eigen::MatrixBase<Derived>&& mat, size_t added_bits, F shift,
       Eigen::MatrixBase<Derived2>& out, bool reverse_at_last = true) const {
     TRACE_EVENT("EvaluationDomain", "Radix2EvaluationDomain::CosetLDEBatch");
     if constexpr (F::Config::kModulusBits > 32) {

--- a/tachyon/math/polynomials/univariate/radix2_evaluation_domain.h
+++ b/tachyon/math/polynomials/univariate/radix2_evaluation_domain.h
@@ -171,7 +171,7 @@ class Radix2EvaluationDomain
     });
 
     if (added_bits == 0) {
-      out = mat;
+      out = std::move(mat);
     } else {
       ExpandWithZeroPad(mat, added_bits, out);
     }

--- a/tachyon/math/polynomials/univariate/radix2_evaluation_domain_unittest.cc
+++ b/tachyon/math/polynomials/univariate/radix2_evaluation_domain_unittest.cc
@@ -53,14 +53,13 @@ TYPED_TEST(Radix2EvaluationDomainTest, CosetLDEBatchDeath) {
   RowMajorMatrix<F> matrix = RowMajorMatrix<F>::Random(1, 3);
   F shift = F::FromMontgomery(F::Config::kSubgroupGenerator);
   RowMajorMatrix<F> result(2, 3);
-  EXPECT_DEATH(domain->CosetLDEBatch(matrix, 1, shift, result), "");
+  EXPECT_DEATH(domain->CosetLDEBatch(std::move(matrix), 1, shift, result), "");
 }
 
 TYPED_TEST(Radix2EvaluationDomainTest, CosetLDEBatch) {
   using F = TypeParam;
   for (uint32_t log_r = 1; log_r < 5; ++log_r) {
     RowMajorMatrix<F> input = RowMajorMatrix<F>::Random(size_t{1} << log_r, 3);
-    RowMajorMatrix<F> input_clone = input;
     NaiveBatchFFT<F> naive;
     F shift = F::FromMontgomery(F::Config::kSubgroupGenerator);
     RowMajorMatrix<F> expected(size_t{1} << (log_r + 1), 3);
@@ -68,7 +67,7 @@ TYPED_TEST(Radix2EvaluationDomainTest, CosetLDEBatch) {
     std::unique_ptr<Radix2EvaluationDomain<F>> domain =
         Radix2EvaluationDomain<F>::Create(size_t{1} << log_r);
     RowMajorMatrix<F> result(size_t{1} << (log_r + 1), 3);
-    domain->CosetLDEBatch(input_clone, 1, shift, result);
+    domain->CosetLDEBatch(std::move(input), 1, shift, result);
     EXPECT_EQ(expected, result);
   }
 }

--- a/tachyon/math/polynomials/univariate/radix2_evaluation_domain_unittest.cc
+++ b/tachyon/math/polynomials/univariate/radix2_evaluation_domain_unittest.cc
@@ -52,21 +52,23 @@ TYPED_TEST(Radix2EvaluationDomainTest, CosetLDEBatchDeath) {
       Radix2EvaluationDomain<F>::Create(1);
   RowMajorMatrix<F> matrix = RowMajorMatrix<F>::Random(1, 3);
   F shift = F::FromMontgomery(F::Config::kSubgroupGenerator);
-  EXPECT_DEATH(domain->CosetLDEBatch(matrix, 1, shift), "");
+  RowMajorMatrix<F> result(2, 3);
+  EXPECT_DEATH(domain->CosetLDEBatch(matrix, 1, shift, result), "");
 }
 
 TYPED_TEST(Radix2EvaluationDomainTest, CosetLDEBatch) {
   using F = TypeParam;
   for (uint32_t log_r = 1; log_r < 5; ++log_r) {
-    RowMajorMatrix<F> expected =
-        RowMajorMatrix<F>::Random(size_t{1} << log_r, 3);
-    RowMajorMatrix<F> result = expected;
+    RowMajorMatrix<F> input = RowMajorMatrix<F>::Random(size_t{1} << log_r, 3);
+    RowMajorMatrix<F> input_clone = input;
     NaiveBatchFFT<F> naive;
     F shift = F::FromMontgomery(F::Config::kSubgroupGenerator);
-    expected = naive.CosetLDEBatch(expected, 1, shift);
+    RowMajorMatrix<F> expected(size_t{1} << (log_r + 1), 3);
+    naive.CosetLDEBatch(input, 1, shift, expected);
     std::unique_ptr<Radix2EvaluationDomain<F>> domain =
         Radix2EvaluationDomain<F>::Create(size_t{1} << log_r);
-    result = domain->CosetLDEBatch(result, 1, shift);
+    RowMajorMatrix<F> result(size_t{1} << (log_r + 1), 3);
+    domain->CosetLDEBatch(input_clone, 1, shift, result);
     EXPECT_EQ(expected, result);
   }
 }

--- a/vendors/scroll_halo2/src/lib.rs
+++ b/vendors/scroll_halo2/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 mod bn254;
 mod cha_cha20_rng;
 mod circuits;

--- a/vendors/sp1/include/baby_bear_poseidon2_two_adic_fri_pcs.h
+++ b/vendors/sp1/include/baby_bear_poseidon2_two_adic_fri_pcs.h
@@ -34,9 +34,9 @@ class TwoAdicFriPcs {
   ~TwoAdicFriPcs();
 
   void allocate_ldes(size_t size) const;
-  rust::Slice<TachyonBabyBear> coset_lde_batch(
-      rust::Slice<TachyonBabyBear> values, size_t cols,
-      const TachyonBabyBear& shift) const;
+  void coset_lde_batch(rust::Slice<TachyonBabyBear> values, size_t cols,
+                       rust::Slice<TachyonBabyBear> extended_values,
+                       const TachyonBabyBear& shift) const;
   std::unique_ptr<ProverData> commit(
       const ProverDataVec& prover_data_vec) const;
   std::unique_ptr<OpeningProof> do_open(const ProverDataVec& prover_data_vec,

--- a/vendors/sp1/src/baby_bear_poseidon2.rs
+++ b/vendors/sp1/src/baby_bear_poseidon2.rs
@@ -395,7 +395,7 @@ pub struct FriProof {
 }
 
 impl Serialize for FriProof {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    fn serialize<S>(&self, _serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -404,7 +404,7 @@ impl Serialize for FriProof {
 }
 
 impl<'de> Deserialize<'de> for FriProof {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    fn deserialize<D>(_deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {

--- a/vendors/sp1/src/baby_bear_poseidon2_two_adic_fri_pcs.cc
+++ b/vendors/sp1/src/baby_bear_poseidon2_two_adic_fri_pcs.cc
@@ -19,17 +19,15 @@ void TwoAdicFriPcs::allocate_ldes(size_t size) const {
       const_cast<tachyon_sp1_baby_bear_poseidon2_two_adic_fri*>(pcs_), size);
 }
 
-rust::Slice<TachyonBabyBear> TwoAdicFriPcs::coset_lde_batch(
+void TwoAdicFriPcs::coset_lde_batch(
     rust::Slice<TachyonBabyBear> values, size_t cols,
+    rust::Slice<TachyonBabyBear> extended_values,
     const TachyonBabyBear& shift) const {
-  size_t new_rows;
-  tachyon_baby_bear* data =
-      tachyon_sp1_baby_bear_poseidon2_two_adic_fri_coset_lde_batch(
-          const_cast<tachyon_sp1_baby_bear_poseidon2_two_adic_fri*>(pcs_),
-          reinterpret_cast<tachyon_baby_bear*>(values.data()),
-          values.size() / cols, cols,
-          reinterpret_cast<const tachyon_baby_bear&>(shift), &new_rows);
-  return {reinterpret_cast<TachyonBabyBear*>(data), new_rows * cols};
+  tachyon_sp1_baby_bear_poseidon2_two_adic_fri_coset_lde_batch(
+      const_cast<tachyon_sp1_baby_bear_poseidon2_two_adic_fri*>(pcs_),
+      reinterpret_cast<tachyon_baby_bear*>(values.data()), values.size() / cols,
+      cols, reinterpret_cast<tachyon_baby_bear*>(extended_values.data()),
+      reinterpret_cast<const tachyon_baby_bear&>(shift));
 }
 
 std::unique_ptr<ProverData> TwoAdicFriPcs::commit(

--- a/vendors/sp1/src/challenger.rs
+++ b/vendors/sp1/src/challenger.rs
@@ -12,8 +12,6 @@ mod test {
     #[test]
     fn test_duplex_challenger() {
         const WIDTH: usize = 16;
-        const ROUNDS_F: usize = 8;
-        const ROUNDS_P: usize = 13;
 
         const RATE: usize = 8;
 

--- a/vendors/sp1/src/lib.rs
+++ b/vendors/sp1/src/lib.rs
@@ -5,9 +5,13 @@ pub mod util;
 
 #[cfg(test)]
 mod test {
+    #[cfg(not(debug_assertions))]
     use anyhow::Result;
+    #[cfg(not(debug_assertions))]
     use sp1_core::io::SP1Stdin;
+    #[cfg(not(debug_assertions))]
     use sp1_core::{runtime::SP1Context, utils::setup_logger};
+    #[cfg(not(debug_assertions))]
     use sp1_prover::{components::DefaultProverComponents, SP1Prover};
 
     #[test]

--- a/vendors/sp1/src/two_adic_fri_pcs.rs
+++ b/vendors/sp1/src/two_adic_fri_pcs.rs
@@ -5,6 +5,7 @@ mod test {
     use p3_challenger::FieldChallenger;
     use p3_commit::Pcs;
     use p3_commit::PolynomialSpace;
+    use p3_commit::TwoAdicMultiplicativeCoset;
     use p3_dft::TwoAdicSubgroupDft;
     use p3_field::AbstractField;
     use p3_fri::TwoAdicFriPcs;
@@ -91,6 +92,25 @@ mod test {
                 .unzip();
 
         assert_eq!(commits_by_round, tachyon_commits_by_round);
+
+        let domain = TwoAdicMultiplicativeCoset {
+            log_n: 2,
+            shift: Val::generator(),
+        };
+        let eval = <TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs> as Pcs<
+            Challenge,
+            Challenger,
+        >>::get_evaluations_on_domain(&pcs, &data_by_round[0], 1, domain)
+        .to_row_major_matrix();
+        let tachyon_eval = <TachyonTwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs> as Pcs<
+            Challenge,
+            Challenger,
+        >>::get_evaluations_on_domain(
+            &tachyon_pcs, &tachyon_data_by_round[0], 1, domain
+        )
+        .to_row_major_matrix();
+
+        assert_eq!(eval, tachyon_eval);
 
         let ldes_vec = domains_and_polys_by_round
             .iter()

--- a/vendors/sp1/src/two_adic_fri_pcs.rs
+++ b/vendors/sp1/src/two_adic_fri_pcs.rs
@@ -183,8 +183,5 @@ mod test {
         assert!(tachyon_pcs
             .verify(rounds, &tachyon_proof, &mut tachyon_challenger_for_verify)
             .is_ok());
-
-        // TODO(chokobole): `std::mem::forget` was used to prevent it from double-free. We need to figure out a more elegant solution.
-        std::mem::forget(tachyon_data_by_round);
     }
 }

--- a/vendors/sp1/src/two_adic_fri_pcs.rs
+++ b/vendors/sp1/src/two_adic_fri_pcs.rs
@@ -9,7 +9,6 @@ mod test {
     use p3_field::AbstractField;
     use p3_fri::TwoAdicFriPcs;
     use p3_matrix::{bitrev::BitReversableMatrix, dense::RowMajorMatrix, Matrix};
-    use p3_util::log2_strict_usize;
     use rand::{Rng, SeedableRng};
     use rand_chacha::ChaCha20Rng;
     use sp1_core::utils::baby_bear_poseidon2::{
@@ -29,8 +28,6 @@ mod test {
 
     #[test]
     fn test_two_adic_fri_pcs() {
-        const ROWS: usize = 32;
-        const COLS: usize = 5;
         const LOG_N: usize = 20;
 
         let perm = my_perm();
@@ -102,7 +99,6 @@ mod test {
                     .into_iter()
                     .map(|(domain, evals)| {
                         assert_eq!(domain.size(), evals.height());
-                        let log_n = log2_strict_usize(domain.size());
                         let shift = Val::generator() / domain.shift;
                         // Commit to the bit-reversed LDE.
                         Dft {}
@@ -116,7 +112,7 @@ mod test {
 
         for (i, ldes) in ldes_vec.clone().into_iter().enumerate() {
             for (j, lde) in ldes.into_iter().enumerate() {
-                let v = assert_eq!(
+                assert_eq!(
                     lde.to_row_major_matrix(),
                     tachyon_data_by_round[i].ldes[j]
                         .clone()
@@ -138,7 +134,7 @@ mod test {
             .iter()
             .zip(points_by_round.clone())
             .collect::<Vec<_>>();
-        let (opening_by_round, proof) = pcs.open(data_and_points, &mut challenger);
+        let (opening_by_round, _proof) = pcs.open(data_and_points, &mut challenger);
 
         let tachyon_data_and_points = tachyon_data_by_round
             .iter()


### PR DESCRIPTION
# Description

The commit to matrices are roughly performed in the order below:

`baby_bear_poseidon2::TwoAdicFri::commit()` → `tachyon_sp1_baby_bear_poseidon2_two_adic_fri_allocate_ldes()` -> `tachyon_sp1_baby_bear_poseidon2_two_adic_fri_commit()` → `FieldMerkleTreeMMCS::Commit()` → `Radix2EvaluationDomain::CosetLDEBatch()` → `ExpandInPlaceWithZeroPad()` (This generates the leaves of a merkle tree, which is a vector of the matrix(Low Degree Extension, a.k.a, LDE) which is stored in a `ProverData`).

Previously, LDE was owned by both the C++ and Rust side. In order to prevent the resulting double-free, we add an additional function `std::mem::forget()` on the Rust side. This approach forces us to modify Plonky3 code, but the problem is we can't find where to modify for `0.1.3-succinct` version in Plonky3. A naive possible solution is to allocate memory on the C++ side and de-allocate it on the Rust side, but this doesn't work because of the different memory management system and instead causes memory corruption.

To prevent a double-free or memory corruption without modifications to Plonky3 code, the Rust side should own the leaves of the `FieldMerkleTree`. The `FieldMerkleTreeMMCS::Commit()` must accept Rust allocated leaves, while the existing version is renamed to `FieldMerkleTreeMMCS::CommitOwned()` for internal use, such as unit tests. Similarly, `FieldMerkleTree::Build()` becomes `FieldMerkleTree::BuildOwned()`.

`Radix2EvaluationDomain::CosetLDEBatch()` now requires Rust allocated expanded matrices, internal memory allocation is removed, and `ExpandInPlaceWithZeroPad()` is renamed to `ExpandWithZeroPad()` .

`tachyon_sp1_baby_bear_poseidon2_two_adic_fri_commit()` is changed to accept Rust allocated leaves for the same reason.