### PR TITLE
feat(circom): introduce witness generation tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,6 @@ jobs:
 
       - name: Run Buildifier
         run: |
-          find . -iname "*.bazel" -o -iname "*.bzl" | xargs buildifier --lint=fix
-          find . -iname "*.bazel" -o -iname "*.bzl" | xargs buildifier --mode=check
+          find . -iname "*.bazel" -o -iname "*.bzl" -o -name "WORKSPACE" -o -iname "*.BUILD" | xargs buildifier --lint=fix
+          find . -iname "*.bazel" -o -iname "*.bzl" -o -name "WORKSPACE" -o -iname "*.BUILD" | xargs buildifier --mode=check
           git diff --exit-code

--- a/third_party/goldilocks/goldilocks.BUILD
+++ b/third_party/goldilocks/goldilocks.BUILD
@@ -21,10 +21,10 @@ cc_library(
         ["-mavx512f"],
         ["-mavx2"],
     ) + tachyon_openmp_copts(),
-    linkopts = tachyon_openmp_linkopts(),
     defines = if_has_avx512(["__AVX512__"]),
     include_prefix = "third_party/goldilocks/include",
     includes = ["src"],
+    linkopts = tachyon_openmp_linkopts(),
     strip_include_prefix = "src",
     deps = ["@local_config_gmp//:gmp"],
 )

--- a/third_party/hwloc/hwloc.BUILD
+++ b/third_party/hwloc/hwloc.BUILD
@@ -1,6 +1,7 @@
+load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
+
 # hwloc: Portable Hardware Locality Library
 load("@local_config_cuda//cuda:build_defs.bzl", "if_cuda")
