### PR TITLE
fix(circom): delete old parts before splitting

### DIFF
--- a/vendors/circom/circomlib/build/compile_witness_generator.sh
+++ b/vendors/circom/circomlib/build/compile_witness_generator.sh
@@ -12,6 +12,7 @@ function compile_witness_generator() {
   cp ../../../iden3_circom/code_producers/src/c_elements/$2/* .
 
   echo "Splitting source file into smaller pieces..."
+  rm part_*
   ./split_tool $1 --output_dir=. -- -std=c++11 -I../../external/llvm-project/clang/staging/include
 
   echo "Compiling everything..."


### PR DESCRIPTION
# Description

When compiling witness generator, sometimes # of parts becomes smaller which results in trying to compile non-overwritten old circuit parts with new parts, causing conflict. This PR fixes it by removing old split parts at the start of every run.
