### PR TITLE
fix(benchmark): fix faulty fri benchmark

### DIFF
--- a/benchmark/fri/fri_benchmark.cc
+++ b/benchmark/fri/fri_benchmark.cc
@@ -83,7 +83,7 @@ void Run(const FRIConfig& config) {
       crypto::GetPoseidon2InternalShiftArray<Params>());
   Poseidon2 sponge(std::move(poseidon2_config));
   MyHasher hasher(sponge);
-  MyCompressor compressor(std::move(sponge));
+  MyCompressor compressor(sponge);
 
   auto packed_config = crypto::Poseidon2Config<PackedParams>::Create(
       crypto::GetPoseidon2InternalShiftArray<PackedParams>());

--- a/benchmark/poseidon2/poseidon2_benchmark_runner.h
+++ b/benchmark/poseidon2/poseidon2_benchmark_runner.h
@@ -40,7 +40,7 @@ class Poseidon2BenchmarkRunner {
           crypto::Poseidon2ExternalMatrix<
               crypto::Poseidon2HorizenExternalMatrix<Field>>,
           Params>
-          sponge(std::move(config));
+          sponge(config);
       crypto::SpongeState<Params> state;
       base::TimeTicks start = base::TimeTicks::Now();
       for (size_t j = 0; j < 10000; ++j) {


### PR DESCRIPTION
Fixes error made in from 76ded8d5a45d191ad831d116a6c9ef3f37d4cde7 which prevented the Fri benchmark from running properly. 