-load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
 
 package(
     default_visibility = ["//visibility:public"],

--- a/third_party/perfetto/perfetto.BUILD
+++ b/third_party/perfetto/perfetto.BUILD
@@ -4,8 +4,8 @@ package(default_visibility = ["//visibility:public"])
 
 cc_library(
     name = "perfetto",
-    hdrs = ["sdk/perfetto.h"],
     srcs = ["sdk/perfetto.cc"],
-    strip_include_prefix = "sdk",
+    hdrs = ["sdk/perfetto.h"],
     include_prefix = "third_party/perfetto",
+    strip_include_prefix = "sdk",
 )

--- a/vendors/circom/README.md
+++ b/vendors/circom/README.md
@@ -81,3 +81,19 @@ Optional arguments:
 --disable_fast_twiddles_mode
                     Disables fast twiddle mode on Icicle NTT domain initialization.
 ```
+
+## How to compile witness generator
+
+This creates a witness_generator binary similar to when circom is used, but compiles much faster in comparison.
+
+```shell
+bazel build -c opt //circomlib/build:compile_witness_generator
+
+bazel-bin/circomlib/build/compile_witness_generator --help
+Usage:
+bazel-bin/circomlib/build/compile_witness_generator [OPTION]...
+
+-h, --help  help
+--cpp,      A path to circuit .cpp file
+-f, --field A field to use. default: bn128, supported: bls12381 bn128 goldilocks grumpkin pallas secq256r1 vesta
+```

--- a/vendors/circom/WORKSPACE
+++ b/vendors/circom/WORKSPACE
@@ -3,6 +3,31 @@ workspace(name = "kroma_network_circom")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
+    name = "iden3_circom",
+    build_file = "@kroma_network_circom//:circom.BUILD",
+    sha256 = "ba2c82edabdca7190f4f152e3c4ebcdf3656805dc4c1c7e1d37a991d5a79e1cd",
+    strip_prefix = "circom-2.1.9",
+    urls = ["https://github.com/iden3/circom/archive/v2.1.9.tar.gz"],
+)
+
+http_archive(
+    name = "llvm-raw",
+    build_file_content = "# empty",
+    sha256 = "50b3ef31b228ea0c96ae074005bfac087c56e6a4b1c147592dd33f41cad0706b",
+    strip_prefix = "llvm-project-81d5412439efd0860c0a8dd51b831204f118d485",
+    urls = ["https://github.com/llvm/llvm-project/archive/81d5412439efd0860c0a8dd51b831204f118d485.tar.gz"],
+)
+
+load("@llvm-raw//utils/bazel:configure.bzl", "llvm_configure", "llvm_disable_optional_support_deps")
+
+llvm_configure(name = "llvm-project")
+
+# Disables optional dependencies for support like zlib and terminfo. You may
+# instead want to configure them using the macros in the corresponding bzl
+# files.
+llvm_disable_optional_support_deps()
+
+http_archive(
     name = "kroma_network_rules_circom",
     sha256 = "184998343fae865126fe5a31e126b1f8259259fd2a80315ab21251c01625aaf6",
     strip_prefix = "rules_circom-e1f9be5c03fa91f28f92a042f483c608ab4261c6",

--- a/vendors/circom/circom.BUILD
+++ b/vendors/circom/circom.BUILD
@@ -1,0 +1,28 @@
+CURVES = [
+    "bls12381",
+    "bn128",
+    "goldilocks",
+    "grumpkin",
+    "pallas",
+    "secq256r1",
+    "vesta",
+]
+
+TPLS = [
+    "code_producers/src/c_elements/{}/fr.asm",
+    "code_producers/src/c_elements/{}/fr.cpp",
+    "code_producers/src/c_elements/{}/fr.hpp",
+]
+
+C_ELEMENTS = [tpl.format(curve) for tpl in TPLS for curve in CURVES]
+
+filegroup(
+    name = "generated_files",
+    srcs = C_ELEMENTS + [
+        "code_producers/src/c_elements/common/calcwit.cpp",
+        "code_producers/src/c_elements/common/calcwit.hpp",
+        "code_producers/src/c_elements/common/circom.hpp",
+        "code_producers/src/c_elements/common/main.cpp",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/vendors/circom/circomlib/build/BUILD.bazel
+++ b/vendors/circom/circomlib/build/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@kroma_network_tachyon//bazel:tachyon_cc.bzl", "tachyon_cc_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+tachyon_cc_binary(
+    name = "split_tool",
+    srcs = ["split_tool.cc"],
+    deps = [
+        "@kroma_network_tachyon//tachyon/base/files:file",
+        "@kroma_network_tachyon//tachyon/base/strings:string_number_conversions",
+        "@llvm-project//clang:ast",
+        "@llvm-project//clang:frontend",
+        "@llvm-project//clang:lex",
+        "@llvm-project//clang:rewrite",
+        "@llvm-project//clang:tooling",
+        "@llvm-project//llvm:Support",
+    ],
+)
+
+sh_binary(
+    name = "compile_witness_generator",
+    srcs = ["compile_witness_generator.sh"],
+    data = [
+        "Makefile",
+        ":split_tool",
+        "@iden3_circom//:generated_files",
+    ],
+)

--- a/vendors/circom/circomlib/build/Makefile
+++ b/vendors/circom/circomlib/build/Makefile
@@ -1,0 +1,40 @@
+CC = g++
+CFLAGS = -std=c++11 -O3 -I. -I../../external/llvm-project/clang/staging/include
+DEPS_HPP = circom.hpp calcwit.hpp fr.hpp functions.hpp
+
+# Source Files
+SRC = $(wildcard part_*.cpp)
+
+# Object Files
+OBJ = $(SRC:.cpp=.o)
+
+# Additional Object Files
+DEPS_O = main.o calcwit.o fr.o fr_asm.o
+
+# NASM Compiler for Assembly File
+ifeq ($(shell uname),Darwin)
+    NASM = nasm -fmacho64 --prefix _
+endif
+ifeq ($(shell uname),Linux)
+    NASM = nasm -felf64
+endif
+
+# Default Target
+all: witness_generator
+
+# Compilation Rules
+%.o: %.cpp $(DEPS_HPP)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+# Assembly Compilation
+fr_asm.o: fr.asm
+	$(NASM) fr.asm -o fr_asm.o
+
+# Linking
+witness_generator: $(DEPS_O) $(OBJ)
+	$(CC) $(CFLAGS) -o $@ $^ -lgmp
+
+# Clean
+.PHONY: clean
+clean:
+	rm -f $(OBJ) $(DEPS_O) witness_generator

--- a/vendors/circom/circomlib/build/compile_witness_generator.sh
+++ b/vendors/circom/circomlib/build/compile_witness_generator.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+set -e
+
+SUPPORTED_FIELDS=("bls12381" "bn128" "goldilocks" "grumpkin" "pallas" "secq256r1" "vesta")
+
+function compile_witness_generator() {
+  CIRCOMLIB=bazel-bin/circomlib/build/compile_witness_generator.runfiles/kroma_network_circom/circomlib
+  cd ${CIRCOMLIB}/build
+  cp ../../../iden3_circom/code_producers/src/c_elements/common/* .
+  echo "Using $2 field..."
+  cp ../../../iden3_circom/code_producers/src/c_elements/$2/* .
+
+  echo "Splitting source file into smaller pieces..."
+  ./split_tool $1 --output_dir=. -- -std=c++11 -I../../external/llvm-project/clang/staging/include
+
+  echo "Compiling everything..."
+  make -j
+  cd -
+  mv ${CIRCOMLIB}/build/witness_generator witness_generator
+
+  echo "Success"
+}
+
+function usage() {
+  echo "Usage:"
+  echo "$0 [OPTION]..."
+  echo ""
+  echo "-h, --help  help"
+  echo "--cpp,      A path to circuit .cpp file"
+  echo "-f, --field A field to use. default: bn128, supported: ${SUPPORTED_FIELDS[@]}"
+  echo ""
+}
+
+function main() {
+  CPP=""
+  FIELD="bn128"
+  while [[ $# -gt 0 ]]
+  do
+    case $1 in
+      -h | --help)
+        usage
+        exit 0
+      ;;
+      --cpp)
+        CPP=$2
+        shift
+        shift
+      ;;
+      -f | --field)
+        FIELD=$2
+        shift
+        shift
+      ;;
+      *)
+        echo "Unknown option: $1"
+        usage
+        exit 1
+      ;;
+    esac
+  done
+
+  if [[ ${CPP} == "" ]]
+  then
+    echo "No cpp file specified"
+    exit 1
+  fi
+
+  if [[ ! " ${SUPPORTED_FIELDS[@]} " =~ " ${FIELD} " ]]
+  then
+    echo "Unsupported field: $FIELD"
+    exit 1
+  fi
+
+  compile_witness_generator $CPP $FIELD
+}
+
+main "$@"

--- a/vendors/circom/circomlib/build/split_tool.cc
+++ b/vendors/circom/circomlib/build/split_tool.cc
@@ -1,0 +1,361 @@
+// clang-format off(build/include_order)
+#include <clang/AST/AST.h>
+#include <clang/AST/RecursiveASTVisitor.h>
+#include <clang/Frontend/CompilerInstance.h>
+#include <clang/Frontend/FrontendActions.h>
+#include <clang/Lex/Lexer.h>
+#include <clang/Rewrite/Core/Rewriter.h>
+#include <clang/Tooling/CommonOptionsParser.h>
+#include <clang/Tooling/Tooling.h>
+#include <llvm/Support/CommandLine.h>
+#include <llvm/Support/Error.h>
+// clang-format on
+
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "tachyon/base/files/file.h"
+#include "tachyon/base/strings/string_number_conversions.h"
+
+using namespace clang;
+using namespace clang::tooling;
+using namespace tachyon;
+
+class FunctionAndGlobalExtractor
+    : public RecursiveASTVisitor<FunctionAndGlobalExtractor> {
+ public:
+  FunctionAndGlobalExtractor(Rewriter& rewriter, const std::string& input_file,
+                             const std::string& output_dir,
+                             size_t functions_per_file,
+                             size_t max_lines_per_file)
+      : rewriter_(rewriter),
+        input_file_(input_file),
+        output_dir_(output_dir),
+        functions_per_file_(functions_per_file),
+        max_lines_per_file_(max_lines_per_file) {}
+
+  bool VisitFunctionDecl(FunctionDecl* f) {
+    SourceManager& sm = rewriter_.getSourceMgr();
+    if (sm.isInMainFile(f->getLocation()) && f->hasBody()) {
+      std::string func_decl = f->getReturnType().getAsString() + " " +
+                              f->getNameInfo().getAsString() + "(";
+
+      // Get function parameters
+      for (unsigned i = 0; i < f->getNumParams(); ++i) {
+        ParmVarDecl* param = f->getParamDecl(i);
+        if (i > 0) func_decl += ", ";
+        func_decl += param->getOriginalType().getAsString() + " " +
+                     param->getNameAsString();
+      }
+      func_decl += ");";
+
+      function_declarations_.push_back(func_decl);
+
+      if (f->doesThisDeclarationHaveABody()) {
+        // Get function definition
+        SourceLocation start_loc = f->getSourceRange().getBegin();
+        SourceLocation end_loc = f->getSourceRange().getEnd();
+
+        // Extend EndLoc to include the entire function body
+        end_loc =
+            Lexer::getLocForEndOfToken(end_loc, 0, sm, rewriter_.getLangOpts());
+
+        std::string func_def = getSourceText(sm, start_loc, end_loc);
+        function_definitions_.push_back(func_def);
+      }
+    }
+    return true;
+  }
+
+  bool VisitVarDecl(VarDecl* v) {
+    SourceManager& sm = rewriter_.getSourceMgr();
+    if (sm.isInMainFile(v->getLocation()) && v->isFileVarDecl() &&
+        !v->isStaticLocal()) {
+      // Get variable declaration
+      QualType qt = v->getType();
+      std::string var_type = v->getType().getAsString();
+      std::string var_name = v->getNameAsString();
+      std::string var_decl;
+
+      if (qt->isArrayType()) {
+        const ConstantArrayType* array_type =
+            v->getASTContext().getAsConstantArrayType(qt);
+        llvm::APInt array_size = array_type->getSize();
+        std::string elem_type = array_type->getElementType().getAsString();
+        var_decl = "extern " + elem_type + " " + var_name + "[" +
+                   std::to_string(array_size.getLimitedValue()) + "];";
+      } else {
+        var_decl = "extern " + qt.getAsString() + " " + var_name + ";";
+      }
+      global_variable_declarations_.push_back(var_decl);
+
+      // Get variable definition
+      if (v->hasInit()) {
+        SourceLocation start_loc = v->getSourceRange().getBegin();
+        SourceLocation end_loc = v->getSourceRange().getEnd();
+        end_loc =
+            Lexer::getLocForEndOfToken(end_loc, 0, sm, rewriter_.getLangOpts());
+
+        std::string var_def = getSourceText(sm, start_loc, end_loc) + ";";
+        global_variable_definitions_.push_back(var_def);
+      } else {
+        std::string var_def = var_type + " " + var_name + ";";
+        global_variable_definitions_.push_back(var_def);
+      }
+    }
+    return true;
+  }
+
+  void WriteHeaderFile() {
+    base::FilePath output_path =
+        base::FilePath(output_dir_).Append("functions.h");
+    base::File output_file(
+        output_path, base::File::FLAG_CREATE_ALWAYS | base::File::FLAG_WRITE);
+    const std::string_view header_guard =
+        "#ifndef FUNCTIONS_H\n#define FUNCTIONS_H\n";
+    output_file.WriteAtCurrentPos(header_guard.data(), header_guard.size());
+    // Write global variable declarations
+    for (const auto& var_decl : global_variable_declarations_) {
+      output_file.WriteAtCurrentPos(var_decl.c_str(), var_decl.size());
+      output_file.WriteAtCurrentPos("\n", 1);
+    }
+    // Write function declarations
+    for (const auto& func_decl : function_declarations_) {
+      output_file.WriteAtCurrentPos(func_decl.c_str(), func_decl.size());
+      output_file.WriteAtCurrentPos("\n", 1);
+    }
+    const std::string_view header_guard_end = "\n#endif // FUNCTIONS_H\n";
+    output_file.WriteAtCurrentPos(header_guard_end.data(),
+                                  header_guard_end.size());
+  }
+
+  void WriteSourceFiles() {
+    size_t file_count = 1;
+    size_t total_definitions = function_definitions_.size();
+
+    size_t function_index = 0;
+    while (function_index < total_definitions) {
+      base::FilePath output_path =
+          base::FilePath(output_dir_)
+              .Append("part_" + base::NumberToString(file_count) + ".cpp");
+      base::File output_file(
+          output_path, base::File::FLAG_CREATE_ALWAYS | base::File::FLAG_WRITE);
+      size_t current_line_count = 0;
+
+      // Write includes
+      size_t includes_line_count =
+          std::count(includes_code_.begin(), includes_code_.end(), '\n');
+      output_file.WriteAtCurrentPos(includes_code_.c_str(),
+                                    includes_code_.size());
+      current_line_count += includes_line_count;
+
+      // Include the header file
+      const std::string_view include_header_code =
+          "#include \"functions.h\"\n\n";
+      output_file.WriteAtCurrentPos(include_header_code.data(),
+                                    include_header_code.size());
+      current_line_count += 2;
+
+      // Include global variable definitions in the first file
+      if (file_count == 1) {
+        std::string global_vars_code;
+        for (const auto& var_def : global_variable_definitions_) {
+          output_file.WriteAtCurrentPos(var_def.c_str(), var_def.size());
+          output_file.WriteAtCurrentPos("\n", 1);
+          current_line_count +=
+              std::count(var_def.begin(), var_def.end(), '\n') + 1;
+        }
+      }
+
+      size_t functions_written = 0;
+      while (function_index < total_definitions &&
+             functions_written < functions_per_file_ &&
+             current_line_count < max_lines_per_file_) {
+        std::string func_def = function_definitions_[function_index];
+        size_t func_def_line_count =
+            std::count(func_def.begin(), func_def.end(), '\n');
+
+        if (func_def_line_count + current_line_count > max_lines_per_file_ &&
+            functions_written > 0) {
+          break;
+        }
+
+        func_def += "\n\n";
+        output_file.WriteAtCurrentPos(func_def.c_str(), func_def.size());
+        current_line_count += func_def_line_count;
+        ++function_index;
+        ++functions_written;
+      }
+
+      ++file_count;
+    }
+  }
+
+  void SetIncludesCode(const std::string& code) { includes_code_ = code; }
+
+ private:
+  Rewriter& rewriter_;
+  std::string input_file_;
+  std::string output_dir_;
+  size_t functions_per_file_;
+  size_t max_lines_per_file_;
+  std::vector<std::string> function_declarations_;
+  std::vector<std::string> function_definitions_;
+  std::vector<std::string> global_variable_declarations_;
+  std::vector<std::string> global_variable_definitions_;
+  std::string includes_code_;
+
+  std::string getSourceText(const SourceManager& sm, SourceLocation start,
+                            SourceLocation end) {
+    SourceRange range(start, end);
+    bool invalid = false;
+    const char* start_buf = sm.getCharacterData(start, &invalid);
+    const char* end_buf = sm.getCharacterData(end, &invalid);
+    if (invalid) return "";
+
+    return std::string(start_buf, end_buf - start_buf);
+  }
+};
+
+class FunctionAndGlobalExtractorASTConsumer : public ASTConsumer {
+ public:
+  FunctionAndGlobalExtractorASTConsumer(Rewriter& rewriter,
+                                        const std::string& input_file,
+                                        const std::string& output_dir,
+                                        size_t functions_per_file,
+                                        size_t max_lines_per_file)
+      : visitor_(rewriter, input_file, output_dir, functions_per_file,
+                 max_lines_per_file) {}
+
+  void HandleTranslationUnit(ASTContext& context) override {
+    visitor_.TraverseDecl(context.getTranslationUnitDecl());
+    visitor_.WriteHeaderFile();
+    visitor_.WriteSourceFiles();
+  }
+
+  void SetIncludesCode(const std::string& code) {
+    visitor_.SetIncludesCode(code);
+  }
+
+ private:
+  FunctionAndGlobalExtractor visitor_;
+};
+
+class FunctionAndGlobalExtractorFrontendAction : public ASTFrontendAction {
+ public:
+  FunctionAndGlobalExtractorFrontendAction(const std::string& input_file,
+                                           const std::string& output_dir,
+                                           size_t functions_per_file,
+                                           size_t max_lines_per_file)
+      : input_file_(input_file),
+        output_dir_(output_dir),
+        functions_per_file_(functions_per_file),
+        max_lines_per_file_(max_lines_per_file) {}
+
+  std::unique_ptr<ASTConsumer> CreateASTConsumer(CompilerInstance& CI,
+                                                 StringRef file) override {
+    rewriter_.setSourceMgr(CI.getSourceManager(), CI.getLangOpts());
+
+    // Read includes and macros from the beginning of the file
+    std::string includes_code = readIncludesAndMacros(input_file_);
+
+    auto ast_consumer = std::make_unique<FunctionAndGlobalExtractorASTConsumer>(
+        rewriter_, input_file_, output_dir_, functions_per_file_,
+        max_lines_per_file_);
+    ast_consumer->SetIncludesCode(includes_code);
+    return ast_consumer;
+  }
+
+ private:
+  Rewriter rewriter_;
+  std::string input_file_;
+  std::string output_dir_;
+  size_t functions_per_file_;
+  size_t max_lines_per_file_;
+
+  std::string readIncludesAndMacros(const std::string& file_path) {
+    std::ifstream input_stream(file_path);
+    std::string line;
+    std::string includes;
+    while (std::getline(input_stream, line)) {
+      std::string trimmed_line = line;
+      trimmed_line.erase(0, trimmed_line.find_first_not_of(" \t"));
+      if (trimmed_line.rfind("#include", 0) == 0 ||
+          trimmed_line.rfind("#define", 0) == 0) {
+        includes += line + "\n";
+      } else if (trimmed_line.empty()) {
+        continue;
+      } else {
+        break;
+      }
+    }
+    includes += "\n";
+    return includes;
+  }
+};
+
+class MyFrontendActionFactory : public clang::tooling::FrontendActionFactory {
+ public:
+  MyFrontendActionFactory(const std::string& input_file,
+                          const std::string& output_dir,
+                          size_t functions_per_file, size_t max_lines_per_file)
+      : input_file_(input_file),
+        output_dir_(output_dir),
+        functions_per_file_(functions_per_file),
+        max_lines_per_file_(max_lines_per_file) {}
+
+  std::unique_ptr<clang::FrontendAction> create() override {
+    return std::make_unique<FunctionAndGlobalExtractorFrontendAction>(
+        input_file_, output_dir_, functions_per_file_, max_lines_per_file_);
+  }
+
+ private:
+  std::string input_file_;
+  std::string output_dir_;
+  size_t functions_per_file_;
+  size_t max_lines_per_file_;
+};
+
+int main(int argc, const char** argv) {
+  // Define command-line options category
+  llvm::cl::OptionCategory tool_category("split-functions-tool options");
+
+  llvm::cl::opt<std::string> output_dir_option(
+      "output_dir", llvm::cl::desc("Specify output directory"),
+      llvm::cl::value_desc("directory"), llvm::cl::init("split_files"));
+
+  // Parse command-line options
+  auto expected_parser = CommonOptionsParser::create(argc, argv, tool_category);
+  if (!expected_parser) {
+    llvm::errs() << expected_parser.takeError();
+    return 1;
+  }
+  CommonOptionsParser& options_parser = expected_parser.get();
+
+  // Create ClangTool
+  ClangTool tool(options_parser.getCompilations(),
+                 options_parser.getSourcePathList());
+
+  // Get source files
+  const auto& sources = options_parser.getSourcePathList();
+  if (sources.empty()) {
+    llvm::errs() << "No source files provided.\n";
+    return 1;
+  }
+
+  // Initialize variables
+  std::string input_file = sources[0];
+  std::string output_dir = output_dir_option;
+  size_t functions_per_file = 1000;
+  size_t max_lines_per_file = 100000;
+
+  // Create a custom FrontendActionFactory
+  auto action_factory = std::make_unique<MyFrontendActionFactory>(
+      input_file, output_dir, functions_per_file, max_lines_per_file);
+
+  // Run the tool
+  int result = tool.run(action_factory.get());
+
+  return result;
+}


### PR DESCRIPTION
# Description

This PR introduces a new tool to compile the circuit CPP file generated from the `.circom` file. For large circuits, the generated `CPP` file can get very large making compilation near impossible and even cause OOM errors sometimes. With this tool, the original compilation time which took many hours will be reduced to just few minutes.
